### PR TITLE
Editor UI polish: icon toolbar, Add popover, canvas zoom overlay, unified Element header

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,29 +87,37 @@ you're doing, the **canvas**, and two sections below — **Element** (per-elemen
 for the current selection) and **Project** (page-level settings like canvas size, grid,
 background):
 
-- **select** — the default tool. Click an element to select it; Shift/Ctrl-click or drag
+- **Select** — the default tool. Click an element to select it; Shift/Ctrl-click or drag
   a box to select several at once. Arrow keys nudge the selection (Shift+arrow jumps a
-  full grid cell), and **Ctrl/Cmd+C/V/D** copy / paste / duplicate. With a selection,
-  the context row offers **duplicate** and **delete**, and the **Element** section below
-  the canvas exposes the full property editor for whatever you have selected.
-- **wall** — drag to draw. Endpoints snap to nearby corners; start a new wall on an
+  full grid cell); **Ctrl/Cmd+C/V/D** copy / paste / duplicate; **Ctrl/Cmd+Z** undoes
+  (**Shift+Z** or **Ctrl+Y** redoes); **Escape** cancels an in-progress draw or clears
+  the selection. The **Element** section below the canvas names the selection
+  (e.g. *Door · 60 units*) and carries its **duplicate** / **delete** buttons along
+  with the full property editor.
+- **Wall** — drag to draw. Endpoints snap to nearby corners; start a new wall on an
   existing corner to continue the perimeter. The context row's **straighten** toggle
   keeps walls horizontal/vertical and corner-snapped (turn it off to draw freely), and
   the **Snap** segmented control (`On` / `Off` / `Custom`) governs snapping for *all*
   tools — `Custom` lets you snap to a percentage of the grid (e.g. 50% = half a cell).
-- **door / window** — click to drop; it snaps onto the nearest wall. The context row
+- **Door / Window** — click to drop; it snaps onto the nearest wall. The context row
   shows a **Length** field for the *next* opening you place, so you can size doors and
   windows before placing them. Assign a sensor after placement (in the **Element**
   section) to animate the opening open/closed — see **Doors & windows**.
-- **tracker** — drag to draw a rectangular tracked area, then bind one or two distance
+- **Tracker** — drag to draw a rectangular tracked area, then bind one or two distance
   sensors (X axis and/or Y axis) in the **Element** section to animate a live position
   marker inside the zone — see **Tracker**. The zone outline is visible only in the
   editor; the live card shows just the marker.
-- **+ device / + text / + furniture…** — drop a new element; the **Element** section
-  below the canvas shows its full property editor so you can configure it right away.
-- **floor** — add, rename, switch and delete floors.
+- **+ Add** — one popover for everything droppable: device, text, and all furniture
+  types shown as their actual glyphs (pick a sofa by seeing a sofa). The new element is
+  selected immediately so the **Element** section is ready for configuring it.
+- **floor** — switch floors with the dropdown, add one with **+**; rename and delete
+  live behind the gear button.
 
-Undo/redo and a zoom slider live at the right of the tools row.
+Undo/redo buttons sit at the right of the tools row. Zoom controls live on the canvas
+itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button
+snaps back to 100%, and **Ctrl/Cmd+scroll** zooms from the keyboard/trackpad. The
+**Project** section (canvas size, grid, background) is collapsed by default — click its
+header to expand.
 
 ## Elements
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -524,6 +524,31 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- canvas (SVG) pointer handling: drawing walls/openings -------------
 
