### PR TITLE
Add browser dev harness (un-gitignore dev/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ deploy.env
 # never commit secrets
 *.secret
 .env
-dev/*

--- a/README.md
+++ b/README.md
@@ -419,10 +419,50 @@ trackers:
 npm install
 npm run build      # bundles to dist/easy-floorplan-card.js
 npm run watch      # rebuild on change
+npm run typecheck  # tsc --noEmit
+npm test           # vitest (pure-logic tests; no browser)
 ```
 
 Releases are built and attached automatically by GitHub Actions when a GitHub release
 is published.
+
+### Browser dev harness
+
+Iterating on the editor / card without a Home Assistant instance:
+
+```bash
+npm run serve      # opens /dev/ on the Vite dev server with HMR
+```
+
+This mounts the **real** `easy-floorplan-card-editor` and `easy-floorplan-card`
+side-by-side in a plain HTML page with:
+
+- a minimal `hass` mock + tiny `<ha-card>` and `<ha-icon>` stubs so the card
+  renders outside HA — the entity / icon pickers are already feature-detected
+  inside the editor and fall back to plain inputs;
+- a `config-changed` round-trip between the editor and the live preview, so
+  edits in the editor instantly update the card (matching how HA wires it);
+- a **Tracker emulator** panel that appears whenever the current config has
+  at least one tracker — per-axis sliders write straight into the mock
+  `hass.states[entity].state`, and an **Auto-orbit** toggle drives them on
+  `requestAnimationFrame` so the pulsating triangle / line animations can be
+  observed without HA;
+- vite HMR — saving any `src/*.ts` reloads the page (the harness invalidates
+  itself on hot updates so duplicate custom-element registrations don't
+  happen).
+
+The harness lives entirely under `dev/` (`dev.ts`, `index.html`) and is **not**
+included in the production build — `vite build` only entry-points
+`src/index.ts`.
+
+Useful flags inside `dev/dev.ts`:
+
+- `START_WITH_DEMO` — flip to `true` to start with a sample room (walls, door,
+  window over a background image) instead of a blank floor. Handy for testing
+  rendering changes without drawing from scratch.
+
+Pair this with `./deploy-dev.sh <branch>` (a personal, gitignored helper) when
+you also want to smoke-test against a real HA install.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ automatically to the card and screen size.
   while open.
 - **Furniture** — gray line-art diagrams: table, round table, desk, chair, sofa, bed,
   wardrobe, rug, plant, fridge, stove, sink, toilet, stairs, tv.
+- **Live position tracker** — draw a rectangular tracked area and bind one or two
+  orthogonal distance sensors (e.g. mmWave / radar). The card linearly maps each
+  sensor's `[min, max]` reading to the rectangle's edges and animates a pulsating
+  triangle with ripples at the resolved `(x, y)`. With only one sensor configured
+  it falls back to a faint pulsating line with ripples along the unknown axis.
+  The zone outline is visible only in the editor — the live card shows just the
+  animation.
 - **Text labels** and a configurable **canvas background color**.
 - **Background image** — drop in a floor-plan image (per floor) and trace walls, doors and
   devices over it, with adjustable opacity.
@@ -93,6 +100,10 @@ background):
   shows a **Length** field for the *next* opening you place, so you can size doors and
   windows before placing them. Assign a sensor after placement (in the **Element**
   section) to animate the opening open/closed — see **Doors & windows**.
+- **tracker** — drag to draw a rectangular tracked area, then bind one or two distance
+  sensors (X axis and/or Y axis) in the **Element** section to animate a live position
+  marker inside the zone — see **Tracker**. The zone outline is visible only in the
+  editor; the live card shows just the marker.
 - **+ device / + text / + furniture…** — drop a new element; the **Element** section
   below the canvas shows its full property editor so you can configure it right away.
 - **floor** — add, rename, switch and delete floors.
@@ -103,8 +114,8 @@ Undo/redo and a zoom slider live at the right of the tools row.
 
 Everything you place on the plan is an **element** you can select, move (freely or
 snapped to a grid), nudge with arrow keys, copy/paste, duplicate and delete. The element
-types are **devices**, **doors & windows**, **furniture** and **text** — and each floor
-holds its own set of them.
+types are **devices**, **doors & windows**, **furniture**, **text** and **trackers** —
+and each floor holds its own set of them.
 
 ### Devices
 
@@ -159,6 +170,68 @@ Openings without a sensor keep the static look.
 
 <img width="540" height="304" alt="door_window_demo" src="https://github.com/user-attachments/assets/091b3c89-5202-4025-8a0f-0fe867276be2" />
 
+### Live position trackers
+
+A **tracker** turns one or two distance sensors into a live marker that moves around
+the floor plan in real time. The classic use case is a pair of mmWave / radar /
+LIDAR sensors aimed along orthogonal axes — each one reports the target's distance
+from itself, and together they pin down an `(x, y)` position. With only one sensor
+you still get useful information: the position along that axis.
+
+1. Pick the **Tracker** tool from the toolbar.
+2. Drag on the canvas to draw a rectangle covering the area you want to track.
+3. With the new tracker selected, fill in the **Element** section below the canvas:
+   - **X sensor** — the entity that measures horizontal distance, plus a
+     `min` and `max` distance reading (in the sensor's own units, usually metres)
+     that correspond to the rectangle's left and right edges.
+   - **Y sensor** — same, for vertical distance / top and bottom edges.
+   - **Invert** per axis — if a higher reading should map to the *near* edge
+     instead of the *far* edge, tick this. Saves you flipping `min` and `max`.
+
+You can leave one of the axes empty: the tracker still works, it just draws a line
+spanning the unknown axis instead of a point.
+
+#### How it animates
+
+- **Both sensors set** — a small pulsating triangle glides to the resolved
+  `(x, y)`, emitting concentric ripple rings. Readings outside `[min, max]` clamp
+  to the rectangle's edge so a glitch never sends the marker off the plan.
+- **Only one sensor set** — a faint pulsating line spans the unknown axis at the
+  known coordinate, with ripple bands expanding along it. This honestly conveys
+  "the target is *somewhere* on this line" without pretending you know more.
+- **Both sensors unavailable** — nothing renders in the live card (no ghost
+  markers when the sensors drop out). The editor still shows the zone outline so
+  you can find and reposition it.
+
+The marker color and dot size are configurable per tracker. Updates are smoothed
+with a short CSS transition, so the marker glides between readings instead of
+snapping (handy when sensors update at 1–4 Hz).
+
+#### Tips for calibrating the range
+
+Distance sensors are usually mounted on a wall and report the gap to the closest
+target, but it's rare for the rectangle you drew on the plan to match `[0, max]`
+of the sensor exactly. Two common adjustments:
+
+- **Offset** — if the sensor is mounted *outside* the tracked rectangle (e.g.
+  bolted to the wall a metre behind it), set `min` to that offset so a reading
+  of "1.0 m" lands at the near edge instead of off-plan.
+- **Direction** — if the sensor faces the far edge (so distance *grows* as the
+  target moves toward the near edge), tick **invert** instead of swapping `min`
+  and `max`. Same result, fewer footguns.
+
+#### Editor-only zone
+
+The zone rectangle (dashed outline, light fill) is drawn **only in the editor**
+so you can grab and resize it. The dashboard view renders just the animated
+marker — your finished plan stays clean.
+
+#### Sensor compatibility
+
+Anything that resolves to a finite number works: `sensor` entities reporting
+distance, `input_number` helpers (great for testing), `number` entities, etc.
+States of `unavailable`, `unknown`, or non-numeric values are treated as
+"no reading" — the corresponding axis falls back to its no-data behaviour.
 
 ## Configuration reference
 
@@ -250,6 +323,40 @@ domains open the more-info dialog.
 `toilet`, `stairs`, `tv`. `color` defaults to gray so furniture reads differently from
 walls.
 
+### Tracker
+
+A live (x, y) position estimate driven by one or two orthogonal distance sensors,
+animated inside a rectangular tracked area:
+
+```yaml
+{ id, x, y, w, h, angle?, color?, dotSize?,
+  xSensor?: { entity, min, max, invert? },
+  ySensor?: { entity, min, max, invert? } }
+```
+
+- `x`, `y`, `w`, `h` define the rectangle in canvas units (top-left + size).
+- `xSensor` / `ySensor` are each `{ entity, min, max, invert? }`. The card linearly
+  maps `[min, max]` to the rectangle's edges along the sensor's axis; `invert`
+  flips the mapping. Both sensors are optional and independent.
+- With **both** sensors set → a pulsating triangle with ripple rings glides to the
+  computed `(x, y)`.
+- With **only one** sensor set → a faint pulsating line spans the unknown axis,
+  with ripples expanding along it.
+- The rectangle itself is **invisible at runtime** (visible only in the editor for
+  drawing and resizing); only the marker animation appears in the dashboard.
+
+```yaml
+trackers:
+  - id: kitchen_radar
+    x: 100
+    y: 100
+    w: 400
+    h: 270
+    color: "#26c6da"
+    xSensor: { entity: sensor.radar_x_distance, min: 0, max: 4.0 }
+    ySensor: { entity: sensor.radar_y_distance, min: 0, max: 2.7 }
+```
+
 ### Example
 
 ```yaml
@@ -295,6 +402,15 @@ furniture:
   - { id: f1, type: sofa, x: 250, y: 420, w: 170, h: 72, angle: 0 }
 texts:
   - { id: t1, x: 500, y: 60, text: Living Room, size: 22 }
+trackers:
+  - id: pet
+    x: 120
+    y: 130
+    w: 760
+    h: 350
+    color: "#26c6da"
+    xSensor: { entity: sensor.radar_x_distance, min: 0, max: 7.6 }
+    ySensor: { entity: sensor.radar_y_distance, min: 0, max: 3.5 }
 ```
 
 ## Development

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -1,0 +1,335 @@
+/**
+ * Local dev harness — mounts the real editor + live card side by side with a
+ * sample config and a minimal mock `hass`, so you can iterate on rendering
+ * (walls, openings, background image, furniture…) in a normal browser with
+ * Vite hot-reload. No Home Assistant and no service-worker caching.
+ *
+ * Run with: `npm run serve` (opens /dev/ on the Vite dev server).
+ *
+ * Only two HA-provided custom elements are needed at runtime: <ha-card> and
+ * <ha-icon>. The entity/icon pickers are already guarded behind
+ * `customElements.get(...)` in the editor and fall back to plain inputs, so we
+ * don't stub them here.
+ */
+import type { FloorplanCardConfig, Tracker, TrackerSensor } from "../src/types";
+
+// ---- minimal HA element stubs ---------------------------------------------
+if (!customElements.get("ha-card")) {
+  class HaCardStub extends HTMLElement {
+    private _header?: string;
+    set header(v: string | undefined) {
+      this._header = v;
+      this._render();
+    }
+    connectedCallback() {
+      this._render();
+    }
+    private _render() {
+      if (!this.shadowRoot) this.attachShadow({ mode: "open" });
+      this.shadowRoot!.innerHTML = `
+        <style>
+          :host { display:block; border:1px solid #e0e0e0; border-radius:8px;
+                  overflow:hidden; background:var(--card-background-color,#fff); }
+          h3 { margin:0; padding:8px 12px; font:600 14px system-ui; border-bottom:1px solid #eee; }
+        </style>
+        ${this._header ? `<h3>${this._header}</h3>` : ""}
+        <slot></slot>`;
+    }
+  }
+  customElements.define("ha-card", HaCardStub);
+}
+
+if (!customElements.get("ha-icon")) {
+  // Render the mdi name as a tiny placeholder dot+label so icons are visible
+  // without pulling in the real mdi icon set.
+  class HaIconStub extends HTMLElement {
+    static observedAttributes = ["icon"];
+    private _icon = "";
+    set icon(v: string) {
+      this._icon = v;
+      this._render();
+    }
+    attributeChangedCallback(_n: string, _o: string, v: string) {
+      this._icon = v;
+      this._render();
+    }
+    connectedCallback() {
+      this._render();
+    }
+    private _render() {
+      if (!this.shadowRoot) this.attachShadow({ mode: "open" });
+      this.shadowRoot!.innerHTML = `
+        <style>:host{display:inline-flex;align-items:center;justify-content:center;
+          width:var(--mdc-icon-size,24px);height:var(--mdc-icon-size,24px);}
+          i{display:block;width:62%;height:62%;border-radius:50%;
+            background:currentColor;opacity:0.85;}</style>
+        <i title="${this._icon}"></i>`;
+    }
+  }
+  customElements.define("ha-icon", HaIconStub);
+}
+
+// ---- register the real card + editor --------------------------------------
+import "../src/index";
+
+// ---- a minimal mock hass ---------------------------------------------------
+const hass = {
+  states: {
+    "binary_sensor.front_door": { state: "off", attributes: { friendly_name: "Front Door" } },
+    "light.living_room": { state: "on", attributes: { friendly_name: "Living Room" } },
+  },
+  locale: { language: "en" },
+  themes: { darkMode: false },
+  callService: (...args: unknown[]) => console.log("[mock hass] callService", ...args),
+  formatEntityState: (s: { state: string }) => s.state,
+  localize: (k: string) => k,
+} as unknown;
+
+// ---- a sample floorplan (one floor, with a bg image, a door + a window) ----
+// Diagonal-gradient SVG data URI so you can clearly see the image showing
+// through door/window gaps in the walls.
+const bgImage =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='1000' height='600'>
+       <defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'>
+         <stop offset='0' stop-color='#ffd54f'/><stop offset='1' stop-color='#4fc3f7'/>
+       </linearGradient></defs>
+       <rect width='1000' height='600' fill='url(#g)'/>
+       <g stroke='#000' stroke-opacity='0.18'>
+         ${Array.from({ length: 11 }, (_, i) => `<line x1='${i * 100}' y1='0' x2='${i * 100}' y2='600'/>`).join("")}
+         ${Array.from({ length: 7 }, (_, i) => `<line x1='0' y1='${i * 100}' x2='1000' y2='${i * 100}'/>`).join("")}
+       </g>
+     </svg>`
+  );
+
+// Start with a blank floor so you can draw a perimeter from scratch. Flip
+// START_WITH_DEMO to true to instead load a sample room (walls + door + window
+// over the background image) — handy for testing rendering of existing plans.
+const START_WITH_DEMO = false;
+
+const demoFloor = {
+  id: "f1",
+  name: "Floor 1",
+  image: bgImage,
+  imageOpacity: 1,
+  walls: [
+    { id: "w1", x1: 100, y1: 100, x2: 900, y2: 100 },
+    { id: "w2", x1: 900, y1: 100, x2: 900, y2: 500 },
+    { id: "w3", x1: 900, y1: 500, x2: 100, y2: 500 },
+    { id: "w4", x1: 100, y1: 500, x2: 100, y2: 100 },
+  ],
+  openings: [
+    { id: "o1", type: "window" as const, x: 500, y: 100, length: 140, angle: 0 },
+    { id: "o2", type: "door" as const, x: 500, y: 500, length: 90, angle: 0 },
+  ],
+  items: [],
+  texts: [],
+  furniture: [],
+  trackers: [],
+};
+
+const emptyFloor = {
+  id: "f1",
+  name: "Floor 1",
+  walls: [],
+  openings: [],
+  items: [],
+  texts: [],
+  furniture: [],
+  trackers: [],
+};
+
+const config: FloorplanCardConfig = {
+  type: "easy-floorplan-card",
+  title: "Dev floorplan",
+  width: 1000,
+  height: 600,
+  grid: 20,
+  snap: 0,
+  background: "#ffffff",
+  walls: [],
+  openings: [],
+  items: [],
+  texts: [],
+  furniture: [],
+  defaultFloor: "f1",
+  floors: [START_WITH_DEMO ? demoFloor : emptyFloor],
+};
+
+// ---- mount -----------------------------------------------------------------
+const editor = document.createElement("easy-floorplan-card-editor") as HTMLElement & {
+  hass: unknown;
+  setConfig: (c: FloorplanCardConfig) => void;
+};
+const card = document.createElement("easy-floorplan-card") as HTMLElement & {
+  hass: unknown;
+  setConfig: (c: FloorplanCardConfig) => void;
+};
+
+editor.hass = hass;
+card.hass = hass;
+editor.setConfig(config);
+card.setConfig(config);
+
+// Editing in the editor fires `config-changed`; mirror HA by feeding the new
+// config back into both the editor (round-trip) and the live preview.
+editor.addEventListener("config-changed", (e: Event) => {
+  const next = (e as CustomEvent).detail.config as FloorplanCardConfig;
+  card.setConfig(next);
+  editor.setConfig(next);
+  refreshTrackerEmu(next);
+});
+
+// ---- tracker emulator -------------------------------------------------------
+// Mock distance sensors so the Tracker animations can be exercised without HA.
+// For every tracker found in the config we expose a slider per configured
+// sensor (X / Y); an Auto-orbit toggle drives both sliders with a slow
+// Lissajous curve via rAF so the pulsating triangle / line continually moves.
+//
+// Sensor values are written into `hass.states[entity].state` and `hass` is
+// reassigned to a fresh object so Lit's @property hass triggers a re-render.
+
+type MockStates = Record<string, { state: string; attributes?: Record<string, unknown> }>;
+const baseStates = hass.states as MockStates;
+
+function setHassState(entity: string, value: number) {
+  baseStates[entity] = { state: String(value) };
+  // Re-assign hass with a *new* states object reference so Lit picks up the
+  // change (Lit treats hass as opaque and re-renders on identity change).
+  const nextHass = { ...hass, states: { ...baseStates } };
+  card.hass = nextHass;
+  editor.hass = nextHass;
+}
+
+const orbitState = new Map<string, { rafId: number | null }>();
+
+function refreshTrackerEmu(cfg: FloorplanCardConfig) {
+  const host = document.getElementById("tracker-emu")!;
+  const pane = document.getElementById("tracker-emu-pane")!;
+  const trackers: Tracker[] = (cfg.floors ?? []).flatMap((f) => f.trackers ?? []);
+  if (!trackers.length) {
+    pane.style.display = "none";
+    host.replaceChildren();
+    // Cancel any pending orbit raf when the last tracker is removed.
+    for (const [, st] of orbitState) if (st.rafId != null) cancelAnimationFrame(st.rafId);
+    orbitState.clear();
+    return;
+  }
+  pane.style.display = "block";
+
+  const frag = document.createDocumentFragment();
+  for (const tr of trackers) {
+    const panel = document.createElement("div");
+    panel.className = "tracker-panel";
+    const xs = tr.xSensor;
+    const ys = tr.ySensor;
+    const head = document.createElement("header");
+    head.innerHTML = `<strong>Tracker ${tr.id.slice(0, 10)}</strong>`;
+
+    // Auto-orbit only makes sense when at least one sensor is configured.
+    const orbitLabel = document.createElement("label");
+    orbitLabel.className = "orbit";
+    const orbitChk = document.createElement("input");
+    orbitChk.type = "checkbox";
+    orbitChk.disabled = !xs && !ys;
+    orbitLabel.append(orbitChk, document.createTextNode("Auto-orbit"));
+    head.appendChild(orbitLabel);
+    panel.appendChild(head);
+
+    panel.appendChild(buildAxisRow("X", xs));
+    panel.appendChild(buildAxisRow("Y", ys));
+    frag.appendChild(panel);
+
+    // Wire orbit AFTER sliders exist so we can drive them.
+    const st = orbitState.get(tr.id) ?? { rafId: null as number | null };
+    orbitState.set(tr.id, st);
+    if (st.rafId != null) {
+      cancelAnimationFrame(st.rafId);
+      st.rafId = null;
+    }
+    orbitChk.addEventListener("change", () => {
+      if (!orbitChk.checked) {
+        if (st.rafId != null) cancelAnimationFrame(st.rafId);
+        st.rafId = null;
+        return;
+      }
+      const t0 = performance.now();
+      const tick = (now: number) => {
+        const t = (now - t0) / 1000;
+        if (xs) {
+          const v = xs.min + ((Math.sin(t * 0.9) + 1) / 2) * (xs.max - xs.min);
+          setHassState(xs.entity, round2(v));
+          const slider = panel.querySelector<HTMLInputElement>(`input[data-axis="X"]`);
+          if (slider) slider.value = String(v);
+        }
+        if (ys) {
+          const v = ys.min + ((Math.sin(t * 1.3 + Math.PI / 3) + 1) / 2) * (ys.max - ys.min);
+          setHassState(ys.entity, round2(v));
+          const slider = panel.querySelector<HTMLInputElement>(`input[data-axis="Y"]`);
+          if (slider) slider.value = String(v);
+        }
+        st.rafId = requestAnimationFrame(tick);
+      };
+      st.rafId = requestAnimationFrame(tick);
+    });
+  }
+  host.replaceChildren(frag);
+}
+
+function buildAxisRow(axis: "X" | "Y", s: TrackerSensor | undefined): HTMLElement {
+  const row = document.createElement("div");
+  row.className = "axis-row";
+  if (!s) {
+    row.innerHTML = `<span class="ent">${axis} sensor</span><span class="ent" style="grid-column:2/4;opacity:.6;">(not configured)</span>`;
+    return row;
+  }
+  // Initialize state so the dot has a starting position even before the user
+  // moves the slider (otherwise the entity reads NaN and we'd render stale).
+  const start = baseStates[s.entity]?.state;
+  const initial = Number.isFinite(Number(start)) ? Number(start) : (s.min + s.max) / 2;
+  if (start == null) setHassState(s.entity, initial);
+
+  const ent = document.createElement("span");
+  ent.className = "ent";
+  ent.textContent = `${axis}: ${s.entity}`;
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.dataset.axis = axis;
+  slider.min = String(s.min);
+  slider.max = String(s.max);
+  slider.step = String(Math.max(0.01, (s.max - s.min) / 200));
+  slider.value = String(initial);
+  const val = document.createElement("span");
+  val.className = "ent";
+  val.style.textAlign = "right";
+  val.textContent = String(initial);
+  slider.addEventListener("input", () => {
+    const v = Number(slider.value);
+    val.textContent = String(v);
+    setHassState(s.entity, v);
+  });
+  row.append(ent, slider, val);
+  return row;
+}
+
+function round2(v: number): number {
+  return Math.round(v * 100) / 100;
+}
+
+// Initial render — covers the case where the starter config already has trackers.
+refreshTrackerEmu(config);
+
+// Clear the hosts before mounting so re-running this module (HMR, etc.) can
+// never stack a second editor/card on top of the first — duplicate mounts make
+// edits in one instance look like they "disappear" in the other.
+const editorHost = document.getElementById("editor-host")!;
+const cardHost = document.getElementById("card-host")!;
+editorHost.replaceChildren(editor);
+cardHost.replaceChildren(card);
+
+// If this module is hot-reloaded, do a full page reload instead of re-executing
+// the top-level side effects (which would re-define elements and re-mount).
+if (import.meta.hot) {
+  import.meta.hot.accept(() => import.meta.hot!.invalidate());
+}

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Easy Floorplan — local dev harness</title>
+    <style>
+      /* Home Assistant theme variables. The card/editor style many things with
+         var(--primary-text-color) etc. WITHOUT fallbacks, so outside HA those
+         resolve to nothing (e.g. wall stroke -> none -> invisible). Defining the
+         common HA vars here makes the harness render like a real HA light theme. */
+      :root {
+        color-scheme: light;
+        --primary-text-color: #212121;
+        --secondary-text-color: #727272;
+        --disabled-text-color: #bdbdbd;
+        --primary-color: #03a9f4;
+        --accent-color: #ff9800;
+        --error-color: #db4437;
+        --card-background-color: #ffffff;
+        --primary-background-color: #fafafa;
+        --secondary-background-color: #e5e5e5;
+        --divider-color: rgba(0, 0, 0, 0.12);
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        background: #eceff1;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 16px;
+        box-sizing: border-box;
+        min-height: 100vh;
+      }
+      /* Editor is the thing you interact with — give it the full width. */
+      #editor-host { width: 100%; }
+      /* Live preview is a smaller reference below the editor. */
+      #card-pane { max-width: 720px; }
+      .pane { min-width: 0; }
+      .pane h2 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #607d8b;
+        margin: 0 0 8px;
+      }
+      #editor-host, #card-host, #tracker-emu { background: #fff; border-radius: 8px; }
+      #card-host { padding: 12px; }
+      #tracker-emu {
+        padding: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        font-size: 13px;
+      }
+      #tracker-emu .tracker-panel {
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        padding: 8px 10px;
+      }
+      #tracker-emu .tracker-panel header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      #tracker-emu .tracker-panel header strong { font-size: 12px; color: #455a64; }
+      #tracker-emu .axis-row { display: grid; grid-template-columns: 110px 1fr 60px; gap: 6px; align-items: center; }
+      #tracker-emu .axis-row .ent { color: #607d8b; font-family: ui-monospace, monospace; font-size: 12px; }
+      #tracker-emu label.orbit { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #455a64; }
+      .note {
+        grid-column: 1 / -1;
+        font-size: 12px;
+        color: #607d8b;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="note">
+      Local dev harness — edits in the editor update the live preview instantly.
+      No Home Assistant, no service-worker cache. Hot-reloads on source changes.
+    </p>
+    <div class="pane">
+      <h2>Editor</h2>
+      <div id="editor-host"></div>
+    </div>
+    <div class="pane" id="card-pane">
+      <h2>Live card preview</h2>
+      <div id="card-host"></div>
+    </div>
+    <div class="pane" id="tracker-emu-pane" style="max-width:720px;display:none;">
+      <h2>Tracker emulator (dev only)</h2>
+      <div id="tracker-emu"></div>
+    </div>
+    <script type="module" src="./dev.ts"></script>
+  </body>
+</html>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -13,6 +13,8 @@ import type {
   FurnitureType,
   ItemKind,
   ItemDisplay,
+  Tracker,
+  TrackerSensor,
 } from "./types";
 import {
   DEFAULT_CUSTOM_PERCENT,
@@ -22,6 +24,7 @@ import {
   DEFAULT_ITEM_SIZE,
   DEFAULT_TEXT_SIZE,
   DEFAULT_RIPPLE_SIZE,
+  DEFAULT_TRACKER_DOT_SIZE,
   FURNITURE_DEFAULT_SIZE,
   emptyConfig,
   getFloors,
@@ -38,6 +41,8 @@ import {
   openingDefaultOpen,
   renderRipple,
   renderFurniture,
+  renderTracker,
+  trackerSensorReading,
   defaultIcon,
   kindFromEntity,
   snapToWall,
@@ -80,8 +85,8 @@ const FURNITURE_LABELS: Record<FurnitureType, string> = {
   tv: "tv",
 };
 
-type Tool = "select" | "wall" | "door" | "window";
-type SelKind = "wall" | "opening" | "item" | "text" | "furniture";
+type Tool = "select" | "wall" | "door" | "window" | "tracker";
+type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker";
 type Sel = { kind: SelKind; id: string };
 type OverlaySel = { kind: "item" | "text"; id: string };
 
@@ -115,6 +120,7 @@ interface Clipboard {
   items: FloorItem[];
   texts: FloorText[];
   furniture: Furniture[];
+  trackers: Tracker[];
 }
 
 /** Snap distance (virtual units) for openings onto walls / wall endpoints onto each other. */
@@ -136,6 +142,8 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _selection: Sel[] = [];
   @state() private _activeFloorId!: string;
   @state() private _draft: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  /** While dragging the Tracker tool, the rectangle being drawn (top-left corner + opposite corner). */
+  @state() private _draftTracker: { x0: number; y0: number; x1: number; y1: number } | null = null;
   /** When true, walls are drawn freely (no horizontal/vertical or corner gravity). */
   @state() private _freeWalls = false;
   /** Default length applied to a freshly placed door/window. User-editable from the context bar. */
@@ -177,6 +185,7 @@ export class FloorplanCardEditor extends LitElement {
       items: [],
       texts: [],
       furniture: [],
+      trackers: [],
     };
     if (!this._activeFloorId || !floors.some((f) => f.id === this._activeFloorId)) {
       this._activeFloorId =
@@ -495,6 +504,7 @@ export class FloorplanCardEditor extends LitElement {
     const iIds = this._idsOfKind("item");
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
+    const trIds = this._idsOfKind("tracker");
     this._commitFloor({
       walls: f.walls.map((w) =>
         wIds.has(w.id) ? { ...w, x1: w.x1 + dx, y1: w.y1 + dy, x2: w.x2 + dx, y2: w.y2 + dy } : w
@@ -504,6 +514,9 @@ export class FloorplanCardEditor extends LitElement {
       texts: f.texts.map((t) => (tIds.has(t.id) ? { ...t, x: t.x + dx, y: t.y + dy } : t)),
       furniture: f.furniture.map((fu) =>
         fIds.has(fu.id) ? { ...fu, x: fu.x + dx, y: fu.y + dy } : fu
+      ),
+      trackers: (f.trackers ?? []).map((tr) =>
+        trIds.has(tr.id) ? { ...tr, x: tr.x + dx, y: tr.y + dy } : tr
       ),
     });
   }
@@ -526,6 +539,13 @@ export class FloorplanCardEditor extends LitElement {
       this._addOpening(this._tool, this._snap(raw.x), this._snap(raw.y));
       return;
     }
+    if (this._tool === "tracker") {
+      const x = this._snap(raw.x);
+      const y = this._snap(raw.y);
+      this._draftTracker = { x0: x, y0: y, x1: x, y1: y };
+      (ev.target as Element).setPointerCapture?.(ev.pointerId);
+      return;
+    }
     // Select tool, empty canvas: start a marquee (rubber-band) selection.
     this._marqueeAdd = ev.shiftKey || ev.ctrlKey || ev.metaKey;
     this._marquee = { x0: raw.x, y0: raw.y, x1: raw.x, y1: raw.y };
@@ -537,6 +557,15 @@ export class FloorplanCardEditor extends LitElement {
       const raw = this._toVirtual(ev, false);
       const s = this._snapWallEnd(this._draft.x1, this._draft.y1, raw.x, raw.y);
       this._draft = { ...this._draft, x2: s.x, y2: s.y };
+      return;
+    }
+    if (this._tool === "tracker" && this._draftTracker) {
+      const raw = this._toVirtual(ev, false);
+      this._draftTracker = {
+        ...this._draftTracker,
+        x1: this._snap(raw.x),
+        y1: this._snap(raw.y),
+      };
       return;
     }
     if (this._marquee) {
@@ -555,6 +584,31 @@ export class FloorplanCardEditor extends LitElement {
         const wall: Wall = { id: uid("wall"), ...d };
         this._commitFloor({ walls: [...this._floor().walls, wall] });
         this._selection = [{ kind: "wall", id: wall.id }];
+      }
+      return;
+    }
+    if (this._tool === "tracker" && this._draftTracker) {
+      const d = this._draftTracker;
+      this._draftTracker = null;
+      // Browsers throw NotFoundError if the pointer was never captured on this
+      // target (e.g. in HA's editor dialog, or when events arrive synthetically
+      // without a matching pointerdown). The thrown error would skip the rest
+      // of the handler and silently swallow the drag — which is exactly what
+      // "drag to draw the tracker isn't working" looked like. Pointerup
+      // implicitly releases capture anyway, so a best-effort release is fine.
+      try {
+        (ev.target as Element).releasePointerCapture?.(ev.pointerId);
+      } catch {
+        /* no active capture — already released by the implicit pointerup release */
+      }
+      const x = Math.min(d.x0, d.x1);
+      const y = Math.min(d.y0, d.y1);
+      const w = Math.abs(d.x1 - d.x0);
+      const h = Math.abs(d.y1 - d.y0);
+      // Reject zero-size drags (a stray click) so the tool doesn't litter the
+      // canvas with invisible trackers.
+      if (w >= this.grid / 2 && h >= this.grid / 2) {
+        this._addTracker(x, y, w, h);
       }
       return;
     }
@@ -593,6 +647,8 @@ export class FloorplanCardEditor extends LitElement {
     for (const it of f.items) if (inside(it.x, it.y)) out.push({ kind: "item", id: it.id });
     for (const t of f.texts) if (inside(t.x, t.y)) out.push({ kind: "text", id: t.id });
     for (const fu of f.furniture) if (inside(fu.x, fu.y)) out.push({ kind: "furniture", id: fu.id });
+    for (const tr of f.trackers ?? [])
+      if (inside(tr.x + tr.w / 2, tr.y + tr.h / 2)) out.push({ kind: "tracker", id: tr.id });
     return out;
   }
 
@@ -631,9 +687,13 @@ export class FloorplanCardEditor extends LitElement {
       } else if (s.kind === "text") {
         const t = f.texts.find((x) => x.id === s.id);
         if (t) m.set(`text:${t.id}`, { kind: "pt", x: t.x, y: t.y });
-      } else {
+      } else if (s.kind === "furniture") {
         const fu = f.furniture.find((x) => x.id === s.id);
         if (fu) m.set(`furniture:${fu.id}`, { kind: "pt", x: fu.x, y: fu.y });
+      } else {
+        // tracker — stored by top-left corner.
+        const tr = (f.trackers ?? []).find((x) => x.id === s.id);
+        if (tr) m.set(`tracker:${tr.id}`, { kind: "pt", x: tr.x, y: tr.y });
       }
     }
     return m;
@@ -711,6 +771,10 @@ export class FloorplanCardEditor extends LitElement {
       }),
       furniture: f.furniture.map((el) => {
         const o = orig.get(`furniture:${el.id}`);
+        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+      }),
+      trackers: (f.trackers ?? []).map((el) => {
+        const o = orig.get(`tracker:${el.id}`);
         return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
       }),
     };
@@ -795,6 +859,27 @@ export class FloorplanCardEditor extends LitElement {
     this._tool = "select";
   }
 
+  /**
+   * Drop a new Tracker on the active floor sized to the user's drag and
+   * select it so the per-element editor (entity pickers + sensor ranges) is
+   * immediately reachable. Tool switches back to Select so the user can
+   * configure / move the new tracker without re-dragging.
+   */
+  private _addTracker(x: number, y: number, w: number, h: number): void {
+    const tr: Tracker = {
+      id: uid("tracker"),
+      x,
+      y,
+      w,
+      h,
+      angle: 0,
+      dotSize: DEFAULT_TRACKER_DOT_SIZE,
+    };
+    this._commitFloor({ trackers: [...(this._floor().trackers ?? []), tr] });
+    this._selection = [{ kind: "tracker", id: tr.id }];
+    this._tool = "select";
+  }
+
   private _addText(): void {
     const t: FloorText = {
       id: uid("text"),
@@ -816,12 +901,14 @@ export class FloorplanCardEditor extends LitElement {
     const iIds = this._idsOfKind("item");
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
+    const trIds = this._idsOfKind("tracker");
     this._commitFloor({
       walls: f.walls.filter((w) => !wIds.has(w.id)),
       openings: f.openings.filter((o) => !oIds.has(o.id)),
       items: f.items.filter((i) => !iIds.has(i.id)),
       texts: f.texts.filter((t) => !tIds.has(t.id)),
       furniture: f.furniture.filter((fu) => !fIds.has(fu.id)),
+      trackers: (f.trackers ?? []).filter((tr) => !trIds.has(tr.id)),
     });
     this._clearSel();
   }
@@ -836,12 +923,14 @@ export class FloorplanCardEditor extends LitElement {
     const iIds = this._idsOfKind("item");
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
+    const trIds = this._idsOfKind("tracker");
     this._clipboard = structuredClone({
       walls: f.walls.filter((w) => wIds.has(w.id)),
       openings: f.openings.filter((o) => oIds.has(o.id)),
       items: f.items.filter((it) => iIds.has(it.id)),
       texts: f.texts.filter((t) => tIds.has(t.id)),
       furniture: f.furniture.filter((fu) => fIds.has(fu.id)),
+      trackers: (f.trackers ?? []).filter((tr) => trIds.has(tr.id)),
     });
   }
 
@@ -885,12 +974,19 @@ export class FloorplanCardEditor extends LitElement {
       x: fu.x + off,
       y: fu.y + off,
     }));
+    const newTrackers: Tracker[] = (cb.trackers ?? []).map((tr) => ({
+      ...tr,
+      id: uid("tracker"),
+      x: tr.x + off,
+      y: tr.y + off,
+    }));
     this._commitFloor({
       walls: [...f.walls, ...newWalls],
       openings: [...f.openings, ...newOpenings],
       items: [...f.items, ...newItems],
       texts: [...f.texts, ...newTexts],
       furniture: [...f.furniture, ...newFurn],
+      trackers: [...(f.trackers ?? []), ...newTrackers],
     });
     this._selection = [
       ...newWalls.map((w) => ({ kind: "wall" as const, id: w.id })),
@@ -898,6 +994,7 @@ export class FloorplanCardEditor extends LitElement {
       ...newItems.map((it) => ({ kind: "item" as const, id: it.id })),
       ...newTexts.map((t) => ({ kind: "text" as const, id: t.id })),
       ...newFurn.map((fu) => ({ kind: "furniture" as const, id: fu.id })),
+      ...newTrackers.map((tr) => ({ kind: "tracker" as const, id: tr.id })),
     ];
     this._tool = "select";
   }
@@ -969,6 +1066,30 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
+  private _updateTracker(id: string, partial: Partial<Tracker>): void {
+    this._commitFloor({
+      trackers: (this._floor().trackers ?? []).map((t) =>
+        t.id === id ? { ...t, ...partial } : t
+      ),
+    });
+  }
+
+  /** Patch a single field on one of a tracker's sensor sub-objects (X / Y axis). */
+  private _updateTrackerSensor(
+    id: string,
+    axis: "xSensor" | "ySensor",
+    partial: Partial<TrackerSensor> | null,
+  ): void {
+    const tr = (this._floor().trackers ?? []).find((t) => t.id === id);
+    if (!tr) return;
+    if (partial === null) {
+      this._updateTracker(id, { [axis]: undefined });
+      return;
+    }
+    const cur = tr[axis] ?? { entity: "", min: 0, max: 5 };
+    this._updateTracker(id, { [axis]: { ...cur, ...partial } });
+  }
+
   private _patchConfig(partial: Partial<FloorplanCardConfig>): void {
     this._commit({ ...this._config, ...partial });
   }
@@ -1015,6 +1136,14 @@ export class FloorplanCardEditor extends LitElement {
           straighten
         </button>
         <span class="ctx-hint">Drag to draw. Endpoints snap to nearby corners to close rooms.</span>
+      `;
+    } else if (t === "tracker") {
+      label = "Tracker";
+      body = html`
+        <span class="ctx-hint"
+          >Drag on the canvas to draw the tracked area; bind one or two
+          distance sensors in the Element editor.</span
+        >
       `;
     } else if (t === "door" || t === "window") {
       label = t === "door" ? "Door" : "Window";
@@ -1143,7 +1272,7 @@ export class FloorplanCardEditor extends LitElement {
         <div class="toolbar">
           <!-- Tools — modes; exactly one is active at a time -->
           <div class="seg" role="group" aria-label="Tool">
-            ${(["select", "wall", "door", "window"] as Tool[]).map(
+            ${(["select", "wall", "door", "window", "tracker"] as Tool[]).map(
               (t) => html`
                 <button
                   class=${this._tool === t ? "active" : ""}
@@ -1151,6 +1280,7 @@ export class FloorplanCardEditor extends LitElement {
                   @click=${() => {
                     this._tool = t;
                     this._draft = null;
+                    this._draftTracker = null;
                   }}
                 >
                   ${t}
@@ -1266,6 +1396,17 @@ export class FloorplanCardEditor extends LitElement {
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
               ${floor.openings.map((o) => this._renderOpeningSel(o))}
+              ${(floor.trackers ?? []).map((tr) => this._renderTrackerSel(tr))}
+              ${
+                this._draftTracker
+                  ? svg`<rect class="tracker-draft"
+                              x=${Math.min(this._draftTracker.x0, this._draftTracker.x1)}
+                              y=${Math.min(this._draftTracker.y0, this._draftTracker.y1)}
+                              width=${Math.abs(this._draftTracker.x1 - this._draftTracker.x0)}
+                              height=${Math.abs(this._draftTracker.y1 - this._draftTracker.y0)}
+                              rx="4" />`
+                  : nothing
+              }
               ${
                 this._draft
                   ? svg`<line x1=${this._draft.x1} y1=${this._draft.y1}
@@ -1358,6 +1499,33 @@ export class FloorplanCardEditor extends LitElement {
           color: selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
           open: openingDefaultOpen(o),
         })}
+      </g>`;
+  }
+
+  /**
+   * Render a Tracker in the editor SVG with its zone outline visible (so the
+   * user can grab/resize it) plus a hit overlay for drag-to-move and a dashed
+   * selection rectangle when active.
+   */
+  private _renderTrackerSel(tr: Tracker): TemplateResult {
+    const selected = this._isSel("tracker", tr.id);
+    const xRead = trackerSensorReading(this.hass?.states, tr.xSensor?.entity);
+    const yRead = trackerSensorReading(this.hass?.states, tr.ySensor?.entity);
+    return svg`
+      <g class="tracker-hit ${selected ? "selected" : ""}"
+         @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "tracker", id: tr.id })}>
+        ${renderTracker(tr, { editing: true, xReading: xRead, yReading: yRead })}
+        <rect x=${tr.x} y=${tr.y} width=${tr.w} height=${tr.h}
+              transform="rotate(${tr.angle ?? 0} ${tr.x + tr.w / 2} ${tr.y + tr.h / 2})"
+              class="tracker-hit-rect" />
+        ${
+          selected
+            ? svg`<rect x=${tr.x - 4} y=${tr.y - 4}
+                        width=${tr.w + 8} height=${tr.h + 8}
+                        transform="rotate(${tr.angle ?? 0} ${tr.x + tr.w / 2} ${tr.y + tr.h / 2})"
+                        class="tracker-outline" />`
+            : nothing
+        }
       </g>`;
   }
 
@@ -1978,11 +2146,193 @@ export class FloorplanCardEditor extends LitElement {
       `;
     }
 
