### PR TITLE
Redesign editor toolbar into a two-row context bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,23 @@ HACS adds the dashboard resource automatically.
 
 ## Usage
 
-Edit a dashboard → **Add card** → search **Easy Floorplan**. Use the toolbar:
+Edit a dashboard → **Add card** → search **Easy Floorplan**. The editor has a **tools
+row** and, below it, a **context row** that shows options and actions for whatever you're
+currently doing:
 
+- **select** — the default tool. Click an element to move, rotate, resize, recolor or
+  delete it; Shift/Ctrl-click or drag a box to select several at once. Arrow keys nudge
+  the selection (Shift+arrow jumps a full grid cell), and **Ctrl/Cmd+C/V/D** copy / paste
+  / duplicate. With a selection, the context row offers **duplicate** and **delete**.
 - **wall** — drag to draw. Endpoints snap to nearby corners; start a new wall on an
-  existing corner to continue the perimeter.
+  existing corner to continue the perimeter. The context row's **straighten** toggle keeps
+  walls horizontal/vertical and corner-snapped — turn it off to draw freely at any angle.
 - **door / window** — click to drop; it snaps onto the nearest wall. Assign a sensor in
   the side panel to animate it open/closed (see **Doors & windows**).
-- **+ device / + text / + furniture…** — add elements, then edit them in the side panel.
-- **select** — move, rotate, resize, recolor, delete. Shift/Ctrl-click or drag a box to
-  select several at once; arrow keys nudge the selection (Shift+arrow jumps a full grid
-  cell), and **Ctrl/Cmd+C/V/D** copy / paste / duplicate.
-- **floor** — add, rename, switch and delete floors (top-right of the toolbar).
+- **+ device / + text / + furniture…** — drop a new element, then edit it in the side panel.
+- **floor** — add, rename, switch and delete floors.
 
-Undo/redo and a zoom slider are in the toolbar.
+Undo/redo and a zoom slider live at the right of the tools row.
 
 ## Elements
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -935,6 +935,59 @@ export class FloorplanCardEditor extends LitElement {
     return this._selection.some((s) => s.kind === kind && s.id === id);
   }
 