+  /**
+   * Best-effort pointer capture. `setPointerCapture` throws NotFoundError when
+   * the pointer id isn't active (synthetic events, or HA's dialog re-targeting
+   * the pointer), which would abort the rest of the calling handler — we hit
+   * exactly that with the tracker tool's drag-to-draw. Capture is an
+   * enhancement (smooth dragging past the canvas edge), never a requirement,
+   * so failures are safe to swallow.
+   */
+  private _capturePointer(ev: PointerEvent, target: Element | null = ev.target as Element): void {
+    try {
+      target?.setPointerCapture?.(ev.pointerId);
+    } catch {
+      /* pointer not active — drag still works, just without capture */
+    }
+  }
+
+  /** Best-effort release; pointerup releases capture implicitly anyway. */
+  private _releasePointer(ev: PointerEvent, target: Element | null = ev.target as Element): void {
+    try {
+      target?.releasePointerCapture?.(ev.pointerId);
+    } catch {
+      /* no active capture — already released by the implicit pointerup release */
+    }
+  }
+
   private _onCanvasDown(ev: PointerEvent): void {
     if (ev.button !== 0) return;
     const raw = this._toVirtual(ev, false);
@@ -533,7 +558,7 @@ export class FloorplanCardEditor extends LitElement {
         ? { x: this._snap(raw.x), y: this._snap(raw.y) }
         : this._snapWallPoint(raw.x, raw.y);
       this._draft = { x1: s.x, y1: s.y, x2: s.x, y2: s.y };
-      (ev.target as Element).setPointerCapture?.(ev.pointerId);
+      this._capturePointer(ev);
       return;
     }
     if (this._tool === "door" || this._tool === "window") {
@@ -544,13 +569,13 @@ export class FloorplanCardEditor extends LitElement {
       const x = this._snap(raw.x);
       const y = this._snap(raw.y);
       this._draftTracker = { x0: x, y0: y, x1: x, y1: y };
-      (ev.target as Element).setPointerCapture?.(ev.pointerId);
+      this._capturePointer(ev);
       return;
     }
     // Select tool, empty canvas: start a marquee (rubber-band) selection.
     this._marqueeAdd = ev.shiftKey || ev.ctrlKey || ev.metaKey;
     this._marquee = { x0: raw.x, y0: raw.y, x1: raw.x, y1: raw.y };
-    (ev.target as Element).setPointerCapture?.(ev.pointerId);
+    this._capturePointer(ev);
   }
 
   private _onCanvasMove(ev: PointerEvent): void {
@@ -591,17 +616,7 @@ export class FloorplanCardEditor extends LitElement {
     if (this._tool === "tracker" && this._draftTracker) {
       const d = this._draftTracker;
       this._draftTracker = null;
-      // Browsers throw NotFoundError if the pointer was never captured on this
-      // target (e.g. in HA's editor dialog, or when events arrive synthetically
-      // without a matching pointerdown). The thrown error would skip the rest
-      // of the handler and silently swallow the drag — which is exactly what
-      // "drag to draw the tracker isn't working" looked like. Pointerup
-      // implicitly releases capture anyway, so a best-effort release is fine.
-      try {
-        (ev.target as Element).releasePointerCapture?.(ev.pointerId);
-      } catch {
-        /* no active capture — already released by the implicit pointerup release */
-      }
+      this._releasePointer(ev);
       const x = Math.min(d.x0, d.x1);
       const y = Math.min(d.y0, d.y1);
       const w = Math.abs(d.x1 - d.x0);
@@ -616,7 +631,7 @@ export class FloorplanCardEditor extends LitElement {
     if (this._marquee) {
       const m = this._marquee;
       this._marquee = null;
-      (ev.target as Element).releasePointerCapture?.(ev.pointerId);
+      this._releasePointer(ev);
       const moved = Math.hypot(m.x1 - m.x0, m.y1 - m.y0) > 4;
       if (!moved) {
         // A plain click on empty canvas clears the selection.
@@ -629,7 +644,7 @@ export class FloorplanCardEditor extends LitElement {
     }
     if (this._drag) {
       this._drag = null;
-      (ev.target as Element).releasePointerCapture?.(ev.pointerId);
+      this._releasePointer(ev);
     }
   }
 
@@ -668,7 +683,7 @@ export class FloorplanCardEditor extends LitElement {
       endpoint,
     };
     this._pushHistory();
-    (ev.target as Element).setPointerCapture?.(ev.pointerId);
+    this._capturePointer(ev);
   }
 
   /** Capture the start positions of every selected element on the active floor. */
@@ -794,7 +809,7 @@ export class FloorplanCardEditor extends LitElement {
       orig: this._snapshotSelection(),
     };
     this._pushHistory();
-    (ev.currentTarget as Element).setPointerCapture?.(ev.pointerId);
+    this._capturePointer(ev, ev.currentTarget as Element);
   }
 
   private _onOverlayMove(ev: PointerEvent): void {
@@ -804,7 +819,7 @@ export class FloorplanCardEditor extends LitElement {
   private _onOverlayUp(ev: PointerEvent): void {
     if (this._drag) {
       this._drag = null;
-      (ev.currentTarget as Element).releasePointerCapture?.(ev.pointerId);
+      this._releasePointer(ev, ev.currentTarget as Element);
     }
   }
 
@@ -2345,7 +2360,7 @@ export class FloorplanCardEditor extends LitElement {
             <ha-entity-picker
               .hass=${this.hass}
               .value=${s.presence?.entity ?? ""}
-              .includeDomains=${["binary_sensor", "input_boolean"]}
+              .includeDomains=${["binary_sensor", "input_boolean", "device_tracker"]}
               allow-custom-entity
               @value-changed=${(e: CustomEvent) => {
                 const v = (e.detail.value as string) || "";

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -91,6 +91,25 @@ type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker";
 type Sel = { kind: SelKind; id: string };
 type OverlaySel = { kind: "item" | "text"; id: string };
 
+/** Toolbar metadata per tool: mdi icon + label (icons make the modes scannable). */
+const TOOL_META: Record<Tool, { icon: string; label: string }> = {
+  select: { icon: "mdi:cursor-default", label: "Select" },
+  wall: { icon: "mdi:wall", label: "Wall" },
+  door: { icon: "mdi:door", label: "Door" },
+  window: { icon: "mdi:window-closed-variant", label: "Window" },
+  tracker: { icon: "mdi:crosshairs-gps", label: "Tracker" },
+};
+
+/** Icon shown in the Element header per selected element kind. */
+const SEL_KIND_ICON: Record<SelKind, string> = {
+  wall: "mdi:wall",
+  opening: "mdi:door",
+  item: "mdi:lightbulb-outline",
+  text: "mdi:format-text",
+  furniture: "mdi:sofa-outline",
+  tracker: "mdi:crosshairs-gps",
+};
+
 /** Snapshot of an element's position at drag start, for group translation. */
 type OrigPos =
   | { kind: "wall"; x1: number; y1: number; x2: number; y2: number }
@@ -153,8 +172,15 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _history: FloorplanCardConfig[] = [];
   @state() private _future: FloorplanCardConfig[] = [];
   @state() private _zoom = 1;
+  /** Floor gear popover (rename / delete floor) visibility. */
+  @state() private _floorMenuOpen = false;
+  /** "+ Add" popover (device / text / furniture glyphs) visibility. */
+  @state() private _addMenuOpen = false;
+  /** Project section expanded? Collapsed by default — page settings are touched rarely. */
+  @state() private _projectOpen = false;
 
   @query("svg") private _svg?: SVGSVGElement;
+  @query(".canvas-wrap") private _canvasWrap?: HTMLElement;
 
   private _drag: Drag | null = null;
   /** True when the active marquee should add to (rather than replace) the selection. */
@@ -488,9 +514,17 @@ export class FloorplanCardEditor extends LitElement {
       return;
     }
     if (ev.key === "Escape") {
-      // Cancel an in-progress draft / marquee first; otherwise clear the
-      // selection. Only swallow the key when it actually did something, so
-      // HA's dialog still closes on Escape when there's nothing to cancel.
+      // Close an open popover first, then cancel an in-progress draft /
+      // marquee, then clear the selection. Only swallow the key when it
+      // actually did something, so HA's dialog still closes on Escape when
+      // there's nothing to cancel.
+      if (this._floorMenuOpen || this._addMenuOpen) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._floorMenuOpen = false;
+        this._addMenuOpen = false;
+        return;
+      }
       if (this._draft || this._draftTracker || this._marquee) {
         ev.preventDefault();
         ev.stopPropagation();
@@ -1148,6 +1182,61 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- rendering ----------------------------------------------------------
 
+  // ---- zoom ----------------------------------------------------------------
+
+  private _setZoom(z: number): void {
+    this._zoom = Math.min(3, Math.max(0.5, Math.round(z * 100) / 100));
+  }
+
+  /** Ctrl/Cmd + wheel zooms the canvas (also catches trackpad pinch); plain wheel scrolls. */
+  private _onCanvasWheel(ev: WheelEvent): void {
+    if (!ev.ctrlKey && !ev.metaKey) return;
+    ev.preventDefault();
+    this._setZoom(this._zoom - Math.sign(ev.deltaY) * 0.1);
+  }
+
+  /** Reset to 100% (where the stage fits the wrap width) and scroll home. */
+  private _fitView(): void {
+    this._setZoom(1);
+    this._canvasWrap?.scrollTo({ top: 0, left: 0 });
+  }
+
+  /** One-line description of the selected element for the Element header. */
+  private _selectionSummary(sel: Sel): string {
+    const f = this._floor();
+    switch (sel.kind) {
+      case "wall": {
+        const w = f.walls.find((x) => x.id === sel.id);
+        return w ? `Wall · ${Math.round(Math.hypot(w.x2 - w.x1, w.y2 - w.y1))} units` : "Wall";
+      }
+      case "opening": {
+        const o = f.openings.find((x) => x.id === sel.id);
+        if (!o) return "Opening";
+        return `${o.type === "door" ? "Door" : "Window"} · ${Math.round(o.length)} units`;
+      }
+      case "item": {
+        const it = f.items.find((x) => x.id === sel.id);
+        return it?.entity ? `Device · ${it.entity}` : "Device";
+      }
+      case "text": {
+        const t = f.texts.find((x) => x.id === sel.id);
+        const txt = t?.text ?? "";
+        if (!txt) return "Text";
+        return `Text · “${txt.length > 24 ? `${txt.slice(0, 24)}…` : txt}”`;
+      }
+      case "furniture": {
+        const fu = f.furniture.find((x) => x.id === sel.id);
+        if (!fu) return "Furniture";
+        const label = FURNITURE_LABELS[fu.type];
+        return `${label.charAt(0).toUpperCase()}${label.slice(1)} · ${Math.round(fu.w)}×${Math.round(fu.h)}`;
+      }
+      default: {
+        const tr = (f.trackers ?? []).find((x) => x.id === sel.id);
+        return tr ? `Tracker · ${Math.round(tr.w)}×${Math.round(tr.h)}` : "Tracker";
+      }
+    }
+  }
+
   /** Cached grid templates; rebuilding hundreds of lines on every render is wasteful. */
   private _gridCache: { key: string; lines: TemplateResult[] } | null = null;
 
@@ -1231,27 +1320,20 @@ export class FloorplanCardEditor extends LitElement {
         <span class="ctx-hint">Click on a wall to drop a ${t}; it snaps onto the wall.</span>
       `;
     } else {
-      // Selection actions only — the full per-element editor renders BELOW the
-      // canvas in its own area (so the context bar's height stays stable as
-      // selections change, and the canvas doesn't jump up and down).
+      // Tool hints only — the per-element editor AND its actions (duplicate /
+      // delete) live in the Element section below the canvas, so the bar's
+      // height stays stable and the selection has a single home.
       label = "Select";
       const n = this._selection.length;
-      if (n === 0) {
-        body = html`<span class="ctx-hint"
-          >Click an element to select it, or drag a box to select several.</span
-        >`;
-      } else {
-        body = html`
-          <span class="ctx-count">${n} selected</span>
-          <button title="Duplicate the selection" @click=${this._duplicate}>⧉ duplicate</button>
-          <button class="danger" title="Delete the selection" @click=${this._deleteSelected}>
-            🗑 delete
-          </button>
-          ${n > 1
-            ? html`<span class="ctx-hint">Edit elements one at a time.</span>`
-            : nothing}
-        `;
-      }
+      body =
+        n === 0
+          ? html`<span class="ctx-hint"
+              >Click an element to select it, or drag a box to select several.</span
+            >`
+          : html`
+              <span class="ctx-count">${n} selected</span>
+              <span class="ctx-hint">Properties and actions are in the Element section below.</span>
+            `;
     }
 
     return html`
@@ -1329,8 +1411,24 @@ export class FloorplanCardEditor extends LitElement {
     const c = this._config;
     const floor = this._floor();
     const floors = c.floors ?? [];
+    const floorEmpty =
+      !floor.walls.length &&
+      !floor.openings.length &&
+      !floor.items.length &&
+      !floor.texts.length &&
+      !floor.furniture.length &&
+      !(floor.trackers ?? []).length;
     return html`
       <div class="editor">
+        ${this._floorMenuOpen || this._addMenuOpen
+          ? html`<div
+              class="pop-backdrop"
+              @click=${() => {
+                this._floorMenuOpen = false;
+                this._addMenuOpen = false;
+              }}
+            ></div>`
+          : nothing}
         <div class="toolbar">
           <!-- Tools — modes; exactly one is active at a time -->
           <div class="seg" role="group" aria-label="Tool">
@@ -1339,52 +1437,51 @@ export class FloorplanCardEditor extends LitElement {
                 <button
                   class=${this._tool === t ? "active" : ""}
                   aria-pressed=${this._tool === t}
+                  title=${TOOL_META[t].label}
                   @click=${() => {
                     this._tool = t;
                     this._draft = null;
                     this._draftTracker = null;
                   }}
                 >
-                  ${t}
+                  <ha-icon icon=${TOOL_META[t].icon}></ha-icon>${TOOL_META[t].label}
                 </button>`
             )}
           </div>
 
           <span class="divider"></span>
 
-          <!-- Insert — one-shot: drops a new element on the active floor -->
-          <div class="group" aria-label="Insert">
-            <button @click=${() => this._addItem("generic")}>+ device</button>
-            <button @click=${this._addText}>+ text</button>
-            <select
-              class="furn-add"
-              @change=${(e: Event) => {
-                const v = (e.target as HTMLSelectElement).value as FurnitureType | "";
-                if (v) this._addFurniture(v);
-                (e.target as HTMLSelectElement).value = "";
+          <!-- Insert — one popover for everything droppable on the floor -->
+          <span class="pop-wrap">
+            <button
+              aria-haspopup="true"
+              aria-expanded=${this._addMenuOpen}
+              @click=${() => {
+                this._addMenuOpen = !this._addMenuOpen;
+                this._floorMenuOpen = false;
               }}
             >
-              <option value="">+ furniture…</option>
-              ${FURNITURE_TYPES.map((t) => html`<option value=${t}>${FURNITURE_LABELS[t]}</option>`)}
-            </select>
-          </div>
+              + Add
+            </button>
+            ${this._addMenuOpen ? this._renderAddMenu() : nothing}
+          </span>
 
           <span class="spacer"></span>
 
           <!-- History -->
           <div class="group">
-            <button aria-label="Undo" title="Undo" ?disabled=${!this._history.length} @click=${this._undo}>
-              ↶
+            <button aria-label="Undo" title="Undo (Ctrl/Cmd+Z)" ?disabled=${!this._history.length} @click=${this._undo}>
+              <ha-icon icon="mdi:undo"></ha-icon>
             </button>
-            <button aria-label="Redo" title="Redo" ?disabled=${!this._future.length} @click=${this._redo}>
-              ↷
+            <button aria-label="Redo" title="Redo (Ctrl/Cmd+Shift+Z)" ?disabled=${!this._future.length} @click=${this._redo}>
+              <ha-icon icon="mdi:redo"></ha-icon>
             </button>
           </div>
 
           <span class="divider"></span>
 
-          <!-- Floor -->
-          <span class="floors">
+          <!-- Floor — switch + add inline; rename/delete behind the gear -->
+          <span class="floors pop-wrap">
             <label>floor</label>
             <select @change=${(e: Event) => this._switchFloor((e.target as HTMLSelectElement).value)}>
               ${floors.map(
@@ -1392,47 +1489,50 @@ export class FloorplanCardEditor extends LitElement {
                   html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>${f.name}</option>`
               )}
             </select>
-            <input
-              class="floor-name"
-              type="text"
-              title="Rename floor"
-              .value=${floor?.name ?? ""}
-              @change=${(e: Event) =>
-                this._renameFloor(this._activeFloorId, (e.target as HTMLInputElement).value)}
-            />
-            <button title="Add a floor (copies the current walls)" @click=${this._addFloor}>+ floor</button>
+            <button title="Add a floor (copies the current walls)" @click=${this._addFloor}>+</button>
             <button
-              class="danger"
-              title="Delete the current floor"
-              ?disabled=${floors.length <= 1}
-              @click=${this._deleteFloor}
-            >
-              − floor
-            </button>
-          </span>
-
-          <span class="divider"></span>
-
-          <!-- Zoom -->
-          <span class="zoom">
-            <label>zoom</label>
-            <input
-              type="range"
-              min="0.5"
-              max="3"
-              step="0.1"
-              .value=${String(this._zoom)}
-              @input=${(e: Event) => {
-                this._zoom = Number((e.target as HTMLInputElement).value);
+              aria-label="Floor settings"
+              title="Rename or delete this floor"
+              aria-haspopup="true"
+              aria-expanded=${this._floorMenuOpen}
+              @click=${() => {
+                this._floorMenuOpen = !this._floorMenuOpen;
+                this._addMenuOpen = false;
               }}
-            />
-            <span class="zoom-val">${Math.round(this._zoom * 100)}%</span>
+            >
+              <ha-icon icon="mdi:cog-outline"></ha-icon>
+            </button>
+            ${this._floorMenuOpen
+              ? html`<div class="pop">
+                  <div class="pop-row">
+                    <label>Rename</label>
+                    <input
+                      class="floor-name"
+                      type="text"
+                      .value=${floor?.name ?? ""}
+                      @change=${(e: Event) =>
+                        this._renameFloor(this._activeFloorId, (e.target as HTMLInputElement).value)}
+                    />
+                  </div>
+                  <button
+                    class="danger pop-action"
+                    ?disabled=${floors.length <= 1}
+                    @click=${() => {
+                      this._deleteFloor();
+                      this._floorMenuOpen = false;
+                    }}
+                  >
+                    <ha-icon icon="mdi:delete-outline"></ha-icon> Delete this floor
+                  </button>
+                </div>`
+              : nothing}
           </span>
         </div>
 
         ${this._renderContextBar()}
 
-        <div class="canvas-wrap">
+        <div class="canvas-outer">
+        <div class="canvas-wrap" @wheel=${this._onCanvasWheel}>
           <div class="stage" style="aspect-ratio: ${c.width} / ${c.height}; width:${this._zoom * 100}%;">
             <svg
               viewBox="0 0 ${c.width} ${c.height}"
@@ -1493,9 +1593,85 @@ export class FloorplanCardEditor extends LitElement {
             </div>
           </div>
         </div>
+        ${floorEmpty && !this._draft && !this._draftTracker
+          ? html`<div class="empty-hint">
+              <div>
+                <b>Draw your first room:</b> pick the <b>Wall</b> tool and drag on the canvas.<br />
+                Then drop doors, windows and devices onto it.
+              </div>
+            </div>`
+          : nothing}
+        <div class="zoom-overlay">
+          <button aria-label="Zoom out" title="Zoom out" @click=${() => this._setZoom(this._zoom - 0.25)}>
+            <ha-icon icon="mdi:minus"></ha-icon>
+          </button>
+          <button class="zoom-val-btn" title="Reset zoom to 100%" @click=${() => this._setZoom(1)}>
+            ${Math.round(this._zoom * 100)}%
+          </button>
+          <button aria-label="Zoom in" title="Zoom in" @click=${() => this._setZoom(this._zoom + 0.25)}>
+            <ha-icon icon="mdi:plus"></ha-icon>
+          </button>
+          <button aria-label="Fit to view" title="Fit to view" @click=${this._fitView}>
+            <ha-icon icon="mdi:fit-to-screen-outline"></ha-icon>
+          </button>
+        </div>
+        </div>
 
         ${this._renderElementEdit()}
         ${this._renderPanel()}
+      </div>
+    `;
+  }
+
+  /** The "+ Add" popover: device, text, then every furniture type as its real glyph. */
+  private _renderAddMenu(): TemplateResult {
+    const close = () => {
+      this._addMenuOpen = false;
+    };
+    return html`
+      <div class="pop left add-pop">
+        <button
+          class="add-entry"
+          @click=${() => {
+            this._addItem("generic");
+            close();
+          }}
+        >
+          <ha-icon icon="mdi:lightbulb-outline"></ha-icon> Device
+        </button>
+        <button
+          class="add-entry"
+          @click=${() => {
+            this._addText();
+            close();
+          }}
+        >
+          <ha-icon icon="mdi:format-text"></ha-icon> Text
+        </button>
+        <div class="add-furn-grid">
+          ${FURNITURE_TYPES.map((t) => {
+            const size = FURNITURE_DEFAULT_SIZE[t];
+            // Glyphs are drawn centered at the origin; pad the viewBox a bit
+            // (tv draws its stand below the box, plants overflow slightly).
+            const pad = Math.max(size.w, size.h) * 0.25 + 6;
+            const vb = `${-size.w / 2 - pad} ${-size.h / 2 - pad} ${size.w + pad * 2} ${size.h + pad * 2}`;
+            return html`
+              <button
+                class="furn-cell"
+                title=${FURNITURE_LABELS[t]}
+                @click=${() => {
+                  this._addFurniture(t);
+                  close();
+                }}
+              >
+                <svg viewBox=${vb}>
+                  ${renderFurniture({ id: "preview", type: t, x: 0, y: 0, w: size.w, h: size.h })}
+                </svg>
+                <span>${FURNITURE_LABELS[t]}</span>
+              </button>
+            `;
+          })}
+        </div>
       </div>
     `;
   }
@@ -1508,21 +1684,37 @@ export class FloorplanCardEditor extends LitElement {
    */
   private _renderElementEdit(): TemplateResult {
     const n = this._selection.length;
-    let body: TemplateResult;
-    if (n === 0) {
-      body = html`<p class="hint">Select an element on the canvas to edit its properties here.</p>`;
-    } else if (n > 1) {
-      body = html`<p class="hint">
-        <b>${n} elements selected.</b> Edit them one at a time, or use the
-        Duplicate/Delete buttons in the context bar above.
-      </p>`;
-    } else {
-      body = this._renderSelectionEditor();
+    const sel = this._primary();
+    if (n === 0 || !sel) {
+      return html`
+        <section class="edit-area">
+          <h3 class="section-title">Element</h3>
+          <p class="hint">Select an element on the canvas to edit its properties here.</p>
+        </section>
+      `;
     }
+    // Header names the selection and carries its actions, so everything about
+    // the selected element lives in one place (the context bar stays tool-only).
+    const summary = n > 1 ? `${n} elements selected` : this._selectionSummary(sel);
+    const icon = n > 1 ? "mdi:select-group" : SEL_KIND_ICON[sel.kind];
     return html`
       <section class="edit-area">
-        <h3 class="section-title">Element</h3>
-        ${body}
+        <div class="edit-head">
+          <ha-icon icon=${icon}></ha-icon>
+          <span class="edit-title">${summary}</span>
+          <span class="head-spacer"></span>
+          <button aria-label="Duplicate" title="Duplicate (Ctrl/Cmd+D)" @click=${this._duplicate}>
+            <ha-icon icon="mdi:content-duplicate"></ha-icon>
+          </button>
+          <button class="danger" aria-label="Delete" title="Delete (Del)" @click=${this._deleteSelected}>
+            <ha-icon icon="mdi:delete-outline"></ha-icon>
+          </button>
+        </div>
+        ${n > 1
+          ? html`<p class="hint">
+              Edit elements one at a time. Drag any selected element to move the whole group.
+            </p>`
+          : html`<div class="rows">${this._renderSelectionEditor()}</div>`}
       </section>
     `;
   }
@@ -1679,9 +1871,33 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   private _renderPanel(): TemplateResult {
+    // Collapsed by default — page-level settings are touched rarely, and
+    // collapsing them keeps the Element editor close to the canvas.
     return html`
       <section class="panel">
-        <h3 class="section-title">Project</h3>
+        <button
+          class="section-toggle"
+          aria-expanded=${this._projectOpen}
+          @click=${() => {
+            this._projectOpen = !this._projectOpen;
+          }}
+        >
+          <ha-icon icon=${this._projectOpen ? "mdi:chevron-down" : "mdi:chevron-right"}></ha-icon>
+          <span class="section-title-inline">Project</span>
+          ${this._projectOpen
+            ? nothing
+            : html`<span class="section-summary"
+                >${this._config.title || "Untitled"} · ${this._config.width}×${this._config.height}</span
+              >`}
+        </button>
+        ${this._projectOpen ? this._renderPanelBody() : nothing}
+      </section>
+    `;
+  }
+
+  private _renderPanelBody(): TemplateResult {
+    return html`
+      <div class="rows panel-body">
         <div class="row">
           <label>Title</label>
           <input
@@ -1712,7 +1928,7 @@ export class FloorplanCardEditor extends LitElement {
               })}
           />
         </div>
-        <div class="row">
+        <div class="row wide">
           <label>Grid size</label>
           <input
             type="number"
@@ -1741,7 +1957,7 @@ export class FloorplanCardEditor extends LitElement {
               this._patchConfig({ background: (e.target as HTMLInputElement).value || undefined })}
           />
         </div>
-        <div class="row">
+        <div class="row wide">
           <label>Bg image</label>
           <input
             type="text"
@@ -1767,7 +1983,7 @@ export class FloorplanCardEditor extends LitElement {
               />
             </div>`
           : nothing}
-      </section>
+      </div>
     `;
   }
 
@@ -1850,7 +2066,7 @@ export class FloorplanCardEditor extends LitElement {
             }}
           />
         </div>
-        <div class="row">
+        <div class="row wide">
           <label>Sensor</label>
           <ha-entity-picker
             .hass=${this.hass}
@@ -1900,7 +2116,7 @@ export class FloorplanCardEditor extends LitElement {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
       return html`
-        <div class="row">
+        <div class="row wide">
           <label>Entity</label>
           <ha-entity-picker
             .hass=${this.hass}
@@ -1912,7 +2128,7 @@ export class FloorplanCardEditor extends LitElement {
             }}
           ></ha-entity-picker>
         </div>
-        <div class="row">
+        <div class="row wide">
           <label>2nd entity</label>
           <ha-entity-picker
             .hass=${this.hass}
@@ -1924,7 +2140,7 @@ export class FloorplanCardEditor extends LitElement {
               })}
           ></ha-entity-picker>
         </div>
-        <div class="row">
+        <div class="row wide">
           <label>Icon</label>
           ${customElements.get("ha-icon-picker")
             ? html`<ha-icon-picker
@@ -2346,7 +2562,7 @@ export class FloorplanCardEditor extends LitElement {
   ): TemplateResult {
     const s = tr[axis];
     return html`
-      <div class="row">
+      <div class="row wide">
         <label>${label}</label>
         <ha-entity-picker
           .hass=${this.hass}
@@ -2397,7 +2613,7 @@ export class FloorplanCardEditor extends LitElement {
               invert
             </label>
           </div>
-          <div class="row">
+          <div class="row wide">
             <label>${label} presence</label>
             <ha-entity-picker
               .hass=${this.hass}
@@ -2670,30 +2886,161 @@ export class FloorplanCardEditor extends LitElement {
       stroke-dasharray: 6 4;
       pointer-events: none;
     }
-    .zoom {
-      display: flex;
+    /* Toolbar icons sit inline with their labels; smaller than content icons. */
+    .toolbar ha-icon {
+      --mdc-icon-size: 16px;
+    }
+    .seg button {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+    }
+    /* === Popovers (floor gear, + Add). The backdrop is a fixed transparent
+       layer below the popover that closes it on any outside click. === */
+    .pop-wrap {
+      position: relative;
+      display: inline-flex;
       align-items: center;
       gap: 4px;
     }
-    .zoom label {
+    .pop {
+      position: absolute;
+      top: calc(100% + 6px);
+      right: 0;
+      z-index: 20;
+      min-width: 220px;
+      padding: 8px;
+      background: var(--card-background-color, #fff);
+      border: 1px solid var(--divider-color, #ccc);
+      border-radius: 8px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+    }
+    .pop.left {
+      left: 0;
+      right: auto;
+    }
+    .pop-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 19;
+    }
+    .pop-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 8px;
+    }
+    .pop-row label {
+      flex: 0 0 60px;
       font-size: 12px;
       color: var(--secondary-text-color);
     }
-    .zoom input[type="range"] {
-      width: 90px;
-    }
-    .zoom-val {
-      font-size: 12px;
-      color: var(--secondary-text-color);
-      min-width: 34px;
-    }
-    .furn-add {
+    .pop-row input {
+      flex: 1;
+      min-width: 0;
+      padding: 4px 6px;
+      border-radius: 4px;
       border: 1px solid var(--divider-color, #ccc);
       background: var(--card-background-color, #fff);
       color: var(--primary-text-color);
-      border-radius: 6px;
+    }
+    .pop-action {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      width: 100%;
+      justify-content: center;
+      font-size: 13px;
+    }
+    .add-pop {
+      min-width: 300px;
+    }
+    .add-entry {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      border: none;
+      background: none;
       padding: 6px 8px;
-      cursor: pointer;
+      border-radius: 6px;
+      text-align: left;
+      font-size: 13px;
+    }
+    .add-entry:hover {
+      background: var(--secondary-background-color, #f5f5f5);
+    }
+    .add-furn-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 4px;
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid var(--divider-color, #eee);
+    }
+    .furn-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+      border: none;
+      background: none;
+      padding: 6px 2px;
+      border-radius: 6px;
+      font-size: 11px;
+      color: var(--secondary-text-color);
+      text-transform: none;
+    }
+    .furn-cell:hover {
+      background: var(--secondary-background-color, #f5f5f5);
+    }
+    .furn-cell svg {
+      position: static;
+      width: 38px;
+      height: 30px;
+      display: block;
+    }
+    /* === Canvas chrome: the zoom overlay and first-run hint live on a
+       relative wrapper OUTSIDE the scroll container so they don't scroll
+       away with the stage. === */
+    .canvas-outer {
+      position: relative;
+    }
+    .zoom-overlay {
+      position: absolute;
+      right: 26px;
+      bottom: 12px;
+      z-index: 2;
+      display: flex;
+      gap: 4px;
+    }
+    .zoom-overlay button {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px 7px;
+      font-size: 12px;
+      background: var(--card-background-color, #fff);
+    }
+    .zoom-overlay ha-icon {
+      --mdc-icon-size: 15px;
+    }
+    .zoom-val-btn {
+      min-width: 46px;
+      justify-content: center;
+    }
+    .empty-hint {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 16px;
+      font-size: 14px;
+      line-height: 1.6;
+      color: var(--secondary-text-color);
+      /* Never block the first wall being drawn straight through the hint. */
+      pointer-events: none;
     }
     .floors {
       display: flex;
@@ -2963,6 +3310,79 @@ export class FloorplanCardEditor extends LitElement {
       text-transform: uppercase;
       letter-spacing: 0.06em;
       color: var(--secondary-text-color);
+    }
+    /* Element header: kind icon + summary + the selection's actions. */
+    .edit-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+    .edit-head ha-icon {
+      --mdc-icon-size: 18px;
+      color: var(--secondary-text-color);
+    }
+    .edit-head .edit-title {
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .edit-head .head-spacer {
+      flex: 1;
+    }
+    .edit-head button {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 8px;
+    }
+    .edit-head button ha-icon {
+      --mdc-icon-size: 16px;
+      color: inherit;
+    }
+    /* Collapsible Project section header. */
+    .section-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      width: 100%;
+      border: none;
+      background: none;
+      padding: 2px 0;
+      margin: 0;
+      cursor: pointer;
+      color: var(--secondary-text-color);
+      text-align: left;
+    }
+    .section-toggle ha-icon {
+      --mdc-icon-size: 16px;
+    }
+    .section-toggle .section-title-inline {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .section-toggle .section-summary {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+      opacity: 0.8;
+      text-transform: none;
+    }
+    .panel-body {
+      margin-top: 10px;
+    }
+    /* Field rows flow into responsive columns so the below-canvas sections
+       stay short at HA-dialog width (~700px fits two columns). Rows that
+       need the full width (entity pickers, long hints) opt out via .wide. */
+    .rows {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      column-gap: 16px;
+      align-items: start;
+    }
+    .rows .row.wide,
+    .rows > .hint,
+    .rows > p {
+      grid-column: 1 / -1;
     }
     .row {
       display: flex;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -474,6 +474,36 @@ export class FloorplanCardEditor extends LitElement {
       }
       return;
     }
+    // Undo / redo — the toolbar buttons exist, but the keyboard is what
+    // everyone reaches for first. Ctrl/Cmd+Z, Shift for redo, plus Ctrl+Y.
+    if (mod && key === "z") {
+      ev.preventDefault();
+      if (ev.shiftKey) this._redo();
+      else this._undo();
+      return;
+    }
+    if (mod && key === "y") {
+      ev.preventDefault();
+      this._redo();
+      return;
+    }
+    if (ev.key === "Escape") {
+      // Cancel an in-progress draft / marquee first; otherwise clear the
+      // selection. Only swallow the key when it actually did something, so
+      // HA's dialog still closes on Escape when there's nothing to cancel.
+      if (this._draft || this._draftTracker || this._marquee) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._draft = null;
+        this._draftTracker = null;
+        this._marquee = null;
+      } else if (this._selection.length) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._clearSel();
+      }
+      return;
+    }
     if ((ev.key === "Delete" || ev.key === "Backspace") && this._selection.length) {
       ev.preventDefault();
       this._deleteSelected();
@@ -1058,6 +1088,12 @@ export class FloorplanCardEditor extends LitElement {
     this._clearSel();
   }
 
+  private _updateWall(id: string, partial: Partial<Wall>): void {
+    this._commitFloor({
+      walls: this._floor().walls.map((w) => (w.id === id ? { ...w, ...partial } : w)),
+    });
+  }
+
   private _updateOpening(id: string, partial: Partial<Opening>): void {
     this._commitFloor({
       openings: this._floor().openings.map((o) => (o.id === id ? { ...o, ...partial } : o)),
@@ -1112,14 +1148,24 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- rendering ----------------------------------------------------------
 
+  /** Cached grid templates; rebuilding hundreds of lines on every render is wasteful. */
+  private _gridCache: { key: string; lines: TemplateResult[] } | null = null;
+
   private _renderGrid(): TemplateResult[] {
-    const lines: TemplateResult[] = [];
     const { width, height } = this._config;
     const g = this.grid;
+    // This runs on every render — including every pointermove while drawing
+    // or dragging. The grid only depends on canvas size + spacing, so return
+    // the same template array until one of those changes; Lit then sees
+    // identical items and skips diffing the (potentially hundreds of) lines.
+    const key = `${width}x${height}x${g}`;
+    if (this._gridCache?.key === key) return this._gridCache.lines;
+    const lines: TemplateResult[] = [];
     for (let x = 0; x <= width; x += g)
       lines.push(svg`<line x1=${x} y1="0" x2=${x} y2=${height} class="grid" />`);
     for (let y = 0; y <= height; y += g)
       lines.push(svg`<line x1="0" y1=${y} x2=${width} y2=${y} class="grid" />`);
+    this._gridCache = { key, lines };
     return lines;
   }
 
@@ -1726,6 +1772,41 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * Shared "Angle" row (slider + number box) used by every rotatable element.
+   * Centralizes the wrap-to-0..360 math and guards the number box against a
+   * cleared field — `Number("")` is 0 but `Number("abc")`/partial input is
+   * NaN, which previously got stored and broke the element's transform.
+   */
+  private _renderAngleRow(value: number, apply: (angle: number) => void): TemplateResult {
+    const current = Math.round(value);
+    return html`
+      <div class="row">
+        <label>Angle</label>
+        <input
+          type="range"
+          min="0"
+          max="360"
+          .value=${String(value)}
+          @input=${(e: Event) => apply(Number((e.target as HTMLInputElement).value))}
+        />
+        <input
+          class="num"
+          type="number"
+          min="0"
+          max="360"
+          .value=${String(current)}
+          @change=${(e: Event) => {
+            const input = e.target as HTMLInputElement;
+            const n = Number(input.value);
+            if (input.value !== "" && Number.isFinite(n)) apply(((n % 360) + 360) % 360);
+            else input.value = String(current);
+          }}
+        />
+      </div>
+    `;
+  }
+
+  /**
    * Editor fields for the currently-selected element, rendered inline inside the
    * context bar so the user can configure the selection without scrolling away
    * from the canvas. Returns nothing when the selection isn't exactly one
@@ -1757,9 +1838,16 @@ export class FloorplanCardEditor extends LitElement {
           <label>Length</label>
           <input
             type="number"
+            min="1"
             .value=${String(o.length)}
-            @change=${(e: Event) =>
-              this._updateOpening(o.id, { length: Number((e.target as HTMLInputElement).value) })}
+            @change=${(e: Event) => {
+              const input = e.target as HTMLInputElement;
+              const n = Number(input.value);
+              // A cleared / invalid field would store 0 or NaN — an invisible
+              // opening that's impossible to click again. Keep the old length.
+              if (input.value !== "" && n >= 1) this._updateOpening(o.id, { length: n });
+              else input.value = String(o.length);
+            }}
           />
         </div>
         <div class="row">
@@ -1804,29 +1892,7 @@ export class FloorplanCardEditor extends LitElement {
                 />
               </div>`
           : nothing}
-        <div class="row">
-          <label>Angle</label>
-          <input
-            type="range"
-            min="0"
-            max="360"
-            .value=${String(o.angle)}
-            @input=${(e: Event) =>
-              this._updateOpening(o.id, { angle: Number((e.target as HTMLInputElement).value) })}
-          />
-          <input
-            class="num"
-            type="number"
-            min="0"
-            max="360"
-            step="1"
-            .value=${String(Math.round(o.angle))}
-            @change=${(e: Event) =>
-              this._updateOpening(o.id, {
-                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
-              })}
-          />
-        </div>
+        ${this._renderAngleRow(o.angle, (angle) => this._updateOpening(o.id, { angle }))}
       `;
     }
 
@@ -1911,28 +1977,7 @@ export class FloorplanCardEditor extends LitElement {
               })}
           />
         </div>
-        <div class="row">
-          <label>Angle</label>
-          <input
-            type="range"
-            min="0"
-            max="360"
-            .value=${String(it.angle ?? 0)}
-            @input=${(e: Event) =>
-              this._updateItem(it.id, { angle: Number((e.target as HTMLInputElement).value) })}
-          />
-          <input
-            class="num"
-            type="number"
-            min="0"
-            max="360"
-            .value=${String(Math.round(it.angle ?? 0))}
-            @change=${(e: Event) =>
-              this._updateItem(it.id, {
-                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
-              })}
-          />
-        </div>
+        ${this._renderAngleRow(it.angle ?? 0, (angle) => this._updateItem(it.id, { angle }))}
         <div class="row">
           <label>Display</label>
           <select
@@ -2067,28 +2112,7 @@ export class FloorplanCardEditor extends LitElement {
               this._updateText(t.id, { color: (e.target as HTMLInputElement).value || undefined })}
           />
         </div>
-        <div class="row">
-          <label>Angle</label>
-          <input
-            type="range"
-            min="0"
-            max="360"
-            .value=${String(t.angle ?? 0)}
-            @input=${(e: Event) =>
-              this._updateText(t.id, { angle: Number((e.target as HTMLInputElement).value) })}
-          />
-          <input
-            class="num"
-            type="number"
-            min="0"
-            max="360"
-            .value=${String(Math.round(t.angle ?? 0))}
-            @change=${(e: Event) =>
-              this._updateText(t.id, {
-                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
-              })}
-          />
-        </div>
+        ${this._renderAngleRow(t.angle ?? 0, (angle) => this._updateText(t.id, { angle }))}
       `;
     }
 
@@ -2127,28 +2151,7 @@ export class FloorplanCardEditor extends LitElement {
               this._updateFurniture(f.id, { h: Number((e.target as HTMLInputElement).value) || f.h })}
           />
         </div>
-        <div class="row">
-          <label>Angle</label>
-          <input
-            type="range"
-            min="0"
-            max="360"
-            .value=${String(f.angle ?? 0)}
-            @input=${(e: Event) =>
-              this._updateFurniture(f.id, { angle: Number((e.target as HTMLInputElement).value) })}
-          />
-          <input
-            class="num"
-            type="number"
-            min="0"
-            max="360"
-            .value=${String(Math.round(f.angle ?? 0))}
-            @change=${(e: Event) =>
-              this._updateFurniture(f.id, {
-                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
-              })}
-          />
-        </div>
+        ${this._renderAngleRow(f.angle ?? 0, (angle) => this._updateFurniture(f.id, { angle }))}
         <div class="row">
           <label>Color</label>
           <input
@@ -2216,28 +2219,7 @@ export class FloorplanCardEditor extends LitElement {
               this._updateTracker(tr.id, { y: Number((e.target as HTMLInputElement).value) })}
           />
         </div>
-        <div class="row">
-          <label>Angle</label>
-          <input
-            type="range"
-            min="0"
-            max="360"
-            .value=${String(tr.angle ?? 0)}
-            @input=${(e: Event) =>
-              this._updateTracker(tr.id, { angle: Number((e.target as HTMLInputElement).value) })}
-          />
-          <input
-            class="num"
-            type="number"
-            min="0"
-            max="360"
-            .value=${String(Math.round(tr.angle ?? 0))}
-            @change=${(e: Event) =>
-              this._updateTracker(tr.id, {
-                angle: ((Number((e.target as HTMLInputElement).value) % 360) + 360) % 360,
-              })}
-          />
-        </div>
+        ${this._renderAngleRow(tr.angle ?? 0, (angle) => this._updateTracker(tr.id, { angle }))}
         <div class="row">
           <label>Color</label>
           <input
@@ -2285,11 +2267,71 @@ export class FloorplanCardEditor extends LitElement {
       `;
     }
 
-    // sel.kind === "wall" (or unknown) — no inline editor today; the user can
-    // drag the wall or its endpoint handles directly on the canvas.
-    return html`<span class="ctx-hint"
-      >Drag the line to move it, or the round handles to move an endpoint.</span
-    >`;
+    if (sel.kind === "wall") {
+      const w = this._floor().walls.find((x) => x.id === sel.id);
+      if (!w) return html`${nothing}`;
+      const length = Math.round(Math.hypot(w.x2 - w.x1, w.y2 - w.y1));
+      // One coordinate input; a cleared / invalid field restores the old value.
+      const coord = (value: number, apply: (n: number) => void) => html`
+        <input
+          class="num"
+          type="number"
+          .value=${String(Math.round(value))}
+          @change=${(e: Event) => {
+            const input = e.target as HTMLInputElement;
+            const n = Number(input.value);
+            if (input.value !== "" && Number.isFinite(n)) apply(n);
+            else input.value = String(Math.round(value));
+          }}
+        />
+      `;
+      return html`
+        <div class="row">
+          <label>Start X / Y</label>
+          ${coord(w.x1, (x1) => this._updateWall(w.id, { x1 }))}
+          ${coord(w.y1, (y1) => this._updateWall(w.id, { y1 }))}
+        </div>
+        <div class="row">
+          <label>End X / Y</label>
+          ${coord(w.x2, (x2) => this._updateWall(w.id, { x2 }))}
+          ${coord(w.y2, (y2) => this._updateWall(w.id, { y2 }))}
+        </div>
+        <div class="row">
+          <label>Length</label>
+          <input
+            class="num"
+            type="number"
+            min="1"
+            .value=${String(length)}
+            @change=${(e: Event) => {
+              const input = e.target as HTMLInputElement;
+              const n = Number(input.value);
+              if (input.value === "" || !(n >= 1)) {
+                input.value = String(length);
+                return;
+              }
+              // Resize from the start point along the wall's current
+              // direction (a zero-length wall extends horizontally).
+              const dx = w.x2 - w.x1;
+              const dy = w.y2 - w.y1;
+              const cur = Math.hypot(dx, dy);
+              const ux = cur > 0 ? dx / cur : 1;
+              const uy = cur > 0 ? dy / cur : 0;
+              this._updateWall(w.id, {
+                x2: Math.round(w.x1 + ux * n),
+                y2: Math.round(w.y1 + uy * n),
+              });
+            }}
+          />
+          <span class="hint">Resizes from the start point, keeping the direction.</span>
+        </div>
+        <p class="hint">
+          Or drag the line on the canvas to move it, and the round handles to move an endpoint.
+        </p>
+      `;
+    }
+
+    return html`${nothing}`;
   }
 
   /**

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, svg, nothing, type TemplateResult } from "lit";
+import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
 import {
@@ -34,6 +34,8 @@ export class FloorplanCard extends LitElement {
   /** View-state: which floor is shown. Never persisted to config. */
   @state() private _activeFloorId?: string;
   private readonly _wallMaskId = `fp-wall-mask-${FloorplanCard._nextWallMaskId++}`;
+  /** Entity ids this plan actually displays; used to skip irrelevant hass updates. */
+  private _watchedEntities: Set<string> = new Set();
 
   public setConfig(config: FloorplanCardConfig): void {
     if (!config) throw new Error("Invalid configuration");
@@ -47,6 +49,43 @@ export class FloorplanCard extends LitElement {
       texts: config.texts ?? [],
       furniture: config.furniture ?? [],
     };
+    this._watchedEntities = this._collectWatchedEntities(this._config);
+  }
+
+  /** Every entity id whose state can change what this card draws (all floors). */
+  private _collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
+    const ids = new Set<string>();
+    for (const f of getFloors(c)) {
+      for (const o of f.openings) if (o.entity) ids.add(o.entity);
+      for (const it of f.items) {
+        if (it.entity) ids.add(it.entity);
+        if (it.secondaryEntity) ids.add(it.secondaryEntity);
+      }
+      for (const tr of f.trackers) {
+        for (const s of [tr.xSensor, tr.ySensor]) {
+          if (s?.entity) ids.add(s.entity);
+          if (s?.presence?.entity) ids.add(s.presence.entity);
+        }
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * HA pushes a fresh `hass` on every state change anywhere in the instance —
+   * for most updates nothing on this plan moved. Skip those renders entirely:
+   * HA replaces an entity's state object whenever it changes, so a reference
+   * compare per watched entity is enough to detect a relevant update.
+   */
+  protected shouldUpdate(changed: PropertyValues): boolean {
+    // Anything but a pure hass tick (config change, floor switch, first render).
+    if (!(changed.size === 1 && changed.has("hass"))) return true;
+    const prev = changed.get("hass") as HomeAssistant | undefined;
+    if (!prev || !this.hass) return true;
+    for (const id of this._watchedEntities) {
+      if (prev.states[id] !== this.hass.states[id]) return true;
+    }
+    return false;
   }
 
   public getCardSize(): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { FloorplanCard } from "./floorplan-card";
 import "./editor";
+import { version } from "../package.json";
 
 export { FloorplanCard };
 
@@ -16,4 +17,8 @@ w.customCards.push({
 });
 
 // eslint-disable-next-line no-console
-console.info("%c EASY-FLOORPLAN %c 0.4.2 ", "background:#03a9f4;color:#fff", "color:#03a9f4");
+console.info(
+  `%c EASY-FLOORPLAN %c ${version} `,
+  "background:#03a9f4;color:#fff",
+  "color:#03a9f4"
+);

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -172,10 +172,10 @@ describe("makeFloor", () => {
 });
 
 describe("getFloors", () => {
-  it("returns the floors array when present and non-empty", () => {
+  it("returns the floors when present and non-empty (normalized copies)", () => {
     const floors = [makeFloor("A"), makeFloor("B")];
     const c = { ...emptyConfig("x"), floors } as FloorplanCardConfig;
-    expect(getFloors(c)).toBe(floors);
+    expect(getFloors(c)).toStrictEqual(floors);
   });
 
   it("wraps a legacy flat config into a single implicit floor", () => {
@@ -192,6 +192,40 @@ describe("getFloors", () => {
   it("treats an empty floors array as legacy (wraps flat arrays)", () => {
     const c = { ...emptyConfig("x"), floors: [] } as FloorplanCardConfig;
     expect(getFloors(c)).toHaveLength(1);
+  });
+
+  it("backfills element arrays missing from hand-written floors", () => {
+    // A minimal hand-written multi-floor config: only walls provided. Every
+    // other element array must come back as [] so render paths can map over
+    // them without crashing.
+    const c = {
+      ...emptyConfig("x"),
+      floors: [
+        {
+          id: "f1",
+          name: "Hand-written",
+          walls: [{ id: "w1", x1: 0, y1: 0, x2: 10, y2: 0 }],
+        } as unknown,
+      ],
+    } as FloorplanCardConfig;
+    const [f] = getFloors(c);
+    expect(f.walls).toHaveLength(1);
+    expect(f.openings).toEqual([]);
+    expect(f.items).toEqual([]);
+    expect(f.texts).toEqual([]);
+    expect(f.furniture).toEqual([]);
+    expect(f.trackers).toEqual([]);
+  });
+
+  it("preserves extra floor fields (image, opacity) while backfilling", () => {
+    const c = {
+      ...emptyConfig("x"),
+      floors: [{ id: "f1", name: "F", image: "/local/plan.png", imageOpacity: 0.5 } as unknown],
+    } as FloorplanCardConfig;
+    const [f] = getFloors(c);
+    expect(f.image).toBe("/local/plan.png");
+    expect(f.imageOpacity).toBe(0.5);
+    expect(f.trackers).toEqual([]);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,12 +358,31 @@ export function makeFloor(name: string, walls: Wall[] = []): Floor {
 }
 
 /**
- * Normalize a config into a list of floors. If `floors` is present and non-empty
- * it is returned as-is; otherwise the legacy flat arrays are wrapped into a
- * single floor so old single-floor configs keep rendering unchanged.
+ * Backfill any missing element arrays on a floor. Hand-written YAML configs
+ * (and configs saved by older card versions, from before an element type
+ * existed) routinely omit arrays like `texts` or `trackers`; the render paths
+ * map over them directly, so a missing array would crash the card/editor.
+ */
+function normalizeFloor(f: Floor): Floor {
+  return {
+    ...f,
+    walls: f.walls ?? [],
+    openings: f.openings ?? [],
+    items: f.items ?? [],
+    texts: f.texts ?? [],
+    furniture: f.furniture ?? [],
+    trackers: f.trackers ?? [],
+  };
+}
+
+/**
+ * Normalize a config into a list of floors. If `floors` is present and
+ * non-empty each floor is returned with any missing element arrays
+ * backfilled; otherwise the legacy flat arrays are wrapped into a single
+ * floor so old single-floor configs keep rendering unchanged.
  */
 export function getFloors(c: FloorplanCardConfig): Floor[] {
-  if (c.floors && c.floors.length) return c.floors;
+  if (c.floors && c.floors.length) return c.floors.map(normalizeFloor);
   return [
     {
       id: "floor_main",


### PR DESCRIPTION
## Summary

Implements the approved editor UI study (current-vs-proposed wireframes reviewed in chat). Seven improvements, with the sections kept **below the canvas** per review feedback — just streamlined, not moved to a sidebar (HA's dialog is ~700px wide).

### What changed

- **Icon toolbar** — tool buttons get mdi icons + labels (`mdi:cursor-default`, `mdi:wall`, `mdi:door`, `mdi:window-closed-variant`, `mdi:crosshairs-gps`); undo/redo become icon buttons with shortcut tooltips.
- **Compact floor cluster** — dropdown + "+" stay inline; rename and delete move behind a gear popover (rare actions shouldn't cost permanent toolbar width).
- **"+ Add" popover** — replaces the three insert controls. Device, Text, and all 15 furniture types rendered as their *actual glyphs* via `renderFurniture()` in mini SVGs — pick a sofa by seeing a sofa, not by reading a native `<select>`.
- **Canvas zoom overlay** — the toolbar slider is gone; a bottom-right overlay on the canvas offers − / +, a click-to-reset percentage, and fit. Ctrl/Cmd+wheel (and trackpad pinch) zooms. Overlay + hint live on a wrapper *outside* the scroll container so they never scroll away.
- **First-run empty state** — a centered, `pointer-events: none` hint on blank floors ("pick the Wall tool and drag…"); you can draw the first wall straight through it, and it disappears once anything exists.
- **Unified Element header** — names the selection ("Sofa · 170×72", "Device · light.living_room", kind icon) and owns Duplicate/Delete. The context bar is tool-only again, so its height is fully stable across selection changes.
- **Streamlined sections** — Element/Project field rows flow into responsive columns (two at HA-dialog width; entity pickers span full width). Project is collapsed by default with a one-line summary ("Dev floorplan · 1000×600") in its header.
- **Escape** also closes an open popover before falling through to draft-cancel / clear-selection.

## Test plan

- [x] `npm run typecheck`, `npm test`, `npm run build` — all green
- [x] Harness: all five tools render icon+label; old zoom slider gone
- [x] Harness: + Add popover opens with Device/Text + 15 glyph cells; sofa glyph draws as a sofa; clicking inserts + selects; backdrop click closes
- [x] Harness: floor gear popover renames ("Ground floor") and Escape closes it
- [x] Harness: blank floor shows the hint (`pointer-events: none` confirmed); hint gone after first element
- [x] Harness: zoom + → 125%, % click → 100%, Ctrl+wheel → 110%; fit resets
- [x] Harness: Element header shows "Sofa · 170×72" + icon; Duplicate/Delete work from the header; context bar contains only the Snap control
- [x] Harness: `.rows` computes as grid; `.row.wide` spans `1 / -1`; Project collapsed by default, toggles open
- [x] Harness: keyboard regression — Ctrl+D duplicates, Ctrl+Z undoes; console error-free
- [ ] Real-HA smoke via `./deploy-dev.sh editor-ui-polish`: icons render as real mdi glyphs, popovers don't clip in the dialog, toolbar wraps ≤2 rows at dialog width

🤖 Generated with [Claude Code](https://claude.com/claude-code)