### PR TITLE
Code-quality pass: CI checks, tests, and render dedupe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: write
 
+# Opt the bundled JS actions into the Node 24 runtime ahead of GitHub forcing it
+# (Node 20 action runtime is deprecated).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,3 +17,19 @@ jobs:
         uses: hacs/action@main
         with:
           category: plugin
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Type-check
+        run: npm run typecheck
+      - name: Test
+        run: npm test
+      - name: Build
+        run: npm run build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions: {}
+# Least privilege: read-only is all the validation/build jobs need (checkout
+# requires contents: read).
+permissions:
+  contents: read
 
 # Opt the bundled JS actions into the Node 24 runtime ahead of GitHub forcing it
 # (Node 20 action runtime is deprecated).

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,11 @@ on:
 
 permissions: {}
 
+# Opt the bundled JS actions into the Node 24 runtime ahead of GitHub forcing it
+# (Node 20 action runtime is deprecated).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate-hacs:
     runs-on: ubuntu-latest
@@ -24,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Type-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "typescript": "^5.4.0",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -438,6 +439,12 @@
         "emojis-list": "^3.0.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
@@ -787,6 +794,155 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/custom-card-helpers": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/custom-card-helpers/-/custom-card-helpers-1.9.0.tgz",
@@ -849,6 +1005,32 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -856,6 +1038,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -893,6 +1081,24 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -952,6 +1158,27 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -968,6 +1195,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1018,6 +1260,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1027,10 +1275,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
     "node_modules/superstruct": {
       "version": "0.15.5",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1109,6 +1408,28 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -1151,6 +1472,87 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.4",
         "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   },
@@ -1368,6 +1770,12 @@
         "emojis-list": "^3.0.0"
       }
     },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
@@ -1567,6 +1975,110 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
+    "@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "requires": {
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^3.0.2"
+      }
+    },
+    "@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
+    },
+    "cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true
+    },
+    "chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
+    },
+    "check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true
+    },
     "custom-card-helpers": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/custom-card-helpers/-/custom-card-helpers-1.9.0.tgz",
@@ -1624,10 +2136,31 @@
         }
       }
     },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "esbuild": {
       "version": "0.21.5",
@@ -1659,6 +2192,21 @@
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
+    },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.3",
@@ -1710,10 +2258,43 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true
+    },
+    "pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true
     },
     "picocolors": {
@@ -1741,16 +2322,64 @@
         "fsevents": "~2.3.2"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
     "superstruct": {
       "version": "0.15.5",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+    },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true
+    },
+    "tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true
     },
     "tslib": {
       "version": "2.8.1",
@@ -1810,6 +2439,57 @@
             "fsevents": "~2.3.2"
           }
         }
+      }
+    },
+    "vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      }
+    },
+    "vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,17 @@
     "build": "vite build",
     "watch": "vite build --watch",
     "dev": "vite build --watch",