+  /**
+   * The second toolbar row: shows controls and hints for whatever you're
+   * currently doing — options for the active drawing tool, or actions for the
+   * current selection. This keeps contextual controls (which come and go) out
+   * of the always-present top row.
+   */
+  private _renderContextBar(): TemplateResult {
+    const t = this._tool;
+    let label: string;
+    let body: TemplateResult;
+
+    if (t === "wall") {
+      label = "Wall";
+      body = html`
+        <button
+          class=${this._freeWalls ? "" : "active"}
+          title="Snap walls to horizontal/vertical and existing corners (off = draw freely)"
+          @click=${() => {
+            this._freeWalls = !this._freeWalls;
+          }}
+        >
+          straighten
+        </button>
+        <span class="ctx-hint">Drag to draw. Endpoints snap to nearby corners to close rooms.</span>
+      `;
+    } else if (t === "door" || t === "window") {
+      label = t === "door" ? "Door" : "Window";
+      body = html`<span class="ctx-hint">Click on a wall to drop a ${t}; it snaps onto the wall.</span>`;
+    } else {
+      label = "Select";
+      const n = this._selection.length;
+      body =
+        n > 0
+          ? html`
+              <span class="ctx-count">${n} selected</span>
+              <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
+              <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
+                🗑 delete
+              </button>
+            `
+          : html`<span class="ctx-hint"
+              >Click an element to select it, or drag a box to select several.</span
+            >`;
+    }
+
+    return html`
+      <div class="context-bar">
+        <span class="ctx-label">${label}</span>
+        ${body}
+      </div>
+    `;
+  }
+
   protected render(): TemplateResult {
     if (!this._config) return html`${nothing}`;
     const c = this._config;
@@ -943,58 +996,58 @@ export class FloorplanCardEditor extends LitElement {
     return html`
       <div class="editor">
         <div class="toolbar">
-          ${(["select", "wall", "door", "window"] as Tool[]).map(
-            (t) => html`
-              <button
-                class=${this._tool === t ? "active" : ""}
-                @click=${() => {
-                  this._tool = t;
-                  this._draft = null;
-                }}
-              >
-                ${t}
-              </button>`
-          )}
-          ${this._tool === "wall"
-            ? html`<button
-                class=${this._freeWalls ? "" : "active"}
-                title="Snap walls to horizontal/vertical and existing corners (off = draw freely)"
-                @click=${() => {
-                  this._freeWalls = !this._freeWalls;
-                }}
-              >
-                straighten
-              </button>`
-            : nothing}
+          <!-- Tools — modes; exactly one is active at a time -->
+          <div class="seg" role="group" aria-label="Tool">
+            ${(["select", "wall", "door", "window"] as Tool[]).map(
+              (t) => html`
+                <button
+                  class=${this._tool === t ? "active" : ""}
+                  @click=${() => {
+                    this._tool = t;
+                    this._draft = null;
+                  }}
+                >
+                  ${t}
+                </button>`
+            )}
+          </div>
+
+          <span class="divider"></span>
+
+          <!-- Insert — one-shot: drops a new element on the active floor -->
+          <div class="group" aria-label="Insert">
+            <button @click=${() => this._addItem("generic")}>+ device</button>
+            <button @click=${this._addText}>+ text</button>
+            <select
+              class="furn-add"
+              @change=${(e: Event) => {
+                const v = (e.target as HTMLSelectElement).value as FurnitureType | "";
+                if (v) this._addFurniture(v);
+                (e.target as HTMLSelectElement).value = "";
+              }}
+            >
+              <option value="">+ furniture…</option>
+              ${FURNITURE_TYPES.map((t) => html`<option value=${t}>${FURNITURE_LABELS[t]}</option>`)}
+            </select>
+          </div>
+
           <span class="spacer"></span>
-          <button title="Undo" ?disabled=${!this._history.length} @click=${this._undo}>↶ undo</button>
-          <button title="Redo" ?disabled=${!this._future.length} @click=${this._redo}>↷ redo</button>
-          <button @click=${() => this._addItem("generic")}>+ device</button>
-          <button @click=${this._addText}>+ text</button>
-          <select
-            class="furn-add"
-            @change=${(e: Event) => {
-              const v = (e.target as HTMLSelectElement).value as FurnitureType | "";
-              if (v) this._addFurniture(v);
-              (e.target as HTMLSelectElement).value = "";
-            }}
-          >
-            <option value="">+ furniture…</option>
-            ${FURNITURE_TYPES.map((t) => html`<option value=${t}>${FURNITURE_LABELS[t]}</option>`)}
-          </select>
-          <button class="danger" ?disabled=${!this._selection.length} @click=${this._deleteSelected}>
-            delete
-          </button>
+
+          <!-- History -->
+          <div class="group">
+            <button title="Undo" ?disabled=${!this._history.length} @click=${this._undo}>↶</button>
+            <button title="Redo" ?disabled=${!this._future.length} @click=${this._redo}>↷</button>
+          </div>
+
+          <span class="divider"></span>
+
+          <!-- Floor -->
           <span class="floors">
             <label>floor</label>
-            <select
-              @change=${(e: Event) => this._switchFloor((e.target as HTMLSelectElement).value)}
-            >
+            <select @change=${(e: Event) => this._switchFloor((e.target as HTMLSelectElement).value)}>
               ${floors.map(
                 (f) =>
-                  html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>
-                    ${f.name}
-                  </option>`
+                  html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>${f.name}</option>`
               )}
             </select>
             <input
@@ -1005,9 +1058,7 @@ export class FloorplanCardEditor extends LitElement {
               @change=${(e: Event) =>
                 this._renameFloor(this._activeFloorId, (e.target as HTMLInputElement).value)}
             />
-            <button title="Add a floor (copies the current walls)" @click=${this._addFloor}>
-              + floor
-            </button>
+            <button title="Add a floor (copies the current walls)" @click=${this._addFloor}>+ floor</button>
             <button
               class="danger"
               title="Delete the current floor"
@@ -1017,6 +1068,10 @@ export class FloorplanCardEditor extends LitElement {
               − floor
             </button>
           </span>
+
+          <span class="divider"></span>
+
+          <!-- Zoom -->
           <span class="zoom">
             <label>zoom</label>
             <input
@@ -1032,6 +1087,8 @@ export class FloorplanCardEditor extends LitElement {
             <span class="zoom-val">${Math.round(this._zoom * 100)}%</span>
           </span>
         </div>
+
+        ${this._renderContextBar()}
 
         <div class="canvas-wrap">
           <div class="stage" style="aspect-ratio: ${c.width} / ${c.height}; width:${this._zoom * 100}%;">
@@ -1796,6 +1853,73 @@ export class FloorplanCardEditor extends LitElement {
     }
     .toolbar .spacer {
       flex: 1;
+    }
+    /* generic inline cluster of related controls */
+    .group {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    /* vertical rule between toolbar groups */
+    .divider {
+      align-self: stretch;
+      width: 1px;
+      min-height: 26px;
+      margin: 0 4px;
+      background: var(--divider-color, #e0e0e0);
+    }
+    /* tools rendered as a connected segmented control (one active) */
+    .seg {
+      display: inline-flex;
+    }
+    .seg button {
+      border-radius: 0;
+      border-left-width: 0;
+    }
+    .seg button:first-child {
+      border-left-width: 1px;
+      border-top-left-radius: 6px;
+      border-bottom-left-radius: 6px;
+    }
+    .seg button:last-child {
+      border-top-right-radius: 6px;
+      border-bottom-right-radius: 6px;
+    }
+    /* contextual second row: options/actions for the current tool or selection */
+    .context-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 6px;
+      padding: 5px 10px;
+      min-height: 36px;
+      box-sizing: border-box;
+      border: 1px solid var(--divider-color, #e0e0e0);
+      border-radius: 6px;
+      background: var(--secondary-background-color, #f5f5f5);
+    }
+    .context-bar .ctx-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--primary-color, #03a9f4);
+      padding-right: 8px;
+      margin-right: 2px;
+      border-right: 1px solid var(--divider-color, #e0e0e0);
+    }
+    .context-bar .ctx-hint {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+    .context-bar .ctx-count {
+      font-size: 12px;
+      color: var(--primary-text-color);
+    }
+    .context-bar button {
+      padding: 4px 10px;
+      font-size: 13px;
     }
     button {
       cursor: pointer;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1035,8 +1035,12 @@ export class FloorplanCardEditor extends LitElement {
 
           <!-- History -->
           <div class="group">
-            <button title="Undo" ?disabled=${!this._history.length} @click=${this._undo}>↶</button>
-            <button title="Redo" ?disabled=${!this._future.length} @click=${this._redo}>↷</button>
+            <button aria-label="Undo" title="Undo" ?disabled=${!this._history.length} @click=${this._undo}>
+              ↶
+            </button>
+            <button aria-label="Redo" title="Redo" ?disabled=${!this._future.length} @click=${this._redo}>
+              ↷
+            </button>
           </div>
 
           <span class="divider"></span>


### PR DESCRIPTION
## Summary

The editor toolbar packed four different *kinds* of control into one flat row of identical gray buttons — persistent modes, one-shot inserts, contextual options, and document/view chrome — so nothing signaled which buttons work together or which depend on what you're doing. This reorganizes it into two rows.

**Row 1 — always present, grouped with dividers:**
- **Tools** as a connected *segmented control* (`Select · Wall · Door · Window`) so it reads as "pick exactly one"
- **Insert** group (`+ device · + text · + furniture▾`)
- **Undo/Redo** (compact `↶ ↷`)
- **Floor** (switch / rename / + / −)
- **Zoom**

**Row 2 — context bar, changes with the active tool / selection:**
- **Wall** → `straighten` toggle + drawing hint
- **Door / Window** → placement hint
- **Select** → either a "click/drag to select" hint, or `N selected · ⧉ duplicate · 🗑 delete` when something is selected

This isolates everything transient (straighten, delete, duplicate) into one labeled row, and makes modes vs. actions visually distinct.

## Changes
- `src/editor.ts` — two-row toolbar markup, new `_renderContextBar()`, and CSS for the segmented control, group dividers, and context bar.
- `README.md` — updated the Usage section for the new layout and documented the previously-undocumented wall **straighten / free-draw** toggle.

## Test plan
- [ ] Tools row: only one tool is highlighted at a time; switching tools clears any draft.
- [ ] Context row shows `straighten` only for Wall; toggling it switches between snapped and free wall drawing.
- [ ] Door/Window show the placement hint.
- [ ] Selecting element(s) shows `duplicate` / `delete` and the count; both work.
- [ ] Undo/redo, floor add/rename/switch/delete, and zoom all still work.
- [ ] Verify in a real HA instance (theme colors, not just the local harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)