### PR TITLE
Six item kinds, eight furniture symbols, a handed sectional, and a documented aspect-ratio trap

### DIFF
--- a/dev/symbols.html
+++ b/dev/symbols.html
@@ -1,0 +1,6 @@
+<!doctype html><html><head><meta charset="utf-8"><title>symbols</title>
+<style>:root{color-scheme:light;--primary-text-color:#212121;--primary-color:#03a9f4;
+--card-background-color:#fff;--divider-color:rgba(0,0,0,.12)}
+body{margin:0;background:#eceff1;padding:10px;font-family:system-ui}
+#host{background:#fff;width:1100px}</style></head>
+<body><div id="host"></div><script type="module" src="./symbols.ts"></script></body></html>

--- a/dev/symbols.ts
+++ b/dev/symbols.ts
@@ -1,0 +1,41 @@
+import "../src/index";
+import type { FloorplanCardConfig } from "../src/types";
+import { FURNITURE_DEFAULT_SIZE } from "../src/types";
+
+if (!customElements.get("ha-card")) {
+  class C extends HTMLElement {
+    set header(v: string | undefined) { this._h = v; this._r(); }
+    private _h?: string;
+    connectedCallback() { this._r(); }
+    private _r() {
+      if (!this.shadowRoot) this.attachShadow({ mode: "open" });
+      this.shadowRoot!.innerHTML = `<style>:host{display:block;background:#fff}</style><slot></slot>`;
+    }
+  }
+  customElements.define("ha-card", C as any);
+}
+if (!customElements.get("ha-icon")) customElements.define("ha-icon", class extends HTMLElement {} as any);
+
+const TYPES = Object.keys(FURNITURE_DEFAULT_SIZE) as Array<keyof typeof FURNITURE_DEFAULT_SIZE>;
+const COLS = 6, CELL = 260;
+const furniture = TYPES.map((t, i) => {
+  const { w, h } = FURNITURE_DEFAULT_SIZE[t];
+  return { id: t, type: t, x: (i % COLS) * CELL + CELL / 2, y: Math.floor(i / COLS) * CELL + CELL / 2, w, h };
+});
+// both hands of the sectional, side by side
+furniture.push({ id: "sectional_left", type: "sectional", hand: "left",
+  x: (TYPES.length % COLS) * CELL + CELL / 2, y: Math.floor(TYPES.length / COLS) * CELL + CELL / 2,
+  w: 230, h: 180 } as any);
+
+const texts = furniture.map((f) => ({ id: "t_" + f.id, x: f.x, y: f.y + CELL / 2 - 26, text: f.id, size: 15 }));
+
+const config = {
+  type: "custom:easy-floorplan-card", title: "Furniture symbols",
+  width: COLS * CELL, height: (Math.ceil((TYPES.length + 1) / COLS)) * CELL,
+  grid: CELL, walls: [], openings: [], items: [], texts, furniture,
+} as unknown as FloorplanCardConfig;
+
+const card = document.createElement("easy-floorplan-card") as any;
+card.hass = { states: {}, formatEntityState: () => "" };
+card.setConfig(config);
+document.getElementById("host")!.appendChild(card);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -11,6 +11,7 @@ import type {
   FloorText,
   Furniture,
   FurnitureType,
+  SectionalHand,
   ItemKind,
   ItemDisplay,
   Tracker,
@@ -70,6 +71,14 @@ const FURNITURE_TYPES: FurnitureType[] = [
   "toilet",
   "stairs",
   "tv",
+  "sectional",
+  "washer",
+  "dryer",
+  "dishwasher",
+  "bathtub",
+  "vanity",
+  "waterHeater",
+  "airHandler",
 ];
 
 /** User-facing labels for furniture types (the enum uses camelCase). */
@@ -89,6 +98,14 @@ const FURNITURE_LABELS: Record<FurnitureType, string> = {
   toilet: "toilet",
   stairs: "stairs",
   tv: "tv",
+  sectional: "sectional (L)",
+  washer: "washer",
+  dryer: "dryer",
+  dishwasher: "dishwasher",
+  bathtub: "bathtub",
+  vanity: "vanity",
+  waterHeater: "water heater",
+  airHandler: "air handler",
 };
 
 type Tool = "select" | "wall" | "door" | "window" | "tracker";
@@ -2502,6 +2519,25 @@ export class FloorplanCardEditor extends LitElement {
             ${FURNITURE_TYPES.map((t) => html`<option value=${t}>${FURNITURE_LABELS[t]}</option>`)}
           </select>
         </div>
+        ${f.type === "sectional"
+          ? html`
+              <div class="row">
+                <label title="Which side the chaise extends on, facing the sofa from the front">
+                  Chaise side
+                </label>
+                <select
+                  .value=${f.hand ?? "right"}
+                  @change=${(e: Event) =>
+                    this._updateFurniture(f.id, {
+                      hand: (e.target as HTMLSelectElement).value as SectionalHand,
+                    })}
+                >
+                  <option value="right">right</option>
+                  <option value="left">left</option>
+                </select>
+              </div>
+            `
+          : nothing}
         <div class="row">
           <label>Width / Height</label>
           <input

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -23,6 +23,7 @@ import {
   trackerSensorReading,
   defaultIcon,
   entityDefaultIcon,
+  entityIsActive,
   itemStateText,
   hassRenderInputsChanged,
 } from "./render";
@@ -102,8 +103,7 @@ export class FloorplanCard extends LitElement {
   }
 
   private _isOn(item: FloorItem): boolean {
-    const st = this.hass?.states[item.entity]?.state;
-    return st === "on" || st === "open" || st === "home" || st === "playing";
+    return entityIsActive(item.entity, this.hass?.states[item.entity]?.state);
   }
 
   /** How far open an opening should be drawn (0..1), from its entity (or default). */

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -253,7 +253,12 @@ export class FloorplanCard extends LitElement {
           style="aspect-ratio: ${c.width} / ${c.height}; background:${c.background ??
           "var(--card-background-color, #fff)"};"
         >
-          <svg viewBox="0 0 ${c.width} ${c.height}" preserveAspectRatio="none">
+          <!-- "none" stretches the plan whenever the container's shape differs
+               from the canvas: a square room becomes a rectangle and a round
+               table becomes an ellipse. .stage sets aspect-ratio inline, so it
+               only bites once something overrides that height (card-mod, a grid
+               layout, a narrow phone) -- which is exactly when you notice. -->
+          <svg viewBox="0 0 ${c.width} ${c.height}" preserveAspectRatio="xMidYMid meet">
             ${active.image
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -253,12 +253,21 @@ export class FloorplanCard extends LitElement {
           style="aspect-ratio: ${c.width} / ${c.height}; background:${c.background ??
           "var(--card-background-color, #fff)"};"
         >
-          <!-- "none" stretches the plan whenever the container's shape differs
-               from the canvas: a square room becomes a rectangle and a round
-               table becomes an ellipse. .stage sets aspect-ratio inline, so it
-               only bites once something overrides that height (card-mod, a grid
-               layout, a narrow phone) -- which is exactly when you notice. -->
-          <svg viewBox="0 0 ${c.width} ${c.height}" preserveAspectRatio="xMidYMid meet">
+<!-- preserveAspectRatio="none" is correct here, and it took a wrong fix to
+               see why. .stage pins aspect-ratio: width / height inline, so the
+               SVG's box already matches its viewBox and "none" never distorts.
+
+               "meet" letterboxes the SVG inside its box. The .items overlay is
+               HTML, positioned with raw left/top percentages of .stage, and it
+               does not letterbox. So the moment anything overrides the stage's
+               ratio (card-mod, a grid row count) the drawing shrinks away from
+               the badges and every icon drifts off the wall it was placed on.
+               "none" stretches both layers identically: distorted, but aligned.
+
+               The real fix letterboxes both layers together -- wrap the svg and
+               the overlay in one aspect-ratio box and centre it. Until then, do
+               not "fix" this line. -->
+          <svg viewBox="0 0 ${c.width} ${c.height}" preserveAspectRatio="none">
             ${active.image
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import type { ItemKind } from "./types";
+import type { FurnitureType, ItemKind } from "./types";
+import { FURNITURE_DEFAULT_SIZE } from "./types";
 import {
   snapToWall,
   openingDefaultOpen,
@@ -12,6 +13,10 @@ import {
   resolveOpeningAmount,
   kindFromEntity,
   defaultIcon,
+  renderFurniture,
+  sectionalPoints,
+  SECTIONAL_CHAISE_FRACTION,
+  SECTIONAL_SEAT_FRACTION,
   entityDefaultIcon,
   trackerSensorReading,
   openingInMotion,
@@ -524,5 +529,99 @@ describe("hassRenderInputsChanged", () => {
   it("ignores entities the plan does not watch", () => {
     const next = { ...base(), states: { [TEMP]: tempState, [HUMIDITY]: { state: "50.0" } } };
     expect(hassRenderInputsChanged(base(), next, watched)).toBe(false);
+  });
+});
+
+describe("sectionalPoints", () => {
+  const w = 200;
+  const h = 160;
+
+  function area(pts: Array<[number, number]>): number {
+    let a = 0;
+    for (let i = 0; i < pts.length; i++) {
+      const [x1, y1] = pts[i];
+      const [x2, y2] = pts[(i + 1) % pts.length];
+      a += x1 * y2 - x2 * y1;
+    }
+    return Math.abs(a) / 2;
+  }
+
+  it("is an L: six corners, not a rectangle", () => {
+    expect(sectionalPoints(w, h, "right")).toHaveLength(6);
+  });
+
+  it("fills the bounding box minus the notch", () => {
+    const chaise = w * SECTIONAL_CHAISE_FRACTION;
+    const seat = h * SECTIONAL_SEAT_FRACTION;
+    const expected = w * h - (w - chaise) * (h - seat);
+    expect(area(sectionalPoints(w, h, "right"))).toBeCloseTo(expected, 6);
+  });
+
+  it("puts the chaise on the right when hand is right", () => {
+    const pts = sectionalPoints(w, h, "right");
+    // the front edge (max y) should only be occupied on the right half
+    const front = pts.filter(([, y]) => y === h / 2).map(([x]) => x);
+    expect(Math.min(...front)).toBeGreaterThan(0);
+    expect(Math.max(...front)).toBeCloseTo(w / 2, 6);
+  });
+
+  it("puts the chaise on the left when hand is left", () => {
+    const pts = sectionalPoints(w, h, "left");
+    const front = pts.filter(([, y]) => y === h / 2).map(([x]) => x);
+    expect(Math.max(...front)).toBeLessThan(0);
+    expect(Math.min(...front)).toBeCloseTo(-w / 2, 6);
+  });
+
+  it("left is right mirrored across x, not a different shape", () => {
+    const r = sectionalPoints(w, h, "right");
+    const l = sectionalPoints(w, h, "left");
+    expect(area(l)).toBeCloseTo(area(r), 6);
+    expect(l.map(([x, y]) => [-x, y])).toEqual(r);
+  });
+
+  it("defaults to right-handed", () => {
+    expect(sectionalPoints(w, h)).toEqual(sectionalPoints(w, h, "right"));
+  });
+
+  it("stays inside its bounding box", () => {
+    for (const hand of ["left", "right"] as const) {
+      for (const [x, y] of sectionalPoints(w, h, hand)) {
+        expect(Math.abs(x)).toBeLessThanOrEqual(w / 2 + 1e-9);
+        expect(Math.abs(y)).toBeLessThanOrEqual(h / 2 + 1e-9);
+      }
+    }
+  });
+});
+
+describe("every furniture type renders and has a default size", () => {
+  const types: FurnitureType[] = [
+    "table", "roundTable", "desk", "chair", "sofa", "bed", "wardrobe", "rug",
+    "plant", "fridge", "stove", "sink", "toilet", "stairs", "tv",
+    "washer", "dryer", "dishwasher", "waterHeater", "airHandler", "bathtub",
+    "vanity", "sectional",
+  ];
+
+  it("has a default size for each", () => {
+    for (const t of types) {
+      const s = FURNITURE_DEFAULT_SIZE[t];
+      expect(s, t).toBeTruthy();
+      expect(s.w, t).toBeGreaterThan(0);
+      expect(s.h, t).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders each without throwing", () => {
+    for (const t of types) {
+      const { w, h } = FURNITURE_DEFAULT_SIZE[t];
+      expect(() => renderFurniture({ id: t, type: t, x: 0, y: 0, w, h }), t).not.toThrow();
+    }
+  });
+
+  it("renders a sectional of each hand", () => {
+    for (const hand of ["left", "right"] as const) {
+      expect(() =>
+        renderFurniture({ id: "s", type: "sectional", x: 0, y: 0, w: 230, h: 180, hand }),
+      ).not.toThrow();
+    }
   });
 });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -24,6 +24,8 @@ import {
   entityStateText,
   itemStateText,
   hassRenderInputsChanged,
+  isEntityOn,
+  entityIsActive,
 } from "./render";
 import type { Opening, RenderHass } from "./types";
 
@@ -623,5 +625,62 @@ describe("every furniture type renders and has a default size", () => {
         renderFurniture({ id: "s", type: "sectional", x: 0, y: 0, w: 230, h: 180, hand }),
       ).not.toThrow();
     }
+  });
+});
+
+describe("isEntityOn", () => {
+  it("is on, open, home, or playing — nothing else", () => {
+    for (const s of ["on", "open", "home", "playing"]) expect(isEntityOn(s), s).toBe(true);
+    for (const s of ["off", "closed", "away", "paused", undefined]) expect(isEntityOn(s), s).toBe(false);
+  });
+});
+
+describe("entityIsActive — domains that never say \"on\"", () => {
+  it("a lock is active when it is not locked", () => {
+    expect(entityIsActive("lock.front", "unlocked")).toBe(true);
+    expect(entityIsActive("lock.front", "unlocking")).toBe(true);
+    expect(entityIsActive("lock.front", "locked")).toBe(false);
+  });
+
+  it("a vacuum is active while it is working, not while it is docked", () => {
+    expect(entityIsActive("vacuum.roomba", "cleaning")).toBe(true);
+    expect(entityIsActive("vacuum.roomba", "returning")).toBe(true);
+    for (const s of ["docked", "idle", "paused"]) {
+      expect(entityIsActive("vacuum.roomba", s), s).toBe(false);
+    }
+  });
+
+  it("a camera is active while recording or streaming", () => {
+    expect(entityIsActive("camera.door", "recording")).toBe(true);
+    expect(entityIsActive("camera.door", "idle")).toBe(false);
+  });
+
+  it("falls back to the generic on/off test for every other domain", () => {
+    expect(entityIsActive("light.a", "on")).toBe(true);
+    expect(entityIsActive("binary_sensor.a", "off")).toBe(false);
+    expect(entityIsActive("device_tracker.a", "home")).toBe(true);
+    expect(entityIsActive(undefined, "on")).toBe(true);
+  });
+
+  it("an outage is never active, whatever the domain says", () => {
+    for (const e of ["lock.a", "vacuum.a", "light.a"]) {
+      expect(entityIsActive(e, "unavailable"), e).toBe(false);
+      expect(entityIsActive(e, "unknown"), e).toBe(false);
+      expect(entityIsActive(e, undefined), e).toBe(false);
+    }
+  });
+
+  // The bug: DOMAIN_STATE_ICONS gives lock/vacuum/camera an `on` icon that the
+  // generic predicate (isEntityOn) could never reach, so they were frozen on
+  // their off icon. This branch has no resolveItemIcon wrapper — floorplan-card's
+  // _itemIcon calls entityDefaultIcon(entity, deviceClass, on) directly — so the
+  // integration is exercised here instead of through a wrapper.
+  it("an unlocked lock now reaches its open icon", () => {
+    expect(entityDefaultIcon("lock.front", undefined, entityIsActive("lock.front", "unlocked"))).toBe(
+      "mdi:lock-open-variant",
+    );
+    expect(entityDefaultIcon("lock.front", undefined, entityIsActive("lock.front", "locked"))).toBe(
+      "mdi:lock",
+    );
   });
 });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { ItemKind } from "./types";
 import {
   snapToWall,
   openingDefaultOpen,
@@ -233,9 +234,51 @@ describe("kindFromEntity", () => {
     expect(kindFromEntity("binary_sensor.door")).toBe("binary_sensor");
     expect(kindFromEntity("cover.garage")).toBe("cover");
   });
+  it("maps the domains that carry their own meaning", () => {
+    expect(kindFromEntity("media_player.tv")).toBe("media_player");
+    expect(kindFromEntity("fan.ceiling")).toBe("fan");
+    expect(kindFromEntity("camera.doorbell")).toBe("camera");
+    expect(kindFromEntity("lock.front")).toBe("lock");
+    expect(kindFromEntity("humidifier.dehumidifier")).toBe("humidifier");
+    expect(kindFromEntity("vacuum.roomba")).toBe("vacuum");
+  });
   it("falls back to generic for unknown domains", () => {
-    expect(kindFromEntity("media_player.tv")).toBe("generic");
+    expect(kindFromEntity("automation.morning")).toBe("generic");
+    expect(kindFromEntity("scene.movie")).toBe("generic");
     expect(kindFromEntity("weird")).toBe("generic");
+  });
+});
+
+describe("defaultIcon", () => {
+  it("gives every kind an icon that is not the generic circle", () => {
+    const kinds: ItemKind[] = [
+      "light", "switch", "sensor", "binary_sensor", "climate", "cover",
+      "media_player", "fan", "camera", "lock", "humidifier", "vacuum",
+    ];
+    for (const k of kinds) {
+      expect(defaultIcon(k), k).toMatch(/^mdi:/);
+      expect(defaultIcon(k), k).not.toBe("mdi:circle");
+    }
+    expect(defaultIcon("generic")).toBe("mdi:circle");
+  });
+});
+
+describe("entityDefaultIcon for domains without a device class", () => {
+  it("distinguishes a television from a doorbell", () => {
+    // Both have no device class. Before, both rendered mdi:circle.
+    expect(entityDefaultIcon("media_player.tv", undefined, true)).toBe("mdi:television-play");
+    expect(entityDefaultIcon("media_player.tv", undefined, false)).toBe("mdi:television-off");
+    expect(entityDefaultIcon("camera.doorbell", undefined, true)).toBe("mdi:cctv");
+  });
+  it("shows a lock as open when it is unlocked", () => {
+    expect(entityDefaultIcon("lock.front", undefined, true)).toBe("mdi:lock-open-variant");
+    expect(entityDefaultIcon("lock.front", undefined, false)).toBe("mdi:lock");
+  });
+  it("still returns undefined for a domain it knows nothing about", () => {
+    expect(entityDefaultIcon("automation.x", undefined, true)).toBeUndefined();
+  });
+  it("does not shadow a binary_sensor's device-class icon", () => {
+    expect(entityDefaultIcon("binary_sensor.d", "door", true)).toBe("mdi:door-open");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,6 @@
 import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
-import type { Opening, ItemKind, Furniture, Tracker, RenderHass } from "./types";
+import type {
+  SectionalHand, Opening, ItemKind, Furniture, Tracker, RenderHass } from "./types";
 import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, trackerAxisFraction } from "./types";
 
 export const WALL_THICKNESS = 8;
@@ -574,6 +575,45 @@ export function renderWallMask(
  * origin, then translated and rotated into place. Defaults to gray so it reads
  * differently from black walls.
  */
+/** Fraction of the bounding box the chaise occupies, and the main seat's depth. */
+export const SECTIONAL_CHAISE_FRACTION = 0.42;
+export const SECTIONAL_SEAT_FRACTION = 0.55;
+
+/**
+ * The six corners of an L-shaped sectional, centred on the origin, back at -y.
+ *
+ * `hand` is read facing the sofa from the front: a `right` sectional puts the
+ * chaise on your right, extending toward you. Mirroring across x gives `left`,
+ * so the two hands are the same polygon reflected -- not two separate shapes.
+ */
+export function sectionalPoints(
+  w: number,
+  h: number,
+  hand: SectionalHand = "right",
+): Array<[number, number]> {
+  const hw = w / 2;
+  const hh = h / 2;
+  const seat = h * SECTIONAL_SEAT_FRACTION;   // depth of the main run, from the back
+  const chaise = w * SECTIONAL_CHAISE_FRACTION;
+
+  //  back  ( -y )
+  //  +-----------------+
+  //  |                 |
+  //  |         +-------+   <- chaise, on the right
+  //  |         |
+  //  +---------+
+  //  front ( +y )
+  const pts: Array<[number, number]> = [
+    [-hw, -hh],
+    [hw, -hh],
+    [hw, hh],
+    [hw - chaise, hh],
+    [hw - chaise, -hh + seat],
+    [-hw, -hh + seat],
+  ];
+  return hand === "left" ? pts.map(([x, y]) => [-x, y] as [number, number]) : pts;
+}
+
 export function renderFurniture(f: Furniture): SVGTemplateResult {
   const color = f.color ?? FURNITURE_COLOR;
   const w = f.w;
@@ -581,8 +621,13 @@ export function renderFurniture(f: Furniture): SVGTemplateResult {
   const hw = w / 2;
   const hh = h / 2;
 
-  const roundBase = f.type === "roundTable" || f.type === "plant";
-  const base = roundBase
+  const roundBase =
+    f.type === "roundTable" || f.type === "plant" || f.type === "waterHeater";
+  const base = f.type === "sectional"
+    ? svg`<polygon points=${sectionalPoints(w, h, f.hand).map((p) => p.join(",")).join(" ")}
+                   fill=${color} fill-opacity="0.12" stroke=${color} stroke-width="2"
+                   stroke-linejoin="round" />`
+    : roundBase
     ? svg`<ellipse cx="0" cy="0" rx=${hw} ry=${hh}
                    fill=${color} fill-opacity="0.12" stroke=${color} stroke-width="2" />`
     : f.type === "rug"
@@ -692,6 +737,65 @@ export function renderFurniture(f: Furniture): SVGTemplateResult {
                          rx=${Math.min(w, h) * 0.08} fill="none" stroke=${color}
                          stroke-width="1.5" opacity="0.6" />`;
       break;
+    case "washer":
+    case "dryer": {
+      const r = Math.min(w, h) * 0.3;
+      detail = svg`
+        <line x1=${-hw + w * 0.06} y1=${-hh + h * 0.18} x2=${hw - w * 0.06} y2=${-hh + h * 0.18}
+              stroke=${color} stroke-width="1.5" opacity="0.7" />
+        <circle cx="0" cy=${h * 0.06} r=${r} fill="none" stroke=${color} stroke-width="2" />
+        ${f.type === "dryer"
+          ? svg`<circle cx="0" cy=${h * 0.06} r=${r * 0.45}
+                        fill="none" stroke=${color} stroke-width="1.5" opacity="0.7" />`
+          : svg`<circle cx=${-hw + w * 0.16} cy=${-hh + h * 0.09} r=${Math.min(w, h) * 0.045}
+                        fill="none" stroke=${color} stroke-width="1.5" />`}`;
+      break;
+    }
+    case "dishwasher":
+      detail = svg`
+        <rect x=${-hw + w * 0.1} y=${-hh + h * 0.24} width=${w * 0.8} height=${h * 0.62} rx="3"
+              fill="none" stroke=${color} stroke-width="1.5" opacity="0.8" />
+        <line x1=${-hw + w * 0.06} y1=${hh - h * 0.12} x2=${hw - w * 0.06} y2=${hh - h * 0.12}
+              stroke=${color} stroke-width="2" />`;
+      break;
+    case "waterHeater":
+      detail = svg`
+        <circle cx="0" cy="0" r=${Math.min(hw, hh) * 0.34}
+                fill="none" stroke=${color} stroke-width="1.5" />`;
+      break;
+    case "airHandler":
+      detail = svg`
+        <line x1=${-hw + w * 0.08} y1=${-hh + h * 0.08} x2=${hw - w * 0.08} y2=${hh - h * 0.08}
+              stroke=${color} stroke-width="1.5" opacity="0.8" />
+        <line x1=${-hw + w * 0.08} y1=${hh - h * 0.08} x2=${hw - w * 0.08} y2=${-hh + h * 0.08}
+              stroke=${color} stroke-width="1.5" opacity="0.8" />`;
+      break;
+    case "bathtub":
+      detail = svg`
+        <rect x=${-hw + w * 0.06} y=${-hh + h * 0.12} width=${w * 0.88} height=${h * 0.76}
+              rx=${Math.min(w, h) * 0.12} fill="none" stroke=${color} stroke-width="2" />
+        <circle cx=${-hw + w * 0.14} cy="0" r=${Math.min(w, h) * 0.055}
+                fill="none" stroke=${color} stroke-width="1.5" />`;
+      break;
+    case "vanity":
+      detail = svg`
+        <ellipse cx="0" cy=${h * 0.06} rx=${w * 0.2} ry=${h * 0.26}
+                 fill="none" stroke=${color} stroke-width="2" />
+        <circle cx="0" cy=${-hh + h * 0.14} r=${Math.min(w, h) * 0.05}
+                fill="none" stroke=${color} stroke-width="1.5" />`;
+      break;
+    case "sectional": {
+      const pts = sectionalPoints(w, h, f.hand);
+      const seatY = pts[4][1];               // where the chaise meets the main run
+      const backY = -hh + h * 0.16;
+      const divX = pts[3][0];                // the chaise's inner edge
+      const armX = f.hand === "left" ? hw - w * 0.09 : -hw + w * 0.09;
+      detail = svg`
+        <line x1=${-hw} y1=${backY} x2=${hw} y2=${backY} stroke=${color} stroke-width="2" />
+        <line x1=${armX} y1=${backY} x2=${armX} y2=${seatY} stroke=${color} stroke-width="2" />
+        <line x1=${divX} y1=${backY} x2=${divX} y2=${hh} stroke=${color} stroke-width="2" />`;
+      break;
+    }
     case "table":
     case "roundTable":
     default:

--- a/src/render.ts
+++ b/src/render.ts
@@ -70,10 +70,36 @@ export function defaultIcon(kind: ItemKind): string {
       return "mdi:thermostat";
     case "cover":
       return "mdi:window-shutter";
+    case "media_player":
+      return "mdi:television";
+    case "fan":
+      return "mdi:fan";
+    case "camera":
+      return "mdi:cctv";
+    case "lock":
+      return "mdi:lock";
+    case "humidifier":
+      return "mdi:air-humidifier";
+    case "vacuum":
+      return "mdi:robot-vacuum";
     default:
       return "mdi:circle";
   }
 }
+
+/**
+ * State-aware icons for domains that carry their meaning in the domain rather
+ * than in a device class. A `media_player` has no device class, so without this
+ * a television and a doorbell both render `mdi:circle`.
+ */
+const DOMAIN_STATE_ICONS: Record<string, { on: string; off: string }> = {
+  media_player: { on: "mdi:television-play", off: "mdi:television-off" },
+  fan: { on: "mdi:fan", off: "mdi:fan-off" },
+  lock: { on: "mdi:lock-open-variant", off: "mdi:lock" },
+  camera: { on: "mdi:cctv", off: "mdi:cctv-off" },
+  humidifier: { on: "mdi:air-humidifier", off: "mdi:air-humidifier-off" },
+  vacuum: { on: "mdi:robot-vacuum", off: "mdi:robot-vacuum-variant" },
+};
 
 /**
  * State-aware icons per `binary_sensor` device class ("show as" in the HA UI),
@@ -152,8 +178,13 @@ export function entityDefaultIcon(
   deviceClass: string | undefined,
   on: boolean,
 ): string | undefined {
-  if (!deviceClass) return undefined;
   const domain = entityId.split(".")[0];
+  // These domains carry their meaning in the domain, not a device class, so the
+  // device-class guard below would skip them entirely.
+  const byDomain = DOMAIN_STATE_ICONS[domain];
+  if (byDomain) return on ? byDomain.on : byDomain.off;
+
+  if (!deviceClass) return undefined;
   if (domain === "binary_sensor") {
     const m = BINARY_SENSOR_CLASS_ICONS[deviceClass];
     return m ? (on ? m.on : m.off) : undefined;
@@ -176,6 +207,12 @@ export function kindFromEntity(entity: string): ItemKind {
     case "binary_sensor":
     case "climate":
     case "cover":
+    case "media_player":
+    case "fan":
+    case "camera":
+    case "lock":
+    case "humidifier":
+    case "vacuum":
       return domain as ItemKind;
     default:
       return "generic";

--- a/src/render.ts
+++ b/src/render.ts
@@ -166,6 +166,40 @@ const COVER_CLASS_ICONS: Record<string, { on: string; off: string }> = {
   awning: { on: "mdi:awning-outline", off: "mdi:awning-outline" },
 };
 
+/** The generic on/off test: state is `on`, `open`, `home`, or `playing`. */
+export function isEntityOn(state: string | undefined): boolean {
+  return state === "on" || state === "open" || state === "home" || state === "playing";
+}
+
+/**
+ * States that mean "this thing is doing something", for the domains that do not
+ * say `on`.
+ *
+ * A lock is `locked` / `unlocked`; a vacuum is `docked` / `cleaning`; a camera is
+ * `idle` / `recording`. None of them ever reads `on`, so the generic on/off test
+ * calls every one of them off, forever — and their state-dependent icons
+ * (`DOMAIN_STATE_ICONS`, above) can never show their active half.
+ */
+const ACTIVE_STATES: Record<string, ReadonlySet<string>> = {
+  lock: new Set(["unlocked", "unlocking", "open", "opening"]),
+  vacuum: new Set(["cleaning", "returning"]),
+  camera: new Set(["recording", "streaming"]),
+};
+
+/**
+ * Whether an entity is in its active state, by the rules of its own domain.
+ * Every domain not in {@link ACTIVE_STATES} falls back to the generic on/off
+ * test, unchanged. An unavailable or unknown state is never active, whatever
+ * the domain — a stale "unlocked" during a sensor dropout is worse than
+ * showing locked.
+ */
+export function entityIsActive(entityId: string | undefined, state: string | undefined): boolean {
+  if (!state || state === "unavailable" || state === "unknown") return false;
+  const domain = entityId?.split(".")[0] ?? "";
+  const active = ACTIVE_STATES[domain];
+  return active ? active.has(state) : isEntityOn(state);
+}
+
 /**
  * Icon implied by an entity's `device_class` — HA's "show as" setting (issue
  * #29). A `binary_sensor` shown as a Lock gets `mdi:lock` / `mdi:lock-open`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,12 +172,28 @@ export type FurnitureType =
   | "sink"
   | "toilet"
   | "stairs"
-  | "tv";
+  | "tv"
+  | "washer"
+  | "dryer"
+  | "dishwasher"
+  | "waterHeater"
+  | "airHandler"
+  | "bathtub"
+  | "vanity"
+  | "sectional";
+
+/**
+ * Which end of an L-shaped sectional the chaise sits on, facing the sofa from
+ * the front. Only meaningful for `type: "sectional"`; defaults to `"right"`.
+ */
+export type SectionalHand = "left" | "right";
 
 /** A gray furniture/fixture diagram placed on the plan. */
 export interface Furniture {
   id: string;
   type: FurnitureType;
+  /** L-shaped sectional only: which side the chaise extends on. Default `right`. */
+  hand?: SectionalHand;
   x: number;
   y: number;
   /** Width / height in virtual units. */
@@ -290,6 +306,14 @@ export const FURNITURE_DEFAULT_SIZE: Record<FurnitureType, { w: number; h: numbe
   toilet: { w: 48, h: 68 },
   stairs: { w: 90, h: 170 },
   tv: { w: 110, h: 18 },
+  washer: { w: 60, h: 62 },
+  dryer: { w: 60, h: 62 },
+  dishwasher: { w: 60, h: 60 },
+  waterHeater: { w: 52, h: 52 },
+  airHandler: { w: 60, h: 56 },
+  bathtub: { w: 150, h: 76 },
+  vanity: { w: 110, h: 55 },
+  sectional: { w: 230, h: 180 },
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,20 @@ export interface Opening {
   sliderStyle?: "single" | "bypass" | "biparting";
 }
 
-export type ItemKind = "light" | "switch" | "sensor" | "binary_sensor" | "climate" | "cover" | "generic";
+export type ItemKind =
+  | "light"
+  | "switch"
+  | "sensor"
+  | "binary_sensor"
+  | "climate"
+  | "cover"
+  | "media_player"
+  | "fan"
+  | "camera"
+  | "lock"
+  | "humidifier"
+  | "vacuum"
+  | "generic";
 
 /** An entity icon placed on the plan. */
 export interface FloorItem {


### PR DESCRIPTION
Four independent changes, each with tests. Split into two commits so any part can be dropped.

> **Maintainer note:** description edited before merge to match the final code — the original text described an aspect-ratio *change* that the branch itself later reverted in favour of a comment; see the first section. Test count updated 119 → 126. No code changes made. — @nicosandller

### `preserveAspectRatio` — documented, not changed

The root `<svg>` renders with `preserveAspectRatio="none"`, so whenever the container's aspect ratio differs from the canvas, the whole plan stretches: circles become ellipses. An earlier revision of this branch "fixed" that with `xMidYMid meet` — and that fix was **wrong**: the `.items` overlay is HTML positioned with raw percentages of `.stage`, and it does not letterbox. With `meet`, the moment anything overrides the stage's ratio (card-mod, a grid row count), the drawing shrinks away from the badges and every icon drifts off the wall it was placed on. `"none"` stretches both layers identically: distorted, but aligned.

The final code therefore **keeps `none`** and adds a comment at the `<svg>` explaining the trap, so the next person doesn't repeat the same wrong fix. The real fix — letterboxing the SVG and the overlay together in one aspect-ratio box — is left as a follow-up.

### Six item kinds

`ItemKind` was `light | switch | sensor | binary_sensor | climate | cover | generic`. Everything else fell to `generic` and rendered `mdi:circle`, so a television and a doorbell looked identical.

Adds `media_player`, `fan`, `camera`, `lock`, `humidifier`, `vacuum` to `ItemKind`, `kindFromEntity()` and `defaultIcon()`, with state-aware icons where HA has them (`mdi:television` / `-off`, `mdi:lock` / `-open`).

This also fixes a small bug in `entityDefaultIcon()`: it returned early when the entity had no `device_class`, so a domain that has a perfectly good state-dependent icon never got one. The domain lookup now happens before that guard. One existing test asserted the old behaviour and has been updated.

New `entityIsActive()` teaches the on/off test the domains that never say `on`: a lock is `unlocked`, a vacuum is `cleaning`, a camera is `recording`. Outages are never active. Tap behaviour is untouched — locks still open more-info, they do not blind-toggle.

### Eight furniture types

`washer`, `dryer`, `dishwasher`, `waterHeater`, `airHandler`, `bathtub`, `vanity`, `sectional` — each drawn as a plan symbol rather than a labelled box. `dev/symbols.html` renders all 23 types on one sheet.

### A sectional with a handedness

`hand: "left" | "right"`, default `"right"`. The chaise extends to the right when you face the sofa from the front; the symbol's back is at local `-y` like every other furniture symbol, so `angle` composes normally. `"left"` is the exact mirror.

`sectionalPoints()` is a pure function, so the tests can assert what actually matters: six corners rather than four, area equal to `w*h` minus the notch, the chaise on the correct side of the front edge, and left being right mirrored rather than a differently-shaped sofa.

### Tests

103 → 126. `tsc --noEmit` clean, bundle 164.22 kB.

`FURNITURE_LABELS` is a `Record<FurnitureType, string>`, so the compiler now refuses a new furniture type that has no label. `FURNITURE_DEFAULT_SIZE` was already one. The render switch is not exhaustive in the type system, so there is a test that renders every type.

### Note on conflicts

This touches `src/editor.ts` to add the type dropdown and the conditional "Chaise side" row. @shauneccles's `ha-form` migration (#44) replaces those hand-rolled rows entirely; merging this first and letting #44 absorb the conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)