### PR TITLE
Move selection editor into the context bar (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ currently doing:
 - **wall** — drag to draw. Endpoints snap to nearby corners; start a new wall on an
   existing corner to continue the perimeter. The context row's **straighten** toggle keeps
   walls horizontal/vertical and corner-snapped — turn it off to draw freely at any angle.
-- **door / window** — click to drop; it snaps onto the nearest wall. Assign a sensor in
-  the side panel to animate it open/closed (see **Doors & windows**).
-- **+ device / + text / + furniture…** — drop a new element, then edit it in the side panel.
+- **door / window** — click to drop; it snaps onto the nearest wall. The context row
+  shows a **Length** field for the *next* opening you place, so you can size doors and
+  windows before placing them. Assign a sensor after placement to animate it
+  open/closed (see **Doors & windows**).
+- **+ device / + text / + furniture…** — drop a new element, then edit it in the context
+  row above the canvas (selecting any element reveals its full property editor there,
+  so configuring is one click — no scrolling away from the canvas).
 - **floor** — add, rename, switch and delete floors.
 
 Undo/redo and a zoom slider live at the right of the tools row.
@@ -101,7 +105,8 @@ holds its own set of them.
 ### Devices
 
 A **device** binds a Home Assistant entity to a spot on the plan. Add one with
-**+ device**, then pick the entity in the side panel. By default it shows an icon badge:
+**+ device**, then pick the entity in the context row that appears above the canvas.
+By default it shows an icon badge:
 
 - **Tap to act** — lights, switches, covers, fans and `input_boolean`s toggle on tap;
   any other entity opens its more-info dialog.
@@ -134,8 +139,8 @@ Drop a **door** or **window** from the toolbar and it snaps onto the nearest wal
 own a door is drawn open (the familiar swing arc) and a window closed — a static floor
 plan, just like before.
 
-Bind a **Sensor** entity in the side panel — a contact `binary_sensor` or a `cover` — to
-make the opening track its real state:
+Select the opening and bind a **Sensor** entity in the context row above the canvas —
+a contact `binary_sensor` or a `cover` — to make the opening track its real state:
 
 - **Open / closed** — the opening is drawn open when the entity is `on` / `open`, closed
   otherwise. A door's leaf swings around its hinge; a window's two leaves swing outward

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -138,6 +138,8 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _draft: { x1: number; y1: number; x2: number; y2: number } | null = null;
   /** When true, walls are drawn freely (no horizontal/vertical or corner gravity). */
   @state() private _freeWalls = false;
+  /** Default length applied to a freshly placed door/window. User-editable from the context bar. */
+  @state() private _defaultOpeningLength = 60;
   @state() private _marquee: Marquee | null = null;
   @state() private _history: FloorplanCardConfig[] = [];
   @state() private _future: FloorplanCardConfig[] = [];
@@ -751,7 +753,9 @@ export class FloorplanCardEditor extends LitElement {
       type,
       x: snap?.x ?? x,
       y: snap?.y ?? y,
-      length: 60,
+      // User-editable from the door/window context bar so opening size can be
+      // set BEFORE placing (the previous hardcoded 60 forced place-then-resize).
+      length: this._defaultOpeningLength,
       angle: snap?.angle ?? 0,
     };
     this._commitFloor({ openings: [...f.openings, o] });
@@ -1014,22 +1018,53 @@ export class FloorplanCardEditor extends LitElement {
       `;
     } else if (t === "door" || t === "window") {
       label = t === "door" ? "Door" : "Window";
-      body = html`<span class="ctx-hint">Click on a wall to drop a ${t}; it snaps onto the wall.</span>`;
+      // Length input here so the user can size openings BEFORE placing them
+      // (every new opening defaults to this; previously it was hardcoded).
+      body = html`
+        <label class="ctx-field">
+          Length
+          <input
+            class="num"
+            type="number"
+            min="1"
+            .value=${String(this._defaultOpeningLength)}
+            title="Default length applied to the next ${t} you place"
+            @change=${(e: Event) => {
+              this._defaultOpeningLength = Math.max(
+                1,
+                Number((e.target as HTMLInputElement).value) || this._defaultOpeningLength
+              );
+            }}
+          />
+        </label>
+        <span class="ctx-hint">Click on a wall to drop a ${t}; it snaps onto the wall.</span>
+      `;
     } else {
       label = "Select";
       const n = this._selection.length;
-      body =
-        n > 0
-          ? html`
-              <span class="ctx-count">${n} selected</span>
-              <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
-              <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
-                🗑 delete
-              </button>
-            `
-          : html`<span class="ctx-hint"
-              >Click an element to select it, or drag a box to select several.</span
-            >`;
+      if (n === 0) {
+        body = html`<span class="ctx-hint"
+          >Click an element to select it, or drag a box to select several.</span
+        >`;
+      } else if (n === 1) {
+        // Inline editor for the single selected element + the usual actions.
+        body = html`
+          ${this._renderSelectionEditor()}
+          <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
+          <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
+            🗑 delete
+          </button>
+        `;
+      } else {
+        body = html`
+          <span class="ctx-count">${n} selected</span>
+          <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
+          <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
+            🗑 delete
+          </button>
+          <span class="ctx-hint">Edit elements one at a time.</span>
+        `;
+      }
     }
 
     return html`
@@ -1465,29 +1500,20 @@ export class FloorplanCardEditor extends LitElement {
               />
             </div>`
           : nothing}
-        <hr />
-        ${this._renderSelectionProps()}
       </div>
     `;
   }
 
-  private _renderSelectionProps(): TemplateResult {
-    if (this._selection.length > 1)
-      return html`<p class="hint">
-        <b>${this._selection.length} elements selected.</b> Drag any of them to move the group, use
-        <b>arrow keys</b> to nudge, <b>Ctrl/Cmd+C</b> then <b>Ctrl/Cmd+V</b> to copy/paste (paste lands
-        on the current floor), <b>Ctrl/Cmd+D</b> to duplicate, or <b>Delete</b> to remove them.
-      </p>`;
-
+  /**
+   * Editor fields for the currently-selected element, rendered inline inside the
+   * context bar so the user can configure the selection without scrolling away
+   * from the canvas. Returns nothing when the selection isn't exactly one
+   * element — multi-select and empty-select states are handled by the context
+   * bar itself.
+   */
+  private _renderSelectionEditor(): TemplateResult {
     const sel = this._primary();
-    if (!sel)
-      return html`<p class="hint">
-        Pick a tool to draw. Wall ends snap to nearby wall corners — start a new wall on an existing
-        corner to continue the perimeter. Switch to <b>select</b> to move or delete things. Drag a box
-        on empty canvas to select many; <b>Shift</b>/<b>Ctrl</b>-click adds to the selection. With
-        something selected, <b>arrow keys</b> nudge it (hold <b>Shift</b> to jump a full grid cell),
-        and <b>Ctrl/Cmd+C/V/D</b> copy / paste / duplicate.
-      </p>`;
+    if (!sel || this._selection.length !== 1) return html`${nothing}`;
 
     if (sel.kind === "opening") {
       const o = this._floor().openings.find((x) => x.id === sel.id);
@@ -1923,10 +1949,11 @@ export class FloorplanCardEditor extends LitElement {
       `;
     }
 
-    return html`<p class="hint">
-      Wall selected — drag the line to move it, or drag the round handles to move an endpoint
-      (endpoints snap to other wall corners). Use <b>delete</b> to remove it.
-    </p>`;
+    // sel.kind === "wall" (or unknown) — no inline editor today; the user can
+    // drag the wall or its endpoint handles directly on the canvas.
+    return html`<span class="ctx-hint"
+      >Drag the line to move it, or the round handles to move an endpoint.</span
+    >`;
   }
 
   static styles = css`
@@ -2010,6 +2037,30 @@ export class FloorplanCardEditor extends LitElement {
     .context-bar button {
       padding: 4px 10px;
       font-size: 13px;
+    }
+    /* When the selection editor's <div class="row"> blocks render INSIDE the
+       context bar (instead of stacked in a panel), make them inline so several
+       rows sit side-by-side and wrap naturally on narrow widths. */
+    .context-bar .row {
+      margin: 0;
+      flex: 0 0 auto;
+    }
+    .context-bar .row label {
+      flex: 0 0 auto;
+      font-size: 12px;
+    }
+    /* A label + input pair inline in the context bar (e.g. default Length for
+       the Door/Window tools). The <label> wraps both so clicking the text
+       focuses the input. */
+    .context-bar .ctx-field {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+    .context-bar .ctx-field input.num {
+      width: 60px;
     }
     button {
       cursor: pointer;


### PR DESCRIPTION
Closes #5.

## Problem

Editing a selected element required scrolling between the canvas (top of the editor) and the properties panel (bottom). The issue's reporter found it "VERY frustrating" — to the point of giving up on the visual editor and editing YAML directly. They also noted that having to adjust sizes *after* placing is tedious.

## What this PR does

### 1. Selection editor moves into the context bar

The per-element editor fields (rendered by the old `_renderSelectionProps`) now render **inline inside the context bar above the canvas**. Selecting any element exposes its full editor next to where it lives — no scrolling away from the canvas.

| State | Context bar reads |
|---|---|
| Wall tool | `WALL · [Straighten] · "Drag to draw…"` (unchanged) |
| Door / Window tool | `DOOR · Length [60] · "Click on a wall to drop a door…"` *(new Length input — see #2 below)* |
| Select, nothing selected | `SELECT · "Click an element to select it, or drag a box to select several."` |
| **Select, single selection** | **`SELECT · <inline editor for the element> · ⧉ Duplicate · 🗑 Delete`** |
| **Select, multi-selection** | **`SELECT · N selected · ⧉ Duplicate · 🗑 Delete · "Edit elements one at a time."`** |

The **panel keeps the page-level settings** (Title, Canvas W/H, Grid, Snap, Background, Bg image, Image opacity) and is otherwise unchanged — just no more selection-props section.

### 2. Pre-placement default length for doors and windows

`_addOpening` used to hardcode `length: 60`, so every new opening was placed-then-resized. The Door / Window tool's context bar now exposes a **`Length` input** that drives the next placement (`_defaultOpeningLength` state, default `60`). This directly addresses the user's *"only being able to adjust sizes etc after placing is a bit tedious"* note for the worst offender.

## Implementation

- `_renderSelectionProps` → renamed to `_renderSelectionEditor`, returns only the per-kind editor for a single selection. Multi-select and empty-selection hints moved into `_renderContextBar`.
- `_renderContextBar` select branch now has three cases (empty / single / multi); door & window branch has a Length input wired to `_defaultOpeningLength`.
- `_renderPanel` no longer calls the selection-props block.
- CSS: small `.context-bar .row` overrides so the editor's input rows lay out side-by-side and wrap naturally inside the horizontal context bar; new `.ctx-field` rule for the door/window length label+input pair.
- README **Usage** updated for the new workflow.

## What's NOT in scope

- **Page-level settings layout** — stay in the panel exactly as today (per user direction in the planning conversation).
- **Pre-placement defaults for `+ Device` / `+ Text` / `+ Furniture`** — those are one-click placements that select immediately, so the in-context-bar editor handles post-placement sizing without scrolling. Same pattern (state + context-bar input) extends to them later if needed.
- **HA's own preview pane** ("remove the canvas on the right") — that's HA's editor live-preview, not something this card renders. No clean public API to suppress.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 26/26 pass
- [x] `npm run build` succeeds
- [x] Local harness verified: tool switching shows the right context-bar content; the Door tool's Length input updates `_defaultOpeningLength`; dropping a door creates an opening with that length; the in-context-bar editor shows for a single selection (`SELECT · Type · Length · Sensor · Angle · Duplicate · Delete`); multi-select shows the count + actions + the "one at a time" hint; the panel no longer leaks selection hints.
- [ ] Real-HA smoke (`./deploy-dev.sh 5-lots-of-scrolling-between-toolbar-canvas-and-side-panel`) — open the card editor in HA's dialog (~720–900px wide), confirm the context bar's selection editor is usable at HA editor width. If a device's many fields wrap awkwardly, follow up by picking the most-used fields to inline and tucking the rest into a "More…" collapsible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)