### PR TITLE
Openings: sliding doors & windows, orientation, live cover position, and HA integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,19 +163,63 @@ Drop a **door** or **window** from the toolbar and it snaps onto the nearest wal
 own a door is drawn open (the familiar swing arc) and a window closed — a static floor
 plan, just like before.
 
-Select the opening and bind a **Sensor** entity in the **Element** section below the canvas —
-a contact `binary_sensor` or a `cover` — to make the opening track its real state:
+Select the opening and bind an **Entity** in the **Element** section below the canvas — a
+contact `binary_sensor` or a `cover` (Home Assistant's domain for anything that opens: doors,
+gates, garages, blinds, shades, shutters, curtains…) — to make the opening track its real
+state. When you bind an entity the card reads its HA **`device_class`** and sets a sensible
+`type`/`motion` for you (a `window` cover → a window; a `garage` roller → a sliding door);
+adjust either afterwards. Once bound, the opening tracks state:
 
 - **Open / closed** — the opening is drawn open when the entity is `on` / `open`, closed
   otherwise. A door's leaf swings around its hinge; a window's two leaves swing outward
   from the middle. When closed the swing arc is hidden; as the opening moves, the arc
   **draws on**, tracing the path of the leaf edge — animated smoothly.
+- **Partial (position covers)** — if the bound `cover` reports a `current_position`
+  (0–100), the opening is drawn **partly open** to match — a door swings partway, a
+  slider slides partway — and it tracks the position live as the cover moves. Covers
+  without a position, and `binary_sensor`s, use the on/off open/closed behavior above.
+  `Invert` flips the percentage too.
 - **Active color** — while actively open, the leaf/sash and arc take an accent color (the
   same idea as presence ripples) so an open door is easy to spot. Defaults to the primary
   color; pick your own per opening.
 - **Invert** — flip the open/closed interpretation for sensors wired the other way.
+- **Tap to control** — tapping an opening bound to a controllable `cover` toggles it
+  (`cover.toggle`); read-only `binary_sensor`s (and position-only covers) open the entity's
+  more-info dialog instead.
 
-Openings without a sensor keep the static look.
+Openings without an entity keep the static look.
+
+> **Future enhancement — tilt.** HA covers for venetian blinds / shutters also report
+> `current_tilt_position` (0–100, the louvre angle) with its own `*_tilt` services. A
+> top-down plan can't show a swing/slide for tilt, but it could render the closed panel as
+> angled slats (or vary a hatch density) driven by the tilt position, and route taps to the
+> tilt services when only tilt is supported. Not implemented yet — tracked as a follow-up.
+
+**Orientation.** A swing door defaults to hinging at the left jamb and opening toward
+one side of the wall. Use **Hinge** (left / right) and **Opens** (this side / other side)
+in the **Element** section to face it any of the four ways — or set `flipH` / `flipV`
+directly in YAML. These are pure mirrors, so the open/closed animation follows.
+
+**Sliding doors & windows.** Set **Motion → slide** on a door or window and it travels
+*along* the wall instead of swinging — a sliding door (solid panels) or a sliding window
+(thin glass panels). Then pick a **Style**:
+
+- **single** — one panel slides aside into the wall (pocket / barn / single patio).
+- **bypass** — two panels on parallel tracks; one slides behind the other (patio-door style).
+- **biparting** — two panels meet in the middle and part, each recessing into the wall on
+  its own side.
+
+**Slide** (to left / to right) sets the direction (`flipH`; ignored for biparting, which is
+symmetric). Bind a `cover` / `binary_sensor` just like a swing opening and the panel(s) slide
+open and closed with the state (or partly, from a cover's `current_position`).
+
+```yaml
+openings:
+  # sliding window, patio-door style, driven by a cover
+  - { id: patio, type: window, motion: slide, sliderStyle: biparting, x: 640, y: 500, length: 160, angle: 0, entity: cover.patio_door }
+  # a swing door hinged on the right, opening into the other room
+  - { id: hall, type: door, x: 300, y: 100, length: 80, angle: 0, flipH: true, flipV: true }
+```
 
 <img width="540" height="304" alt="door_window_demo" src="https://github.com/user-attachments/assets/091b3c89-5202-4025-8a0f-0fe867276be2" />
 
@@ -283,7 +327,7 @@ The editor writes this config for you; manual editing is optional.
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
 | `walls`      | Wall[]   | `[]`               | Wall segments (single-floor / floor 1).      |
-| `openings`   | Opening[]| `[]`               | Doors and windows.                           |
+| `openings`   | Opening[]| `[]`               | Doors and windows (swing or sliding).        |
 | `items`      | Item[]   | `[]`               | Entity devices.                              |
 | `texts`      | Text[]   | `[]`               | Free text labels.                            |
 | `furniture`  | Furniture[]| `[]`             | Gray furniture/fixture diagrams.             |
@@ -310,16 +354,20 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 
 ### Opening (door / window)
 
-| Field         | Type                | Description                                            |
-| ------------- | ------------------- | ------------------------------------------------------ |
-| `id`          | string              | Unique id.                                             |
-| `type`        | `door` \| `window`  | Symbol drawn.                                          |
-| `x`, `y`      | number              | Center position.                                       |
-| `length`      | number              | Length along the wall.                                 |
-| `angle`       | number              | Rotation in degrees.                                   |
-| `entity`      | string              | Optional contact `binary_sensor` / `cover` driving open/closed. |
-| `invert`      | boolean             | Flip the open/closed interpretation.                   |
-| `activeColor` | string              | Leaf/arc color while actively open (default primary).  |
+| Field         | Type                        | Description                                            |
+| ------------- | --------------------------- | ------------------------------------------------------ |
+| `id`          | string                      | Unique id.                                             |
+| `type`        | `door` \| `window`          | The kind of opening.                                   |
+| `motion`      | `swing` \| `slide`          | How it moves. `swing` (default) hinged door / casement window; `slide` sliding panels. |
+| `x`, `y`      | number                      | Center position.                                       |
+| `length`      | number                      | Length along the wall.                                 |
+| `angle`       | number                      | Rotation in degrees.                                   |
+| `entity`      | string                      | Optional contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
+| `invert`      | boolean                     | Flip the open/closed interpretation.                   |
+| `activeColor` | string                      | Leaf/arc color while actively open (default primary).  |
+| `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
+| `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
+| `sliderStyle` | `single` \| `bypass` \| `biparting` | When `motion: slide`: `single` (default) one panel; `bypass` two stacking panels; `biparting` two centre-parting panels. |
 
 ### Item (device)
 

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -6,10 +6,10 @@
  *
  * Run with: `npm run serve` (opens /dev/ on the Vite dev server).
  *
- * Only two HA-provided custom elements are needed at runtime: <ha-card> and
- * <ha-icon>. The entity/icon pickers are already guarded behind
- * `customElements.get(...)` in the editor and fall back to plain inputs, so we
- * don't stub them here.
+ * A few HA-provided custom elements are stubbed below: <ha-card>, <ha-icon> and
+ * <ha-entity-picker>. The icon picker already falls back to a plain input in the
+ * editor when unregistered, but the entity picker does not, so we stub it here
+ * so Sensor / entity fields are usable outside HA.
  */
 import type { FloorplanCardConfig, Tracker, TrackerSensor } from "../src/types";
 
@@ -67,6 +67,45 @@ if (!customElements.get("ha-icon")) {
     }
   }
   customElements.define("ha-icon", HaIconStub);
