### PR TITLE
Link floorplan floors to Home Assistant floors (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ background):
   types shown as their actual glyphs (pick a sofa by seeing a sofa). The new element is
   selected immediately so the **Element** section is ready for configuring it.
 - **floor** — switch floors with the dropdown, add one with **+**; rename and delete
-  live behind the gear button.
+  live behind the gear button. The gear also offers an **HA floor** dropdown listing
+  your Home Assistant floors — linking one names the plan floor after it (rename
+  afterwards if you like; the link sticks either way).
 
 Undo/redo buttons sit at the right of the tools row. Zoom controls live on the canvas
 itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button
@@ -294,10 +296,14 @@ for backward compatibility.
 
 ### Floor
 
-`{ id, name, image?, imageOpacity?, walls, openings, items, texts, furniture }` — a named
-floor with its own elements. Use the **floor** controls in the editor toolbar to add,
-rename, switch and delete floors; the live card shows a floor switcher in the top-right
-when there is more than one.
+`{ id, name, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture }`
+— a named floor with its own elements. Use the **floor** controls in the editor toolbar
+to add, rename, switch and delete floors; the live card shows a floor switcher in the
+top-right when there is more than one.
+
+**`haFloor`** optionally stores the id of a linked Home Assistant floor (set from the
+editor's floor gear popover). Today the link auto-names the floor; it is kept in the
+config so future features (like area-based entity filtering) can build on it.
 
 Set **`image`** to a background image URL (e.g. `/local/floorplan.png` or an external
 URL) to draw it behind the elements — handy for tracing over a real floor plan. It fills

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -80,6 +80,13 @@ const hass = {
   },
   locale: { language: "en" },
   themes: { darkMode: false },
+  // HA floor registry mock so the editor's "HA floor" link (issue #24) is
+  // exercisable outside HA.
+  floors: {
+    ground: { floor_id: "ground", name: "Ground floor", level: 0 },
+    upstairs: { floor_id: "upstairs", name: "Upstairs", level: 1 },
+    basement: { floor_id: "basement", name: "Basement", level: -1 },
+  },
   callService: (...args: unknown[]) => console.log("[mock hass] callService", ...args),
   formatEntityState: (s: { state: string }) => s.state,
   localize: (k: string) => k,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -30,6 +30,7 @@ import {
   getFloors,
   gridPercentToSnap,
   makeFloor,
+  haFloorsOf,
   resolveSnap,
   snapToGridPercent,
   trackerPresenceDetected,
@@ -1112,6 +1113,47 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
+  /**
+   * Link the active floor to a Home Assistant floor (issue #24). Linking also
+   * names the floor after the HA floor — the point of the association — while
+   * a later manual rename sticks (we never re-sync silently). Unlinking keeps
+   * the current name.
+   */
+  private _linkHaFloor(haFloorId: string): void {
+    const ha = haFloorsOf(this.hass).find((f) => f.floor_id === haFloorId);
+    this._commit({
+      ...this._config,
+      floors: (this._config.floors ?? []).map((f) =>
+        f.id === this._activeFloorId
+          ? { ...f, haFloor: ha?.floor_id, ...(ha ? { name: ha.name } : {}) }
+          : f
+      ),
+    });
+  }
+
+  /** HA-floor link row for the floor gear popover; hidden when HA exposes no floors. */
+  private _renderHaFloorRow(floor: Floor): TemplateResult {
+    const haFloors = haFloorsOf(this.hass);
+    if (!haFloors.length) return html`${nothing}`;
+    return html`
+      <div class="pop-row">
+        <label>HA floor</label>
+        <select
+          .value=${floor?.haFloor ?? ""}
+          @change=${(e: Event) => this._linkHaFloor((e.target as HTMLSelectElement).value)}
+        >
+          <option value="" ?selected=${!floor?.haFloor}>(not linked)</option>
+          ${haFloors.map(
+            (f) =>
+              html`<option value=${f.floor_id} ?selected=${floor?.haFloor === f.floor_id}>
+                ${f.name}
+              </option>`
+          )}
+        </select>
+      </div>
+    `;
+  }
+
   private _deleteFloor(): void {
     const floors = this._config.floors ?? [];
     if (floors.length <= 1) return;
@@ -1504,6 +1546,7 @@ export class FloorplanCardEditor extends LitElement {
             </button>
             ${this._floorMenuOpen
               ? html`<div class="pop">
+                  ${this._renderHaFloorRow(floor)}
                   <div class="pop-row">
                     <label>Rename</label>
                     <input
@@ -2935,7 +2978,8 @@ export class FloorplanCardEditor extends LitElement {
       font-size: 12px;
       color: var(--secondary-text-color);
     }
-    .pop-row input {
+    .pop-row input,
+    .pop-row select {
       flex: 1;
       min-width: 0;
       padding: 4px 6px;

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -8,6 +8,7 @@ import {
   gridPercentToSnap,
   trackerAxisFraction,
   trackerPresenceDetected,
+  haFloorsOf,
   uid,
 } from "./types";
 import type { FloorplanCardConfig, TrackerSensor } from "./types";
@@ -226,6 +227,43 @@ describe("getFloors", () => {
     expect(f.image).toBe("/local/plan.png");
     expect(f.imageOpacity).toBe(0.5);
     expect(f.trackers).toEqual([]);
+  });
+});
+
+describe("haFloorsOf", () => {
+  const hass = {
+    floors: {
+      up: { floor_id: "up", name: "Upstairs", level: 1 },
+      ground: { floor_id: "ground", name: "Ground floor", level: 0 },
+      cellar: { floor_id: "cellar", name: "Cellar", level: -1 },
+    },
+  };
+
+  it("lists HA floors sorted by level then name", () => {
+    expect(haFloorsOf(hass).map((f) => f.floor_id)).toEqual(["cellar", "ground", "up"]);
+  });
+
+  it("sorts same-level floors by name and tolerates a missing level", () => {
+    const h = {
+      floors: {
+        b: { floor_id: "b", name: "B wing" },
+        a: { floor_id: "a", name: "A wing" },
+      },
+    };
+    expect(haFloorsOf(h).map((f) => f.name)).toEqual(["A wing", "B wing"]);
+  });
+
+  it("returns [] for hass objects without a floor registry (older HA, dev harness)", () => {
+    expect(haFloorsOf({})).toEqual([]);
+    expect(haFloorsOf(undefined)).toEqual([]);
+    expect(haFloorsOf(null)).toEqual([]);
+    expect(haFloorsOf({ floors: "bogus" })).toEqual([]);
+  });
+
+  it("drops malformed registry entries", () => {
+    expect(haFloorsOf({ floors: { x: { floor_id: "x" }, ok: { floor_id: "ok", name: "Ok" } } })).toEqual([
+      { floor_id: "ok", name: "Ok" },
+    ]);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,13 @@ export interface Floor {
   id: string;
   name: string;
   /**
+   * Optional link to a Home Assistant floor (its registry `floor_id`).
+   * Selecting one in the editor names this floor after it; the id is kept so
+   * future features (e.g. area filtering, per-floor entity defaults) can use
+   * the association. Purely additive — nothing renders differently today.
+   */
+  haFloor?: string;
+  /**
    * Optional background image URL (e.g. `/local/floorplan.png` or an external
    * URL) drawn behind the elements — handy for tracing over a real floor plan.
    * It fills the virtual canvas, so match the canvas width/height to the image
@@ -322,6 +329,29 @@ export function snapToGridPercent(snap: number, grid: number): number {
  */
 export function gridPercentToSnap(percent: number, grid: number): number {
   return Math.max(1, Math.round((grid * percent) / 100));
+}
+
+/** A Home Assistant floor-registry entry (the subset this card uses). */
+export interface HaFloorInfo {
+  floor_id: string;
+  name: string;
+  /** Vertical ordering in HA (ground = 0, upstairs = 1, basement = -1, …). */
+  level?: number | null;
+}
+
+/**
+ * List the Home Assistant floors from a `hass` object, sorted by level then
+ * name. Older HA versions (before the floor registry was exposed on `hass`)
+ * and the dev harness simply yield `[]`, so callers can hide the control when
+ * there is nothing to link to. Typed loosely because `custom-card-helpers`'
+ * HomeAssistant type predates `hass.floors`.
+ */
+export function haFloorsOf(hass: unknown): HaFloorInfo[] {
+  const floors = (hass as { floors?: Record<string, HaFloorInfo> } | null | undefined)?.floors;
+  if (!floors || typeof floors !== "object") return [];
+  return Object.values(floors)
+    .filter((f): f is HaFloorInfo => !!f && typeof f.floor_id === "string" && typeof f.name === "string")
+    .sort((a, b) => (a.level ?? 0) - (b.level ?? 0) || a.name.localeCompare(b.name));
 }
 
 export function emptyConfig(type: string): FloorplanCardConfig {


### PR DESCRIPTION
## Summary

Implements #24: the floor gear popover gains an **HA floor** dropdown listing your Home Assistant floors (from the `hass.floors` registry, sorted by level then name). Linking one:

- stores its `floor_id` in the new optional `Floor.haFloor` field, and
- names the plan floor after it — the "automatically get a name" ask from the issue.

Design choices:

- **Rename still wins.** Linking names the floor once; a later manual rename sticks — we never silently re-sync, so a custom name can't be clobbered by a hass update.
- **Unlink keeps the name**, only clears the association.
- **Graceful degradation.** `haFloorsOf(hass)` returns `[]` on HA versions that predate the floor registry (and on malformed registries), and the control hides entirely — nothing to explain, nothing to break.
- **`haFloor` is additive.** Nothing renders differently today; the id is persisted so area-based features (#25) can build on the association.

Files: `src/types.ts` (field + `haFloorsOf` helper), `src/editor.ts` (popover row + `_linkHaFloor`), `src/types.test.ts` (+4 tests), `dev/dev.ts` (mock floor registry), `README.md`.

## Test plan

- [x] `npm run typecheck`, `npm test` (45/45, incl. 4 new `haFloorsOf` cases: level/name sorting, missing/bogus registry, malformed entries), `npm run build`
- [x] Harness: gear popover shows **HA floor** above Rename; options sorted Basement → Ground floor → Upstairs
- [x] Linking "Upstairs" → floor renamed "Upstairs", `haFloor: "upstairs"` in config
- [x] Manual rename afterwards sticks; link kept
- [x] Unlink → name kept, `haFloor` cleared; Ctrl+Z restores the link (goes through `_commit`)
- [x] Real-HA smoke: dropdown lists actual HA floors from the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)