### PR TITLE
ci: skip HACS validation on pull requests from forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,11 @@ env:
 
 jobs:
   validate-hacs:
+    # Validates the head repo, not the diff — and a fork has no release asset
+    # for it to find, so it can only ever fail there. `build` still runs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: HACS validation


### PR DESCRIPTION
## Problem

`validate-hacs` fails on every pull request opened from a fork, on grounds that have nothing to do with the change. Example from #26:

```
::INFO:: Repository: shauneccles/easy-floorplan@fix/respect-display-precision
##[error] <Plugin shauneccles/easy-floorplan> Repository structure ... is not compliant
##[error] Repository shauneccles/easy-floorplan not loaded properly in HACS.
```

## Why

`hacs/action` validates the head **repository**, not the diff. This is intended and documented — *"If you have it set up for PRs in your repository, it will run against the fork/branch that made the PR"* ([docs](https://hacs.xyz/docs/publish/action/)) — and it's why the job needs no `actions/checkout`.

HACS resolves a plugin's bundle in `update_filenames()` ([`plugin.py`](https://github.com/hacs/integration/blob/main/custom_components/hacs/repositories/plugin.py)):

1. latest **release** has an asset matching `hacs.json`'s `filename` → compliant;
2. otherwise scan the tree for that file at root or under `dist/`;
3. otherwise raise `Repository structure ... is not compliant`.

Releases are repository-level, not ref-level, so every branch, tag and same-repo PR here resolves against `v0.7.0` — whose asset is `easy-floorplan-card.js` — and passes at step 1. That's why this has never shown up on `main`.

A fork has no releases. It skips step 1, and since `dist/` is untracked (the bundle is built and attached by `release.yml` on publish), step 2 finds nothing either. So it fails at step 3, always. No outside contributor can make this check pass.

## Fix

Run the job on pushes, tags, the nightly cron and same-repo PRs; skip it for fork PRs. A fork's release structure says nothing about the change under review, so nothing is lost.

`build` — type-check, test, build — is untouched and still runs on every pull request, which is the check that actually guards the code.

Because `pull_request` workflows execute from the PR's merge commit, the guard applies to this PR too: `validate-hacs` should report as *skipped* rather than *failed* here, which doubles as a live check that it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)