+    if (sel.kind === "tracker") {
+      const tr = (this._floor().trackers ?? []).find((x) => x.id === sel.id);
+      if (!tr) return html`${nothing}`;
+      return html`
+        ${this._renderTrackerSensorRows(tr, "xSensor", "X sensor")}
+        ${this._renderTrackerSensorRows(tr, "ySensor", "Y sensor")}
+        <div class="row">
+          <label>Width / Height</label>
+          <input
+            class="num"
+            type="number"
+            min="10"
+            .value=${String(tr.w)}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                w: Math.max(10, Number((e.target as HTMLInputElement).value) || tr.w),
+              })}
+          />
+          <input
+            class="num"
+            type="number"
+            min="10"
+            .value=${String(tr.h)}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                h: Math.max(10, Number((e.target as HTMLInputElement).value) || tr.h),
+              })}
+          />
+        </div>
+        <div class="row">
+          <label>Position</label>
+          <input
+            class="num"
+            type="number"
+            .value=${String(Math.round(tr.x))}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, { x: Number((e.target as HTMLInputElement).value) })}
+          />
+          <input
+            class="num"
+            type="number"
+            .value=${String(Math.round(tr.y))}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, { y: Number((e.target as HTMLInputElement).value) })}
+          />
+        </div>
+        <div class="row">
+          <label>Angle</label>
+          <input
+            type="range"
+            min="0"
+            max="360"
+            .value=${String(tr.angle ?? 0)}
+            @input=${(e: Event) =>
+              this._updateTracker(tr.id, { angle: Number((e.target as HTMLInputElement).value) })}
+          />
+          <input
+            class="num"
+            type="number"
+            min="0"
+            max="360"
+            .value=${String(Math.round(tr.angle ?? 0))}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
+              })}
+          />
+        </div>
+        <div class="row">
+          <label>Color</label>
+          <input
+            type="color"
+            .value=${tr.color ?? "#03a9f4"}
+            @input=${(e: Event) =>
+              this._updateTracker(tr.id, { color: (e.target as HTMLInputElement).value })}
+          />
+          <input
+            type="text"
+            placeholder="(primary)"
+            .value=${tr.color ?? ""}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                color: (e.target as HTMLInputElement).value || undefined,
+              })}
+          />
+        </div>
+        <div class="row">
+          <label>Dot size</label>
+          <input
+            type="range"
+            min="6"
+            max="40"
+            step="1"
+            .value=${String(tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE)}
+            @input=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                dotSize: Number((e.target as HTMLInputElement).value),
+              })}
+          />
+          <input
+            class="num"
+            type="number"
+            min="6"
+            max="80"
+            .value=${String(tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE)}
+            @change=${(e: Event) =>
+              this._updateTracker(tr.id, {
+                dotSize:
+                  Number((e.target as HTMLInputElement).value) || DEFAULT_TRACKER_DOT_SIZE,
+              })}
+          />
+        </div>
+      `;
+    }
+
     // sel.kind === "wall" (or unknown) — no inline editor today; the user can
     // drag the wall or its endpoint handles directly on the canvas.
     return html`<span class="ctx-hint"
       >Drag the line to move it, or the round handles to move an endpoint.</span
     >`;
