### PR TITLE
Anchor an item's icon on its coordinate, not its icon-plus-label (#34)

### DIFF
--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -425,7 +425,20 @@ export class FloorplanCard extends LitElement {
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 2px;
+    }
+    /*
+     * The item's x/y anchors its icon, not its icon-plus-label. Were the label
+     * in flow, it would make the column taller and the translate would
+     * push the icon up by half the label's height -- so an item showing state
+     * would sit higher than a bare one beside it, at the same y. The label hangs
+     * below instead, out of flow, and every icon lands on its own y.
+     */
+    .item > .label {
+      position: absolute;
+      top: calc(100% + 2px);
+      left: 50%;
+      transform: translateX(-50%);
+      white-space: nowrap;
     }
     .badge {
       width: 34px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -219,7 +219,11 @@ export class FloorplanCard extends LitElement {
         @click=${() => this._onItemClick(item)}
       >
         ${visual}
-        ${showState ? html`<span class="label">${itemStateText(this.hass, item)}</span>` : nothing}
+        ${showState
+          ? html`<span class="label ${visual === nothing ? "inflow" : ""}"
+              >${itemStateText(this.hass, item)}</span
+            >`
+          : nothing}
       </div>
     `;
   }
@@ -439,6 +443,13 @@ export class FloorplanCard extends LitElement {
       left: 50%;
       transform: translateX(-50%);
       white-space: nowrap;
+    }
+    /* Label-only items (showIcon: false) have no badge to hang under, so the
+       absolute label would drop to y + 2px on a zero-height item. Put it back
+       in flow so it becomes the item's box and centers on (x, y) as before. */
+    .label.inflow {
+      position: static;
+      transform: none;
     }
     .badge {
       width: 34px;


### PR DESCRIPTION
Fixes #34.

`.item` is `translate(-50%, -50%)` over a flex column holding the badge and, when the item shows state, a label. The label is in flow, so it makes the column taller, so the translate pushes the badge up by half the label's height.

Two items placed at the same `y` — one showing state, one not — therefore draw their icons at different heights. The reporter saw it as icons aligned along their bottoms rather than their tops.

The label now hangs below, out of flow. The column's height is the badge's height, so `x`/`y` anchors the icon and every icon lands where it was put. Nothing else moves: an item with `showIcon: false` still centres its label on the coordinate, as before.

### Measured

On a live dashboard, a thermostat badge with `showState` on, against its configured `top`:

| | badge centre |
|---|---|
| label in flow (before) | 41.927% |
| configured `top` | 42.430% |
| label out of flow (after) | 42.430% |

A drift of **7 px** at the default 34 px badge and 12 px label. It grows with the label.

### Testing

None added — this is CSS, and vitest runs here without a DOM. Verified in the browser by measuring the badge's bounding box against the stage, then re-injecting `position: static` on the label to reproduce the old layout and measuring again (the numbers above). Happy to add a DOM-based test if you'd like one; it would be the first in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)