### PR TITLE
QOL pass: stable context bar + new Element area below canvas (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,28 @@ HACS adds the dashboard resource automatically.
 
 ## Usage
 
-Edit a dashboard → **Add card** → search **Easy Floorplan**. The editor has a **tools
-row** and, below it, a **context row** that shows options and actions for whatever you're
-currently doing:
+Edit a dashboard → **Add card** → search **Easy Floorplan**. The editor is laid out
+top-to-bottom as a **tools row**, a **context row** with options/actions for whatever
+you're doing, the **canvas**, and two sections below — **Element** (per-element editor
+for the current selection) and **Project** (page-level settings like canvas size, grid,
+background):
 
-- **select** — the default tool. Click an element to move, rotate, resize, recolor or
-  delete it; Shift/Ctrl-click or drag a box to select several at once. Arrow keys nudge
-  the selection (Shift+arrow jumps a full grid cell), and **Ctrl/Cmd+C/V/D** copy / paste
-  / duplicate. With a selection, the context row offers **duplicate** and **delete**.
+- **select** — the default tool. Click an element to select it; Shift/Ctrl-click or drag
+  a box to select several at once. Arrow keys nudge the selection (Shift+arrow jumps a
+  full grid cell), and **Ctrl/Cmd+C/V/D** copy / paste / duplicate. With a selection,
+  the context row offers **duplicate** and **delete**, and the **Element** section below
+  the canvas exposes the full property editor for whatever you have selected.
 - **wall** — drag to draw. Endpoints snap to nearby corners; start a new wall on an
-  existing corner to continue the perimeter. The context row's **straighten** toggle keeps
-  walls horizontal/vertical and corner-snapped — turn it off to draw freely at any angle.
+  existing corner to continue the perimeter. The context row's **straighten** toggle
+  keeps walls horizontal/vertical and corner-snapped (turn it off to draw freely), and
+  the **Snap** segmented control (`On` / `Off` / `Custom`) governs snapping for *all*
+  tools — `Custom` lets you snap to a percentage of the grid (e.g. 50% = half a cell).
 - **door / window** — click to drop; it snaps onto the nearest wall. The context row
   shows a **Length** field for the *next* opening you place, so you can size doors and
-  windows before placing them. Assign a sensor after placement to animate it
-  open/closed (see **Doors & windows**).
-- **+ device / + text / + furniture…** — drop a new element, then edit it in the context
-  row above the canvas (selecting any element reveals its full property editor there,
-  so configuring is one click — no scrolling away from the canvas).
+  windows before placing them. Assign a sensor after placement (in the **Element**
+  section) to animate the opening open/closed — see **Doors & windows**.
+- **+ device / + text / + furniture…** — drop a new element; the **Element** section
+  below the canvas shows its full property editor so you can configure it right away.
 - **floor** — add, rename, switch and delete floors.
 
 Undo/redo and a zoom slider live at the right of the tools row.
@@ -105,7 +109,7 @@ holds its own set of them.
 ### Devices
 
 A **device** binds a Home Assistant entity to a spot on the plan. Add one with
-**+ device**, then pick the entity in the context row that appears above the canvas.
+**+ device**, then pick the entity in the **Element** section below the canvas.
 By default it shows an icon badge:
 
 - **Tap to act** — lights, switches, covers, fans and `input_boolean`s toggle on tap;
@@ -139,7 +143,7 @@ Drop a **door** or **window** from the toolbar and it snaps onto the nearest wal
 own a door is drawn open (the familiar swing arc) and a window closed — a static floor
 plan, just like before.
 