+  }
+
+  /**
+   * Editor rows for one of a tracker's two sensor mappings (X or Y). Entity
+   * picker is always shown; min / max / invert appear once a sensor entity is
+   * set so the panel stays compact while empty.
+   */
+  private _renderTrackerSensorRows(
+    tr: Tracker,
+    axis: "xSensor" | "ySensor",
+    label: string,
+  ): TemplateResult {
+    const s = tr[axis];
+    return html`
+      <div class="row">
+        <label>${label}</label>
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${s?.entity ?? ""}
+          .includeDomains=${["sensor", "input_number", "number"]}
+          allow-custom-entity
+          @value-changed=${(e: CustomEvent) => {
+            const v = (e.detail.value as string) || "";
+            if (!v) this._updateTrackerSensor(tr.id, axis, null);
+            else this._updateTrackerSensor(tr.id, axis, { entity: v });
+          }}
+        ></ha-entity-picker>
+      </div>
+      ${s
+        ? html`<div class="row">
+            <label>${label} range</label>
+            <input
+              class="num"
+              type="number"
+              step="0.01"
+              title="Reading at the near edge"
+              .value=${String(s.min)}
+              @change=${(e: Event) =>
+                this._updateTrackerSensor(tr.id, axis, {
+                  min: Number((e.target as HTMLInputElement).value),
+                })}
+            />
+            <input
+              class="num"
+              type="number"
+              step="0.01"
+              title="Reading at the far edge"
+              .value=${String(s.max)}
+              @change=${(e: Event) =>
+                this._updateTrackerSensor(tr.id, axis, {
+                  max: Number((e.target as HTMLInputElement).value),
+                })}
+            />
+            <label class="inline-check">
+              <input
+                type="checkbox"
+                .checked=${s.invert ?? false}
+                @change=${(e: Event) =>
+                  this._updateTrackerSensor(tr.id, axis, {
+                    invert: (e.target as HTMLInputElement).checked || undefined,
+                  })}
+              />
+              invert
+            </label>
+          </div>`
+        : nothing}
+    `;
   }
 
   static styles = css`
@@ -2151,7 +2501,8 @@ export class FloorplanCardEditor extends LitElement {
     }
     svg.wall,
     svg.door,
-    svg.window {
+    svg.window,
+    svg.tracker {
       cursor: crosshair;
     }
     .grid {
@@ -2366,6 +2717,104 @@ export class FloorplanCardEditor extends LitElement {
         opacity: 0;
       }
     }
+    /* === Tracker (editor + card share the same animation classes). The zone
+       outline is editor-only and added by renderTracker when editing:true; in
+       the live card only the marker / line shows. Movement transitions are
+       applied to the marker group's transform so the dot/triangle glides
+       between sensor updates rather than jumping. === */
+    /* Scoped to <g> so the rule doesn't also match the <svg>, which carries
+       the active-tool class (e.g. "tracker") for cursor styling. A bare
+       ".tracker" matched the SVG too, and pointer-events is inherited in
+       SVG — so toggling the tracker tool silently killed every pointerdown
+       on the canvas, breaking drag-to-draw. Same trap as line.wall above. */
+    g.tracker {
+      pointer-events: none;
+    }
+    .tracker-zone {
+      transition: opacity 0.2s ease;
+    }
+    .tracker-hit {
+      cursor: move;
+    }
+    .tracker-hit-rect {
+      /* Transparent fill turns the entire zone into a pointer target for drag,
+         without obscuring the dashed outline drawn by the renderer. */
+      fill: transparent;
+      pointer-events: all;
+    }
+    .tracker-outline {
+      fill: none;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 1.5;
+      stroke-dasharray: 6 4;
+      pointer-events: none;
+    }
+    .tracker-draft {
+      fill: var(--primary-color, #03a9f4);
+      fill-opacity: 0.08;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 1.5;
+      stroke-dasharray: 6 4;
+      pointer-events: none;
+    }
+    .tracker-marker {
+      transition: transform 0.4s ease-out;
+      transform-box: fill-box;
+    }
+    .tracker-dot {
+      animation: fp-tracker-pulse 1.4s ease-in-out infinite;
+      transform-box: fill-box;
+      transform-origin: center;
+    }
+    .tracker-ring {
+      animation: fp-tracker-ring 2.2s ease-out infinite;
+      opacity: 0;
+    }
+    .tracker-line {
+      transition: transform 0.4s ease-out;
+    }
+    .tracker-line-stroke {
+      opacity: 0.45;
+      animation: fp-tracker-pulse 1.6s ease-in-out infinite;
+    }
+    .tracker-band {
+      opacity: 0;
+      animation: fp-tracker-band 2.2s ease-out infinite;
+    }
+    .tracker-placeholder {
+      opacity: 0.6;
+    }
+    @keyframes fp-tracker-pulse {
+      0%,
+      100% {
+        transform: scale(0.9);
+        opacity: 0.7;
+      }
+      50% {
+        transform: scale(1.1);
+        opacity: 1;
+      }
+    }
+    @keyframes fp-tracker-ring {
+      0% {
+        r: 0;
+        opacity: 0.7;
+      }
+      100% {
+        r: var(--fp-tracker-ring-max, 60px);
+        opacity: 0;
+      }
+    }
+    @keyframes fp-tracker-band {
+      0% {
+        opacity: 0.5;
+        stroke-width: 1.5;
+      }
+      100% {
+        opacity: 0;
+        stroke-width: 14;
+      }
+    }
     .edit-text {
       position: absolute;
       pointer-events: auto;
@@ -2440,6 +2889,16 @@ export class FloorplanCardEditor extends LitElement {
     }
     .row input.num {
       flex: 0 0 64px;
+    }
+    /* Compact inline checkbox+label used inside a .row that already has its
+       primary <label> on the left (e.g. the Tracker sensor "invert" toggle). */
+    .row .inline-check {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 12px;
+      color: var(--secondary-text-color);
     }
     .hint {
       font-size: 13px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -16,6 +16,8 @@ import {
   openingDefaultOpen,
   renderRipple,
   renderFurniture,
+  renderTracker,
+  trackerSensorReading,
   defaultIcon,
 } from "./render";
 import type { Opening } from "./types";
@@ -217,6 +219,13 @@ export class FloorplanCard extends LitElement {
                 accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
               });
             })}
+            ${(active.trackers ?? []).map((tr) =>
+              renderTracker(tr, {
+                editing: false,
+                xReading: trackerSensorReading(this.hass?.states, tr.xSensor?.entity),
+                yReading: trackerSensorReading(this.hass?.states, tr.ySensor?.entity),
+              })
+            )}
           </svg>
           <div class="items">
             ${active.texts.map((t) => this._renderText(t, c))}
@@ -415,6 +424,64 @@ export class FloorplanCard extends LitElement {
       100% {
         transform: scale(1);
         opacity: 0;
+      }
+    }
+    /* === Tracker animations (live card). The zone outline is editor-only —
+       renderTracker is called with editing:false here, so only the marker /
+       line and ripples render. Movement transitions on the group's transform
+       so the dot/triangle glides between sensor updates rather than jumping. === */
+    .tracker-marker {
+      transition: transform 0.4s ease-out;
+    }
+    .tracker-dot {
+      animation: fp-tracker-pulse 1.4s ease-in-out infinite;
+      transform-box: fill-box;
+      transform-origin: center;
+    }
+    .tracker-ring {
+      animation: fp-tracker-ring 2.2s ease-out infinite;
+      opacity: 0;
+    }
+    .tracker-line {
+      transition: transform 0.4s ease-out;
+    }
+    .tracker-line-stroke {
+      opacity: 0.45;
+      animation: fp-tracker-pulse 1.6s ease-in-out infinite;
+    }
+    .tracker-band {
+      opacity: 0;
+      animation: fp-tracker-band 2.2s ease-out infinite;
+    }
+    @keyframes fp-tracker-pulse {
+      0%,
+      100% {
+        transform: scale(0.9);
+        opacity: 0.7;
+      }
+      50% {
+        transform: scale(1.1);
+        opacity: 1;
+      }
+    }
+    @keyframes fp-tracker-ring {
+      0% {
+        r: 0;
+        opacity: 0.7;
+      }
+      100% {
+        r: var(--fp-tracker-ring-max, 60px);
+        opacity: 0;
+      }
+    }
+    @keyframes fp-tracker-band {
+      0% {
+        opacity: 0.5;
+        stroke-width: 1.5;
+      }
+      100% {
+        opacity: 0;
+        stroke-width: 14;
       }
     }
   `;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { snapToWall, openingDefaultOpen, kindFromEntity, defaultIcon } from "./render";