-    "serve": "vite --open /dev/"
+    "serve": "vite --open /dev/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
-  "keywords": ["home-assistant", "lovelace", "custom-card", "hacs", "floorplan"],
+  "keywords": [
+    "home-assistant",
+    "lovelace",
+    "custom-card",
+    "hacs",
+    "floorplan"
+  ],
   "license": "MIT",
   "author": "Nicolas Sandller",
   "repository": {
@@ -26,6 +34,7 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -380,6 +380,12 @@ export class FloorplanCardEditor extends LitElement {
   // ---- keyboard nudging ---------------------------------------------------
 
   private _handleKeyDown(ev: KeyboardEvent): void {
+    // The listener is on `window` (capture phase) so HA's dialog can't swallow
+    // arrow keys before we see them — the canvas itself isn't focusable. But
+    // that also means a hidden/background editor instance would otherwise react,
+    // so ignore the event unless this editor is actually visible.
+    const checkVisibility = (this as { checkVisibility?: () => boolean }).checkVisibility;
+    if (checkVisibility && !checkVisibility.call(this)) return;
     // Don't hijack keys while typing in a field / picker.
     const path = ev.composedPath();
     if (
@@ -955,6 +961,7 @@ export class FloorplanCardEditor extends LitElement {
       body = html`
         <button
           class=${this._freeWalls ? "" : "active"}
+          aria-pressed=${!this._freeWalls}
           title="Snap walls to horizontal/vertical and existing corners (off = draw freely)"
           @click=${() => {
             this._freeWalls = !this._freeWalls;
@@ -1006,6 +1013,7 @@ export class FloorplanCardEditor extends LitElement {
               (t) => html`
                 <button
                   class=${this._tool === t ? "active" : ""}
+                  aria-pressed=${this._tool === t}
                   @click=${() => {
                     this._tool = t;
                     this._draft = null;
@@ -1286,18 +1294,20 @@ export class FloorplanCardEditor extends LitElement {
           <label>Canvas W / H</label>
           <input
             type="number"
+            min="1"
             .value=${String(this._config.width)}
             @change=${(e: Event) =>
               this._patchConfig({
-                width: Number((e.target as HTMLInputElement).value) || DEFAULT_WIDTH,
+                width: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_WIDTH),
               })}
           />
           <input
             type="number"
+            min="1"
             .value=${String(this._config.height)}
             @change=${(e: Event) =>
               this._patchConfig({
-                height: Number((e.target as HTMLInputElement).value) || DEFAULT_HEIGHT,
+                height: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_HEIGHT),
               })}
           />
         </div>
@@ -1387,8 +1397,8 @@ export class FloorplanCardEditor extends LitElement {
         Pick a tool to draw. Wall ends snap to nearby wall corners — start a new wall on an existing
         corner to continue the perimeter. Switch to <b>select</b> to move or delete things. Drag a box
         on empty canvas to select many; <b>Shift</b>/<b>Ctrl</b>-click adds to the selection. With
-        something selected, <b>arrow keys</b> nudge it (hold <b>Shift</b> for 1-unit steps), and
-        <b>Ctrl/Cmd+C/V/D</b> copy / paste / duplicate.
+        something selected, <b>arrow keys</b> nudge it (hold <b>Shift</b> to jump a full grid cell),
+        and <b>Ctrl/Cmd+C/V/D</b> copy / paste / duplicate.
       </p>`;
 
     if (sel.kind === "opening") {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -30,6 +30,7 @@ import {
 import {
   WALL_THICKNESS,
   renderOpening,
+  renderWallMask,
   openingDefaultOpen,
   renderRipple,
   renderFurniture,
@@ -197,9 +198,12 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   private _patchFloors(partial: Partial<Floor>): Floor[] {
-    return (this._config.floors ?? []).map((f) =>
-      f.id === this._activeFloorId ? { ...f, ...partial } : f
-    );
+    const floors = this._config.floors ?? [];
+    // Patch the floor actually being shown. Fall back to the first floor when
+    // `_activeFloorId` is stale (matching `_floor()`), so edits are never
+    // silently dropped onto a non-existent floor id.
+    const active = floors.find((f) => f.id === this._activeFloorId) ?? floors[0];
+    return floors.map((f) => (active && f.id === active.id ? { ...f, ...partial } : f));
   }
 
   protected firstUpdated(): void {
@@ -1117,18 +1121,7 @@ export class FloorplanCardEditor extends LitElement {
                 : nothing}
               ${this._renderGrid()}
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
-              <defs>
-                <mask id=${this._wallMaskId} maskUnits="userSpaceOnUse">
-                  <rect x="0" y="0" width=${c.width} height=${c.height} fill="white" />
-                  ${floor.openings.map((o) => {
-                    const cutH = WALL_THICKNESS + 4;
-                    const half = o.length / 2;
-                    return svg`<rect x=${o.x - half} y=${o.y - cutH / 2}
-                                     width=${o.length} height=${cutH} fill="black"
-                                     transform="rotate(${o.angle} ${o.x} ${o.y})" />`;
-                  })}
-                </mask>
-              </defs>
+              ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
               ${floor.openings.map((o) => this._renderOpeningSel(o))}
               ${
@@ -1191,15 +1184,10 @@ export class FloorplanCardEditor extends LitElement {
     return svg`
       <g class="opening-hit"
          @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "opening", id: o.id })}>
-        ${renderOpening(
-          o,
-          selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
-          "var(--card-background-color, #fff)",
-          openingDefaultOpen(o),
-          false,
-          undefined,
-          false
-        )}
+        ${renderOpening(o, {
+          color: selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
+          open: openingDefaultOpen(o),
+        })}
       </g>`;
   }
 

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -220,7 +220,7 @@ export class FloorplanCard extends LitElement {
           </svg>
           <div class="items">
             ${active.texts.map((t) => this._renderText(t, c))}
-            ${active.items.map((it) => this._renderItem(it, c))}
+            ${active.items.filter((it) => it.entity).map((it) => this._renderItem(it, c))}
           </div>
           ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
         </div>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -12,6 +12,7 @@ import {
 import {
   WALL_THICKNESS,
   renderOpening,
+  renderWallMask,
   openingDefaultOpen,
   renderRipple,
   renderFurniture,
@@ -199,18 +200,7 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
             ${active.furniture.map((f) => renderFurniture(f))}
-            <defs>
-              <mask id=${this._wallMaskId} maskUnits="userSpaceOnUse">
-                <rect x="0" y="0" width=${c.width} height=${c.height} fill="white" />
-                ${active.openings.map((o) => {
-                  const cutH = WALL_THICKNESS + 4;
-                  const half = o.length / 2;
-                  return svg`<rect x=${o.x - half} y=${o.y - cutH / 2}
-                                   width=${o.length} height=${cutH} fill="black"
-                                   transform="rotate(${o.angle} ${o.x} ${o.y})" />`;
-                })}
-              </mask>
-            </defs>
+            ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
             <g mask=${`url(#${this._wallMaskId})`}>
               ${active.walls.map(
                 (w) => svg`
@@ -220,15 +210,12 @@ export class FloorplanCard extends LitElement {
             </g>
             ${active.openings.map((o) => {
               const isOpen = this._openingIsOpen(o);
-              return renderOpening(
-                o,
-                "var(--primary-text-color)",
-                "var(--card-background-color, #fff)",
-                isOpen,
-                !!o.entity && isOpen,
-                o.activeColor ?? "var(--primary-color, #03a9f4)",
-                false
-              );
+              return renderOpening(o, {
+                color: "var(--primary-text-color)",
+                open: isOpen,
+                active: !!o.entity && isOpen,
+                accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
+              });
             })}
           </svg>
           <div class="items">

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { snapToWall, openingDefaultOpen, kindFromEntity, defaultIcon } from "./render";
+import type { Opening } from "./types";
+
+describe("snapToWall", () => {
+  const hWall = { x1: 0, y1: 0, x2: 100, y2: 0 }; // horizontal
+  const vWall = { x1: 0, y1: 0, x2: 0, y2: 100 }; // vertical
+
+  it("projects a nearby point onto a horizontal wall (angle 0)", () => {
+    const r = snapToWall(50, 5, [hWall], 35);
+    expect(r).not.toBeNull();
+    expect(r!.x).toBeCloseTo(50);
+    expect(r!.y).toBeCloseTo(0);
+    expect(r!.angle).toBeCloseTo(0);
+  });
+
+  it("reports a 90° angle for a vertical wall", () => {
+    const r = snapToWall(5, 50, [vWall], 35);
+    expect(r).not.toBeNull();
+    expect(r!.x).toBeCloseTo(0);
+    expect(r!.y).toBeCloseTo(50);
+    expect(Math.abs(r!.angle)).toBeCloseTo(90);
+  });
+
+  it("clamps the projection to the wall's endpoints", () => {
+    // A point just past the right end snaps to the endpoint, not beyond it.
+    const r = snapToWall(110, 5, [hWall], 35);
+    expect(r).not.toBeNull();
+    expect(r!.x).toBeCloseTo(100);
+    expect(r!.y).toBeCloseTo(0);
+  });
+
+  it("returns null when no wall is within the threshold", () => {
+    expect(snapToWall(50, 200, [hWall], 35)).toBeNull();
+  });
+
+  it("picks the closest of several walls", () => {
+    const r = snapToWall(50, 8, [hWall, { x1: 0, y1: 100, x2: 100, y2: 100 }], 35);
+    expect(r!.y).toBeCloseTo(0); // nearer to the top wall
+  });
+
+  it("ignores zero-length walls", () => {
+    expect(snapToWall(0, 0, [{ x1: 10, y1: 10, x2: 10, y2: 10 }], 35)).toBeNull();
+  });
+});
+
+describe("openingDefaultOpen", () => {
+  it("draws doors open and windows closed by default", () => {
+    expect(openingDefaultOpen({ type: "door" } as Opening)).toBe(true);
+    expect(openingDefaultOpen({ type: "window" } as Opening)).toBe(false);
+  });
+});
+
+describe("kindFromEntity", () => {
+  it("maps known domains to their kind", () => {
+    expect(kindFromEntity("light.kitchen")).toBe("light");
+    expect(kindFromEntity("binary_sensor.door")).toBe("binary_sensor");
+    expect(kindFromEntity("cover.garage")).toBe("cover");
+  });
+  it("falls back to generic for unknown domains", () => {
+    expect(kindFromEntity("media_player.tv")).toBe("generic");
+    expect(kindFromEntity("weird")).toBe("generic");
+  });
+});
+
+describe("defaultIcon", () => {
+  it("returns a sensible mdi icon per kind", () => {
+    expect(defaultIcon("light")).toBe("mdi:lightbulb");
+    expect(defaultIcon("cover")).toBe("mdi:window-shutter");
+    expect(defaultIcon("generic")).toBe("mdi:circle");
+  });
+});

--- a/src/render.ts
+++ b/src/render.ts
@@ -49,32 +49,29 @@ export function openingDefaultOpen(o: Opening): boolean {
   return o.type === "door";
 }
 
+/** Style options for {@link renderOpening}. */
+export interface OpeningStyle {
+  /** Base color of the jambs / leaf / swing arc. */
+  color: string;
+  /** Whether the opening is drawn open (default `true`). */
+  open?: boolean;
+  /** Entity-driven "actively open" state: tints the moving parts with `accent`. */
+  active?: boolean;
+  /** Accent color used while `active` (default the HA primary color). */
+  accent?: string;
+}
+
 /**
  * Render a door or window as an SVG group centered at the origin, then translated
- * and rotated into place. A background-colored "cut" masks the wall so the opening
- * reads as a gap, then the symbol (window panes / door swing) is drawn on top.
- *
- * The moving parts (door leaf, window sash) carry CSS classes so the host
- * component's styles can transition them smoothly between open and closed.
- *
- * @param bg    Color used to mask the wall behind the opening (the card background).
- * @param open  Whether the opening is currently open.
+ * and rotated into place. The wall behind the opening is cut away by the host via
+ * an SVG mask (see {@link renderWallMask}), so this draws only the symbol — jambs,
+ * swing arc and the moving leaf/sash, which carry CSS classes so the host's styles
+ * can transition them smoothly between open and closed.
  */
-export function renderOpening(
-  o: Opening,
-  color: string,
-  bg: string,
-  open = true,
-  active = false,
-  accent = "var(--primary-color, #03a9f4)",
-  drawCut = true
-): SVGTemplateResult {
+export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResult {
+  const { color, open = true, active = false, accent = "var(--primary-color, #03a9f4)" } = style;
   const half = o.length / 2;
   const cutH = WALL_THICKNESS + 4;
-  // Mask out the wall segment behind the opening.
-  const cut = drawCut
-    ? svg`<rect x=${-half} y=${-cutH / 2} width=${o.length} height=${cutH} fill=${bg} />`
-    : svg``;
   // The moving parts take the accent color when actively open (sensor-driven).
   const tone = active ? accent : color;
 
@@ -85,7 +82,6 @@ export function renderOpening(
     // tracing a quarter-circle arc (radius = half) that draws on as it opens.
     const arcLen = (Math.PI / 2) * half;
     body = svg`
-        ${cut}
         <!-- jambs -->
         <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
               stroke=${color} stroke-width="2" />
@@ -120,7 +116,6 @@ export function renderOpening(
     // the door edge. arcLen is the quarter-circle length (radius = o.length).
     const arcLen = (Math.PI / 2) * o.length;
     body = svg`
-        ${cut}
         <!-- swing arc: hidden when closed, drawn as it opens -->
         <path class="fp-door-arc"
               d="M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}"
@@ -135,6 +130,34 @@ export function renderOpening(
       `;
   }
   return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">${body}</g>`;
+}
+
+/**
+ * Build an SVG `<mask>` (white field with a black rect at each opening) that, when
+ * applied to the wall layer, removes the wall pixels behind doors/windows so a gap
+ * shows through — including any background image. Shared by the live card and the
+ * editor so both cut walls identically. Wrap the wall strokes in
+ * `<g mask="url(#id)">` (or set `mask="url(#id)"` on each wall line).
+ */
+export function renderWallMask(
+  openings: Opening[],
+  width: number,
+  height: number,
+  id: string
+): SVGTemplateResult {
+  const cutH = WALL_THICKNESS + 4;
+  return svg`
+    <defs>
+      <mask id=${id} maskUnits="userSpaceOnUse">
+        <rect x="0" y="0" width=${width} height=${height} fill="white" />
+        ${openings.map((o) => {
+          const half = o.length / 2;
+          return svg`<rect x=${o.x - half} y=${o.y - cutH / 2}
+                           width=${o.length} height=${cutH} fill="black"
+                           transform="rotate(${o.angle} ${o.x} ${o.y})" />`;
+        })}
+      </mask>
+    </defs>`;
 }
 
 /**

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { emptyConfig, makeFloor, getFloors, uid } from "./types";
+import type { FloorplanCardConfig } from "./types";
+
+describe("emptyConfig", () => {
+  it("produces a blank, valid single-floor config", () => {
+    const c = emptyConfig("custom:easy-floorplan-card");
+    expect(c.type).toBe("custom:easy-floorplan-card");
+    expect(c.width).toBe(1000);
+    expect(c.height).toBe(600);
+    expect(c.grid).toBe(20);
+    expect(c.walls).toEqual([]);
+    expect(c.openings).toEqual([]);
+    expect(c.items).toEqual([]);
+  });
+});
+
+describe("makeFloor", () => {
+  it("creates a named floor with a unique id and empty element arrays", () => {
+    const f = makeFloor("Upstairs");
+    expect(f.name).toBe("Upstairs");
+    expect(f.id).toMatch(/^floor_/);
+    expect(f.walls).toEqual([]);
+    expect(f.openings).toEqual([]);
+  });
+
+  it("seeds the floor with the provided walls", () => {
+    const walls = [{ id: "w1", x1: 0, y1: 0, x2: 10, y2: 0 }];
+    expect(makeFloor("F", walls).walls).toBe(walls);
+  });
+
+  it("gives each floor a distinct id", () => {
+    expect(makeFloor("a").id).not.toBe(makeFloor("b").id);
+  });
+});
+
+describe("getFloors", () => {
+  it("returns the floors array when present and non-empty", () => {
+    const floors = [makeFloor("A"), makeFloor("B")];
+    const c = { ...emptyConfig("x"), floors } as FloorplanCardConfig;
+    expect(getFloors(c)).toBe(floors);
+  });
+
+  it("wraps a legacy flat config into a single implicit floor", () => {
+    const c = {
+      ...emptyConfig("x"),
+      walls: [{ id: "w1", x1: 0, y1: 0, x2: 10, y2: 0 }],
+    } as FloorplanCardConfig;
+    const floors = getFloors(c);
+    expect(floors).toHaveLength(1);
+    expect(floors[0].id).toBe("floor_main");
+    expect(floors[0].walls).toEqual(c.walls);
+  });
+
+  it("treats an empty floors array as legacy (wraps flat arrays)", () => {
+    const c = { ...emptyConfig("x"), floors: [] } as FloorplanCardConfig;
+    expect(getFloors(c)).toHaveLength(1);
+  });
+});
+
+describe("uid", () => {
+  it("prefixes the id and stays unique", () => {
+    expect(uid("wall")).toMatch(/^wall_/);
+    expect(uid("x")).not.toBe(uid("x"));
+  });
+});


### PR DESCRIPTION
Addresses **items 1–11** from the codebase review.

## 1. CI now type-checks, tests, and builds
`vite build` uses esbuild, which strips types **without checking them**, and `validate.yml` only ran HACS structure validation — so a real type error could ship. Added `typecheck`/`test` scripts and a `build` job (`npm ci → typecheck → test → build`) on every push/PR.

## 2. Tests for the geometry/util layer
New Vitest suite (`src/render.test.ts`, `src/types.test.ts`): `snapToWall`, `openingDefaultOpen`, `kindFromEntity`, `defaultIcon`, `getFloors` (incl. legacy migration), `emptyConfig`, `makeFloor`, `uid`. 18 tests, all green.

## 3. `_patchFloors` no longer silently drops edits
Resolves the active floor with the same `?? floors[0]` fallback as `_floor()`.

## 4. Removed duplication + dead code in rendering
Extracted a shared `renderWallMask()` into `render.ts` (removed the duplicated `<defs><mask>` from card + editor); dropped the unreachable `bg`/`drawCut`/cut path from `renderOpening`. Bundle shrank ~0.6 kB.

## 5. `renderOpening` takes an options object
`renderOpening(o, { color, open?, active?, accent? })` instead of 7 positional args.

## 6. Fixed an incorrect panel hint
Shift+arrow jumps a **full grid cell** (the hint wrongly said "1-unit steps"; now matches `_handleKeyDown` and the README).

## 7. Scoped the global keydown handler
Ignores the event when the editor instance isn't visible (`checkVisibility`), so a hidden/background editor can't react; clarified the window/capture intent.

## 8. Accessibility
`aria-pressed` on the segmented tool buttons and the wall **straighten** toggle (undo/redo already had `aria-label`s).

## 9. Robustness
Canvas width/height clamp to a positive minimum; the live card no longer renders device items with no entity assigned yet.

## 10. (No change — intentional)
The full re-render on drag is a scaling note, not a bug; Lit's diffing handles typical floorplans, and a real fix would be a risky refactor for no current benefit.

## 11. CI Node 24
Bumped both workflows to `node-version: 24` and opted the bundled JS actions into the Node 24 runtime (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`) ahead of the GitHub deprecation.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — 18/18 pass
- [x] `npm run build` succeeds
- [x] Harness: walls/doors render with the mask cut; aria-pressed reflects the active tool; empty-entity devices hidden in the live card
- [ ] Sanity-check in a real HA instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)