### PR TITLE
Clarify Snap vs Grid in the editor (+ wall snapping & selection fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ automatically to the card and screen size.
   the top-right (in both the editor and the live card).
 - **Multi-select & copy/paste** — shift/ctrl-click or drag a box to select many; move,
   duplicate (Ctrl/Cmd+D), copy/paste (Ctrl/Cmd+C/V) or delete them together.
-- **Free placement** — elements aren't locked to the visible grid, so you can center them
-  precisely; an optional **Snap** setting re-enables grid snapping at any granularity.
+- **Snapping** — by default walls and elements snap to the visible grid; switch **Snap to**
+  to **Off** for free placement, or **Custom** to snap to your own step.
 - **Auto-scaling** — a virtual coordinate space + SVG means the plan rescales to any
   card or screen size with no reflow.
 
@@ -161,10 +161,10 @@ The editor writes this config for you; manual editing is optional.
 | ------------ | -------- | ------------------ | -------------------------------------------- |
 | `type`       | string   | —                  | `custom:easy-floorplan-card`                 |
 | `title`      | string   | —                  | Optional card header.                        |
-| `width`      | number   | `1000`             | Virtual canvas width.                        |
-| `height`     | number   | `600`              | Virtual canvas height.                       |
-| `grid`       | number   | `20`               | Visible grid spacing; wall endpoints snap to this while drawing. |
-| `snap`       | number   | follows `grid`     | Placement / drag / nudge snap step. Omit (or leave unset) to follow the visible grid; set to `0` for free placement; set to any other number for a custom step. |
+| `width`      | number   | `1000`             | Virtual canvas width, in canvas units.       |
+| `height`     | number   | `600`              | Virtual canvas height, in canvas units.      |
+| `grid`       | number   | `20`               | Gap between grid lines, in canvas units (so on a 1000-wide canvas, `20` ≈ 50 columns). A **smaller** number means a **finer** grid with more lines. |
+| `snap`       | number   | follows `grid`     | Snap step for placement / drag / nudge / wall drawing, in canvas units. Omit to snap to the visible grid; set `0` for free placement; set any other number for a custom step (smaller than `grid` = finer, larger = coarser). |
 | `background` | string   | card background    | Canvas background color (CSS / hex).         |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The editor writes this config for you; manual editing is optional.
 | `width`      | number   | `1000`             | Virtual canvas width, in canvas units.       |
 | `height`     | number   | `600`              | Virtual canvas height, in canvas units.      |
 | `grid`       | number   | `20`               | Gap between grid lines, in canvas units (so on a 1000-wide canvas, `20` ≈ 50 columns). A **smaller** number means a **finer** grid with more lines. |
-| `snap`       | number   | follows `grid`     | Snap step for placement / drag / nudge / wall drawing, in canvas units. Omit to snap to the visible grid; set `0` for free placement; set any other number for a custom step (smaller than `grid` = finer, larger = coarser). |
+| `snap`       | number   | follows `grid`     | Snap step for placement / drag / nudge / wall drawing, in canvas units. Omit to snap to the visible grid; set `0` for free placement; set any other number for a custom step. The editor shows a custom step as a **percentage of the grid** (e.g. `50` % of a `20` grid is stored here as `10`), but the value here is always absolute. |
 | `background` | string   | card background    | Canvas background color (CSS / hex).         |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ The editor writes this config for you; manual editing is optional.
 | `title`      | string   | —                  | Optional card header.                        |
 | `width`      | number   | `1000`             | Virtual canvas width.                        |
 | `height`     | number   | `600`              | Virtual canvas height.                       |
-| `grid`       | number   | `20`               | Visible grid spacing (a visual guide).       |
-| `snap`       | number   | `0`                | Placement snap step; `0` = free placement.   |
+| `grid`       | number   | `20`               | Visible grid spacing; wall endpoints snap to this while drawing. |
+| `snap`       | number   | follows `grid`     | Placement / drag / nudge snap step. Omit (or leave unset) to follow the visible grid; set to `0` for free placement; set to any other number for a custom step. |
 | `background` | string   | card background    | Canvas background color (CSS / hex).         |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -15,6 +15,7 @@ import type {
   ItemDisplay,
 } from "./types";
 import {
+  DEFAULT_CUSTOM_SNAP,
   DEFAULT_GRID,
   DEFAULT_HEIGHT,
   DEFAULT_WIDTH,
@@ -25,6 +26,7 @@ import {
   emptyConfig,
   getFloors,
   makeFloor,
+  resolveSnap,
   uid,
 } from "./types";
 import {
@@ -234,13 +236,37 @@ export class FloorplanCardEditor extends LitElement {
     return Math.round(v / g) * g;
   }
 
-  /** Placement snap step; 0 means free placement (no snapping). */
-  private get snapStep(): number {
-    return this._config.snap ?? 0;
+  /**
+   * Resolved placement snap step. `snap` is tri-state in the config: unset
+   * means "follow the grid" (the default behaviour), `0` is free placement,
+   * any other number is a custom step. See {@link resolveSnap}.
+   */
+  private get _resolvedSnap(): number {
+    return resolveSnap(this._config.snap, this.grid);
+  }
+
+  /** Which radio option the panel's "Snap to" control shows as active. */
+  private get _snapMode(): "grid" | "off" | "custom" {
+    const s = this._config.snap;
+    if (s == null) return "grid";
+    if (s === 0) return "off";
+    return "custom";
+  }
+
+  private _setSnapMode(mode: "grid" | "off" | "custom"): void {
+    if (mode === "grid") {
+      this._patchConfig({ snap: undefined });
+    } else if (mode === "off") {
+      this._patchConfig({ snap: 0 });
+    } else {
+      // Keep an existing custom value; otherwise seed with the project default.
+      const cur = this._config.snap;
+      this._patchConfig({ snap: cur && cur > 0 ? cur : DEFAULT_CUSTOM_SNAP });
+    }
   }
 
   private _snap(v: number): number {
-    const s = this.snapStep;
+    const s = this._resolvedSnap;
     return s > 0 ? Math.round(v / s) * s : v;
   }
 
@@ -442,7 +468,9 @@ export class FloorplanCardEditor extends LitElement {
     if (!d) return;
     ev.preventDefault();
     // Default nudge is fine (snap step, or 1 unit when free); Shift jumps a grid cell.
-    const step = ev.shiftKey ? this.grid : this.snapStep || 1;
+    // Default nudge follows the resolved snap (= the grid when unset, or the
+    // explicit custom step). Shift always jumps a full grid cell.
+    const step = ev.shiftKey ? this.grid : this._resolvedSnap || 1;
     this._nudge(d[0] * step, d[1] * step);
   }
 
@@ -802,11 +830,13 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
-  /** Paste the clipboard onto the active floor, offset by one grid step, with fresh ids. */
+  /** Paste the clipboard onto the active floor, offset by one snap step, with fresh ids. */
   private _paste(): void {
     if (!this._clipboard) return;
     const cb = structuredClone(this._clipboard);
-    const off = this.grid;
+    // Offset by the resolved snap so paste lands on the same step as drag.
+    // Fall back to the grid when snap is explicitly off (`0`) to avoid overlap.
+    const off = this._resolvedSnap || this.grid;
     const f = this._floor();
     const newWalls: Wall[] = cb.walls.map((w) => ({
       ...w,
@@ -1278,6 +1308,58 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
+  /**
+   * The panel's "Snap to" row: a three-option segmented control over the
+   * tri-state `snap` config. **Grid** (unset) follows the visible grid;
+   * **Off** (`0`) is truly free placement; **Custom** (`> 0`) exposes a number
+   * input for a bespoke step.
+   */
+  private _renderSnapRow(): TemplateResult {
+    const mode = this._snapMode;
+    const opts: { id: "grid" | "off" | "custom"; label: string }[] = [
+      { id: "grid", label: "Grid" },
+      { id: "off", label: "Off" },
+      { id: "custom", label: "Custom" },
+    ];
+    const hint =
+      mode === "grid"
+        ? `Elements snap to the ${this.grid}-unit grid above.`
+        : mode === "off"
+          ? "Elements can be placed anywhere (free placement)."
+          : "Elements snap to this step.";
+    return html`
+      <div class="row">
+        <label>Snap to</label>
+        <div class="seg" role="group" aria-label="Snap mode">
+          ${opts.map(
+            (o) => html`
+              <button
+                class=${mode === o.id ? "active" : ""}
+                aria-pressed=${mode === o.id}
+                @click=${() => this._setSnapMode(o.id)}
+              >
+                ${o.label}
+              </button>
+            `
+          )}
+        </div>
+        ${mode === "custom"
+          ? html`<input
+              class="num"
+              type="number"
+              min="1"
+              .value=${String(this._config.snap ?? DEFAULT_CUSTOM_SNAP)}
+              @change=${(e: Event) =>
+                this._patchConfig({
+                  snap: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_SNAP),
+                })}
+            />`
+          : nothing}
+        <span class="hint">${hint}</span>
+      </div>
+    `;
+  }
+
   private _renderPanel(): TemplateResult {
     return html`
       <div class="panel">
@@ -1315,27 +1397,16 @@ export class FloorplanCardEditor extends LitElement {
           <label>Grid</label>
           <input
             type="number"
+            min="1"
             .value=${String(this.grid)}
             @change=${(e: Event) =>
               this._patchConfig({
-                grid: Number((e.target as HTMLInputElement).value) || DEFAULT_GRID,
+                grid: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_GRID),
               })}
           />
+          <span class="hint">Visible grid; wall corners snap here.</span>
         </div>
-        <div class="row">
-          <label>Snap</label>
-          <input
-            class="num"
-            type="number"
-            min="0"
-            .value=${String(this.snapStep)}
-            @change=${(e: Event) =>
-              this._patchConfig({
-                snap: Number((e.target as HTMLInputElement).value) || undefined,
-              })}
-          />
-          <span class="hint">0 = free placement</span>
-        </div>
+        ${this._renderSnapRow()}
         <div class="row">
           <label>Background</label>
           <input

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -230,12 +230,6 @@ export class FloorplanCardEditor extends LitElement {
     return this._config.grid ?? DEFAULT_GRID;
   }
 
-  /** Round to the visible grid (used for wall-drawing gravity, independent of `snap`). */
-  private _snapToGrid(v: number): number {
-    const g = this.grid;
-    return Math.round(v / g) * g;
-  }
-
   /**
    * Resolved placement snap step. `snap` is tri-state in the config: unset
    * means "follow the grid" (the default behaviour), `0` is free placement,
@@ -297,15 +291,17 @@ export class FloorplanCardEditor extends LitElement {
     return best;
   }
 
-  /** Snap a raw point to a nearby existing wall endpoint, else to the visible grid. */
+  /** Snap a raw point to a nearby existing wall endpoint, else to the snap step. */
   private _snapWallPoint(rawX: number, rawY: number): { x: number; y: number } {
-    return this._nearestCorner(rawX, rawY) ?? { x: this._snapToGrid(rawX), y: this._snapToGrid(rawY) };
+    return this._nearestCorner(rawX, rawY) ?? { x: this._snap(rawX), y: this._snap(rawY) };
   }
 
   /**
    * Snap a wall's moving endpoint while drawing. Existing corners win (so rooms
    * close/continue); otherwise, unless free-draw is on, apply "gravity" toward
-   * horizontal/vertical relative to the start point.
+   * horizontal/vertical relative to the start point. The position itself snaps
+   * to the configured snap step (which is the grid by default, or nothing when
+   * Snap is Off) — "straighten" only governs the H/V alignment, not snapping.
    */
   private _snapWallEnd(
     x1: number,
@@ -319,10 +315,10 @@ export class FloorplanCardEditor extends LitElement {
     const dx = rawX - x1;
     const dy = rawY - y1;
     const t = Math.tan((WALL_AXIS_SNAP_DEG * Math.PI) / 180);
-    // Sticky: align flat to an axis when close, and pull the free coordinate to the grid.
-    if (Math.abs(dy) <= Math.abs(dx) * t) return { x: this._snapToGrid(rawX), y: y1 }; // horizontal
-    if (Math.abs(dx) <= Math.abs(dy) * t) return { x: x1, y: this._snapToGrid(rawY) }; // vertical
-    return { x: this._snapToGrid(rawX), y: this._snapToGrid(rawY) };
+    // Sticky: align flat to an axis when close; the free coordinate snaps to step.
+    if (Math.abs(dy) <= Math.abs(dx) * t) return { x: this._snap(rawX), y: y1 }; // horizontal
+    if (Math.abs(dx) <= Math.abs(dy) * t) return { x: x1, y: this._snap(rawY) }; // vertical
+    return { x: this._snap(rawX), y: this._snap(rawY) };
   }
 
   // ---- config mutation + history ----------------------------------------
@@ -1323,10 +1319,11 @@ export class FloorplanCardEditor extends LitElement {
     ];
     const hint =
       mode === "grid"
-        ? `Elements snap to the ${this.grid}-unit grid above.`
+        ? `Walls and elements snap to the ${this.grid}-unit grid above.`
         : mode === "off"
-          ? "Elements can be placed anywhere (free placement)."
-          : "Elements snap to this step.";
+          ? "No snapping — place walls and elements freely at any position."
+          : `Snap to this many canvas units (grid is ${this.grid}; ` +
+            `a smaller value snaps finer than the grid, a larger value coarser).`;
     return html`
       <div class="row">
         <label>Snap to</label>
@@ -1345,15 +1342,16 @@ export class FloorplanCardEditor extends LitElement {
         </div>
         ${mode === "custom"
           ? html`<input
-              class="num"
-              type="number"
-              min="1"
-              .value=${String(this._config.snap ?? DEFAULT_CUSTOM_SNAP)}
-              @change=${(e: Event) =>
-                this._patchConfig({
-                  snap: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_SNAP),
-                })}
-            />`
+                class="num"
+                type="number"
+                min="1"
+                .value=${String(this._config.snap ?? DEFAULT_CUSTOM_SNAP)}
+                @change=${(e: Event) =>
+                  this._patchConfig({
+                    snap: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_SNAP),
+                  })}
+              />
+              <span class="hint">units</span>`
           : nothing}
         <span class="hint">${hint}</span>
       </div>
@@ -1394,7 +1392,7 @@ export class FloorplanCardEditor extends LitElement {
           />
         </div>
         <div class="row">
-          <label>Grid</label>
+          <label>Grid size</label>
           <input
             type="number"
             min="1"
@@ -1404,7 +1402,10 @@ export class FloorplanCardEditor extends LitElement {
                 grid: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_GRID),
               })}
           />
-          <span class="hint">Visible grid; wall corners snap here.</span>
+          <span class="hint">
+            Gap between grid lines, in canvas units (canvas is ${this._config.width}×${this._config
+              .height}). Smaller = finer grid, more lines.
+          </span>
         </div>
         ${this._renderSnapRow()}
         <div class="row">
@@ -2047,8 +2048,14 @@ export class FloorplanCardEditor extends LitElement {
       cursor: crosshair;
     }
     .grid {
-      stroke: var(--divider-color, #e0e0e0);
-      stroke-width: 0.5;
+      /* Theme text colour at low opacity so the grid stays visible over a
+         background image (and on both light and dark themes); non-scaling-stroke
+         keeps the lines a crisp ~1px at any canvas size / zoom. Editor-only —
+         the live card never draws a grid. */
+      stroke: var(--primary-text-color, #212121);
+      stroke-opacity: 0.25;
+      stroke-width: 1;
+      vector-effect: non-scaling-stroke;
     }
     .wall {
       stroke: var(--primary-text-color);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -15,7 +15,7 @@ import type {
   ItemDisplay,
 } from "./types";
 import {
-  DEFAULT_CUSTOM_SNAP,
+  DEFAULT_CUSTOM_PERCENT,
   DEFAULT_GRID,
   DEFAULT_HEIGHT,
   DEFAULT_WIDTH,
@@ -25,8 +25,10 @@ import {
   FURNITURE_DEFAULT_SIZE,
   emptyConfig,
   getFloors,
+  gridPercentToSnap,
   makeFloor,
   resolveSnap,
+  snapToGridPercent,
   uid,
 } from "./types";
 import {
@@ -253,10 +255,23 @@ export class FloorplanCardEditor extends LitElement {
     } else if (mode === "off") {
       this._patchConfig({ snap: 0 });
     } else {
-      // Keep an existing custom value; otherwise seed with the project default.
+      // Keep an existing custom value; otherwise seed with the default percent
+      // of the current grid (stored as an absolute step).
       const cur = this._config.snap;
-      this._patchConfig({ snap: cur && cur > 0 ? cur : DEFAULT_CUSTOM_SNAP });
+      this._patchConfig({
+        snap: cur && cur > 0 ? cur : gridPercentToSnap(DEFAULT_CUSTOM_PERCENT, this.grid),
+      });
     }
+  }
+
+  /** Update the grid; rescale a custom snap so its percentage of the grid is preserved. */
+  private _setGrid(newGrid: number): void {
+    const patch: Partial<FloorplanCardConfig> = { grid: newGrid };
+    if (this._snapMode === "custom") {
+      const pct = snapToGridPercent(this._config.snap as number, this.grid);
+      patch.snap = gridPercentToSnap(pct, newGrid);
+    }
+    this._patchConfig(patch);
   }
 
   private _snap(v: number): number {
@@ -1317,13 +1332,15 @@ export class FloorplanCardEditor extends LitElement {
       { id: "off", label: "Off" },
       { id: "custom", label: "Custom" },
     ];
+    const customPercent = snapToGridPercent(this._config.snap as number, this.grid);
     const hint =
       mode === "grid"
         ? `Walls and elements snap to the ${this.grid}-unit grid above.`
         : mode === "off"
           ? "No snapping — place walls and elements freely at any position."
-          : `Snap to this many canvas units (grid is ${this.grid}; ` +
-            `a smaller value snaps finer than the grid, a larger value coarser).`;
+          : // % of grid: 100% = the grid; 50% = half a grid cell; 200% = two cells.
+            `Snap to ${customPercent}% of the grid (= ${this._resolvedSnap} units). ` +
+            `Below 100% snaps finer than the grid, above 100% coarser.`;
     return html`
       <div class="row">
         <label>Snap to</label>
@@ -1345,13 +1362,14 @@ export class FloorplanCardEditor extends LitElement {
                 class="num"
                 type="number"
                 min="1"
-                .value=${String(this._config.snap ?? DEFAULT_CUSTOM_SNAP)}
-                @change=${(e: Event) =>
-                  this._patchConfig({
-                    snap: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_SNAP),
-                  })}
+                step="5"
+                .value=${String(customPercent)}
+                @change=${(e: Event) => {
+                  const pct = Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_PERCENT);
+                  this._patchConfig({ snap: gridPercentToSnap(pct, this.grid) });
+                }}
               />
-              <span class="hint">units</span>`
+              <span class="hint">% of grid</span>`
           : nothing}
         <span class="hint">${hint}</span>
       </div>
@@ -1398,9 +1416,7 @@ export class FloorplanCardEditor extends LitElement {
             min="1"
             .value=${String(this.grid)}
             @change=${(e: Event) =>
-              this._patchConfig({
-                grid: Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_GRID),
-              })}
+              this._setGrid(Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_GRID))}
           />
           <span class="hint">
             Gap between grid lines, in canvas units (canvas is ${this._config.width}×${this._config

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2072,6 +2072,9 @@ export class FloorplanCardEditor extends LitElement {
       stroke-opacity: 0.25;
       stroke-width: 1;
       vector-effect: non-scaling-stroke;
+      /* Purely decorative — must never intercept pointers, or a press that lands
+         on a grid line would capture the pointer there and break wall drawing. */
+      pointer-events: none;
     }
     .wall {
       stroke: var(--primary-text-color);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2073,17 +2073,22 @@ export class FloorplanCardEditor extends LitElement {
       stroke-width: 1;
       vector-effect: non-scaling-stroke;
     }
-    .wall {
+    /* Scoped to <line> so the rule doesn't accidentally match the <svg>,
+       which carries the active-tool class (e.g. "wall") on the canvas. A
+       bare ".wall" selector matched the SVG too, and because pointer-events
+       is inherited in SVG, setting it to none disabled the entire canvas
+       — so no pointerdown reached the wall-draw handler. */
+    line.wall {
       stroke: var(--primary-text-color);
       /* The wide transparent .wall-hit line beneath handles selection/drag.
          Without this, the visible line (painted on top) swallows clicks on the
          wall body, so you could only grab it just *outside* the body. */
       pointer-events: none;
     }
-    .wall.selected {
+    line.wall.selected {
       stroke: var(--primary-color, #03a9f4);
     }
-    .wall.draft {
+    line.wall.draft {
       opacity: 0.5;
       pointer-events: none;
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2075,6 +2075,10 @@ export class FloorplanCardEditor extends LitElement {
     }
     .wall {
       stroke: var(--primary-text-color);
+      /* The wide transparent .wall-hit line beneath handles selection/drag.
+         Without this, the visible line (painted on top) swallows clicks on the
+         wall body, so you could only grab it just *outside* the body. */
+      pointer-events: none;
     }
     .wall.selected {
       stroke: var(--primary-color, #03a9f4);

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { emptyConfig, makeFloor, getFloors, uid } from "./types";
+import { emptyConfig, makeFloor, getFloors, resolveSnap, uid } from "./types";
 import type { FloorplanCardConfig } from "./types";
+
+describe("resolveSnap", () => {
+  it("falls back to the grid when snap is unset (the new default)", () => {
+    expect(resolveSnap(undefined, 20)).toBe(20);
+    expect(resolveSnap(null, 20)).toBe(20);
+  });
+
+  it("returns 0 for free placement when snap is explicitly 0", () => {
+    expect(resolveSnap(0, 20)).toBe(0);
+  });
+
+  it("returns the custom step when snap is a positive number", () => {
+    expect(resolveSnap(5, 20)).toBe(5);
+    expect(resolveSnap(25, 20)).toBe(25);
+  });
+});
 
 describe("emptyConfig", () => {
   it("produces a blank, valid single-floor config", () => {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { emptyConfig, makeFloor, getFloors, resolveSnap, uid } from "./types";
+import {
+  emptyConfig,
+  makeFloor,
+  getFloors,
+  resolveSnap,
+  snapToGridPercent,
+  gridPercentToSnap,
+  uid,
+} from "./types";
 import type { FloorplanCardConfig } from "./types";
 
 describe("resolveSnap", () => {
@@ -15,6 +23,36 @@ describe("resolveSnap", () => {
   it("returns the custom step when snap is a positive number", () => {
     expect(resolveSnap(5, 20)).toBe(5);
     expect(resolveSnap(25, 20)).toBe(25);
+  });
+});
+
+describe("snapToGridPercent / gridPercentToSnap", () => {
+  it("expresses a snap step as a percentage of the grid", () => {
+    expect(snapToGridPercent(10, 20)).toBe(50);
+    expect(snapToGridPercent(20, 20)).toBe(100);
+    expect(snapToGridPercent(40, 20)).toBe(200); // coarser than the grid
+    expect(snapToGridPercent(5, 20)).toBe(25);
+  });
+
+  it("converts a percentage of the grid back into an absolute step", () => {
+    expect(gridPercentToSnap(50, 20)).toBe(10);
+    expect(gridPercentToSnap(100, 20)).toBe(20);
+    expect(gridPercentToSnap(200, 20)).toBe(40);
+  });
+
+  it("clamps the resulting step to at least 1 unit", () => {
+    expect(gridPercentToSnap(1, 20)).toBe(1); // 0.2 -> clamped
+    expect(gridPercentToSnap(0, 20)).toBe(1);
+  });
+
+  it("round-trips common values", () => {
+    for (const pct of [25, 50, 100, 200]) {
+      expect(snapToGridPercent(gridPercentToSnap(pct, 20), 20)).toBe(pct);
+    }
+  });
+
+  it("guards against a zero grid", () => {
+    expect(snapToGridPercent(10, 0)).toBe(100);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,12 +177,14 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /** Visible editor grid spacing in virtual units (purely a visual guide). */
   grid?: number;
   /**
-   * Placement snap step in virtual units. Tri-state:
+   * Placement snap step in virtual (canvas) units. Tri-state:
    * - **unset** — placement/drag/nudge snap to the visible `grid` (the default).
    * - **`0`** — free placement (no snapping anywhere).
-   * - **`> 0`** — snap to this custom step (independent of the grid).
+   * - **`> 0`** — snap to this custom step (absolute units).
    *
-   * Resolve with {@link resolveSnap}.
+   * The editor presents a custom step as a percentage of the grid (e.g. `50` %
+   * of a `20` grid is stored here as `10`), but the stored value is always
+   * absolute. Resolve with {@link resolveSnap}.
    */
   snap?: number;
   /** Canvas background color (CSS / hex). Falls back to the card background. */
@@ -205,19 +207,40 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
 export const DEFAULT_WIDTH = 1000;
 export const DEFAULT_HEIGHT = 600;
 export const DEFAULT_GRID = 20;
-/** Step used when a user picks the **Custom** snap mode without an existing value. */
-export const DEFAULT_CUSTOM_SNAP = 10;
+/**
+ * Default for the **Custom** snap mode, as a percentage of the grid — i.e. half
+ * a grid cell. The editor expresses custom snap relative to the grid; the stored
+ * `snap` value remains an absolute step in canvas units.
+ */
+export const DEFAULT_CUSTOM_PERCENT = 50;
 
 /**
  * Resolve a `snap` config value into the effective step that placement / drag
- * / nudge should use, given the visible `grid`.
+ * / nudge / wall drawing should use, given the visible `grid`.
  *
  * - `null` / `undefined` → follow the visible grid (most intuitive default).
  * - `0` → free placement (no snapping).
- * - any other number → that exact step.
+ * - any other number → that exact step (absolute, in canvas units).
  */
 export function resolveSnap(snap: number | null | undefined, grid: number): number {
   return snap == null ? grid : snap;
+}
+
+/**
+ * Express a custom (absolute) snap step as a percentage of the grid, for the
+ * editor UI. `50` means "half a grid cell". Rounded to a whole percent.
+ */
+export function snapToGridPercent(snap: number, grid: number): number {
+  if (grid <= 0) return 100;
+  return Math.round((snap / grid) * 100);
+}
+
+/**
+ * Convert a percentage-of-grid back into an absolute snap step (canvas units),
+ * clamped to a sensible minimum so the step is never zero/negative.
+ */
+export function gridPercentToSnap(percent: number, grid: number): number {
+  return Math.max(1, Math.round((grid * percent) / 100));
 }
 
 export function emptyConfig(type: string): FloorplanCardConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,8 +177,12 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /** Visible editor grid spacing in virtual units (purely a visual guide). */
   grid?: number;
   /**
-   * Placement snap step in virtual units. When 0 or unset, elements are placed
-   * freely (no snapping); when > 0, placement/drag/nudge round to this step.
+   * Placement snap step in virtual units. Tri-state:
+   * - **unset** — placement/drag/nudge snap to the visible `grid` (the default).
+   * - **`0`** — free placement (no snapping anywhere).
+   * - **`> 0`** — snap to this custom step (independent of the grid).
+   *
+   * Resolve with {@link resolveSnap}.
    */
   snap?: number;
   /** Canvas background color (CSS / hex). Falls back to the card background. */
@@ -201,6 +205,20 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
 export const DEFAULT_WIDTH = 1000;
 export const DEFAULT_HEIGHT = 600;
 export const DEFAULT_GRID = 20;
+/** Step used when a user picks the **Custom** snap mode without an existing value. */
+export const DEFAULT_CUSTOM_SNAP = 10;
+
+/**
+ * Resolve a `snap` config value into the effective step that placement / drag
+ * / nudge should use, given the visible `grid`.
+ *
+ * - `null` / `undefined` → follow the visible grid (most intuitive default).
+ * - `0` → free placement (no snapping).
+ * - any other number → that exact step.
+ */
+export function resolveSnap(snap: number | null | undefined, grid: number): number {
+  return snap == null ? grid : snap;
+}
 
 export function emptyConfig(type: string): FloorplanCardConfig {
   return {


### PR DESCRIPTION
Reworks the confusing **Grid** / **Snap** settings in the editor and fixes a couple of related wall bugs found along the way.

## Problem

The editor exposed two fields — **Grid** and **Snap** — that looked related but drove **independent** behaviour, with only a tiny "0 = free placement" hint. Walls snapped to the grid; everything else didn't snap to anything by default. That's exactly the *"some things respect the grid changes and others don't"* user feedback (and confusing even to the author).

## What's in this PR

### 1. Tri-state "Snap to" control
The numeric Snap field becomes a segmented control backed by a tri-state `snap` config:

| Mode | `snap` | Behaviour |
|---|---|---|
| **Grid** (new default) | unset | placement / drag / nudge / wall drawing snap to the visible grid |
| **Off** | `0` | free placement (today's behaviour, kept for existing opt-outs) |
| **Custom** | `> 0` | a custom step |

Resolution lives in one pure helper, `resolveSnap(snap, grid)` (tested).

### 2. Custom snap is expressed as a **percentage of the grid**
"50% of grid" is far easier to reason about than "10 units" (25% = quarter cell, 200% = two cells). The input shows a percentage with a "% of grid" suffix; the hint shows the resolved absolute step ("Snap to 25% of the grid (= 5 units)"). Changing the grid **rescales** a custom snap to preserve its percentage. Storage stays **absolute** (`snap` in canvas units), so existing YAML keeps working — only the editor presentation is a percentage. Helpers `snapToGridPercent` / `gridPercentToSnap` are pure and tested.

### 3. Clearer Grid field
Renamed to **"Grid size"** with a hint explaining it's the gap between grid lines in canvas units and that **smaller = finer**, plus the canvas size for reference.

### 4. Wall drawing now respects the snap setting
Previously walls always rounded to the grid via `_snapToGrid`, even with Snap **Off**. Now wall endpoints go through the resolved snap, so Snap=Off draws walls freely while **straighten** still keeps them horizontal/vertical. Removed the now-dead `_snapToGrid`.

### 5. Edit-canvas grid stays visible over a background image
The grid was a sub-pixel light-gray hairline that vanished over an image. It's now a theme-aware colour at low opacity with a non-scaling 1px stroke. **The live card still never draws a grid.**

### 6. Fix: select/drag a wall by clicking its body
A wall's visible line (painted on top of the wide transparent `.wall-hit` line) swallowed clicks on its body, so you could only grab a wall in the thin margin just *outside* it. Set `pointer-events: none` on the visible line so clicks fall through to the hit line — the whole wall body is now selectable/draggable. (Wall-specific; other elements wrap everything in one hit `<g>`.)

## Files
- `src/types.ts` — `resolveSnap`, `snapToGridPercent`, `gridPercentToSnap`, `DEFAULT_CUSTOM_PERCENT`, JSDoc.
- `src/editor.ts` — segmented "Snap to" control, `_resolvedSnap` / `_snapMode` / `_setSnapMode` / `_setGrid`, unified wall snapping, grid visibility CSS, wall `pointer-events` fix, reworded Grid/Snap UI.
- `src/types.test.ts` — tests for all the pure snap helpers.
- `README.md` — Configuration reference + feature bullet updated.

## Verification
- `npm run typecheck` ✅ · `npm test` ✅ 26/26 · `npm run build` ✅
- Live harness:
  - Snap modes resolve correctly (Grid → grid step, Off → free, Custom 25% of 20 → step 5; door at raw (137,93) → (135,95)).
  - Grid 20→40 preserves Custom 25% (step rescales 5→10).
  - Snap=Off walls draw at raw coords but stay straightened (y1==y2).
  - Grid lines visible over a vivid background image in the editor; absent in the live preview.
  - Clicking a wall's dead-centre body selects it (`elementFromPoint` → `line.wall-hit`).

## Behavioural change vs `main`
Only users who never set `snap` see a change: placement now snaps to the grid by default (matching the visible grid). Explicit `snap: 0` / `snap: N` are unchanged.

## Closes
- Feedback item #4 (inconsistent grid behaviour); contributes to #2 (wall flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)