+import {
+  snapToWall,
+  openingDefaultOpen,
+  kindFromEntity,
+  defaultIcon,
+  trackerSensorReading,
+} from "./render";
 import type { Opening } from "./types";
 
 describe("snapToWall", () => {
@@ -60,6 +66,24 @@ describe("kindFromEntity", () => {
   it("falls back to generic for unknown domains", () => {
     expect(kindFromEntity("media_player.tv")).toBe("generic");
     expect(kindFromEntity("weird")).toBe("generic");
+  });
+});
+
+describe("trackerSensorReading", () => {
+  const states = {
+    "sensor.x": { state: "2.5" },
+    "sensor.bad": { state: "unavailable" },
+    "sensor.text": { state: "open" },
+  };
+  it("parses a numeric entity state", () => {
+    expect(trackerSensorReading(states, "sensor.x")).toBe(2.5);
+  });
+  it("returns null for missing entity, missing state, or non-numeric reading", () => {
+    expect(trackerSensorReading(states, undefined)).toBeNull();
+    expect(trackerSensorReading(undefined, "sensor.x")).toBeNull();
+    expect(trackerSensorReading(states, "sensor.missing")).toBeNull();
+    expect(trackerSensorReading(states, "sensor.bad")).toBeNull();
+    expect(trackerSensorReading(states, "sensor.text")).toBeNull();
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
-import type { Opening, ItemKind, Furniture } from "./types";
-import { FURNITURE_COLOR } from "./types";
+import type { Opening, ItemKind, Furniture, Tracker } from "./types";
+import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, trackerAxisFraction } from "./types";
 
 export const WALL_THICKNESS = 8;
 
@@ -315,6 +315,127 @@ export function renderRipple(
       )}
     </div>
   `;
+}
+
+/** Read a tracker sensor's current numeric value from HA, returning null when unavailable. */
+export function trackerSensorReading(
+  states: Record<string, { state: string } | undefined> | undefined,
+  entity: string | undefined,
+): number | null {
+  if (!entity || !states) return null;
+  const raw = states[entity]?.state;
+  if (raw == null || raw === "unavailable" || raw === "unknown") return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Options for {@link renderTracker}. */
+export interface TrackerRenderOptions {
+  /**
+   * Whether the tracker is being rendered inside the editor. In the editor the
+   * zone rectangle is drawn (semi-transparent fill + dashed stroke) so the user
+   * can see / grab the tracked area. In the live card it is invisible — only
+   * the tracked-object animation renders.
+   */
+  editing: boolean;
+  /** Live X-axis sensor reading (null when unavailable). */
+  xReading: number | null;
+  /** Live Y-axis sensor reading (null when unavailable). */
+  yReading: number | null;
+}
+
+/**
+ * Render a Tracker as an SVG group: an optional editor-only zone outline plus a
+ * live tracked-object marker driven by 1 or 2 distance sensors. Two-sensor mode
+ * shows a pulsating triangle at the resolved `(x, y)` with concentric ripples;
+ * one-sensor mode shows a faint pulsating line spanning the unknown axis with
+ * ripple bands. CSS keyframes `fp-tracker-pulse`, `fp-tracker-ring` and
+ * `fp-tracker-band` are provided by the host component's styles.
+ */
+export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTemplateResult {
+  const color = t.color ?? "var(--primary-color, #03a9f4)";
+  const dotR = (t.dotSize ?? DEFAULT_TRACKER_DOT_SIZE) / 2;
+  const cx = t.x + t.w / 2;
+  const cy = t.y + t.h / 2;
+  const angle = t.angle ?? 0;
+
+  const fx = trackerAxisFraction(t.xSensor, opts.xReading);
+  const fy = trackerAxisFraction(t.ySensor, opts.yReading);
+  const hasX = fx != null;
+  const hasY = fy != null;
+
+  // Local (centered) coordinates so a rotation around the rect center is trivial.
+  const hw = t.w / 2;
+  const hh = t.h / 2;
+
+  // Zone outline — editor only.
+  const zone = opts.editing
+    ? svg`<rect class="tracker-zone" x=${-hw} y=${-hh} width=${t.w} height=${t.h}
+                fill=${color} fill-opacity="0.08" stroke=${color} stroke-width="1.5"
+                stroke-dasharray="6 4" rx="4" pointer-events="none" />`
+    : svg``;
+
+  let marker: SVGTemplateResult;
+  if (hasX && hasY) {
+    // 2-sensor: pulsating triangle + ripple rings at the resolved (x, y).
+    const mx = -hw + fx! * t.w;
+    const my = -hh + fy! * t.h;
+    // Equilateral-ish triangle pointing up, sized in user units (≈ dotR scale).
+    const tri = `0,${-dotR} ${dotR * 0.9},${dotR * 0.7} ${-dotR * 0.9},${dotR * 0.7}`;
+    const ringMax = Math.max(dotR * 3.5, Math.min(t.w, t.h) * 0.45);
+    marker = svg`
+      <g class="tracker-marker" style="transform:translate(${mx}px, ${my}px);">
+        <circle class="tracker-ring" cx="0" cy="0" r="0"
+                fill="none" stroke=${color} stroke-width="1.5"
+                style="--fp-tracker-ring-max:${ringMax}px;" />
+        <circle class="tracker-ring" cx="0" cy="0" r="0"
+                fill="none" stroke=${color} stroke-width="1.5"
+                style="--fp-tracker-ring-max:${ringMax}px; animation-delay:0.7s;" />
+        <polygon class="tracker-dot" points=${tri} fill=${color} />
+      </g>`;
+  } else if (hasX || hasY) {
+    // 1-sensor: faint pulsating line + ripple bands along the unknown axis.
+    if (hasX) {
+      // Vertical line at the X position, spanning full height.
+      const lx = -hw + fx! * t.w;
+      marker = svg`
+        <g class="tracker-line" style="transform:translate(${lx}px, 0);">
+          <line class="tracker-line-stroke" x1="0" y1=${-hh} x2="0" y2=${hh}
+                stroke=${color} stroke-width="1.5" />
+          <line class="tracker-band" x1="0" y1=${-hh} x2="0" y2=${hh}
+                stroke=${color} stroke-width="3" stroke-linecap="round" />
+          <line class="tracker-band" x1="0" y1=${-hh} x2="0" y2=${hh}
+                stroke=${color} stroke-width="3" stroke-linecap="round"
+                style="animation-delay:0.8s;" />
+        </g>`;
+    } else {
+      // Horizontal line at the Y position, spanning full width.
+      const ly = -hh + fy! * t.h;
+      marker = svg`
+        <g class="tracker-line tracker-line-h" style="transform:translate(0, ${ly}px);">
+          <line class="tracker-line-stroke" x1=${-hw} y1="0" x2=${hw} y2="0"
+                stroke=${color} stroke-width="1.5" />
+          <line class="tracker-band" x1=${-hw} y1="0" x2=${hw} y2="0"
+                stroke=${color} stroke-width="3" stroke-linecap="round" />
+          <line class="tracker-band" x1=${-hw} y1="0" x2=${hw} y2="0"
+                stroke=${color} stroke-width="3" stroke-linecap="round"
+                style="animation-delay:0.8s;" />
+        </g>`;
+    }
+  } else if (opts.editing) {
+    // Editor placeholder: a faint center dot so the user can still see the tracker.
+    marker = svg`<circle class="tracker-placeholder" cx="0" cy="0" r=${dotR}
+                          fill=${color} fill-opacity="0.25" />`;
+  } else {
+    // Runtime + no sensors → render nothing.
+    marker = svg``;
+  }
+
+  return svg`
+    <g class="tracker ${opts.editing ? "editing" : ""}"
+       transform="translate(${cx} ${cy}) rotate(${angle})">
+      ${zone}${marker}
+    </g>`;
 }
 
 /**

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -6,9 +6,10 @@ import {
   resolveSnap,
   snapToGridPercent,
   gridPercentToSnap,
+  trackerAxisFraction,
   uid,
 } from "./types";
-import type { FloorplanCardConfig } from "./types";
+import type { FloorplanCardConfig, TrackerSensor } from "./types";
 
 describe("resolveSnap", () => {
   it("falls back to the grid when snap is unset (the new default)", () => {
@@ -66,6 +67,41 @@ describe("emptyConfig", () => {
     expect(c.walls).toEqual([]);
     expect(c.openings).toEqual([]);
     expect(c.items).toEqual([]);
+    expect(c.trackers).toEqual([]);
+  });
+});
+
+describe("trackerAxisFraction", () => {
+  const s: TrackerSensor = { entity: "sensor.x", min: 0, max: 5 };
+
+  it("maps the reading linearly into 0..1 across [min, max]", () => {
+    expect(trackerAxisFraction(s, 0)).toBe(0);
+    expect(trackerAxisFraction(s, 5)).toBe(1);
+    expect(trackerAxisFraction(s, 2.5)).toBe(0.5);
+  });
+
+  it("clamps readings outside [min, max] into the unit interval", () => {
+    expect(trackerAxisFraction(s, -10)).toBe(0);
+    expect(trackerAxisFraction(s, 999)).toBe(1);
+  });
+
+  it("respects invert by flipping the fraction", () => {
+    expect(trackerAxisFraction({ ...s, invert: true }, 0)).toBe(1);
+    expect(trackerAxisFraction({ ...s, invert: true }, 5)).toBe(0);
+  });
+
+  it("returns null for missing sensor, missing reading, NaN, or zero span", () => {
+    expect(trackerAxisFraction(undefined, 1)).toBeNull();
+    expect(trackerAxisFraction(s, null)).toBeNull();
+    expect(trackerAxisFraction(s, undefined)).toBeNull();
+    expect(trackerAxisFraction(s, NaN)).toBeNull();
+    expect(trackerAxisFraction({ entity: "sensor.x", min: 3, max: 3 }, 3)).toBeNull();
+  });
+
+  it("supports min greater than max via the negative span", () => {
+    const reversed: TrackerSensor = { entity: "sensor.x", min: 5, max: 0 };
+    expect(trackerAxisFraction(reversed, 5)).toBe(0);
+    expect(trackerAxisFraction(reversed, 0)).toBe(1);
   });
 });
 
@@ -76,6 +112,7 @@ describe("makeFloor", () => {
     expect(f.id).toMatch(/^floor_/);
     expect(f.walls).toEqual([]);
     expect(f.openings).toEqual([]);
+    expect(f.trackers).toEqual([]);
   });
 
   it("seeds the floor with the provided walls", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,58 @@ export interface Furniture {
   color?: string;
 }
 
+/**
+ * A live position tracker driven by 1 or 2 distance sensors aimed along
+ * orthogonal axes. The user draws a rectangular tracked area on the floor
+ * plan and binds an HA distance entity to each axis; the card linearly
+ * maps each sensor's `[min, max]` reading to the corresponding edge-to-edge
+ * span of the rectangle.
+ *
+ * With both sensors configured the card animates a pulsating triangle with
+ * ripple rings at the resolved (x, y) inside the zone. With only one
+ * sensor configured it animates a faint pulsating line spanning the
+ * unknown axis (we know the target sits *somewhere* on that line).
+ *
+ * The zone rectangle is visible only in the editor; the live card renders
+ * only the tracked-object animation.
+ */
+export interface Tracker {
+  id: string;
+  /** Top-left in virtual units. */
+  x: number;
+  y: number;
+  /** Size in virtual units. */
+  w: number;
+  h: number;
+  /** Rotation in degrees. Default 0. */
+  angle?: number;
+  /** Marker / ripple color (CSS / hex). Falls back to the primary color. */
+  color?: string;
+  /** Marker diameter in pixels. Default 14. */
+  dotSize?: number;
+  /** Distance sensor mapped to the X axis (rectangle's horizontal span). */
+  xSensor?: TrackerSensor;
+  /** Distance sensor mapped to the Y axis (rectangle's vertical span). */
+  ySensor?: TrackerSensor;
+}
+
+/**
+ * A single distance sensor mapping. `[min, max]` reading values map
+ * linearly to the edge-to-edge span of the tracker rectangle along the
+ * sensor's axis. `invert: true` flips the mapping (max → min edge).
+ */
+export interface TrackerSensor {
+  entity: string;
+  /** Sensor reading when the target is at the "near" edge. */
+  min: number;
+  /** Sensor reading when the target is at the "far" edge. */
+  max: number;
+  /** Flip the mapping so that `max` corresponds to the near edge. */
+  invert?: boolean;
+}
+
+export const DEFAULT_TRACKER_DOT_SIZE = 14;
+
 export const DEFAULT_ITEM_SIZE = 34;
 export const DEFAULT_TEXT_SIZE = 16;
 export const DEFAULT_RIPPLE_SIZE = 80;
@@ -166,6 +218,7 @@ export interface Floor {
   items: FloorItem[];
   texts: FloorText[];
   furniture: Furniture[];
+  trackers: Tracker[];
 }
 
 export interface FloorplanCardConfig extends LovelaceCardConfig {
@@ -202,6 +255,7 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   items: FloorItem[];
   texts?: FloorText[];
   furniture?: Furniture[];
+  trackers?: Tracker[];
 }
 
 export const DEFAULT_WIDTH = 1000;
@@ -254,6 +308,7 @@ export function emptyConfig(type: string): FloorplanCardConfig {
     items: [],
     texts: [],
     furniture: [],
+    trackers: [],
   };
 }
 
@@ -263,7 +318,16 @@ export function uid(prefix: string): string {
 
 /** A fresh, empty floor (optionally seeded with walls). */
 export function makeFloor(name: string, walls: Wall[] = []): Floor {
-  return { id: uid("floor"), name, walls, openings: [], items: [], texts: [], furniture: [] };
+  return {
+    id: uid("floor"),
+    name,
+    walls,
+    openings: [],
+    items: [],
+    texts: [],
+    furniture: [],
+    trackers: [],
+  };
 }
 
 /**
@@ -282,6 +346,26 @@ export function getFloors(c: FloorplanCardConfig): Floor[] {
       items: c.items ?? [],
       texts: c.texts ?? [],
       furniture: c.furniture ?? [],
+      trackers: c.trackers ?? [],
     },
   ];
+}
+
+/**
+ * Resolve a sensor reading into a 0..1 fraction along its axis, applying
+ * `min`/`max` mapping, clamping, and `invert`. Returns `null` when the
+ * sensor is missing, the reading isn't a finite number, or the span is
+ * zero (mis-configured) — callers fall back to neutral / unknown states.
+ */
+export function trackerAxisFraction(
+  sensor: TrackerSensor | undefined,
+  reading: number | null | undefined,
+): number | null {
+  if (!sensor) return null;
+  if (reading == null || !Number.isFinite(reading)) return null;
+  const span = sensor.max - sensor.min;
+  if (span === 0) return null;
+  const f = (reading - sensor.min) / span;
+  const clamped = Math.max(0, Math.min(1, f));
+  return sensor.invert ? 1 - clamped : clamped;
 }


### PR DESCRIPTION
## Summary

Promotes the local-only `dev/` harness into the repo so anyone can iterate on the editor / card without a Home Assistant instance. The harness has been driving local development since the project started — this just makes it tracked, documented, and stable.

- **`dev/index.html` + `dev/dev.ts`** — mounts the real `easy-floorplan-card-editor` and `easy-floorplan-card` side-by-side with:
  - minimal `<ha-card>` / `<ha-icon>` stubs so the card renders outside HA;
  - a mock `hass` (`states`, `callService`, `formatEntityState`, `localize`);
  - a full `config-changed` round-trip between editor and live preview;
  - a **Tracker emulator** panel that auto-appears whenever the config has at least one tracker — per-axis sliders writing into `hass.states[entity].state` plus an **Auto-orbit** toggle that drives them on `requestAnimationFrame` so the animations can be observed continuously;
  - vite HMR with self-invalidation so duplicate custom-element registrations don't happen.
- **`.gitignore`** — drop the blanket `dev/*` ignore.
- **`README.md`** — new *Browser dev harness* subsection under Development explaining `npm run serve`, what's stubbed, the `START_WITH_DEMO` flag, and how the tracker emulator works.

The harness is **dev-only**: `vite.config.ts` entry-points `src/index.ts`, so nothing under `dev/` lands in the published bundle.

## Test plan

- [x] `npm run serve` opens the harness with HMR
- [x] Editor + card render side-by-side, edits round-trip to the live preview
- [x] Drawing a tracker → emulator panel appears with per-axis sliders
- [x] Sliders move the marker; Auto-orbit drives it continuously
- [x] Clearing one sensor → 1-sensor mode renders correctly
- [x] HMR self-invalidates on `dev/dev.ts` save without re-registering custom elements
- [x] `npm run build` still bundles cleanly — only `src/index.ts` is the entry, `dev/` is excluded
- [x] No personal info / secrets in `dev/` (`grep -rE 'secret|password|token|192\.168|hassio' dev/` is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)