### PR TITLE
Render entity state at Home Assistant's configured display precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ By default it shows an icon badge:
 - **Tap to act** — lights, switches, covers, fans and `input_boolean`s toggle on tap;
   any other entity opens its more-info dialog.
 - **Live look** — the badge highlights when the entity is "on". Turn on **Show state**
-  to display the current value next to it. Add a **2nd entity** to show two readings in
-  one element — e.g. a temperature and a humidity sensor render together as `21 °C · 45 %`.
+  to display the current value next to it, formatted exactly as Home Assistant would —
+  including the entity's configured display precision. Add a **2nd entity** to show two
+  readings in one element — e.g. a temperature and a humidity sensor render together as
+  `21.5 °C · 45%`.
 - **Follows "show as"** — the icon and state label respect the entity's
   **device class** (HA's *show as* setting): a `binary_sensor` shown as a Lock renders
   `mdi:lock` / `mdi:lock-open` and reads "Locked" / "Unlocked", a door contact gets

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -112,17 +112,69 @@ if (!customElements.get("ha-entity-picker")) {
 import "../src/index";
 
 // ---- a minimal mock hass ---------------------------------------------------
+// The two sensors below carry full-precision states (two decimals) while their
+// registry entries ask for one, mirroring a typical MQTT device. Keep it that
+// way: a mock that pre-rounds, or a `formatEntityState` that returns the raw
+// state, hides display bugs here that users would hit in HA.
+const SENSOR_TEMPERATURE = "sensor.living_area_temperature";
+const SENSOR_HUMIDITY = "sensor.living_area_humidity";
+
+/** Stand-in for HA's entity registry — the only place display precision lives. */
+const entityRegistry: Record<string, { entity_id: string; display_precision?: number }> = {
+  [SENSOR_TEMPERATURE]: { entity_id: SENSOR_TEMPERATURE, display_precision: 1 },
+  [SENSOR_HUMIDITY]: { entity_id: SENSOR_HUMIDITY, display_precision: 1 },
+};
+
+/** Approximates HA's own formatter: registry precision, then HA's unit spacing. */
+function mockFormatEntityState(s: {
+  entity_id?: string;
+  state: string;
+  attributes?: Record<string, unknown>;
+}): string {
+  if (s.state === "unavailable") return "Unavailable";
+  if (s.state === "unknown") return "Unknown";
+  // "Show as" wording (issue #29): a lock device_class reads Locked/Unlocked
+  // instead of the raw on/off, like HA's localized formatter does.
+  if (s.attributes?.device_class === "lock") return s.state === "on" ? "Unlocked" : "Locked";
+  const precision = s.entity_id ? entityRegistry[s.entity_id]?.display_precision : undefined;
+  const num = Number(s.state);
+  const body = precision != null && Number.isFinite(num) ? num.toFixed(precision) : s.state;
+  const unit = s.attributes?.unit_of_measurement as string | undefined;
+  if (!unit) return body;
+  return unit === "%" || unit === "°" ? `${body}${unit}` : `${body} ${unit}`;
+}
+
 const hass = {
   states: {
-    "binary_sensor.front_door": { state: "off", attributes: { friendly_name: "Front Door" } },
-    "light.living_room": { state: "on", attributes: { friendly_name: "Living Room" } },
+    "binary_sensor.front_door": {
+      entity_id: "binary_sensor.front_door",
+      state: "off",
+      attributes: { friendly_name: "Front Door" },
+    },
+    "light.living_room": {
+      entity_id: "light.living_room",
+      state: "on",
+      attributes: { friendly_name: "Living Room" },
+    },
     // "Show as" demo (issue #29): a binary_sensor with device_class lock should
     // render mdi:lock / mdi:lock-open instead of the generic kind icon.
     "binary_sensor.door_lock": {
+      entity_id: "binary_sensor.door_lock",
       state: "off",
       attributes: { friendly_name: "Door Lock", device_class: "lock" },
     },
+    [SENSOR_TEMPERATURE]: {
+      entity_id: SENSOR_TEMPERATURE,
+      state: "17.94",
+      attributes: { friendly_name: "Living Area Temperature", unit_of_measurement: "°C" },
+    },
+    [SENSOR_HUMIDITY]: {
+      entity_id: SENSOR_HUMIDITY,
+      state: "49.31",
+      attributes: { friendly_name: "Living Area Humidity", unit_of_measurement: "%" },
+    },
   },
+  entities: entityRegistry,
   locale: { language: "en" },
   themes: { darkMode: false },
   // HA floor registry mock so the editor's "HA floor" link (issue #24) is
@@ -133,13 +185,7 @@ const hass = {
     basement: { floor_id: "basement", name: "Basement", level: -1 },
   },
   callService: (...args: unknown[]) => console.log("[mock hass] callService", ...args),
-  // Crude stand-in for HA's localizing formatter so the "show as" state text
-  // (issue #29) is demonstrable in the harness: lock device_class reads
-  // Locked/Unlocked instead of the raw on/off.
-  formatEntityState: (s: { state: string; attributes?: Record<string, unknown> }) => {
-    if (s?.attributes?.device_class === "lock") return s.state === "on" ? "Unlocked" : "Locked";
-    return s.state;
-  },
+  formatEntityState: mockFormatEntityState,
   localize: (k: string) => k,
 } as unknown;
 
@@ -181,7 +227,18 @@ const demoFloor = {
     { id: "o1", type: "window" as const, x: 500, y: 100, length: 140, angle: 0 },
     { id: "o2", type: "door" as const, x: 500, y: 500, length: 90, angle: 0 },
   ],
-  items: [],
+  // A temperature reading paired with humidity — both stored at two decimals but
+  // configured to display one, so the badge should read "17.9 °C · 49.3%".
+  items: [
+    {
+      id: "i1",
+      entity: SENSOR_TEMPERATURE,
+      secondaryEntity: SENSOR_HUMIDITY,
+      x: 500,
+      y: 300,
+      kind: "sensor" as const,
+    },
+  ],
   texts: [],
   furniture: [],
   trackers: [],

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -23,6 +23,8 @@ import {
   trackerSensorReading,
   defaultIcon,
   entityDefaultIcon,
+  itemStateText,
+  hassRenderInputsChanged,
 } from "./render";
 import type { Opening } from "./types";
 
@@ -76,19 +78,14 @@ export class FloorplanCard extends LitElement {
 
   /**
    * HA pushes a fresh `hass` on every state change anywhere in the instance —
-   * for most updates nothing on this plan moved. Skip those renders entirely:
-   * HA replaces an entity's state object whenever it changes, so a reference
-   * compare per watched entity is enough to detect a relevant update.
+   * for most updates nothing on this plan moved. Skip those renders entirely.
    */
   protected shouldUpdate(changed: PropertyValues): boolean {
     // Anything but a pure hass tick (config change, floor switch, first render).
     if (!(changed.size === 1 && changed.has("hass"))) return true;
     const prev = changed.get("hass") as HomeAssistant | undefined;
     if (!prev || !this.hass) return true;
-    for (const id of this._watchedEntities) {
-      if (prev.states[id] !== this.hass.states[id]) return true;
-    }
-    return false;
+    return hassRenderInputsChanged(prev, this.hass, this._watchedEntities);
   }
 
   public getCardSize(): number {
@@ -119,34 +116,6 @@ export class FloorplanCard extends LitElement {
   private _openingActive(o: Opening): boolean {
     const state = o.entity ? this.hass?.states[o.entity] : undefined;
     return openingIsActive(o, state);
-  }
-
-  /** Formatted "state unit" for a single entity, or "—" when unavailable. */
-  private _entityStateText(entityId?: string): string {
-    if (!entityId) return "—";
-    const stateObj = this.hass?.states[entityId];
-    if (!stateObj) return "—";
-    // Prefer HA's own formatter: it localizes and respects the entity's
-    // device_class ("show as"), so a binary_sensor shown as a Lock reads
-    // "Unlocked" instead of the raw "on" (issue #29).
-    const format = (this.hass as unknown as { formatEntityState?: (s: unknown) => string })
-      ?.formatEntityState;
-    if (format) {
-      try {
-        return format(stateObj);
-      } catch {
-        /* fall through to the raw state below */
-      }
-    }
-    const unit = stateObj.attributes?.unit_of_measurement;
-    return unit ? `${stateObj.state} ${unit}` : stateObj.state;
-  }
-
-  /** State text for the item: primary entity, plus secondary (e.g. humidity) when set. */
-  private _stateText(item: FloorItem): string {
-    const primary = this._entityStateText(item.entity);
-    if (!item.secondaryEntity) return primary;
-    return `${primary} · ${this._entityStateText(item.secondaryEntity)}`;
   }
 
   private _itemIcon(item: FloorItem): string {
@@ -250,7 +219,7 @@ export class FloorplanCard extends LitElement {
         @click=${() => this._onItemClick(item)}
       >
         ${visual}
-        ${showState ? html`<span class="label">${this._stateText(item)}</span>` : nothing}
+        ${showState ? html`<span class="label">${itemStateText(this.hass, item)}</span>` : nothing}
       </div>
     `;
   }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -15,8 +15,11 @@ import {
   trackerSensorReading,
   openingInMotion,
   openingIsActive,
+  entityStateText,
+  itemStateText,
+  hassRenderInputsChanged,
 } from "./render";
-import type { Opening } from "./types";
+import type { Opening, RenderHass } from "./types";
 
 describe("snapToWall", () => {
   const hWall = { x1: 0, y1: 0, x2: 100, y2: 0 }; // horizontal
@@ -355,5 +358,128 @@ describe("resolveOpeningAmount keeps trusting a live position", () => {
     // would jump 0 -> 1 -> 0.07 on covers that stream position every second.
     expect(resolveOpeningAmount(cover, { state: "opening", attributes: { current_position: 0 } })).toBe(0);
     expect(resolveOpeningAmount(cover, { state: "opening", attributes: { current_position: 7 } })).toBeCloseTo(0.07);
+  });
+});
+
+// Stand-in for the real `hass`: `formatEntityState` rounds to the entity's
+// configured precision and applies HA's unit spacing, and states are seeded raw
+// — so a card that renders `stateObj.state` directly cannot pass these tests.
+function fakeHass(
+  entities: { entity_id: string; state: string; unit?: string }[],
+  displayPrecision: Record<string, number> = {},
+): RenderHass {
+  const states: Record<string, { entity_id: string; state: string; attributes: object }> = {};
+  for (const e of entities) {
+    states[e.entity_id] = {
+      entity_id: e.entity_id,
+      state: e.state,
+      attributes: e.unit ? { unit_of_measurement: e.unit } : {},
+    };
+  }
+  const formatEntityState = (stateObj: { entity_id: string; state: string; attributes: any }) => {
+    const raw = stateObj.state;
+    if (raw === "unavailable") return "Unavailable";
+    if (raw === "unknown") return "Unknown";
+    const dp = displayPrecision[stateObj.entity_id];
+    const num = Number(raw);
+    const body = dp != null && Number.isFinite(num) ? num.toFixed(dp) : raw;
+    const unit: string | undefined = stateObj.attributes.unit_of_measurement;
+    if (!unit) return body;
+    return unit === "%" || unit === "°" ? `${body}${unit}` : `${body} ${unit}`;
+  };
+  return { states, formatEntityState } as unknown as RenderHass;
+}
+
+// Real sensors: raw two-decimal states, both configured to display one.
+const TEMP = "sensor.living_area_sensor_temperature";
+const HUMIDITY = "sensor.living_area_sensor_humidity";
+const livingArea = () =>
+  fakeHass(
+    [
+      { entity_id: TEMP, state: "17.94", unit: "°C" },
+      { entity_id: HUMIDITY, state: "49.31", unit: "%" },
+    ],
+    { [TEMP]: 1, [HUMIDITY]: 1 },
+  );
+
+describe("entityStateText", () => {
+  it("renders a sensor at the precision HA is configured to display", () => {
+    expect(entityStateText(livingArea(), TEMP)).toBe("17.9 °C");
+  });
+
+  it("lets HA decide the spacing between value and unit", () => {
+    expect(entityStateText(livingArea(), HUMIDITY)).toBe("49.3%");
+  });
+
+  it("renders an unavailable entity the way HA does, with no unit appended", () => {
+    const hass = fakeHass([{ entity_id: TEMP, state: "unavailable", unit: "°C" }], { [TEMP]: 1 });
+    expect(entityStateText(hass, TEMP)).toBe("Unavailable");
+  });
+
+  it("leaves a state HA has no precision for untouched", () => {
+    const hass = fakeHass([{ entity_id: "sensor.raw", state: "17.94", unit: "°C" }]);
+    expect(entityStateText(hass, "sensor.raw")).toBe("17.94 °C");
+  });
+
+  it("shows an em dash when the entity is absent, unset, or hass has not arrived", () => {
+    expect(entityStateText(livingArea(), "sensor.missing")).toBe("—");
+    expect(entityStateText(livingArea(), undefined)).toBe("—");
+    expect(entityStateText(undefined, TEMP)).toBe("—");
+  });
+});
+
+describe("itemStateText", () => {
+  it("renders the primary entity alone when no secondary is paired", () => {
+    expect(itemStateText(livingArea(), { entity: TEMP })).toBe("17.9 °C");
+  });
+
+  it("pairs a temperature entity with its humidity entity", () => {
+    expect(itemStateText(livingArea(), { entity: TEMP, secondaryEntity: HUMIDITY })).toBe(
+      "17.9 °C · 49.3%",
+    );
+  });
+
+  it("still renders the primary when the secondary entity is missing", () => {
+    expect(itemStateText(livingArea(), { entity: TEMP, secondaryEntity: "sensor.gone" })).toBe(
+      "17.9 °C · —",
+    );
+  });
+});
+
+describe("hassRenderInputsChanged", () => {
+  const watched = [TEMP];
+  const tempState = { entity_id: TEMP, state: "17.94" };
+  // HA starts with a placeholder that echoes the raw state, then swaps in the real one.
+  const rawFormatter = (s: { state: string }) => s.state;
+  const preciseFormatter = () => "17.9 °C";
+  const base = () =>
+    ({ states: { [TEMP]: tempState }, formatEntityState: preciseFormatter }) as any;
+
+  it("ignores a tick where nothing this plan draws has moved", () => {
+    const next = { ...base(), states: { [TEMP]: tempState, "light.elsewhere": { state: "on" } } };
+    expect(hassRenderInputsChanged(base(), next, watched)).toBe(false);
+  });
+
+  it("notices a watched entity's new state object", () => {
+    const next = { ...base(), states: { [TEMP]: { entity_id: TEMP, state: "18.02" } } };
+    expect(hassRenderInputsChanged(base(), next, watched)).toBe(true);
+  });
+
+  it("notices HA swapping its startup formatter for the real one", () => {
+    // Until this lands the card shows raw states, and no state object moves with it.
+    const prev = { ...base(), formatEntityState: rawFormatter };
+    expect(hassRenderInputsChanged(prev, base(), watched)).toBe(true);
+  });
+
+  it("notices HA rebuilding the formatter after a precision or locale edit", () => {
+    // HA rebuilds it asynchronously as a new function, so its identity — not
+    // `entities` or `locale` — is what signals that a reading's text changed.
+    const next = { ...base(), formatEntityState: () => "17.94 °C" };
+    expect(hassRenderInputsChanged(base(), next, watched)).toBe(true);
+  });
+
+  it("ignores entities the plan does not watch", () => {
+    const next = { ...base(), states: { [TEMP]: tempState, [HUMIDITY]: { state: "50.0" } } };
+    expect(hassRenderInputsChanged(base(), next, watched)).toBe(false);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,59 @@
 import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
-import type { Opening, ItemKind, Furniture, Tracker } from "./types";
+import type { Opening, ItemKind, Furniture, Tracker, RenderHass } from "./types";
 import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, trackerAxisFraction } from "./types";
 
 export const WALL_THICKNESS = 8;
+
+/** Shown in place of a reading when an entity is unset or absent from `hass`. */
+const NO_STATE = "—";
+
+/**
+ * An entity's state as HA itself would render it, or "—" when there is none.
+ *
+ * A state carries the sensor's full precision; the decimals to display live in
+ * the entity registry, as do the locale's number format, the blank before a
+ * unit, and the wording of `unavailable`. Only HA can resolve all of that.
+ */
+export function entityStateText(
+  hass: RenderHass | undefined,
+  entityId: string | undefined,
+): string {
+  if (!entityId || !hass) return NO_STATE;
+  const stateObj = hass.states[entityId];
+  if (!stateObj) return NO_STATE;
+  return hass.formatEntityState(stateObj);
+}
+
+/**
+ * Whether a fresh `hass` can change anything this plan draws.
+ *
+ * Readings are worded by `hass.formatEntityState`, which HA rebuilds — as a new
+ * function, on a later tick — whenever the registry, locale, translations or
+ * config change. Its identity is the signal that arrives *with* the new
+ * wording; watching the registry instead would render while the formatter is
+ * still the old one, then skip the update that carries the new one.
+ */
+export function hassRenderInputsChanged(
+  prev: RenderHass,
+  next: RenderHass,
+  watchedEntities: Iterable<string>,
+): boolean {
+  if (prev.formatEntityState !== next.formatEntityState) return true;
+  for (const id of watchedEntities) {
+    if (prev.states[id] !== next.states[id]) return true;
+  }
+  return false;
+}
+
+/** State text for an item: primary entity, plus secondary (e.g. humidity) when set. */
+export function itemStateText(
+  hass: RenderHass | undefined,
+  item: { entity: string; secondaryEntity?: string },
+): string {
+  const primary = entityStateText(hass, item.entity);
+  if (!item.secondaryEntity) return primary;
+  return `${primary} · ${entityStateText(hass, item.secondaryEntity)}`;
+}
 
 /** Default mdi icon per item kind, used when neither config nor entity supplies one. */
 export function defaultIcon(kind: ItemKind): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,33 @@
-import type { HomeAssistant, LovelaceCardConfig } from "custom-card-helpers";
+import type { HomeAssistant as BaseHomeAssistant, LovelaceCardConfig } from "custom-card-helpers";
 
-export type { HomeAssistant };
+/**
+ * A single entity's state object. Reached by indexed access off the base `hass`
+ * so we don't take a direct dependency on `home-assistant-js-websocket`, which
+ * is only a transitive dep via `custom-card-helpers`.
+ */
+export type HassEntity = BaseHomeAssistant["states"][string];
+
+/**
+ * `custom-card-helpers` 1.9 predates `formatEntityState`, which real HA has
+ * carried since 2023.9 and which this card relies on. Declare it rather than
+ * casting at every use.
+ */
+export interface HomeAssistant extends BaseHomeAssistant {
+  /**
+   * HA's own state formatter. It applies the entity registry's display
+   * precision, the locale's number format, the blank before a unit and the
+   * wording of `unavailable` — none of which live on the state object. HA
+   * hands out a placeholder that echoes the raw state until translations and
+   * the registry load, then replaces the function whenever an input changes.
+   */
+  formatEntityState(stateObj: HassEntity, state?: string): string;
+}
+
+/** The slice of `hass` the card draws from. */
+export interface RenderHass {
+  states: Record<string, HassEntity | undefined>;
+  formatEntityState(stateObj: HassEntity): string;
+}
 
 /** A straight wall segment in virtual coordinate space. */
 export interface Wall {


### PR DESCRIPTION
## The bug

The card built its state label by pasting the unit onto the raw state:

```ts
const unit = stateObj.attributes?.unit_of_measurement;
return unit ? `${stateObj.state} ${unit}` : stateObj.state;
```

An entity's `state` always carries the sensor's **full** precision. The decimals to *display* live in the entity registry, never on the state object — so this can never respect a user's precision setting.

Reproduced against a live HA with a Zigbee2MQTT climate sensor:

| Entity | Raw `state` | Registry | HA dashboard | This card (before) |
|---|---|---|---|---|
| `sensor.living_area_sensor_temperature` | `"17.94"` | `suggested_display_precision: 1` | `17.9 °C` | `17.94 °C` |
| `sensor.living_area_sensor_humidity` | `"49.31"` | `display_precision: 1` | `49.3%` | `49.31 %` |

Worth noting those are two *different* registry fields — a user override and an integration hint. A fix that reads only `options.sensor.display_precision` would fix the humidity sensor and leave the temperature one broken.

## The fix

Delegate to `hass.formatEntityState(stateObj)` — HA's own formatter — instead of formatting by hand. Because the card was reimplementing HA's display rules, the same line was also causing three related divergences, all fixed by the same change:

| | before | after |
|---|---|---|
| precision | `17.94 °C` | `17.9 °C` |
| blank before unit | `49.31 %` | `49.3%` |
| unavailable entity | `unavailable °C` | `Unavailable` |
| toggle with **Show state** | `on` | `On` |

The last two are visible behavior changes, and intentional: they are what HA renders everywhere else on the dashboard.

### Also: a stale-render bug this exposed

`shouldUpdate` skipped a render unless a *watched entity's state object* changed. But a reading's text also depends on the formatter, and the formatter is not a state object.

HA hands a card a placeholder `formatEntityState` that echoes the raw state ([`connection-mixin.ts`](https://github.com/home-assistant/frontend/blob/dev/src/state/connection-mixin.ts)), then [`StateDisplayMixin`](https://github.com/home-assistant/frontend/blob/dev/src/state/state-display-mixin.ts) **asynchronously** rebuilds the real one — a fresh function — whenever the registry, locale, translations or config change, and publishes it in a *later* `hass` update.

That ordering matters. The update carrying a new `entities` still holds the **old** formatter; the update carrying the **new** formatter holds an unchanged `entities`. So watching the registry would render on the first and skip the second — a precision edit would never take effect, and a dashboard loaded before translations finished would show raw, unrounded states until an unrelated entity happened to tick.

`hassRenderInputsChanged` therefore compares `formatEntityState` **by identity**. It is the signal that arrives *with* the new wording, and it subsumes every input that produces it, so no render is wasted on a change that cannot yet alter any text. Ordinary state ticks leave it untouched, so the existing fast path is preserved.

## Notes

- **Type declarations.** `custom-card-helpers@1.9` predates `hass.formatEntityState`. The local `HomeAssistant` now extends the base interface to declare it rather than casting at each use. It is declared required — the card depends on HA ≥ 2023.9, and no fallback is included on purpose.
- **No new runtime dependency**; the `custom-card-helpers` import stays `import type`, so the bundle is unchanged.
- **Dev harness.** `dev/dev.ts` mocked `formatEntityState: (s) => s.state`, which masked exactly this bug locally. It now mirrors HA (registry precision + HA's unit spacing) and ships a temperature+humidity pair stored at two decimals but configured to display one.
- **README** example corrected: HA writes `45%`, not `45 %`.

## Testing

New pure helpers in `render.ts` (`entityStateText`, `itemStateText`, `hassRenderInputsChanged`) keep the existing convention of pure, unit-tested functions with no DOM.

Every fix here was driven red-then-green. The precision tests failed with the reported bug beforehand (`expected '17.94 °C' to be '17.9 °C'`, `expected '49.31 %' to be '49.3%'`); the `shouldUpdate` tests failed with `expected false to be true`.

Beyond the unit tests, I mounted the real `<easy-floorplan-card>` element in a DOM: it renders `17.9 °C · 49.3%`, and when only the formatter is swapped (states untouched) the badge repaints from `17.94 °C · 49.31 %` to `17.9 °C · 49.3%`, while an unrelated entity tick still skips the render.

`npm test` 85 passing · `npm run typecheck` clean · `npm run build` clean.

Rebased onto `main` after #22 merged. Note that `validate-hacs` fails here for reasons unrelated to this change — see #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)