+}
+
+if (!customElements.get("ha-entity-picker")) {
+  // The editor normally pulls <ha-entity-picker> in via loadCardHelpers(), which
+  // only exists inside HA. Outside HA that load no-ops and the picker renders as
+  // an empty unknown element (no way to bind a Sensor). Stub it with a plain text
+  // input that emits the same `value-changed` event the editor listens for.
+  class HaEntityPickerStub extends HTMLElement {
+    private _value = "";
+    private _input?: HTMLInputElement;
+    set value(v: string) {
+      this._value = v ?? "";
+      if (this._input) this._input.value = this._value;
+    }
+    get value(): string {
+      return this._value;
+    }
+    connectedCallback() {
+      if (this._input) return;
+      const input = document.createElement("input");
+      input.type = "text";
+      input.placeholder = "entity id (dev stub)";
+      input.value = this._value;
+      input.style.width = "100%";
+      input.addEventListener("change", () => {
+        this._value = input.value;
+        this.dispatchEvent(
+          new CustomEvent("value-changed", {
+            detail: { value: input.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      this._input = input;
+      this.appendChild(input);
+    }
+  }
+  customElements.define("ha-entity-picker", HaEntityPickerStub);
 }
 
 // ---- register the real card + editor --------------------------------------
@@ -179,6 +218,7 @@ editor.addEventListener("config-changed", (e: Event) => {
   card.setConfig(next);
   editor.setConfig(next);
   refreshTrackerEmu(next);
+  refreshOpeningEmu(next);
 });
 
 // ---- tracker emulator -------------------------------------------------------
@@ -208,6 +248,102 @@ function setHassBinary(entity: string, on: boolean) {
   const nextHass = { ...hass, states: { ...baseStates } };
   card.hass = nextHass;
   editor.hass = nextHass;
+}
+
+/**
+ * Drive an opening's bound entity so the door/window/slider animates open and
+ * closed. Uses `cover` open/closed states for cover entities and on/off for
+ * everything else (contact `binary_sensor`, `input_boolean`, …) — the card
+ * treats `on`/`open` as open either way.
+ */
+function setOpeningState(entity: string, open: boolean) {
+  const domain = entity.split(".")[0];
+  const state = domain === "cover" ? (open ? "open" : "closed") : open ? "on" : "off";
+  baseStates[entity] = { state };
+  const nextHass = { ...hass, states: { ...baseStates } };
+  card.hass = nextHass;
+  editor.hass = nextHass;
+}
+
+/** Drive a cover's `current_position` (0–100) so partial-open renders in realtime. */
+function setCoverPosition(entity: string, pos: number) {
+  baseStates[entity] = {
+    state: pos > 0 ? "open" : "closed",
+    attributes: { current_position: pos },
+  };
+  const nextHass = { ...hass, states: { ...baseStates } };
+  card.hass = nextHass;
+  editor.hass = nextHass;
+}
+
+/**
+ * Opening emulator: one open/closed toggle per entity-bound opening in the
+ * config, so the swing/slide animation can be exercised without Home Assistant.
+ * (The card only animates openings that carry a `Sensor` entity — bind one in
+ * the editor and its toggle appears here.)
+ */
+function refreshOpeningEmu(cfg: FloorplanCardConfig) {
+  const host = document.getElementById("opening-emu")!;
+  const pane = document.getElementById("opening-emu-pane")!;
+  const openings = (cfg.floors ?? []).flatMap((f) => f.openings ?? []).filter((o) => o.entity);
+  if (!openings.length) {
+    pane.style.display = "none";
+    host.replaceChildren();
+    return;
+  }
+  pane.style.display = "block";
+
+  const frag = document.createDocumentFragment();
+  const seen = new Set<string>();
+  for (const o of openings) {
+    const entity = o.entity!;
+    if (seen.has(entity)) continue; // one control per entity, even if reused
+    seen.add(entity);
+
+    const row = document.createElement("div");
+    row.className = "op-row";
+    const label = document.createElement("span");
+    label.className = "ent";
+    label.textContent = `${o.type}: ${entity}`;
+    row.appendChild(label);
+
+    if (entity.split(".")[0] === "cover") {
+      // Position-aware cover: a 0–100 slider drives partial-open in realtime.
+      const wrap = document.createElement("label");
+      wrap.className = "op-toggle";
+      const slider = document.createElement("input");
+      slider.type = "range";
+      slider.min = "0";
+      slider.max = "100";
+      const curPos = baseStates[entity]?.attributes?.current_position;
+      slider.value = String(typeof curPos === "number" ? curPos : 0);
+      const valLbl = document.createElement("span");
+      valLbl.textContent = `${slider.value}%`;
+      slider.addEventListener("input", () => {
+        setCoverPosition(entity, Number(slider.value));
+        valLbl.textContent = `${slider.value}%`;
+      });
+      wrap.append(slider, valLbl);
+      row.appendChild(wrap);
+    } else {
+      const toggleWrap = document.createElement("label");
+      toggleWrap.className = "op-toggle";
+      const chk = document.createElement("input");
+      chk.type = "checkbox";
+      const cur = baseStates[entity]?.state;
+      chk.checked = cur === "on" || cur === "open";
+      const stateLbl = document.createElement("span");
+      stateLbl.textContent = chk.checked ? "open" : "closed";
+      chk.addEventListener("change", () => {
+        setOpeningState(entity, chk.checked);
+        stateLbl.textContent = chk.checked ? "open" : "closed";
+      });
+      toggleWrap.append(chk, stateLbl);
+      row.appendChild(toggleWrap);
+    }
+    frag.appendChild(row);
+  }
+  host.replaceChildren(frag);
 }
 
 const orbitState = new Map<string, { rafId: number | null }>();
@@ -362,8 +498,10 @@ function round2(v: number): number {
   return Math.round(v * 100) / 100;
 }
 
-// Initial render — covers the case where the starter config already has trackers.
+// Initial render — covers the case where the starter config already has trackers
+// or entity-bound openings.
 refreshTrackerEmu(config);
+refreshOpeningEmu(config);
 
 // Clear the hosts before mounting so re-running this module (HMR, etc.) can
 // never stack a second editor/card on top of the first — duplicate mounts make

--- a/dev/index.html
+++ b/dev/index.html
@@ -45,7 +45,11 @@
         color: #607d8b;
         margin: 0 0 8px;
       }
-      #editor-host, #card-host, #tracker-emu { background: #fff; border-radius: 8px; }
+      #editor-host, #card-host, #tracker-emu, #opening-emu { background: #fff; border-radius: 8px; }
+      #opening-emu { padding: 8px 12px; display: flex; flex-direction: column; gap: 6px; }
+      #opening-emu .op-row { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
+      #opening-emu .op-row .ent { color: #607d8b; font-family: ui-monospace, monospace; font-size: 12px; }
+      #opening-emu label.op-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: #455a64; }
       #card-host { padding: 12px; }
       #tracker-emu {
         padding: 12px;
@@ -89,6 +93,10 @@
     <div class="pane" id="card-pane">
       <h2>Live card preview</h2>
       <div id="card-host"></div>
+    </div>
+    <div class="pane" id="opening-emu-pane" style="max-width:720px;display:none;">
+      <h2>Opening emulator (dev only)</h2>
+      <div id="opening-emu"></div>
     </div>
     <div class="pane" id="tracker-emu-pane" style="max-width:720px;display:none;">
       <h2>Tracker emulator (dev only)</h2>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -40,6 +40,9 @@ import {
   renderOpening,
   renderWallMask,
   openingDefaultOpen,
+  openingMotion,
+  sliderStyleOf,
+  openingFromDeviceClass,
   renderRipple,
   renderFurniture,
   renderTracker,
@@ -1752,6 +1755,10 @@ export class FloorplanCardEditor extends LitElement {
         ${renderOpening(o, {
           color: selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
           open: openingDefaultOpen(o),
+          // Draw sliding openings partly open in the editor so the slide
+          // direction and panel style are visible — a closed slider looks
+          // symmetric, which would make the Slide / Style controls appear inert.
+          amount: openingMotion(o) === "slide" ? 0.55 : undefined,
         })}
       </g>`;
   }
@@ -2051,6 +2058,24 @@ export class FloorplanCardEditor extends LitElement {
           </select>
         </div>
         <div class="row">
+          <label>Motion</label>
+          <select
+            .value=${openingMotion(o)}
+            @change=${(e: Event) => {
+              const motion = (e.target as HTMLSelectElement).value as "swing" | "slide";
+              // sliderStyle only applies while sliding — drop it when switching
+              // back to swing so the config stays clean.
+              this._updateOpening(o.id, {
+                motion: motion === "slide" ? "slide" : undefined,
+                ...(motion === "swing" ? { sliderStyle: undefined } : {}),
+              });
+            }}
+          >
+            <option value="swing">swing</option>
+            <option value="slide">slide</option>
+          </select>
+        </div>
+        <div class="row">
           <label>Length</label>
           <input
             type="number"
@@ -2066,15 +2091,91 @@ export class FloorplanCardEditor extends LitElement {
             }}
           />
         </div>
+        ${o.type === "door" && openingMotion(o) === "swing"
+          ? html`
+              <div class="row">
+                <label>Hinge</label>
+                <select
+                  .value=${o.flipH ? "right" : "left"}
+                  @change=${(e: Event) =>
+                    this._updateOpening(o.id, {
+                      flipH: (e.target as HTMLSelectElement).value === "right" || undefined,
+                    })}
+                >
+                  <option value="left">left</option>
+                  <option value="right">right</option>
+                </select>
+              </div>`
+          : nothing}
+        ${openingMotion(o) === "swing"
+          ? html`
+              <div class="row">
+                <label>Opens</label>
+                <select
+                  .value=${o.flipV ? "other" : "this"}
+                  @change=${(e: Event) =>
+                    this._updateOpening(o.id, {
+                      flipV: (e.target as HTMLSelectElement).value === "other" || undefined,
+                    })}
+                >
+                  <option value="this">this side</option>
+                  <option value="other">other side</option>
+                </select>
+              </div>`
+          : nothing}
+        ${openingMotion(o) === "slide"
+          ? html`
+              ${sliderStyleOf(o) !== "biparting"
+                ? html`
+                    <div class="row">
+                      <label>Slide</label>
+                      <select
+                        .value=${o.flipH ? "right" : "left"}
+                        @change=${(e: Event) =>
+                          this._updateOpening(o.id, {
+                            flipH: (e.target as HTMLSelectElement).value === "right" || undefined,
+                          })}
+                      >
+                        <option value="left">to left</option>
+                        <option value="right">to right</option>
+                      </select>
+                    </div>`
+                : nothing}
+              <div class="row">
+                <label>Style</label>
+                <select
+                  .value=${sliderStyleOf(o)}
+                  @change=${(e: Event) => {
+                    const v = (e.target as HTMLSelectElement).value;
+                    this._updateOpening(o.id, {
+                      sliderStyle: v === "single" ? undefined : (v as "bypass" | "biparting"),
+                    });
+                  }}
+                >
+                  <option value="single">single</option>
+                  <option value="bypass">bypass (stack)</option>
+                  <option value="biparting">biparting (split)</option>
+                </select>
+              </div>`
+          : nothing}
         <div class="row wide">
-          <label>Sensor</label>
+          <label>Entity</label>
           <ha-entity-picker
             .hass=${this.hass}
             .value=${o.entity ?? ""}
             .includeDomains=${["binary_sensor", "cover"]}
             allow-custom-entity
-            @value-changed=${(e: CustomEvent) =>
-              this._updateOpening(o.id, { entity: (e.detail.value as string) || undefined })}
+            @value-changed=${(e: CustomEvent) => {
+              const entity = (e.detail.value as string) || undefined;
+              // Infer type/motion from the entity's HA device_class (e.g. a
+              // `cover` with device_class `window` → a window; a `garage`
+              // roller → a sliding door). Only when the class is known, so we
+              // never clobber a hand-set type with a guess.
+              const dc = entity
+                ? (this.hass?.states[entity]?.attributes?.device_class as string | undefined)
+                : undefined;
+              this._updateOpening(o.id, { entity, ...(dc ? openingFromDeviceClass(dc) : {}) });
+            }}
           ></ha-entity-picker>
         </div>
         ${o.entity

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -14,7 +14,8 @@ import {
   WALL_THICKNESS,
   renderOpening,
   renderWallMask,
-  openingDefaultOpen,
+  resolveOpeningAmount,
+  openingClickAction,
   renderRipple,
   renderFurniture,
   renderTracker,
@@ -106,14 +107,10 @@ export class FloorplanCard extends LitElement {
     return st === "on" || st === "open" || st === "home" || st === "playing";
   }
 
-  /** Whether an opening should be drawn open, from its entity state (or the default). */
-  private _openingIsOpen(o: Opening): boolean {
-    if (!o.entity) return openingDefaultOpen(o);
-    const st = this.hass?.states[o.entity]?.state;
-    if (st === undefined) return openingDefaultOpen(o);
-    // A contact sensor / cover is "open" when on/open; everything else is closed.
-    const open = st === "on" || st === "open";
-    return o.invert ? !open : open;
+  /** How far open an opening should be drawn (0..1), from its entity (or default). */
+  private _openingAmount(o: Opening): number {
+    const state = o.entity ? this.hass?.states[o.entity] : undefined;
+    return resolveOpeningAmount(o, state);
   }
 
   /** Formatted "state unit" for a single entity, or "—" when unavailable. */
@@ -152,6 +149,27 @@ export class FloorplanCard extends LitElement {
       this.dispatchEvent(
         new CustomEvent("hass-more-info", {
           detail: { entityId: item.entity },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  }
+
+  /**
+   * Tapping an entity-bound opening: toggle a controllable `cover`, otherwise
+   * open the entity's more-info dialog (read-only `binary_sensor`s and
+   * position-only covers). See {@link openingClickAction}.
+   */
+  private _onOpeningClick(o: Opening): void {
+    if (!this.hass || !o.entity) return;
+    const features = (this.hass.states[o.entity]?.attributes?.supported_features as number) ?? 0;
+    if (openingClickAction(o.entity, features) === "cover-toggle") {
+      this.hass.callService("cover", "toggle", { entity_id: o.entity });
+    } else {
+      this.dispatchEvent(
+        new CustomEvent("hass-more-info", {
+          detail: { entityId: o.entity },
           bubbles: true,
           composed: true,
         })
@@ -251,13 +269,26 @@ export class FloorplanCard extends LitElement {
               )}
             </g>
             ${active.openings.map((o) => {
-              const isOpen = this._openingIsOpen(o);
-              return renderOpening(o, {
+              const amount = this._openingAmount(o);
+              const symbol = renderOpening(o, {
                 color: "var(--primary-text-color)",
-                open: isOpen,
-                active: !!o.entity && isOpen,
+                open: amount > 0,
+                amount,
+                active: !!o.entity && amount > 0,
                 accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
               });
+              if (!o.entity) return symbol;
+              // Entity-bound openings are tappable — a transparent rect over the
+              // opening's wall gap gives a reliable hit target beyond the thin
+              // leaf/panel strokes.
+              const half = o.length / 2;
+              const cutH = WALL_THICKNESS + 4;
+              return svg`<g class="fp-opening" @click=${() => this._onOpeningClick(o)}>
+                  ${symbol}
+                  <rect class="fp-opening-hit" x=${o.x - half} y=${o.y - cutH / 2}
+                        width=${o.length} height=${cutH}
+                        transform="rotate(${o.angle} ${o.x} ${o.y})" />
+                </g>`;
             })}
             ${(active.trackers ?? []).map((tr) =>
               renderTracker(tr, {
@@ -367,6 +398,20 @@ export class FloorplanCard extends LitElement {
     }
     .fp-door-arc {
       transition: stroke-dashoffset 0.5s ease, stroke 0.5s ease;
+    }
+    .fp-opening {
+      cursor: pointer;
+    }
+    .fp-opening-hit {
+      fill: transparent;
+      pointer-events: all;
+    }
+    .fp-slide-panel {
+      transform-box: fill-box;
+      transition: transform 0.5s ease;
+    }
+    .fp-slide-panel rect {
+      transition: fill 0.5s ease;
     }
     .items {
       position: absolute;

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { renderOpening } from "./render";
+import type { OpeningStyle } from "./render";
+import type { Opening } from "./types";
+
+/**
+ * Serialize a Lit SVGTemplateResult (and its nested templates/arrays) back into
+ * markup so we can assert on the structural invariants of renderOpening — the
+ * scale wrapper, swing angle, slider panels and partial-open transforms — which
+ * are otherwise only exercised in a browser.
+ */
+function serialize(node: unknown): string {
+  if (node == null || node === false) return "";
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+    const { strings, values } = node as { strings: string[]; values: unknown[] };
+    let out = strings[0];
+    for (let i = 0; i < values.length; i++) out += serialize(values[i]) + strings[i + 1];
+    return out;
+  }
+  return String(node);
+}
+
+const base = { id: "x", x: 100, y: 60, length: 90, angle: 0 } as const;
+const svgOf = (o: Partial<Opening>, style: Partial<OpeningStyle> = {}) =>
+  serialize(renderOpening({ ...base, ...o } as Opening, { color: "#000", ...style }));
+
+describe("renderOpening — orientation mirror", () => {
+  it("wraps the body in an identity scale by default (unchanged output)", () => {
+    expect(svgOf({ type: "door" })).toContain("scale(1 1)");
+  });
+  it("mirrors via flipH / flipV", () => {
+    expect(svgOf({ type: "door", flipH: true })).toContain("scale(-1 1)");
+    expect(svgOf({ type: "door", flipV: true })).toContain("scale(1 -1)");
+    expect(svgOf({ type: "door", flipH: true, flipV: true })).toContain("scale(-1 -1)");
+  });
+});
+
+describe("renderOpening — swing door", () => {
+  it("swings the leaf fully open / closed with the binary open flag", () => {
+    expect(svgOf({ type: "door" }, { open: true })).toContain("rotate(-90deg)");
+    expect(svgOf({ type: "door" }, { open: false })).toContain("rotate(0deg)");
+  });
+  it("swings partway for a fractional amount and clamps out-of-range", () => {
+    expect(svgOf({ type: "door" }, { amount: 0.5 })).toContain("rotate(-45deg)");
+    expect(svgOf({ type: "door" }, { amount: 2 })).toContain("rotate(-90deg)"); // clamp high
+    expect(svgOf({ type: "door" }, { amount: -1 })).toContain("rotate(0deg)"); // clamp low
+  });
+});
+
+const sliding = (extra: Partial<Opening> = {}) =>
+  ({ type: "door", motion: "slide", ...extra }) as Partial<Opening>;
+
+describe("renderOpening — sliding door", () => {
+  it("draws a single panel that slides the full length when open", () => {
+    const closed = svgOf(sliding(), { open: false });
+    const open = svgOf(sliding(), { open: true });
+    expect(closed).toContain("fp-slide-panel");
+    expect(closed).toContain("translateX(0px)");
+    expect(open).toContain("translateX(90px)"); // length 90
+  });
+  it("slides partway for a fractional amount", () => {
+    expect(svgOf(sliding(), { amount: 0.5 })).toContain("translateX(45px)");
+  });
+  it("draws two panels for a bypass slider that stack to one side", () => {
+    const bypass = svgOf(sliding({ sliderStyle: "bypass" }), { open: true });
+    // two half-width (45) panels + moving panel stacks by -half when open
+    expect(bypass.match(/width=45/g)?.length).toBe(2);
+    expect(bypass).toContain("translateX(-45px)");
+  });
+  it("parts two panels in opposite directions for a biparting slider", () => {
+    const closed = svgOf(sliding({ sliderStyle: "biparting" }), { open: false });
+    const open = svgOf(sliding({ sliderStyle: "biparting" }), { open: true });
+    expect(closed.match(/width=45/g)?.length).toBe(2);
+    expect(closed).toContain("translateX(0px)"); // meet in the middle when closed
+    // one panel recesses left, the other right, by half (45) each when open
+    expect(open).toContain("translateX(-45px)");
+    expect(open).toContain("translateX(45px)");
+  });
+  it("draws solid door panels (thickness 2.5)", () => {
+    expect(svgOf(sliding(), { open: false })).toContain("height=2.5");
+  });
+});
+
+describe("renderOpening — sliding window", () => {
+  it("slides like a slider but with thin glass panels (thickness 1.5)", () => {
+    const win = svgOf({ type: "window", motion: "slide" }, { open: true });
+    expect(win).toContain("fp-slide-panel");
+    expect(win).toContain("translateX(90px)"); // same slide as a single-panel door
+    expect(win).toContain("height=1.5"); // thinner glass panel
+    expect(win).not.toContain("height=2.5"); // not a solid door panel
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -156,6 +156,15 @@ describe("resolveOpeningOpen", () => {
     expect(resolveOpeningOpen({ ...door, invert: true }, "off")).toBe(true);
   });
 
+  it("fails closed on a sensor outage, even when inverted", () => {
+    // A stale "open" during unavailable/unknown is worse than showing closed —
+    // invert must not flip an outage into "open".
+    expect(resolveOpeningOpen(door, "unavailable")).toBe(false);
+    expect(resolveOpeningOpen(door, "unknown")).toBe(false);
+    expect(resolveOpeningOpen({ ...door, invert: true }, "unavailable")).toBe(false);
+    expect(resolveOpeningOpen({ ...door, invert: true }, "unknown")).toBe(false);
+  });
+
   it("falls back to the type default when no entity or unknown state", () => {
     expect(resolveOpeningOpen({ type: "door" } as Opening, undefined)).toBe(true);
     expect(resolveOpeningOpen({ type: "window" } as Opening, undefined)).toBe(false);
@@ -194,6 +203,21 @@ describe("resolveOpeningAmount", () => {
   it("uses the type default when there is no entity/state", () => {
     expect(resolveOpeningAmount({ type: "door" } as Opening, undefined)).toBe(1);
     expect(resolveOpeningAmount({ type: "door", motion: "slide" } as Opening, undefined)).toBe(0);
+  });
+
+  it("fails closed (0) on a sensor outage, ignoring any stale position", () => {
+    // A cover that goes unavailable can leave a stale current_position; it must
+    // not keep rendering open (and invert must not flip an outage into open).
+    expect(
+      resolveOpeningAmount(door, { state: "unavailable", attributes: { current_position: 100 } }),
+    ).toBe(0);
+    expect(resolveOpeningAmount(door, { state: "unknown" })).toBe(0);
+    expect(
+      resolveOpeningAmount({ ...door, invert: true }, {
+        state: "unavailable",
+        attributes: { current_position: 0 },
+      }),
+    ).toBe(0);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from "vitest";
 import {
   snapToWall,
   openingDefaultOpen,
+  openingMotion,
+  openingMirror,
+  sliderStyleOf,
+  openingFromDeviceClass,
+  openingClickAction,
+  resolveOpeningOpen,
+  resolveOpeningAmount,
   kindFromEntity,
   defaultIcon,
   trackerSensorReading,
@@ -51,9 +58,142 @@ describe("snapToWall", () => {
 });
 
 describe("openingDefaultOpen", () => {
-  it("draws doors open and windows closed by default", () => {
+  it("draws only swing doors open by default; windows and sliding openings closed", () => {
     expect(openingDefaultOpen({ type: "door" } as Opening)).toBe(true);
     expect(openingDefaultOpen({ type: "window" } as Opening)).toBe(false);
+    expect(openingDefaultOpen({ type: "door", motion: "slide" } as Opening)).toBe(false);
+    expect(openingDefaultOpen({ type: "window", motion: "slide" } as Opening)).toBe(false);
+  });
+});
+
+describe("openingMotion", () => {
+  it("defaults to swing and reads the motion field", () => {
+    expect(openingMotion({ type: "door" } as Opening)).toBe("swing");
+    expect(openingMotion({ type: "door", motion: "slide" } as Opening)).toBe("slide");
+    expect(openingMotion({ type: "window", motion: "slide" } as Opening)).toBe("slide");
+  });
+});
+
+describe("openingMirror", () => {
+  it("defaults to no mirror", () => {
+    expect(openingMirror({ type: "door" } as Opening)).toEqual({ sx: 1, sy: 1 });
+  });
+  it("flipH mirrors x, flipV mirrors y, both mirror both", () => {
+    expect(openingMirror({ type: "door", flipH: true } as Opening)).toEqual({ sx: -1, sy: 1 });
+    expect(openingMirror({ type: "door", flipV: true } as Opening)).toEqual({ sx: 1, sy: -1 });
+    expect(openingMirror({ type: "door", flipH: true, flipV: true } as Opening)).toEqual({
+      sx: -1,
+      sy: -1,
+    });
+  });
+});
+
+describe("sliderStyleOf", () => {
+  it("reflects the configured style only when the opening is sliding", () => {
+    expect(sliderStyleOf({ type: "door", motion: "slide" } as Opening)).toBe("single");
+    expect(sliderStyleOf({ type: "door", motion: "slide", sliderStyle: "bypass" } as Opening)).toBe(
+      "bypass",
+    );
+    expect(
+      sliderStyleOf({ type: "window", motion: "slide", sliderStyle: "biparting" } as Opening),
+    ).toBe("biparting");
+  });
+  it("is single for swinging openings regardless of sliderStyle", () => {
+    expect(sliderStyleOf({ type: "door", sliderStyle: "bypass" } as Opening)).toBe("single");
+  });
+});
+
+describe("openingFromDeviceClass", () => {
+  it("maps window-like cover device classes to a window", () => {
+    expect(openingFromDeviceClass("window")).toEqual({ type: "window", motion: undefined });
+    expect(openingFromDeviceClass("blind")).toEqual({ type: "window", motion: "slide" });
+    expect(openingFromDeviceClass("shade")).toEqual({ type: "window", motion: "slide" });
+    expect(openingFromDeviceClass("curtain")).toEqual({ type: "window", motion: "slide" });
+  });
+  it("maps door-like device classes to a door, sliding for rollers", () => {
+    expect(openingFromDeviceClass("door")).toEqual({ type: "door", motion: undefined });
+    expect(openingFromDeviceClass("garage")).toEqual({ type: "door", motion: "slide" });
+    expect(openingFromDeviceClass("gate")).toEqual({ type: "door", motion: undefined });
+  });
+  it("defaults unknown / missing device classes to a swing door", () => {
+    expect(openingFromDeviceClass(undefined)).toEqual({ type: "door", motion: undefined });
+    expect(openingFromDeviceClass("opening")).toEqual({ type: "door", motion: undefined });
+  });
+});
+
+describe("openingClickAction", () => {
+  it("toggles a cover that supports open/close", () => {
+    expect(openingClickAction("cover.blind", 3)).toBe("cover-toggle"); // OPEN|CLOSE
+    expect(openingClickAction("cover.garage", 11)).toBe("cover-toggle"); // OPEN|CLOSE|STOP
+  });
+  it("opens more-info for read-only or position-only entities", () => {
+    expect(openingClickAction("cover.blind", 4)).toBe("more-info"); // SET_POSITION only
+    expect(openingClickAction("cover.blind", 0)).toBe("more-info");
+    expect(openingClickAction("binary_sensor.door", 0)).toBe("more-info");
+  });
+});
+
+describe("resolveOpeningOpen", () => {
+  const door = { type: "door", entity: "binary_sensor.x" } as Opening;
+  const slider = { type: "door", motion: "slide", entity: "cover.x" } as Opening;
+
+  it("maps on/open to open and everything else to closed", () => {
+    expect(resolveOpeningOpen(door, "on")).toBe(true);
+    expect(resolveOpeningOpen(door, "open")).toBe(true);
+    expect(resolveOpeningOpen(door, "off")).toBe(false);
+    expect(resolveOpeningOpen(door, "closed")).toBe(false);
+  });
+
+  it("treats a moving cover (opening/closing) as open", () => {
+    expect(resolveOpeningOpen(door, "opening")).toBe(true);
+    expect(resolveOpeningOpen(door, "closing")).toBe(true);
+    // unavailable/unknown are not open
+    expect(resolveOpeningOpen(door, "unavailable")).toBe(false);
+  });
+
+  it("invert flips the interpretation", () => {
+    expect(resolveOpeningOpen({ ...door, invert: true }, "on")).toBe(false);
+    expect(resolveOpeningOpen({ ...door, invert: true }, "off")).toBe(true);
+  });
+
+  it("falls back to the type default when no entity or unknown state", () => {
+    expect(resolveOpeningOpen({ type: "door" } as Opening, undefined)).toBe(true);
+    expect(resolveOpeningOpen({ type: "window" } as Opening, undefined)).toBe(false);
+    expect(resolveOpeningOpen({ type: "door", motion: "slide" } as Opening, undefined)).toBe(false);
+    // entity bound but state not yet available → default
+    expect(resolveOpeningOpen(slider, undefined)).toBe(false);
+  });
+
+  it("a slider bound to a cover resolves like a door", () => {
+    expect(resolveOpeningOpen(slider, "open")).toBe(true);
+    expect(resolveOpeningOpen(slider, "closed")).toBe(false);
+  });
+});
+
+describe("resolveOpeningAmount", () => {
+  const door = { type: "door", entity: "cover.x" } as Opening;
+  const atPos = (pos: number) => ({ state: "open", attributes: { current_position: pos } });
+
+  it("uses current_position/100 for position covers", () => {
+    expect(resolveOpeningAmount(door, atPos(0))).toBe(0);
+    expect(resolveOpeningAmount(door, atPos(50))).toBe(0.5);
+    expect(resolveOpeningAmount(door, atPos(100))).toBe(1);
+  });
+
+  it("clamps out-of-range positions and applies invert", () => {
+    expect(resolveOpeningAmount(door, atPos(150))).toBe(1);
+    expect(resolveOpeningAmount(door, atPos(-10))).toBe(0);
+    expect(resolveOpeningAmount({ ...door, invert: true }, atPos(30))).toBeCloseTo(0.7);
+  });
+
+  it("falls back to a binary 0/1 when there is no position attribute", () => {
+    expect(resolveOpeningAmount(door, { state: "open" })).toBe(1);
+    expect(resolveOpeningAmount(door, { state: "closed" })).toBe(0);
+  });
+
+  it("uses the type default when there is no entity/state", () => {
+    expect(resolveOpeningAmount({ type: "door" } as Opening, undefined)).toBe(1);
+    expect(resolveOpeningAmount({ type: "door", motion: "slide" } as Opening, undefined)).toBe(0);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -126,18 +126,30 @@ export function openingClickAction(
 }
 
 /**
+ * A sensor-outage state — we have no reliable reading, so callers must fail
+ * **closed** and, crucially, never let `invert` flip an outage into "open"
+ * (matches {@link trackerPresenceDetected}).
+ */
+function isSensorOutage(state: string | undefined): boolean {
+  return state === "unavailable" || state === "unknown";
+}
+
+/**
  * Resolve whether an opening should be drawn open, from the raw state string of
  * its bound entity (or `undefined` when it has no entity / no state yet). A
  * contact `binary_sensor` or `cover` reads open on `on`/`open`; `invert` flips
- * that. With no entity or an unavailable state we fall back to the type default
- * (see {@link openingDefaultOpen}). Shared by doors, windows and sliders — a
- * slider bound to a `cover` resolves exactly like a swing door.
+ * that. With no entity / no state yet we fall back to the type default (see
+ * {@link openingDefaultOpen}); an `unavailable`/`unknown` outage fails closed
+ * regardless of `invert`. Shared by doors, windows and sliders — a slider bound
+ * to a `cover` resolves exactly like a swing door.
  */
 export function resolveOpeningOpen(o: Opening, state: string | undefined): boolean {
   if (!o.entity || state === undefined) return openingDefaultOpen(o);
+  // Fail closed on an outage before applying invert — a stale "open" during a
+  // sensor dropout is worse than showing closed.
+  if (isSensorOutage(state)) return false;
   // `opening`/`closing` are transient cover states: the cover is in motion and
-  // not fully closed, so draw it open. Anything else (closed/off/unavailable/…)
-  // reads closed.
+  // not fully closed, so draw it open. Anything else (closed/off/…) reads closed.
   const open =
     state === "on" || state === "open" || state === "opening" || state === "closing";
   return o.invert ? !open : open;
@@ -149,13 +161,17 @@ export function resolveOpeningOpen(o: Opening, state: string | undefined): boole
  * numeric `current_position` (0–100) that maps linearly to the fraction (with
  * `invert` flipping it); otherwise it collapses to the binary
  * {@link resolveOpeningOpen} (0 or 1). With no entity/state it uses the type
- * default.
+ * default; an `unavailable`/`unknown` outage fails closed (0), ignoring any
+ * stale position.
  */
 export function resolveOpeningAmount(
   o: Opening,
   state: { state: string; attributes?: Record<string, unknown> } | undefined,
 ): number {
   if (!o.entity || !state) return openingDefaultOpen(o) ? 1 : 0;
+  // Fail closed on an outage before reading position — a cover that dropped out
+  // can leave a stale current_position that would otherwise render it open.
+  if (isSensorOutage(state.state)) return 0;
   const pos = state.attributes?.current_position;
   if (typeof pos === "number" && Number.isFinite(pos)) {
     const frac = Math.max(0, Math.min(1, pos / 100));

--- a/src/render.ts
+++ b/src/render.ts
@@ -41,12 +41,127 @@ export function kindFromEntity(entity: string): ItemKind {
 }
 
 /**
- * Default open/closed state for an opening with no associated entity: doors are
- * drawn open (the familiar swing symbol), windows closed (intact glass). This
- * preserves the look of a static floor plan.
+ * How an opening moves — `swing` (hinged door / casement window) or `slide`
+ * (panels travelling along the wall). Defaults to `swing`.
+ */
+export function openingMotion(o: Opening): "swing" | "slide" {
+  return o.motion ?? "swing";
+}
+
+/**
+ * Default open/closed state for an opening with no associated entity: only a
+ * swing door is drawn open (the familiar swing symbol); windows and sliding
+ * openings are drawn closed (intact glass / panels filling the gap). This
+ * preserves the look of a static floor plan — a slider drawn open would read as
+ * a hole rather than a door.
  */
 export function openingDefaultOpen(o: Opening): boolean {
-  return o.type === "door";
+  return o.type === "door" && openingMotion(o) === "swing";
+}
+
+/**
+ * Scale factors that mirror an opening within its own local frame: `flipH`
+ * reflects across the wall's length (hinge jamb / slide direction), `flipV`
+ * across the wall line (which room the door opens into). Applied as a single
+ * `scale(sx sy)` wrapper so the base symbol is drawn once and reused for all
+ * four orientations.
+ */
+export function openingMirror(o: Opening): { sx: 1 | -1; sy: 1 | -1 } {
+  return { sx: o.flipH ? -1 : 1, sy: o.flipV ? -1 : 1 };
+}
+
+/**
+ * Resolve a sliding opening's panel arrangement. Only meaningful while sliding
+ * (swinging openings always resolve to `single`), defaulting to `single`.
+ */
+export function sliderStyleOf(o: Opening): "single" | "bypass" | "biparting" {
+  return openingMotion(o) === "slide" ? (o.sliderStyle ?? "single") : "single";
+}
+
+/** HA `cover` / `binary_sensor` device classes that read as a window (glass). */
+const WINDOW_DEVICE_CLASSES = new Set(["window", "blind", "shade", "shutter", "curtain", "awning"]);
+/** Device classes that roll / slide rather than swing. */
+const SLIDING_DEVICE_CLASSES = new Set([
+  "garage",
+  "garage_door",
+  "blind",
+  "shade",
+  "shutter",
+  "curtain",
+]);
+
+/**
+ * Default opening `type` and `motion` inferred from a bound entity's HA
+ * `device_class` (mirrors how HA itself picks icons/behaviour from it). Window-
+ * like classes render as a window; rolling/sliding classes default to `slide`.
+ * Unknown / missing classes fall back to a swing door. `motion: undefined`
+ * means swing (the default).
+ */
+export function openingFromDeviceClass(deviceClass: string | undefined): {
+  type: Opening["type"];
+  motion: "slide" | undefined;
+} {
+  return {
+    type: WINDOW_DEVICE_CLASSES.has(deviceClass ?? "") ? "window" : "door",
+    motion: SLIDING_DEVICE_CLASSES.has(deviceClass ?? "") ? "slide" : undefined,
+  };
+}
+
+/** Cover feature bits: OPEN = 1, CLOSE = 2 (a cover with either can be toggled). */
+const COVER_OPEN_CLOSE = 0b11;
+
+/**
+ * What tapping an entity-bound opening should do: `cover-toggle` for a `cover`
+ * that supports open/close, otherwise `more-info` (read-only `binary_sensor`s
+ * and position-only covers open the entity dialog instead of a blind toggle).
+ */
+export function openingClickAction(
+  entityId: string,
+  supportedFeatures: number,
+): "cover-toggle" | "more-info" {
+  const domain = entityId.split(".")[0];
+  return domain === "cover" && (supportedFeatures & COVER_OPEN_CLOSE) !== 0
+    ? "cover-toggle"
+    : "more-info";
+}
+
+/**
+ * Resolve whether an opening should be drawn open, from the raw state string of
+ * its bound entity (or `undefined` when it has no entity / no state yet). A
+ * contact `binary_sensor` or `cover` reads open on `on`/`open`; `invert` flips
+ * that. With no entity or an unavailable state we fall back to the type default
+ * (see {@link openingDefaultOpen}). Shared by doors, windows and sliders — a
+ * slider bound to a `cover` resolves exactly like a swing door.
+ */
+export function resolveOpeningOpen(o: Opening, state: string | undefined): boolean {
+  if (!o.entity || state === undefined) return openingDefaultOpen(o);
+  // `opening`/`closing` are transient cover states: the cover is in motion and
+  // not fully closed, so draw it open. Anything else (closed/off/unavailable/…)
+  // reads closed.
+  const open =
+    state === "on" || state === "open" || state === "opening" || state === "closing";
+  return o.invert ? !open : open;
+}
+
+/**
+ * How far open an opening should be drawn, as a fraction 0..1, driving partial
+ * swing / slide for position-aware `cover` entities. When the entity exposes a
+ * numeric `current_position` (0–100) that maps linearly to the fraction (with
+ * `invert` flipping it); otherwise it collapses to the binary
+ * {@link resolveOpeningOpen} (0 or 1). With no entity/state it uses the type
+ * default.
+ */
+export function resolveOpeningAmount(
+  o: Opening,
+  state: { state: string; attributes?: Record<string, unknown> } | undefined,
+): number {
+  if (!o.entity || !state) return openingDefaultOpen(o) ? 1 : 0;
+  const pos = state.attributes?.current_position;
+  if (typeof pos === "number" && Number.isFinite(pos)) {
+    const frac = Math.max(0, Math.min(1, pos / 100));
+    return o.invert ? 1 - frac : frac;
+  }
+  return resolveOpeningOpen(o, state.state) ? 1 : 0;
 }
 
 /** Style options for {@link renderOpening}. */
@@ -55,6 +170,12 @@ export interface OpeningStyle {
   color: string;
   /** Whether the opening is drawn open (default `true`). */
   open?: boolean;
+  /**
+   * How far open, 0..1, for partial rendering from a position-aware `cover`.
+   * When omitted it falls back to the binary `open` (1 when open, else 0), so
+   * existing callers are unaffected. See {@link resolveOpeningAmount}.
+   */
+  amount?: number;
   /** Entity-driven "actively open" state: tints the moving parts with `accent`. */
   active?: boolean;
   /** Accent color used while `active` (default the HA primary color). */
@@ -74,9 +195,12 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   const cutH = WALL_THICKNESS + 4;
   // The moving parts take the accent color when actively open (sensor-driven).
   const tone = active ? accent : color;
+  // Fraction open (0..1) drives partial swing/slide. Defaults to the binary
+  // `open` so callers that don't pass `amount` render exactly as before.
+  const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
 
   let body: SVGTemplateResult;
-  if (o.type === "window") {
+  if (o.type === "window" && openingMotion(o) === "swing") {
     // Two casement leaves hinged at each jamb. Closed, they meet in the middle
     // along the wall; open, they swing outward (up) like double doors, each
     // tracing a quarter-circle arc (radius = half) that draws on as it opens.
@@ -90,27 +214,85 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <!-- swing arcs, drawn from the middle outward -->
         <path class="fp-door-arc" d="M 0 0 A ${half} ${half} 0 0 0 ${-half} ${-half}"
               fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${open ? 0 : arcLen};" />
+              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
         <path class="fp-door-arc" d="M 0 0 A ${half} ${half} 0 0 1 ${half} ${-half}"
               fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${open ? 0 : arcLen};" />
+              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
         <!-- left leaf, hinged at left jamb -->
         <g transform="translate(${-half} 0)">
-          <g class="fp-door-leaf" style="transform:rotate(${open ? -90 : 0}deg);">
+          <g class="fp-door-leaf" style="transform:rotate(${-90 * amt}deg);">
             <rect x="0" y="-1.25" width=${half} height="2.5" style="fill:${tone};" />
           </g>
         </g>
         <!-- right leaf, hinged at right jamb -->
         <g transform="translate(${half} 0)">
-          <g class="fp-leaf-r" style="transform:rotate(${open ? 90 : 0}deg);">
+          <g class="fp-leaf-r" style="transform:rotate(${90 * amt}deg);">
             <rect x=${-half} y="-1.25" width=${half} height="2.5" style="fill:${tone};" />
           </g>
         </g>
       `;
+  } else if (openingMotion(o) === "slide") {
+    // A sliding door / window: panel(s) sit in the opening and travel *along* the
+    // wall. Closed, they fill the gap; open, they slide aside (single), stack
+    // (bypass) or part (biparting). No swing arc. A sliding *window*'s panels are
+    // drawn as a thin glass line so it reads as glass rather than a solid door.
+    const t = o.type === "window" ? 1.5 : 2.5; // glass vs solid panel
+    const jambs = svg`
+        <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />`;
+    const sliderStyle = sliderStyleOf(o);
+    if (sliderStyle === "bypass") {
+      // Double bypass: two half-width panels on parallel tracks. The moving
+      // (back) panel slides left to stack behind the fixed (front) panel.
+      const off = 1.75; // half the gap between the two tracks
+      const shift = -half * amt;
+      body = svg`
+        ${jambs}
+        <!-- tracks -->
+        <line x1=${-half} y1=${-off} x2=${half} y2=${-off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <line x1=${-half} y1=${off} x2=${half} y2=${off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <!-- fixed panel: left half, front track -->
+        <rect x=${-half} y=${off - t / 2} width=${half} height=${t} style="fill:${tone};" />
+        <!-- moving panel: right half, back track -->
+        <g class="fp-slide-panel" style="transform:translateX(${shift}px);">
+          <rect x="0" y=${-off - t / 2} width=${half} height=${t} style="fill:${tone};" />
+        </g>`;
+    } else if (sliderStyle === "biparting") {
+      // Biparting: two half-width panels meet at the centre and part, each
+      // recessing into the wall on its own side (left panel → left, right → right).
+      const shift = half * amt;
+      body = svg`
+        ${jambs}
+        <!-- track -->
+        <line x1=${-half} y1="0" x2=${half} y2="0"
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <g class="fp-slide-panel" style="transform:translateX(${-shift}px);">
+          <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+        </g>
+        <g class="fp-slide-panel" style="transform:translateX(${shift}px);">
+          <rect x="0" y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+        </g>`;
+    } else {
+      // Single panel: fills the opening closed, slides fully aside when open.
+      const shift = o.length * amt;
+      body = svg`
+        ${jambs}
+        <!-- track -->
+        <line x1=${-half} y1="0" x2=${half} y2="0"
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <g class="fp-slide-panel" style="transform:translateX(${shift}px);">
+          <rect x=${-half} y=${-t / 2} width=${o.length} height=${t} style="fill:${tone};" />
+        </g>`;
+    }
   } else {
     // Door leaf hinged at the left jamb: lies along the wall when closed,
-    // swings up (−90°) when open. The leaf is drawn closed and rotated via CSS.
-    const angle = open ? -90 : 0;
+    // swings up (−90° when fully open) by `amt`. The leaf is drawn closed and
+    // rotated via CSS.
+    const angle = -90 * amt;
     // Swing arc revealed via stroke-dashoffset so it "draws on" as the door opens.
     // Path runs from the closed-leaf tip toward the open-leaf tip, so it traces
     // the door edge. arcLen is the quarter-circle length (radius = o.length).
@@ -120,7 +302,7 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <path class="fp-door-arc"
               d="M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}"
               fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${open ? 0 : arcLen};" />
+              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
         <!-- door leaf, hinged at left jamb -->
         <g transform="translate(${-half} 0)">
           <g class="fp-door-leaf" style="transform:rotate(${angle}deg);">
@@ -129,7 +311,13 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         </g>
       `;
   }
-  return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">${body}</g>`;
+  // Orientation mirrors are applied as a single scale wrapper inside the
+  // place-into-position transform, so the base symbol (drawn once, centered at
+  // the origin) reflects into any of the four hinge/swing orientations.
+  const { sx, sy } = openingMirror(o);
+  return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">
+      <g transform="scale(${sx} ${sy})">${body}</g>
+    </g>`;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,14 @@ export type OpeningType = "door" | "window";
  */
 export interface Opening {
   id: string;
+  /** The kind of opening: a `door` (single leaf) or a `window` (two leaves / glass). */
   type: OpeningType;
+  /**
+   * How the opening moves. `swing` (default) is a hinged door / casement window;
+   * `slide` is a sliding door / sliding window whose panel(s) travel along the
+   * wall (see {@link sliderStyle}).
+   */
+  motion?: "swing" | "slide";
   x: number;
   y: number;
   /** Length along the wall, in virtual units. */
@@ -36,6 +43,27 @@ export interface Opening {
   invert?: boolean;
   /** Color of the leaf/sash and swing arc while actively open. Falls back to the primary color. */
   activeColor?: string;
+  /**
+   * Mirror the symbol left↔right in the opening's local frame. For a swing door
+   * this moves the hinge to the other jamb; for a slider it reverses the slide
+   * direction. Absent = the default orientation (hinge/anchor at the left jamb).
+   */
+  flipH?: boolean;
+  /**
+   * Mirror the symbol across the wall line, so the door opens into the room on
+   * the other side. Absent = the default (swings toward the −y / "near" side).
+   */
+  flipV?: boolean;
+  /**
+   * Sliding openings only (`motion: "slide"`): how the panels are arranged.
+   * - `single` (default) — one panel slides aside into the wall.
+   * - `bypass` — two panels on parallel tracks; one slides behind the other
+   *   (patio-door style).
+   * - `biparting` — two panels meet in the middle and part, each recessing into
+   *   the wall on its own side.
+   * Ignored for swinging openings.
+   */
+  sliderStyle?: "single" | "bypass" | "biparting";
 }
 
 export type ItemKind = "light" | "switch" | "sensor" | "binary_sensor" | "climate" | "cover" | "generic";


### PR DESCRIPTION
### 🤖 Disclosure
This contribution was written by an AI agent (Claude Code) working under my direction. I've reviewed the code, and **tested it on a real Home Assistant instance** by installing the fork as a HACS custom repository and driving it with live entities (a `cover` garage roller door, `cover` blind with position, and door/window contact `binary_sensor`s). Sharing it in case it's useful — happy to adjust anything to fit the project's direction, or to close it if it's not a fit.

---

### Summary

Extends openings (doors/windows) from a fixed swing symbol into a richer, Home-Assistant-aware model — **all via optional fields, so every existing config renders unchanged** (no migration):

- **Motion** — `motion: swing | slide`. Swing is today's hinged door / casement window; slide adds sliding **doors *and* windows** whose panels travel along the wall.
- **Sliding styles** — `sliderStyle: single | bypass | biparting` (one panel; two stacking panels; two centre-parting panels that recess into the wall on each side).
- **Orientation** — `flipH` / `flipV` mirror a swing door's hinge jamb and which room it opens into (the four standard door-swing orientations); `flipH` also sets a slider's direction.
- **Live cover position (%)** — if the bound `cover` reports `current_position`, the opening is drawn **partly open** to match and tracks it in real time (a door swings partway, a slider slides partway).
- **HA integration** — binding an entity infers `type`/`motion` from its **`device_class`**, and tapping a cover-backed opening controls it via the **`cover.toggle`** service.

### Behaviour & design notes

- **Orthogonal `type` × `motion` model.** `type` stays `door | window`; `motion` (default `swing`) is a separate axis, so a sliding window is just `window + slide` and composes with the styles/flips. The existing `door`/`window` values are unchanged.
- **Additive & backward-compatible.** Every new field is optional and defaults to current behaviour — a plain `{ type: door }` renders identically (the only added markup is a no-op `scale(1 1)` wrapper). No migration.
- **Reuses the existing art.** Orientation is one `scale(±1, ±1)` wrapper (a no-op when unflipped) and swing/slide a `0..1` fraction defaulting to the binary open state — so the current swing/casement drawing is reused unchanged and `current_position` support is a generalisation, not a special case.
- **HA-native.** Position, states, `device_class` inference and `cover` control follow HA's own conventions (details below). Sliding windows draw thin glass panels vs a door's solid panel, so the two stay distinct even when both slide.

### Home Assistant integration

- **`current_position`** — mapped exactly as HA defines it (`0` = closed → `100` = open); covers without a position, and `binary_sensor`s, use on/off open/closed. `invert` flips either.
- **State handling** — `on`/`open`/`opening`/`closing` read as open; `unavailable`/`unknown` fail safe to closed.
- **`device_class` inference** — on binding an entity, window-like classes (`window`, `blind`, `shade`, `shutter`, `curtain`, `awning`) → a window; rolling/sliding classes (`garage`, `garage_door`, `blind`, `shade`, `shutter`, `curtain`) → `slide`; else a swing door. Applied only at bind time and only when the entity has a known `device_class`, so you can bind first, then hand-adjust `type`/`motion` and it sticks. (In the same spirit as HA deriving icons/behaviour from `device_class`.)
- **Tap to control** — an opening bound to a controllable `cover` toggles via `cover.toggle`, gated on `supported_features`; read-only `binary_sensor`s and position-only covers open the entity's more-info dialog instead.
- **Future — tilt.** HA covers for venetian blinds/shutters also report `current_tilt_position`; a plan can't show a swing/slide for tilt, but could render angled slats / hatch density from it. Noted in the README as a follow-up, not implemented here.

### New config fields (`Opening`)

| Field | Values | Notes |
|---|---|---|
| `motion` | `swing` \| `slide` | Default `swing`. |
| `sliderStyle` | `single` \| `bypass` \| `biparting` | Only when `motion: slide`. |
| `flipH` | boolean | Swing door: hinge jamb. Sliding: slide direction. |
| `flipV` | boolean | Mirror which room a swing opening faces. |

```yaml
openings:
  # sliding window driven by a cover's position (biparting = two centre-parting panels)
  - { id: patio, type: window, motion: slide, sliderStyle: biparting, x: 640, y: 500, length: 160, angle: 0, entity: cover.patio_door }
  # swing door hinged on the right, opening into the other room
  - { id: hall, type: door, x: 300, y: 100, length: 80, angle: 0, flipH: true, flipV: true }
```

### Testing

- **Unit tests** — 70 pass (`npm test`). Adds pure-helper tests (orientation, motion, slider style, cover-position resolution, device_class inference, tap routing) plus `renderOpening` markup regression tests (incl. asserting the unflipped door reduces to a no-op `scale(1 1)` wrapper). `npm run typecheck` and `npm run build` are clean.
- **Dev harness** — extends `dev/` with an opening/cover emulator (open-closed toggle or 0–100 position slider per entity-bound opening) and an `<ha-entity-picker>` stub, so the entity-driven behaviour can be exercised without HA.
- **Real Home Assistant** — installed via HACS custom repo and verified against live entities: `device_class` auto-selection, tap-to-toggle a `cover`, and live partial-open from a position-reporting cover.

### Commits

Split into logical, reviewable commits: model + render engine → live-card integration → editor controls → dev harness → docs.

### Notes for the maintainer

- No new runtime dependencies; minimal bundle-size impact.
- CI (`typecheck` + `test` + `build` + HACS validation) passes locally; no changes to the workflow.

Closes https://github.com/nicosandller/easy-floorplan/issues/21
