### PR TITLE
Respect the entity's device_class ("show as") for icons and state text (closes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ By default it shows an icon badge:
 - **Live look** — the badge highlights when the entity is "on". Turn on **Show state**
   to display the current value next to it. Add a **2nd entity** to show two readings in
   one element — e.g. a temperature and a humidity sensor render together as `21 °C · 45 %`.
+- **Follows "show as"** — the icon and state label respect the entity's
+  **device class** (HA's *show as* setting): a `binary_sensor` shown as a Lock renders
+  `mdi:lock` / `mdi:lock-open` and reads "Locked" / "Unlocked", a door contact gets
+  door icons, a motion sensor gets motion icons, and so on — the same defaults HA
+  itself uses. An explicit icon on the entity, or an **icon** override on the device,
+  still wins.
 - **Make it yours** — override the **icon** (with autocomplete + live preview), set a
   custom **name**, change the **size**, **rotate** it, or hide the icon entirely.
 

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -77,11 +77,23 @@ const hass = {
   states: {
     "binary_sensor.front_door": { state: "off", attributes: { friendly_name: "Front Door" } },
     "light.living_room": { state: "on", attributes: { friendly_name: "Living Room" } },
+    // "Show as" demo (issue #29): a binary_sensor with device_class lock should
+    // render mdi:lock / mdi:lock-open instead of the generic kind icon.
+    "binary_sensor.door_lock": {
+      state: "off",
+      attributes: { friendly_name: "Door Lock", device_class: "lock" },
+    },
   },
   locale: { language: "en" },
   themes: { darkMode: false },
   callService: (...args: unknown[]) => console.log("[mock hass] callService", ...args),
-  formatEntityState: (s: { state: string }) => s.state,
+  // Crude stand-in for HA's localizing formatter so the "show as" state text
+  // (issue #29) is demonstrable in the harness: lock device_class reads
+  // Locked/Unlocked instead of the raw on/off.
+  formatEntityState: (s: { state: string; attributes?: Record<string, unknown> }) => {
+    if (s?.attributes?.device_class === "lock") return s.state === "on" ? "Unlocked" : "Locked";
+    return s.state;
+  },
   localize: (k: string) => k,
 } as unknown;
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -45,6 +45,7 @@ import {
   renderTracker,
   trackerSensorReading,
   defaultIcon,
+  entityDefaultIcon,
   kindFromEntity,
   snapToWall,
 } from "./render";
@@ -1810,7 +1811,16 @@ export class FloorplanCardEditor extends LitElement {
 
   private _renderItemOverlay(it: FloorItem, c: FloorplanCardConfig): TemplateResult {
     const selected = this._isSel("item", it.id);
-    const icon = it.icon ?? defaultIcon(it.kind);
+    // Same icon precedence as the live card: config override → entity's
+    // explicit icon → device_class-implied icon ("show as") → kind default.
+    const st = it.entity ? this.hass?.states[it.entity] : undefined;
+    const stateOn =
+      st?.state === "on" || st?.state === "open" || st?.state === "home" || st?.state === "playing";
+    const icon =
+      it.icon ??
+      (st?.attributes?.icon as string | undefined) ??
+      entityDefaultIcon(it.entity, st?.attributes?.device_class as string | undefined, stateOn) ??
+      defaultIcon(it.kind);
     const label = it.name || it.entity || it.kind;
     const size = it.size ?? DEFAULT_ITEM_SIZE;
     const showIcon = it.showIcon ?? true;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -20,6 +20,7 @@ import {
   renderTracker,
   trackerSensorReading,
   defaultIcon,
+  entityDefaultIcon,
 } from "./render";
 import type { Opening } from "./types";
 
@@ -121,6 +122,18 @@ export class FloorplanCard extends LitElement {
     if (!entityId) return "—";
     const stateObj = this.hass?.states[entityId];
     if (!stateObj) return "—";
+    // Prefer HA's own formatter: it localizes and respects the entity's
+    // device_class ("show as"), so a binary_sensor shown as a Lock reads
+    // "Unlocked" instead of the raw "on" (issue #29).
+    const format = (this.hass as unknown as { formatEntityState?: (s: unknown) => string })
+      ?.formatEntityState;
+    if (format) {
+      try {
+        return format(stateObj);
+      } catch {
+        /* fall through to the raw state below */
+      }
+    }
     const unit = stateObj.attributes?.unit_of_measurement;
     return unit ? `${stateObj.state} ${unit}` : stateObj.state;
   }
@@ -133,8 +146,18 @@ export class FloorplanCard extends LitElement {
   }
 
   private _itemIcon(item: FloorItem): string {
+    // Precedence: config override → entity's explicit icon → the icon implied
+    // by its device_class ("show as", issue #29) → the generic kind default.
     if (item.icon) return item.icon;
-    return this.hass?.states[item.entity]?.attributes?.icon ?? defaultIcon(item.kind);
+    const st = this.hass?.states[item.entity];
+    if (st?.attributes?.icon) return st.attributes.icon;
+    return (
+      entityDefaultIcon(
+        item.entity,
+        st?.attributes?.device_class as string | undefined,
+        this._isOn(item)
+      ) ?? defaultIcon(item.kind)
+    );
   }
 
   private _label(item: FloorItem): string {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -4,6 +4,7 @@ import {
   openingDefaultOpen,
   kindFromEntity,
   defaultIcon,
+  entityDefaultIcon,
   trackerSensorReading,
 } from "./render";
 import type { Opening } from "./types";
@@ -84,6 +85,37 @@ describe("trackerSensorReading", () => {
     expect(trackerSensorReading(states, "sensor.missing")).toBeNull();
     expect(trackerSensorReading(states, "sensor.bad")).toBeNull();
     expect(trackerSensorReading(states, "sensor.text")).toBeNull();
+  });
+});
+
+describe("entityDefaultIcon", () => {
+  it("maps a binary_sensor shown as a Lock to lock icons per state (issue #29)", () => {
+    // on = unlocked for HA's lock device class
+    expect(entityDefaultIcon("binary_sensor.front_door_lock", "lock", true)).toBe("mdi:lock-open");
+    expect(entityDefaultIcon("binary_sensor.front_door_lock", "lock", false)).toBe("mdi:lock");
+  });
+
+  it("is state-aware for other binary_sensor device classes", () => {
+    expect(entityDefaultIcon("binary_sensor.d", "door", true)).toBe("mdi:door-open");
+    expect(entityDefaultIcon("binary_sensor.d", "door", false)).toBe("mdi:door-closed");
+    expect(entityDefaultIcon("binary_sensor.m", "motion", true)).toBe("mdi:motion-sensor");
+    expect(entityDefaultIcon("binary_sensor.w", "window", false)).toBe("mdi:window-closed");
+  });
+
+  it("maps sensor device classes (state-independent)", () => {
+    expect(entityDefaultIcon("sensor.t", "temperature", false)).toBe("mdi:thermometer");
+    expect(entityDefaultIcon("sensor.h", "humidity", true)).toBe("mdi:water-percent");
+  });
+
+  it("maps cover device classes per state", () => {
+    expect(entityDefaultIcon("cover.g", "garage", true)).toBe("mdi:garage-open");
+    expect(entityDefaultIcon("cover.g", "garage", false)).toBe("mdi:garage");
+  });
+
+  it("returns undefined for unknown device classes, missing class, or unmapped domains", () => {
+    expect(entityDefaultIcon("binary_sensor.x", "made_up", true)).toBeUndefined();
+    expect(entityDefaultIcon("binary_sensor.x", undefined, true)).toBeUndefined();
+    expect(entityDefaultIcon("light.x", "lock", true)).toBeUndefined();
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -24,6 +24,97 @@ export function defaultIcon(kind: ItemKind): string {
   }
 }
 
+/**
+ * State-aware icons per `binary_sensor` device class ("show as" in the HA UI),
+ * mirroring Home Assistant's own device-class icon set. `on` is the
+ * device-class's active state (open / detected / unlocked / …).
+ */
+const BINARY_SENSOR_CLASS_ICONS: Record<string, { on: string; off: string }> = {
+  battery: { on: "mdi:battery-alert", off: "mdi:battery" },
+  battery_charging: { on: "mdi:battery-charging", off: "mdi:battery" },
+  carbon_monoxide: { on: "mdi:smoke-detector-alert", off: "mdi:smoke-detector" },
+  cold: { on: "mdi:snowflake", off: "mdi:thermometer" },
+  connectivity: { on: "mdi:check-network-outline", off: "mdi:close-network-outline" },
+  door: { on: "mdi:door-open", off: "mdi:door-closed" },
+  garage_door: { on: "mdi:garage-open", off: "mdi:garage" },
+  gas: { on: "mdi:alert-circle", off: "mdi:check-circle" },
+  heat: { on: "mdi:fire", off: "mdi:thermometer" },
+  light: { on: "mdi:brightness-7", off: "mdi:brightness-5" },
+  lock: { on: "mdi:lock-open", off: "mdi:lock" },
+  moisture: { on: "mdi:water", off: "mdi:water-off" },
+  motion: { on: "mdi:motion-sensor", off: "mdi:motion-sensor-off" },
+  occupancy: { on: "mdi:home", off: "mdi:home-outline" },
+  opening: { on: "mdi:square-outline", off: "mdi:square" },
+  plug: { on: "mdi:power-plug", off: "mdi:power-plug-off" },
+  power: { on: "mdi:power-plug", off: "mdi:power-plug-off" },
+  presence: { on: "mdi:home", off: "mdi:home-outline" },
+  problem: { on: "mdi:alert-circle", off: "mdi:check-circle" },
+  running: { on: "mdi:play", off: "mdi:stop" },
+  safety: { on: "mdi:alert-circle", off: "mdi:check-circle" },
+  smoke: { on: "mdi:smoke-detector-variant-alert", off: "mdi:smoke-detector-variant" },
+  sound: { on: "mdi:music-note", off: "mdi:music-note-off" },
+  tamper: { on: "mdi:vibrate", off: "mdi:check-circle" },
+  vibration: { on: "mdi:vibrate", off: "mdi:crop-portrait" },
+  window: { on: "mdi:window-open", off: "mdi:window-closed" },
+};
+
+/** Icons per `sensor` device class (not state-dependent). */
+const SENSOR_CLASS_ICONS: Record<string, string> = {
+  temperature: "mdi:thermometer",
+  humidity: "mdi:water-percent",
+  battery: "mdi:battery",
+  power: "mdi:flash",
+  energy: "mdi:lightning-bolt",
+  illuminance: "mdi:brightness-5",
+  pressure: "mdi:gauge",
+  carbon_dioxide: "mdi:molecule-co2",
+  pm25: "mdi:air-filter",
+  signal_strength: "mdi:wifi",
+  voltage: "mdi:sine-wave",
+  current: "mdi:current-ac",
+};
+
+/** State-aware icons per `cover` device class. */
+const COVER_CLASS_ICONS: Record<string, { on: string; off: string }> = {
+  garage: { on: "mdi:garage-open", off: "mdi:garage" },
+  garage_door: { on: "mdi:garage-open", off: "mdi:garage" },
+  door: { on: "mdi:door-open", off: "mdi:door-closed" },
+  gate: { on: "mdi:gate-open", off: "mdi:gate" },
+  window: { on: "mdi:window-open", off: "mdi:window-closed" },
+  blind: { on: "mdi:blinds-open", off: "mdi:blinds" },
+  shade: { on: "mdi:roller-shade", off: "mdi:roller-shade-closed" },
+  shutter: { on: "mdi:window-shutter-open", off: "mdi:window-shutter" },
+  curtain: { on: "mdi:curtains", off: "mdi:curtains-closed" },
+  awning: { on: "mdi:awning-outline", off: "mdi:awning-outline" },
+};
+
+/**
+ * Icon implied by an entity's `device_class` — HA's "show as" setting (issue
+ * #29). A `binary_sensor` shown as a Lock gets `mdi:lock` / `mdi:lock-open`,
+ * matching what HA itself renders. Returns `undefined` when the domain /
+ * device class has no mapping so callers can fall back to the kind default.
+ * An explicit config `icon` or a per-entity `attributes.icon` still wins —
+ * this only replaces the generic kind fallback.
+ */
+export function entityDefaultIcon(
+  entityId: string,
+  deviceClass: string | undefined,
+  on: boolean,
+): string | undefined {
+  if (!deviceClass) return undefined;
+  const domain = entityId.split(".")[0];
+  if (domain === "binary_sensor") {
+    const m = BINARY_SENSOR_CLASS_ICONS[deviceClass];
+    return m ? (on ? m.on : m.off) : undefined;
+  }
+  if (domain === "sensor") return SENSOR_CLASS_ICONS[deviceClass];
+  if (domain === "cover") {
+    const m = COVER_CLASS_ICONS[deviceClass];
+    return m ? (on ? m.on : m.off) : undefined;
+  }
+  return undefined;
+}
+
 /** Infer a sensible item kind from an entity id's domain. */
 export function kindFromEntity(entity: string): ItemKind {
   const domain = entity.split(".")[0];


### PR DESCRIPTION
## Summary

Fixes #29: devices ignored HA's **show as** setting — @grischard's `binary_sensor` shown as a Lock rendered the generic radiobox icon and the raw "off" state instead of a lock icon and "Locked".

### Icons

New `entityDefaultIcon(entityId, deviceClass, on)` helper in `render.ts` mirroring HA's own device-class icon sets:

- **`binary_sensor`** — state-aware pairs for lock (`mdi:lock` / `mdi:lock-open`), door, window, garage_door, motion, occupancy, presence, smoke, CO, moisture, plug/power, problem/safety, connectivity, and more (~26 classes).
- **`sensor`** — static icons for temperature, humidity, battery, power, energy, illuminance, pressure, CO₂, etc.
- **`cover`** — open/closed pairs for garage, gate, blind, shade, shutter, curtain, window, door.

It slots into the existing fallback chain, so precedence is: **config `icon` override → the entity's explicit `attributes.icon` → device_class-implied icon → generic kind default**. The live card and the editor overlay share the same chain, so what you see while editing matches the dashboard.

### State text

`_entityStateText` now prefers `hass.formatEntityState` — HA's own localizing, device-class-aware formatter — so the state label reads "Locked" / "Unlocked" (in the user's language) instead of "on" / "off". Older HA versions without the formatter, or a formatter that throws, fall back to the previous raw `state unit` text.

### On by default, not a toggle

The issue discussion suggested an opt-in toggle; this implements the alternative I'd argued for: default-on, because it only replaces the *generic kind fallback* (never an explicit icon), it matches what HA itself shows everywhere else, and both override paths (config `icon`, entity `attributes.icon`) still win. Anyone who dislikes a specific mapping overrides that one device.

## Test plan

- [x] `npm run typecheck`, `npm test` (46/46, +5 new `entityDefaultIcon` cases incl. the issue's lock scenario), `npm run build`
- [x] Harness with a `device_class: lock` demo entity: locked → `mdi:lock` + "Locked"; flip to on → `mdi:lock-open` + "Unlocked" (live update)
- [x] Editor overlay shows the same lock icon as the card
- [x] Config `icon` override beats the device_class mapping
- [x] Entities without a device_class keep today's exact behavior
- [ ] Real-HA smoke: bind the actual "show as Lock" sensor from the issue and confirm icon + localized state text

🤖 Generated with [Claude Code](https://claude.com/claude-code)