### PR TITLE
Accent a cover that is still in transit

### DIFF
--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -15,6 +15,7 @@ import {
   renderOpening,
   renderWallMask,
   resolveOpeningAmount,
+  openingIsActive,
   openingClickAction,
   renderRipple,
   renderFurniture,
@@ -111,6 +112,12 @@ export class FloorplanCard extends LitElement {
   private _openingAmount(o: Opening): number {
     const state = o.entity ? this.hass?.states[o.entity] : undefined;
     return resolveOpeningAmount(o, state);
+  }
+
+  /** Whether an opening wears its accent: drawn open, or a cover still in transit. */
+  private _openingActive(o: Opening): boolean {
+    const state = o.entity ? this.hass?.states[o.entity] : undefined;
+    return openingIsActive(o, state);
   }
 
   /** Formatted "state unit" for a single entity, or "—" when unavailable. */
@@ -274,7 +281,7 @@ export class FloorplanCard extends LitElement {
                 color: "var(--primary-text-color)",
                 open: amount > 0,
                 amount,
-                active: !!o.entity && amount > 0,
+                active: this._openingActive(o),
                 accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
               });
               if (!o.entity) return symbol;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -12,6 +12,8 @@ import {
   kindFromEntity,
   defaultIcon,
   trackerSensorReading,
+  openingInMotion,
+  openingIsActive,
 } from "./render";
 import type { Opening } from "./types";
 
@@ -256,5 +258,70 @@ describe("defaultIcon", () => {
     expect(defaultIcon("light")).toBe("mdi:lightbulb");
     expect(defaultIcon("cover")).toBe("mdi:window-shutter");
     expect(defaultIcon("generic")).toBe("mdi:circle");
+  });
+});
+
+describe("openingInMotion", () => {
+  it("reads the transient cover states as motion", () => {
+    expect(openingInMotion("opening")).toBe(true);
+    expect(openingInMotion("closing")).toBe(true);
+  });
+  it("reads settled, absent and outage states as still", () => {
+    expect(openingInMotion("open")).toBe(false);
+    expect(openingInMotion("closed")).toBe(false);
+    expect(openingInMotion("on")).toBe(false);
+    expect(openingInMotion(undefined)).toBe(false);
+    expect(openingInMotion("unavailable")).toBe(false);
+  });
+});
+
+describe("openingIsActive", () => {
+  const cover = { type: "door", entity: "cover.garage" } as Opening;
+
+  it("accents a cover that is open", () => {
+    expect(openingIsActive(cover, { state: "open", attributes: { current_position: 100 } })).toBe(
+      true,
+    );
+  });
+
+  it("accents a cover that has begun opening but not yet moved", () => {
+    // A real garage door reports opening at position 0 for a full second, and a
+    // rest-only-position cover reports it for the whole travel. Drawn shut, it
+    // must still read as in motion, or a tap looks like it did nothing.
+    expect(openingIsActive(cover, { state: "opening", attributes: { current_position: 0 } })).toBe(
+      true,
+    );
+  });
+
+  it("accents a cover that is closing but still reports itself fully open", () => {
+    expect(openingIsActive(cover, { state: "closing", attributes: { current_position: 100 } })).toBe(
+      true,
+    );
+  });
+
+  it("leaves a settled closed cover unaccented", () => {
+    expect(openingIsActive(cover, { state: "closed", attributes: { current_position: 0 } })).toBe(
+      false,
+    );
+  });
+
+  it("never accents during a sensor outage, even with a stale open position", () => {
+    expect(
+      openingIsActive(cover, { state: "unavailable", attributes: { current_position: 100 } }),
+    ).toBe(false);
+  });
+
+  it("leaves an opening with no entity unaccented", () => {
+    expect(openingIsActive({ type: "door" } as Opening, undefined)).toBe(false);
+  });
+});
+
+describe("resolveOpeningAmount keeps trusting a live position", () => {
+  const cover = { type: "door", entity: "cover.garage" } as Opening;
+  it("does not snap a live-position cover open the moment it starts moving", () => {
+    // Regression guard: overriding a mid-travel position with the binary state
+    // would jump 0 -> 1 -> 0.07 on covers that stream position every second.
+    expect(resolveOpeningAmount(cover, { state: "opening", attributes: { current_position: 0 } })).toBe(0);
+    expect(resolveOpeningAmount(cover, { state: "opening", attributes: { current_position: 7 } })).toBeCloseTo(0.07);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -155,6 +155,11 @@ export function resolveOpeningOpen(o: Opening, state: string | undefined): boole
   return o.invert ? !open : open;
 }
 
+/** A `cover` in transit. Its `current_position` may not have caught up yet. */
+export function openingInMotion(state: string | undefined): boolean {
+  return state === "opening" || state === "closing";
+}
+
 /**
  * How far open an opening should be drawn, as a fraction 0..1, driving partial
  * swing / slide for position-aware `cover` entities. When the entity exposes a
@@ -163,6 +168,11 @@ export function resolveOpeningOpen(o: Opening, state: string | undefined): boole
  * {@link resolveOpeningOpen} (0 or 1). With no entity/state it uses the type
  * default; an `unavailable`/`unknown` outage fails closed (0), ignoring any
  * stale position.
+ *
+ * A live position wins over the `opening`/`closing` state even when the two
+ * disagree: a cover that has begun opening genuinely still sits at 0, and
+ * overriding that would snap the leaf open and back on every cover that streams
+ * its position. {@link openingIsActive} carries the motion instead.
  */
 export function resolveOpeningAmount(
   o: Opening,
@@ -178,6 +188,22 @@ export function resolveOpeningAmount(
     return o.invert ? 1 - frac : frac;
   }
   return resolveOpeningOpen(o, state.state) ? 1 : 0;
+}
+
+/**
+ * Whether an entity-bound opening should wear its accent colour. Drawn-open
+ * covers do, and so does one still in transit: a cover reports `opening` at
+ * position 0 for as long as it takes to move — a full second on a garage door,
+ * the whole travel on a cover that only publishes position at rest. Without
+ * this the leaf sits shut and unaccented and a tap reads as having done
+ * nothing. An outage is never active (see {@link isSensorOutage}).
+ */
+export function openingIsActive(
+  o: Opening,
+  state: { state: string; attributes?: Record<string, unknown> } | undefined,
+): boolean {
+  if (!o.entity || !state || isSensorOutage(state.state)) return false;
+  return openingInMotion(state.state) || resolveOpeningAmount(o, state) > 0;
 }
 
 /** Style options for {@link renderOpening}. */


### PR DESCRIPTION
## The bug

An opening's accent colour came from the rendered position:

```ts
active: !!o.entity && amount > 0,
```

and `resolveOpeningAmount` short-circuits on `current_position` whenever the entity publishes one. A cover reports `opening` while its position is still `0` — for a full second on a garage door, and for the **entire travel** on the many covers that only publish position at rest. Throughout that window the leaf was drawn shut with no accent, so tapping a door looked like it had done nothing.

This directly contradicts what the codebase already says. `resolveOpeningOpen` documents:

> `opening`/`closing` are transient cover states: the cover is in motion and not fully closed, so draw it open.

But the live card never calls it. `_openingAmount` → `resolveOpeningAmount` → returns early on `current_position`, and the binary fallback is unreachable for any position-reporting cover. The two resolvers disagreed, and the card used the one that cannot see motion.

Found on a real garage door: `supported_features: 11` (OPEN|CLOSE|STOP, no SET_POSITION) yet it reports `current_position`, and HA held `state: "opening", current_position: 0, is_closed: true` for a full second after the tap.

## The fix

Carry the motion separately rather than letting it override the position:

```ts
export function openingInMotion(state: string | undefined): boolean {
  return state === "opening" || state === "closing";
}

export function openingIsActive(o, state): boolean {
  if (!o.entity || !state || isSensorOutage(state.state)) return false;
  return openingInMotion(state.state) || resolveOpeningAmount(o, state) > 0;
}
```

**`resolveOpeningAmount` is deliberately unchanged.** The tempting fix — letting `opening`/`closing` override a contradicting position — would snap the leaf fully open and straight back on every cover that streams its position each second (`0` → `1` → `0.07`). There is a regression test pinning that.

An outage stays unaccented, consistent with the fail-closed handling in #18.

## Why the original review missed it

Worth recording, because the gap was structural rather than careless.

1. **The two states were never tested together.** `resolveOpeningAmount` had coverage for `current_position` at 0/50/100, and `resolveOpeningOpen` had coverage for `opening`/`closing`. Nothing ever paired a *transient state* with a *position that had not caught up yet* — which is the only input where the two resolvers disagree. Each function looked correct in isolation, and was.

2. **The dev harness cannot produce the failing input.** `setCoverPosition` writes state and position together and consistently (`state: pos > 0 ? "open" : "closed"`), and `setOpeningState` writes a state with no position at all. Neither emits "moving, but position still reads the far end" — so no amount of clicking around `npm run serve` would ever show it. Real covers emit exactly that, on every single open.

3. **`active` had no test at all.** It was computed inline in the Lit component rather than in a pure helper, and the repo's tests only cover pure functions. Extracting `openingIsActive` is what makes it testable, which is half the point of this change.

4. **Nobody paused a moving door.** The reviewed flow was open → wait → closed. The bug only shows during travel, and travel is where a garage door spends 15 seconds. Tapping stop mid-travel is what surfaced it.

## Testing

Red-then-green. `openingIsActive` with `{state: "opening", current_position: 0}` returns `false` under the old `amount > 0` rule and `true` after. Added a regression test asserting `resolveOpeningAmount` still returns `0` for that same input, so a future "fix" cannot reintroduce the flicker.

9 new tests; 81 passing. `npm run typecheck` and `npm run build` clean.

Note `validate-hacs` fails here for reasons unrelated to this change — see #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)