-Select the opening and bind a **Sensor** entity in the context row above the canvas —
+Select the opening and bind a **Sensor** entity in the **Element** section below the canvas —
 a contact `binary_sensor` or a `cover` — to make the opening track its real state:
 
 - **Open / closed** — the opening is drawn open when the entity is `on` / `open`, closed

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1003,22 +1003,6 @@ export class FloorplanCardEditor extends LitElement {
 
     if (t === "wall") {
       label = "Wall";
-      // Snap mode lives next to Straighten so the two drawing-aid controls sit
-      // together. The same setting governs placement/drag across all tools — it
-      // moved here from the project-config panel below.
-      const snapMode = this._snapMode;
-      const customPercent = snapToGridPercent(this._config.snap as number, this.grid);
-      const snapOpts: { id: "grid" | "off" | "custom"; label: string }[] = [
-        { id: "grid", label: "On" },
-        { id: "off", label: "Off" },
-        { id: "custom", label: "Custom" },
-      ];
-      const snapHint =
-        snapMode === "grid"
-          ? `Snapping to the ${this.grid}-unit grid.`
-          : snapMode === "off"
-            ? "No snapping — free placement."
-            : `Snap = ${customPercent}% of grid (${this._resolvedSnap} units).`;
       body = html`
         <button
           class=${this._freeWalls ? "" : "active"}
@@ -1030,43 +1014,7 @@ export class FloorplanCardEditor extends LitElement {
         >
           straighten
         </button>
-        <span class="ctx-field-label">Snap</span>
-        <div class="seg" role="group" aria-label="Snap mode">
-          ${snapOpts.map(
-            (o) => html`
-              <button
-                class=${snapMode === o.id ? "active" : ""}
-                aria-pressed=${snapMode === o.id}
-                title=${o.id === "grid"
-                  ? "Snap to the grid"
-                  : o.id === "off"
-                    ? "Free placement"
-                    : "Custom step (% of grid)"}
-                @click=${() => this._setSnapMode(o.id)}
-              >
-                ${o.label}
-              </button>
-            `
-          )}
-        </div>
-        ${snapMode === "custom"
-          ? html`<input
-                class="num"
-                type="number"
-                min="1"
-                step="5"
-                .value=${String(customPercent)}
-                title="Custom snap step, as a percentage of the grid"
-                @change=${(e: Event) => {
-                  const pct = Math.max(
-                    1,
-                    Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_PERCENT
-                  );
-                  this._patchConfig({ snap: gridPercentToSnap(pct, this.grid) });
-                }}
-              /><span class="ctx-field-label">%</span>`
-          : nothing}
-        <span class="ctx-hint">${snapHint}</span>
+        <span class="ctx-hint">Drag to draw. Endpoints snap to nearby corners to close rooms.</span>
       `;
     } else if (t === "door" || t === "window") {
       label = t === "door" ? "Door" : "Window";
@@ -1119,7 +1067,69 @@ export class FloorplanCardEditor extends LitElement {
       <div class="context-bar">
         <span class="ctx-label">${label}</span>
         ${body}
+        <span class="ctx-divider"></span>
+        ${this._renderSnapControl()}
       </div>
+    `;
+  }
+
+  /**
+   * Snap control rendered at the end of the context bar for every tool. The
+   * setting governs placement / drag / wall drawing across all tools, so the
+   * control needs to be reachable regardless of which tool is active.
+   */
+  private _renderSnapControl(): TemplateResult {
+    const mode = this._snapMode;
+    const customPercent = snapToGridPercent(this._config.snap as number, this.grid);
+    const opts: { id: "grid" | "off" | "custom"; label: string }[] = [
+      { id: "grid", label: "On" },
+      { id: "off", label: "Off" },
+      { id: "custom", label: "Custom" },
+    ];
+    const hint =
+      mode === "grid"
+        ? `Snapping to the ${this.grid}-unit grid.`
+        : mode === "off"
+          ? "No snapping — free placement."
+          : `Snap = ${customPercent}% of grid (${this._resolvedSnap} units).`;
+    return html`
+      <span class="ctx-field-label">Snap</span>
+      <div class="seg" role="group" aria-label="Snap mode">
+        ${opts.map(
+          (o) => html`
+            <button
+              class=${mode === o.id ? "active" : ""}
+              aria-pressed=${mode === o.id}
+              title=${o.id === "grid"
+                ? "Snap to the grid"
+                : o.id === "off"
+                  ? "Free placement"
+                  : "Custom step (% of grid)"}
+              @click=${() => this._setSnapMode(o.id)}
+            >
+              ${o.label}
+            </button>
+          `
+        )}
+      </div>
+      ${mode === "custom"
+        ? html`<input
+              class="num"
+              type="number"
+              min="1"
+              step="5"
+              .value=${String(customPercent)}
+              title="Custom snap step, as a percentage of the grid"
+              @change=${(e: Event) => {
+                const pct = Math.max(
+                  1,
+                  Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_PERCENT
+                );
+                this._patchConfig({ snap: gridPercentToSnap(pct, this.grid) });
+              }}
+            /><span class="ctx-field-label">%</span>`
+        : nothing}
+      <span class="ctx-hint">${hint}</span>
     `;
   }
 
@@ -2078,6 +2088,15 @@ export class FloorplanCardEditor extends LitElement {
     }
     .context-bar input.num {
       width: 60px;
+    }
+    /* Thin vertical rule separating the tool-specific contents from the
+       always-on Snap control on the right side of the context bar. */
+    .ctx-divider {
+      flex: 0 0 1px;
+      align-self: stretch;
+      min-height: 22px;
+      margin: 0 4px;
+      background: var(--divider-color, #e0e0e0);
     }
     button {
       cursor: pointer;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1003,6 +1003,22 @@ export class FloorplanCardEditor extends LitElement {
 
     if (t === "wall") {
       label = "Wall";
+      // Snap mode lives next to Straighten so the two drawing-aid controls sit
+      // together. The same setting governs placement/drag across all tools — it
+      // moved here from the project-config panel below.
+      const snapMode = this._snapMode;
+      const customPercent = snapToGridPercent(this._config.snap as number, this.grid);
+      const snapOpts: { id: "grid" | "off" | "custom"; label: string }[] = [
+        { id: "grid", label: "On" },
+        { id: "off", label: "Off" },
+        { id: "custom", label: "Custom" },
+      ];
+      const snapHint =
+        snapMode === "grid"
+          ? `Snapping to the ${this.grid}-unit grid.`
+          : snapMode === "off"
+            ? "No snapping — free placement."
+            : `Snap = ${customPercent}% of grid (${this._resolvedSnap} units).`;
       body = html`
         <button
           class=${this._freeWalls ? "" : "active"}
@@ -1014,7 +1030,43 @@ export class FloorplanCardEditor extends LitElement {
         >
           straighten
         </button>
-        <span class="ctx-hint">Drag to draw. Endpoints snap to nearby corners to close rooms.</span>
+        <span class="ctx-field-label">Snap</span>
+        <div class="seg" role="group" aria-label="Snap mode">
+          ${snapOpts.map(
+            (o) => html`
+              <button
+                class=${snapMode === o.id ? "active" : ""}
+                aria-pressed=${snapMode === o.id}
+                title=${o.id === "grid"
+                  ? "Snap to the grid"
+                  : o.id === "off"
+                    ? "Free placement"
+                    : "Custom step (% of grid)"}
+                @click=${() => this._setSnapMode(o.id)}
+              >
+                ${o.label}
+              </button>
+            `
+          )}
+        </div>
+        ${snapMode === "custom"
+          ? html`<input
+                class="num"
+                type="number"
+                min="1"
+                step="5"
+                .value=${String(customPercent)}
+                title="Custom snap step, as a percentage of the grid"
+                @change=${(e: Event) => {
+                  const pct = Math.max(
+                    1,
+                    Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_PERCENT
+                  );
+                  this._patchConfig({ snap: gridPercentToSnap(pct, this.grid) });
+                }}
+              /><span class="ctx-field-label">%</span>`
+          : nothing}
+        <span class="ctx-hint">${snapHint}</span>
       `;
     } else if (t === "door" || t === "window") {
       label = t === "door" ? "Door" : "Window";
@@ -1040,21 +1092,15 @@ export class FloorplanCardEditor extends LitElement {
         <span class="ctx-hint">Click on a wall to drop a ${t}; it snaps onto the wall.</span>
       `;
     } else {
+      // Selection actions only — the full per-element editor renders BELOW the
+      // canvas in its own area (so the context bar's height stays stable as
+      // selections change, and the canvas doesn't jump up and down).
       label = "Select";
       const n = this._selection.length;
       if (n === 0) {
         body = html`<span class="ctx-hint"
           >Click an element to select it, or drag a box to select several.</span
         >`;
-      } else if (n === 1) {
-        // Inline editor for the single selected element + the usual actions.
-        body = html`
-          ${this._renderSelectionEditor()}
-          <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
-          <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
-            🗑 delete
-          </button>
-        `;
       } else {
         body = html`
           <span class="ctx-count">${n} selected</span>
@@ -1062,7 +1108,9 @@ export class FloorplanCardEditor extends LitElement {
           <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
             🗑 delete
           </button>
-          <span class="ctx-hint">Edit elements one at a time.</span>
+          ${n > 1
+            ? html`<span class="ctx-hint">Edit elements one at a time.</span>`
+            : nothing}
         `;
       }
     }
@@ -1233,8 +1281,36 @@ export class FloorplanCardEditor extends LitElement {
           </div>
         </div>
 
+        ${this._renderElementEdit()}
         ${this._renderPanel()}
       </div>
+    `;
+  }
+
+  /**
+   * Per-element editor area, rendered BELOW the canvas with a small title.
+   * Kept separate from the project panel so users can tell the two apart, and
+   * separate from the context bar so the bar's height stays stable across
+   * selection changes (the canvas no longer jumps when you click around).
+   */
+  private _renderElementEdit(): TemplateResult {
+    const n = this._selection.length;
+    let body: TemplateResult;
+    if (n === 0) {
+      body = html`<p class="hint">Select an element on the canvas to edit its properties here.</p>`;
+    } else if (n > 1) {
+      body = html`<p class="hint">
+        <b>${n} elements selected.</b> Edit them one at a time, or use the
+        Duplicate/Delete buttons in the context bar above.
+      </p>`;
+    } else {
+      body = this._renderSelectionEditor();
+    }
+    return html`
+      <section class="edit-area">
+        <h3 class="section-title">Element</h3>
+        ${body}
+      </section>
     `;
   }
 
@@ -1354,66 +1430,10 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
-  /**
-   * The panel's "Snap to" row: a three-option segmented control over the
-   * tri-state `snap` config. **Grid** (unset) follows the visible grid;
-   * **Off** (`0`) is truly free placement; **Custom** (`> 0`) exposes a number
-   * input for a bespoke step.
-   */
-  private _renderSnapRow(): TemplateResult {
-    const mode = this._snapMode;
-    const opts: { id: "grid" | "off" | "custom"; label: string }[] = [
-      { id: "grid", label: "Grid" },
-      { id: "off", label: "Off" },
-      { id: "custom", label: "Custom" },
-    ];
-    const customPercent = snapToGridPercent(this._config.snap as number, this.grid);
-    const hint =
-      mode === "grid"
-        ? `Walls and elements snap to the ${this.grid}-unit grid above.`
-        : mode === "off"
-          ? "No snapping — place walls and elements freely at any position."
-          : // % of grid: 100% = the grid; 50% = half a grid cell; 200% = two cells.
-            `Snap to ${customPercent}% of the grid (= ${this._resolvedSnap} units). ` +
-            `Below 100% snaps finer than the grid, above 100% coarser.`;
-    return html`
-      <div class="row">
-        <label>Snap to</label>
-        <div class="seg" role="group" aria-label="Snap mode">
-          ${opts.map(
-            (o) => html`
-              <button
-                class=${mode === o.id ? "active" : ""}
-                aria-pressed=${mode === o.id}
-                @click=${() => this._setSnapMode(o.id)}
-              >
-                ${o.label}
-              </button>
-            `
-          )}
-        </div>
-        ${mode === "custom"
-          ? html`<input
-                class="num"
-                type="number"
-                min="1"
-                step="5"
-                .value=${String(customPercent)}
-                @change=${(e: Event) => {
-                  const pct = Math.max(1, Number((e.target as HTMLInputElement).value) || DEFAULT_CUSTOM_PERCENT);
-                  this._patchConfig({ snap: gridPercentToSnap(pct, this.grid) });
-                }}
-              />
-              <span class="hint">% of grid</span>`
-          : nothing}
-        <span class="hint">${hint}</span>
-      </div>
-    `;
-  }
-
   private _renderPanel(): TemplateResult {
     return html`
-      <div class="panel">
+      <section class="panel">
+        <h3 class="section-title">Project</h3>
         <div class="row">
           <label>Title</label>
           <input
@@ -1458,7 +1478,6 @@ export class FloorplanCardEditor extends LitElement {
               .height}). Smaller = finer grid, more lines.
           </span>
         </div>
-        ${this._renderSnapRow()}
         <div class="row">
           <label>Background</label>
           <input
@@ -1500,7 +1519,7 @@ export class FloorplanCardEditor extends LitElement {
               />
             </div>`
           : nothing}
-      </div>
+      </section>
     `;
   }
 
@@ -2038,17 +2057,6 @@ export class FloorplanCardEditor extends LitElement {
       padding: 4px 10px;
       font-size: 13px;
     }
-    /* When the selection editor's <div class="row"> blocks render INSIDE the
-       context bar (instead of stacked in a panel), make them inline so several
-       rows sit side-by-side and wrap naturally on narrow widths. */
-    .context-bar .row {
-      margin: 0;
-      flex: 0 0 auto;
-    }
-    .context-bar .row label {
-      flex: 0 0 auto;
-      font-size: 12px;
-    }
     /* A label + input pair inline in the context bar (e.g. default Length for
        the Door/Window tools). The <label> wraps both so clicking the text
        focuses the input. */
@@ -2060,6 +2068,15 @@ export class FloorplanCardEditor extends LitElement {
       color: var(--secondary-text-color);
     }
     .context-bar .ctx-field input.num {
+      width: 60px;
+    }
+    /* Inline label for a control rendered loose in the context bar (e.g. the
+       "Snap" word next to the segmented control). */
+    .context-bar .ctx-field-label {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+    }
+    .context-bar input.num {
       width: 60px;
     }
     button {
@@ -2088,8 +2105,12 @@ export class FloorplanCardEditor extends LitElement {
       border-radius: 8px;
       overflow: auto;
       resize: both;
-      height: 62vh;
-      min-height: 320px;
+      /* Size to the canvas's own aspect ratio rather than forcing a fixed
+         viewport-relative height. This avoids the empty band above and below
+         the grid that used to appear with the default 1000×600 canvas, and
+         leaves room for the Element / Project sections below. The user can
+         still drag-resize via the corner handle (resize: both). */
+      min-height: 200px;
       background: var(--secondary-background-color, #f5f5f5);
       display: flex;
       align-items: flex-start;
@@ -2355,10 +2376,21 @@ export class FloorplanCardEditor extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .panel {
+    /* The panel ("Project" config) and the new element-edit area share the
+       same boxed look so the two sections below the canvas read as siblings. */
+    .panel,
+    .edit-area {
       border: 1px solid var(--divider-color, #ccc);
       border-radius: 8px;
       padding: 10px;
+    }
+    .section-title {
+      margin: 0 0 8px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--secondary-text-color);
     }
     .row {
       display: flex;


### PR DESCRIPTION
Closes #11.

## Problem

Issue #11 called out a bunch of related QOL friction from PR #10's "selection editor in the context bar" round:

- The context bar's height changed with the selection (a wall has a few fields; an opening or device has many), so the canvas hopped up and down every time you clicked something.
- The default canvas (1000×600) was rendered inside a `height: 62vh` wrap, so a typical viewport had empty bands above and below the grid.
- Snap lived in the project-config panel, away from the wall-drawing controls it actually affects most visibly.
- The two areas below the canvas (selection editor and project config) had no titles — easy to confuse.

## What's in this PR

### Stable context bar; per-element editor in its own area below the canvas
- The context bar now only carries **tool-stable** controls + the selection's `⧉ Duplicate` / `🗑 Delete` buttons. Its height no longer changes with the selection — the canvas stays put.
- A new **`Element`** section renders below the canvas with a small title:
  - **Nothing selected** → "Select an element on the canvas to edit its properties here."
  - **Single selection** → the full per-element editor (the existing `_renderSelectionEditor`, just moved).
  - **Multi-selection** → "*N* elements selected. Edit them one at a time, or use the Duplicate/Delete buttons in the context bar above."

### Snap moves to the wall context bar
A segmented control `On` / `Off` / `Custom` sits next to **Straighten**. `Custom` reveals the `% of grid` input. The setting still governs placement/drag for every tool — only the *home* of the control moved. Snap is removed from the Project panel and the now-unused `_renderSnapRow` helper is deleted.

### Project panel gets a "PROJECT" title (matching "ELEMENT")
Small uppercase section titles so the two areas below the canvas read as siblings.

### Canvas wrap fits the grid instead of `62vh`
Dropped `height: 62vh`; lowered `min-height` from 320px to 200px. The canvas sizes to its SVG aspect ratio at the available width, so the default 1000×600 canvas no longer has empty bands above/below the grid. The corner drag-resize handle (`resize: both`) still works.

## Verified in the harness (`npx vite --open /dev/`)

- Wall tool context bar reads: `WALL · [Straighten] · Snap [On | Off | Custom] · "Snapping to the 20-unit grid."` (hint switches with the mode; Custom shows the `% of grid` input and a hint like "Snap = 25% of grid (5 units).").
- Select with no selection: context bar = `SELECT · "Click an element…"` ; element area = `ELEMENT · "Select an element on the canvas to edit its properties here."`
- Select with single selection (e.g. a door): context bar = `SELECT · 1 selected · Duplicate · Delete` ; element area = `ELEMENT · Type · Length · Sensor · Angle · …`
- Multi-select: context bar = `SELECT · N selected · Duplicate · Delete · "Edit elements one at a time."` ; element area = `ELEMENT · "N elements selected. Edit them one at a time…"`
- Project panel renders with a `PROJECT` title and no Snap row.
- Canvas wrap renders at ~SVG-height (508px at the harness width with the default 1000×600 canvas), no longer a 62vh band.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 26/26 pass
- [x] `npm run build` succeeds
- [x] Local harness verified (above)
- [ ] Real-HA smoke (`./deploy-dev.sh 11-change-context-bar-and-canvas-to-min-height`) — open the card editor in HA's dialog and confirm at the typical HA-dialog width that the layout reads well (Element + Project below the canvas, Snap visible in the wall context bar).

## NOT in scope
- HA's own card-editor preview pane on the right — there's no public hook to suppress it (see [issue #5 comment](https://github.com/nicosandller/easy-floorplan/issues/5#issuecomment-4589709648)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)