### PR TITLE
Editor: full-screen edit mode, input correctness, and HA-norms alignment

### DIFF
--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { nearestCorner, snapWallEnd, elementsInRect, applyDelta } from "./editor-geometry";
+import type { OrigPos } from "./editor-geometry";
+import type { Floor } from "./types";
+
+const walls = [{ x1: 0, y1: 0, x2: 100, y2: 0 }];
+
+describe("nearestCorner", () => {
+  it("finds an endpoint within range", () => {
+    expect(nearestCorner(walls, 3, 4, 26)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("returns null when out of range", () => {
+    expect(nearestCorner(walls, 50, 50, 26)).toBeNull();
+  });
+
+  it("prefers the closest endpoint", () => {
+    expect(nearestCorner(walls, 95, 2, 26)).toEqual({ x: 100, y: 0 });
+  });
+});
+
+describe("snapWallEnd", () => {
+  const snap = (v: number) => Math.round(v / 10) * 10;
+
+  it("snaps flat to horizontal within the axis-gravity angle", () => {
+    expect(snapWallEnd(walls, 0, 50, 80, 53, snap, false, 10)).toEqual({ x: 80, y: 50 });
+  });
+
+  it("snaps flat to vertical within the axis-gravity angle", () => {
+    expect(snapWallEnd(walls, 0, 50, 3, 120, snap, false, 10)).toEqual({ x: 0, y: 120 });
+  });
+
+  it("keeps the free angle outside the gravity zone", () => {
+    expect(snapWallEnd(walls, 0, 0, 52, 48, snap, false, 10)).toEqual({ x: 50, y: 50 });
+  });
+
+  it("an existing corner beats axis gravity", () => {
+    expect(snapWallEnd(walls, 0, 50, 98, 3, snap, false, 10)).toEqual({ x: 100, y: 0 });
+  });
+
+  it("free mode only grid-snaps (corners and axes ignored)", () => {
+    expect(snapWallEnd(walls, 0, 0, 52, 48, snap, true, 10)).toEqual({ x: 50, y: 50 });
+    // (95, 12) is within corner-snap range of (100, 0): free mode must ignore
+    // the corner and yield the plain grid snap instead.
+    expect(snapWallEnd(walls, 0, 50, 95, 12, snap, true, 10)).toEqual({ x: 100, y: 10 });
+  });
+});
+
+const floor = {
+  id: "f",
+  name: "F",
+  walls: [{ id: "w", x1: 0, y1: 0, x2: 100, y2: 0 }],
+  openings: [{ id: "o", type: "door", x: 10, y: 10 }],
+  items: [{ id: "i", kind: "light", x: 200, y: 200, entity: "light.a" }],
+  texts: [],
+  furniture: [],
+  trackers: [{ id: "t", x: 0, y: 0, w: 20, h: 20 }],
+} as unknown as Floor;
+
+describe("elementsInRect", () => {
+  it("selects wall by midpoint, tracker by center, point elements by anchor", () => {
+    const hits = elementsInRect(floor, { x0: 0, y0: 0, x1: 60, y1: 60 });
+    expect(hits).toEqual([
+      { kind: "wall", id: "w" },
+      { kind: "opening", id: "o" },
+      { kind: "tracker", id: "t" },
+    ]);
+  });
+
+  it("handles inverted rects", () => {
+    const hits = elementsInRect(floor, { x0: 60, y0: 60, x1: 0, y1: 0 });
+    expect(hits.length).toBe(3);
+  });
+});
+
+describe("applyDelta", () => {
+  it("translates only snapshotted elements; walls by all four coords", () => {
+    const f = {
+      id: "f",
+      name: "F",
+      walls: [
+        { id: "w", x1: 0, y1: 0, x2: 100, y2: 0 },
+        { id: "w2", x1: 5, y1: 5, x2: 6, y2: 6 },
+      ],
+      openings: [],
+      items: [],
+      texts: [],
+      furniture: [],
+      trackers: [],
+    } as unknown as Floor;
+    const orig = new Map<string, OrigPos>([
+      ["wall:w", { kind: "wall", x1: 0, y1: 0, x2: 100, y2: 0 }],
+    ]);
+    const out = applyDelta(f, 10, 20, orig);
+    expect(out.walls![0]).toMatchObject({ x1: 10, y1: 20, x2: 110, y2: 20 });
+    expect(out.walls![1]).toMatchObject({ x1: 5, y1: 5 });
+  });
+
+  it("translates point elements from their snapshot, not their current position", () => {
+    const f = {
+      ...floor,
+      openings: [{ id: "o", type: "door", x: 999, y: 999 }],
+    } as unknown as Floor;
+    const orig = new Map<string, OrigPos>([["opening:o", { kind: "pt", x: 10, y: 10 }]]);
+    const out = applyDelta(f, 5, 5, orig);
+    expect(out.openings![0]).toMatchObject({ x: 15, y: 15 });
+  });
+});

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -1,0 +1,132 @@
+import type { Floor, Wall } from "./types";
+
+/** Element kinds addressable by the editor's selection model. */
+export type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker";
+
+export interface Sel {
+  kind: SelKind;
+  id: string;
+}
+
+/** Snapshot of an element's position at drag start, for group translation. */
+export type OrigPos =
+  | { kind: "wall"; x1: number; y1: number; x2: number; y2: number }
+  | { kind: "pt"; x: number; y: number };
+
+/** A rectangle described by two opposite corners (any orientation). */
+export interface Rect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+type WallSegment = Pick<Wall, "x1" | "y1" | "x2" | "y2">;
+
+/** Snap distance (virtual units) for wall endpoints onto each other. */
+export const ENDPOINT_SNAP = 26;
+
+/** Nearest existing wall endpoint within `maxDist`, or null. */
+export function nearestCorner(
+  walls: readonly WallSegment[],
+  rawX: number,
+  rawY: number,
+  maxDist: number
+): { x: number; y: number } | null {
+  let best: { x: number; y: number } | null = null;
+  let bestDist = maxDist;
+  for (const w of walls) {
+    for (const e of [
+      { x: w.x1, y: w.y1 },
+      { x: w.x2, y: w.y2 },
+    ]) {
+      const d = Math.hypot(rawX - e.x, rawY - e.y);
+      if (d < bestDist) {
+        bestDist = d;
+        best = { x: e.x, y: e.y };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Snap a wall's moving endpoint while drawing. Existing corners win (so rooms
+ * close/continue); otherwise, unless free-draw is on, apply "gravity" toward
+ * horizontal/vertical relative to the start point. The position itself snaps
+ * via `snap` (the grid by default, or nothing when Snap is Off) — "straighten"
+ * only governs the H/V alignment, not snapping.
+ */
+export function snapWallEnd(
+  walls: readonly WallSegment[],
+  x1: number,
+  y1: number,
+  rawX: number,
+  rawY: number,
+  snap: (v: number) => number,
+  free: boolean,
+  axisSnapDeg: number,
+  cornerSnap = ENDPOINT_SNAP
+): { x: number; y: number } {
+  if (free) return { x: snap(rawX), y: snap(rawY) };
+  const corner = nearestCorner(walls, rawX, rawY, cornerSnap);
+  if (corner) return corner;
+  const dx = rawX - x1;
+  const dy = rawY - y1;
+  const t = Math.tan((axisSnapDeg * Math.PI) / 180);
+  // Sticky: align flat to an axis when close; the free coordinate snaps to step.
+  if (Math.abs(dy) <= Math.abs(dx) * t) return { x: snap(rawX), y: y1 }; // horizontal
+  if (Math.abs(dx) <= Math.abs(dy) * t) return { x: x1, y: snap(rawY) }; // vertical
+  return { x: snap(rawX), y: snap(rawY) };
+}
+
+/** All floor elements whose reference point lies inside the (any-orientation) rect. */
+export function elementsInRect(f: Floor, m: Rect): Sel[] {
+  const minX = Math.min(m.x0, m.x1);
+  const maxX = Math.max(m.x0, m.x1);
+  const minY = Math.min(m.y0, m.y1);
+  const maxY = Math.max(m.y0, m.y1);
+  const inside = (x: number, y: number) => x >= minX && x <= maxX && y >= minY && y <= maxY;
+  const out: Sel[] = [];
+  for (const w of f.walls)
+    if (inside((w.x1 + w.x2) / 2, (w.y1 + w.y2) / 2)) out.push({ kind: "wall", id: w.id });
+  for (const o of f.openings) if (inside(o.x, o.y)) out.push({ kind: "opening", id: o.id });
+  for (const it of f.items) if (inside(it.x, it.y)) out.push({ kind: "item", id: it.id });
+  for (const t of f.texts) if (inside(t.x, t.y)) out.push({ kind: "text", id: t.id });
+  for (const fu of f.furniture) if (inside(fu.x, fu.y)) out.push({ kind: "furniture", id: fu.id });
+  for (const tr of f.trackers ?? [])
+    if (inside(tr.x + tr.w / 2, tr.y + tr.h / 2)) out.push({ kind: "tracker", id: tr.id });
+  return out;
+}
+
+/** Translate every snapshotted element by (dx, dy). */
+export function applyDelta(f: Floor, dx: number, dy: number, orig: Map<string, OrigPos>): Partial<Floor> {
+  return {
+    walls: f.walls.map((w) => {
+      const o = orig.get(`wall:${w.id}`);
+      return o && o.kind === "wall"
+        ? { ...w, x1: o.x1 + dx, y1: o.y1 + dy, x2: o.x2 + dx, y2: o.y2 + dy }
+        : w;
+    }),
+    openings: f.openings.map((el) => {
+      const o = orig.get(`opening:${el.id}`);
+      return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+    items: f.items.map((el) => {
+      const o = orig.get(`item:${el.id}`);
+      return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+    texts: f.texts.map((el) => {
+      const o = orig.get(`text:${el.id}`);
+      return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+    furniture: f.furniture.map((el) => {
+      const o = orig.get(`furniture:${el.id}`);
+      return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+    trackers: (f.trackers ?? []).map((el) => {
+      const o = orig.get(`tracker:${el.id}`);
+      return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+  };
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -53,6 +53,8 @@ import {
   entityDefaultIcon,
   kindFromEntity,
   snapToWall,
+  collectWatchedEntities,
+  hassRenderInputsChanged,
 } from "./render";
 
 const FURNITURE_TYPES: FurnitureType[] = [
@@ -165,6 +167,8 @@ export class FloorplanCardEditor extends LitElement {
   private readonly _wallMaskId = `fp-edit-wall-mask-${FloorplanCardEditor._nextWallMaskId++}`;
 
   @property({ attribute: false }) public hass?: HomeAssistant;
+  /** Entity ids this plan displays; used to skip irrelevant hass updates. */
+  private _watchedEntities: Set<string> = new Set();
   @state() private _config!: FloorplanCardConfig;
   @state() private _tool: Tool = "select";
   @state() private _selection: Sel[] = [];
@@ -254,6 +258,23 @@ export class FloorplanCardEditor extends LitElement {
       this._future = [];
       this._liveEditKey = null;
     }
+    this._watchedEntities = collectWatchedEntities(this._config);
+  }
+
+  /**
+   * HA replaces `hass` on every state change in the instance; the editor's
+   * render is expensive (full SVG + panels). Skip ticks that can't change
+   * anything we draw. Entity pickers keep the `hass` they last rendered with —
+   * acceptable, the registry data they browse changes rarely.
+   */
+  protected shouldUpdate(changed: PropertyValues): boolean {
+    if (!(changed.size === 1 && changed.has("hass"))) return true;
+    const prev = changed.get("hass") as HomeAssistant | undefined;
+    if (!prev || !this.hass) return true;
+    // The HA-floor link select reads the floor registry.
+    const floorsOf = (h: HomeAssistant) => (h as { floors?: unknown }).floors;
+    if (floorsOf(prev) !== floorsOf(this.hass)) return true;
+    return hassRenderInputsChanged(prev, this.hass, this._watchedEntities);
   }
 
   // ---- active floor access -----------------------------------------------
@@ -284,6 +305,13 @@ export class FloorplanCardEditor extends LitElement {
 
   protected firstUpdated(): void {
     void this._ensurePickers();
+    // Upgrade the plain-input fallbacks in place whenever a picker element
+    // gets defined later (by us or by another editor the user opened).
+    for (const tag of ["ha-entity-picker", "ha-icon-picker"]) {
+      if (!customElements.get(tag)) {
+        void customElements.whenDefined(tag).then(() => this.requestUpdate());
+      }
+    }
   }
 
   /**
@@ -295,8 +323,11 @@ export class FloorplanCardEditor extends LitElement {
    * hides the popover on its own. Browsers without the API keep the fixed
    * fallback, which is already correct on the mobile dialog (transform: none).
    */
-  protected updated(changed: PropertyValues): void {
-    if (!changed.has("_fullscreen") || !this._fullscreen) return;
+  protected updated(): void {
+    // Re-asserted on every render while fullscreen (not just the transition):
+    // idempotent via :popover-open, and it self-heals if the browser
+    // force-hid the popover, e.g. across a disconnect/reconnect.
+    if (!this._fullscreen) return;
     const el = this._editorEl;
     if (!el?.isConnected || typeof el.showPopover !== "function") return;
     if (!el.matches(":popover-open")) {
@@ -437,9 +468,15 @@ export class FloorplanCardEditor extends LitElement {
 
   private _emit(config: FloorplanCardConfig): void {
     this._config = config;
-    this._lastEmitted = config;
+    // Emit without the legacy flat arrays: `floors` is the source of truth,
+    // and empty stubs would otherwise be persisted into the user's YAML.
+    const out = { ...config };
+    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers"] as const) {
+      if (!out[key]?.length) delete out[key];
+    }
+    this._lastEmitted = out;
     this.dispatchEvent(
-      new CustomEvent("config-changed", { detail: { config }, bubbles: true, composed: true })
+      new CustomEvent("config-changed", { detail: { config: out }, bubbles: true, composed: true })
     );
   }
 
@@ -1756,7 +1793,13 @@ export class FloorplanCardEditor extends LitElement {
                   html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>${f.name}</option>`
               )}
             </select>
-            <button title="Add a floor (copies the current walls)" @click=${this._addFloor}>+</button>
+            <button
+              aria-label="Add floor"
+              title="Add a floor (copies the current walls)"
+              @click=${this._addFloor}
+            >
+              +
+            </button>
             <button
               aria-label="Floor settings"
               title="Rename or delete this floor"
@@ -1896,9 +1939,42 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
+  /**
+   * `ha-entity-picker` when defined, else a plain entity-id input — mirrors
+   * the icon-picker fallback so entity binding never silently dead-ends when
+   * the helper load fails or the editor runs outside HA.
+   */
+  private _renderEntityPicker(
+    value: string,
+    onChange: (entity: string) => void,
+    includeDomains?: string[]
+  ): TemplateResult {
+    if (customElements.get("ha-entity-picker")) {
+      return html`<ha-entity-picker
+        .hass=${this.hass}
+        .value=${value}
+        .includeDomains=${includeDomains}
+        allow-custom-entity
+        @value-changed=${(e: CustomEvent) => onChange((e.detail.value as string) ?? "")}
+      ></ha-entity-picker>`;
+    }
+    return html`<input
+      type="text"
+      placeholder="sensor.example"
+      .value=${value}
+      @change=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
+    />`;
+  }
+
   /** Toggle the full-screen workspace. */
   private _toggleFullscreen(): void {
     this._fullscreen = !this._fullscreen;
+    if (this._fullscreen && this._canvasWrap) {
+      // A drag-resized canvas carries inline width/height that would defeat
+      // the fullscreen flex fill.
+      this._canvasWrap.style.width = "";
+      this._canvasWrap.style.height = "";
+    }
     // Any open toolbar popover would be orphaned by the layout change.
     this._floorMenuOpen = false;
     this._addMenuOpen = false;
@@ -2324,11 +2400,10 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
-   * Editor fields for the currently-selected element, rendered inline inside the
-   * context bar so the user can configure the selection without scrolling away
-   * from the canvas. Returns nothing when the selection isn't exactly one
-   * element — multi-select and empty-select states are handled by the context
-   * bar itself.
+   * Editor fields for the currently-selected element, rendered in the Element
+   * section below the canvas (docked beside it in fullscreen). Returns nothing
+   * when the selection isn't exactly one element — multi-select and
+   * empty-select states are handled by the Element header itself.
    */
   private _renderSelectionEditor(): TemplateResult {
     const sel = this._primary();
@@ -2454,13 +2529,10 @@ export class FloorplanCardEditor extends LitElement {
           : nothing}
         <div class="row wide">
           <label>Entity</label>
-          <ha-entity-picker
-            .hass=${this.hass}
-            .value=${o.entity ?? ""}
-            .includeDomains=${["binary_sensor", "cover"]}
-            allow-custom-entity
-            @value-changed=${(e: CustomEvent) => {
-              const entity = (e.detail.value as string) || undefined;
+          ${this._renderEntityPicker(
+            o.entity ?? "",
+            (value) => {
+              const entity = value || undefined;
               // Infer type/motion from the entity's HA device_class (e.g. a
               // `cover` with device_class `window` → a window; a `garage`
               // roller → a sliding door). Only when the class is known, so we
@@ -2469,8 +2541,9 @@ export class FloorplanCardEditor extends LitElement {
                 ? (this.hass?.states[entity]?.attributes?.device_class as string | undefined)
                 : undefined;
               this._updateOpening(o.id, { entity, ...(dc ? openingFromDeviceClass(dc) : {}) });
-            }}
-          ></ha-entity-picker>
+            },
+            ["binary_sensor", "cover"]
+          )}
         </div>
         ${o.entity
           ? html`<div class="row">
@@ -2519,27 +2592,15 @@ export class FloorplanCardEditor extends LitElement {
       return html`
         <div class="row wide">
           <label>Entity</label>
-          <ha-entity-picker
-            .hass=${this.hass}
-            .value=${it.entity}
-            allow-custom-entity
-            @value-changed=${(e: CustomEvent) => {
-              const entity = e.detail.value as string;
-              this._updateItem(it.id, { entity, kind: kindFromEntity(entity) });
-            }}
-          ></ha-entity-picker>
+          ${this._renderEntityPicker(it.entity, (entity) =>
+            this._updateItem(it.id, { entity, kind: kindFromEntity(entity) })
+          )}
         </div>
         <div class="row wide">
           <label>2nd entity</label>
-          <ha-entity-picker
-            .hass=${this.hass}
-            .value=${it.secondaryEntity ?? ""}
-            allow-custom-entity
-            @value-changed=${(e: CustomEvent) =>
-              this._updateItem(it.id, {
-                secondaryEntity: (e.detail.value as string) || undefined,
-              })}
-          ></ha-entity-picker>
+          ${this._renderEntityPicker(it.secondaryEntity ?? "", (value) =>
+            this._updateItem(it.id, { secondaryEntity: value || undefined })
+          )}
         </div>
         <div class="row wide">
           <label>Icon</label>
@@ -2839,15 +2900,24 @@ export class FloorplanCardEditor extends LitElement {
             class="num"
             type="number"
             .value=${String(Math.round(tr.x))}
-            @change=${(e: Event) =>
-              this._updateTracker(tr.id, { x: Number((e.target as HTMLInputElement).value) })}
+            @change=${(e: Event) => {
+              const input = e.target as HTMLInputElement;
+              const n = Number(input.value);
+              // A cleared/garbled field must not teleport the tracker to 0.
+              if (input.value !== "" && Number.isFinite(n)) this._updateTracker(tr.id, { x: n });
+              else input.value = String(Math.round(tr.x));
+            }}
           />
           <input
             class="num"
             type="number"
             .value=${String(Math.round(tr.y))}
-            @change=${(e: Event) =>
-              this._updateTracker(tr.id, { y: Number((e.target as HTMLInputElement).value) })}
+            @change=${(e: Event) => {
+              const input = e.target as HTMLInputElement;
+              const n = Number(input.value);
+              if (input.value !== "" && Number.isFinite(n)) this._updateTracker(tr.id, { y: n });
+              else input.value = String(Math.round(tr.y));
+            }}
           />
         </div>
         ${this._renderAngleRow(
@@ -2983,17 +3053,14 @@ export class FloorplanCardEditor extends LitElement {
     return html`
       <div class="row wide">
         <label>${label}</label>
-        <ha-entity-picker
-          .hass=${this.hass}
-          .value=${s?.entity ?? ""}
-          .includeDomains=${["sensor", "input_number", "number"]}
-          allow-custom-entity
-          @value-changed=${(e: CustomEvent) => {
-            const v = (e.detail.value as string) || "";
+        ${this._renderEntityPicker(
+          s?.entity ?? "",
+          (v) => {
             if (!v) this._updateTrackerSensor(tr.id, axis, null);
             else this._updateTrackerSensor(tr.id, axis, { entity: v });
-          }}
-        ></ha-entity-picker>
+          },
+          ["sensor", "input_number", "number"]
+        )}
       </div>
       ${s
         ? html`<div class="row">
@@ -3004,10 +3071,14 @@ export class FloorplanCardEditor extends LitElement {
               step="0.01"
               title="Reading at the near edge"
               .value=${String(s.min)}
-              @change=${(e: Event) =>
-                this._updateTrackerSensor(tr.id, axis, {
-                  min: Number((e.target as HTMLInputElement).value),
-                })}
+              @change=${(e: Event) => {
+                const input = e.target as HTMLInputElement;
+                const n = Number(input.value);
+                // A cleared field must not silently collapse the range to 0.
+                if (input.value !== "" && Number.isFinite(n))
+                  this._updateTrackerSensor(tr.id, axis, { min: n });
+                else input.value = String(s.min);
+              }}
             />
             <input
               class="num"
@@ -3015,10 +3086,13 @@ export class FloorplanCardEditor extends LitElement {
               step="0.01"
               title="Reading at the far edge"
               .value=${String(s.max)}
-              @change=${(e: Event) =>
-                this._updateTrackerSensor(tr.id, axis, {
-                  max: Number((e.target as HTMLInputElement).value),
-                })}
+              @change=${(e: Event) => {
+                const input = e.target as HTMLInputElement;
+                const n = Number(input.value);
+                if (input.value !== "" && Number.isFinite(n))
+                  this._updateTrackerSensor(tr.id, axis, { max: n });
+                else input.value = String(s.max);
+              }}
             />
             <label class="inline-check">
               <input
@@ -3034,18 +3108,14 @@ export class FloorplanCardEditor extends LitElement {
           </div>
           <div class="row wide">
             <label>${label} presence</label>
-            <ha-entity-picker
-              .hass=${this.hass}
-              .value=${s.presence?.entity ?? ""}
-              .includeDomains=${["binary_sensor", "input_boolean", "device_tracker"]}
-              allow-custom-entity
-              @value-changed=${(e: CustomEvent) => {
-                const v = (e.detail.value as string) || "";
+            ${this._renderEntityPicker(
+              s.presence?.entity ?? "",
+              (v) =>
                 this._updateTrackerSensor(tr.id, axis, {
                   presence: v ? { entity: v, invert: s.presence?.invert } : undefined,
-                });
-              }}
-            ></ha-entity-picker>
+                }),
+              ["binary_sensor", "input_boolean", "device_tracker"]
+            )}
             ${s.presence
               ? html`<label class="inline-check" title="Treat 'off' as detected">
                   <input
@@ -3076,8 +3146,9 @@ export class FloorplanCardEditor extends LitElement {
     /* Full-screen workspace, shown as a popover so the top layer lifts it clear
        of HA's edit dialog (whose surface is transformed — see updated()). The
        resets undo the UA popover defaults: fit-content size, auto margins, a
-       solid border and padding. z-index and the fixed position only matter to
-       the fallback path, where the dialog sets --dialog-z-index: 6. */
+       solid border and padding. The fixed position only matters to the
+       non-popover fallback, where the transformed dialog surface is the
+       containing block — there "fullscreen" fills the dialog, not the page. */
     .editor.fullscreen {
       position: fixed;
       inset: 0;
@@ -3093,9 +3164,6 @@ export class FloorplanCardEditor extends LitElement {
       color: inherit;
       background: var(--card-background-color, #fff);
       overflow: hidden;
-    }
-    .editor.fullscreen::backdrop {
-      background: rgba(0, 0, 0, 0.6);
     }
     /* Toolbar-icon button (Expand/Exit) — match the gear button's icon+label
        alignment so it reads as part of the toolbar. */
@@ -3150,6 +3218,9 @@ export class FloorplanCardEditor extends LitElement {
     @media (max-width: 900px) {
       .editor.fullscreen .workspace {
         flex-direction: column;
+        /* Stacked panels can exceed a short viewport (phone landscape) — the
+           root clips, so the workspace itself must scroll. */
+        overflow-y: auto;
       }
       .editor.fullscreen .side {
         flex: 0 0 auto;
@@ -3274,7 +3345,7 @@ export class FloorplanCardEditor extends LitElement {
     }
     button.active {
       background: var(--primary-color, #03a9f4);
-      color: #fff;
+      color: var(--text-primary-color, #fff);
       border-color: var(--primary-color, #03a9f4);
     }
     button.danger {
@@ -3584,7 +3655,7 @@ export class FloorplanCardEditor extends LitElement {
     }
     .handle {
       fill: var(--primary-color, #03a9f4);
-      stroke: #fff;
+      stroke: var(--card-background-color, #fff);
       stroke-width: 1.5;
       cursor: grab;
     }
@@ -3940,11 +4011,6 @@ export class FloorplanCardEditor extends LitElement {
       font-size: 13px;
       color: var(--secondary-text-color);
       line-height: 1.5;
-    }
-    hr {
-      border: none;
-      border-top: 1px solid var(--divider-color, #eee);
-      margin: 10px 0;
     }
   `;
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -50,12 +50,23 @@ import {
   renderTracker,
   trackerSensorReading,
   defaultIcon,
-  entityDefaultIcon,
   kindFromEntity,
+  resolveItemIcon,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
 } from "./render";
+import {
+  ENDPOINT_SNAP,
+  applyDelta,
+  elementsInRect,
+  nearestCorner,
+  snapWallEnd,
+  type OrigPos,
+  type Rect,
+  type Sel,
+  type SelKind,
+} from "./editor-geometry";
 
 const FURNITURE_TYPES: FurnitureType[] = [
   "table",
@@ -95,8 +106,6 @@ const FURNITURE_LABELS: Record<FurnitureType, string> = {
 };
 
 type Tool = "select" | "wall" | "door" | "window" | "tracker";
-type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker";
-type Sel = { kind: SelKind; id: string };
 type OverlaySel = { kind: "item" | "text"; id: string };
 
 /** Toolbar metadata per tool: mdi icon + label (icons make the modes scannable). */
@@ -118,11 +127,6 @@ const SEL_KIND_ICON: Record<SelKind, string> = {
   tracker: "mdi:crosshairs-gps",
 };
 
-/** Snapshot of an element's position at drag start, for group translation. */
-type OrigPos =
-  | { kind: "wall"; x1: number; y1: number; x2: number; y2: number }
-  | { kind: "pt"; x: number; y: number };
-
 interface Drag {
   /** The element under the pointer (drives snapping); the whole selection moves with it. */
   primary: Sel;
@@ -134,14 +138,11 @@ interface Drag {
   endpoint?: 1 | 2;
   /** Set once the drag actually moved something (history snapshots lazily). */
   moved?: boolean;
+  /** The exact history entry this drag pushed, so cancel can remove it by identity. */
+  snapshot?: FloorplanCardConfig;
 }
 
-interface Marquee {
-  x0: number;
-  y0: number;
-  x1: number;
-  y1: number;
-}
+type Marquee = Rect;
 
 /** Elements copied to the in-memory clipboard (not part of the config). */
 interface Clipboard {
@@ -153,9 +154,8 @@ interface Clipboard {
   trackers: Tracker[];
 }
 
-/** Snap distance (virtual units) for openings onto walls / wall endpoints onto each other. */
+/** Snap distance (virtual units) for openings onto walls. */
 const WALL_SNAP = 35;
-const ENDPOINT_SNAP = 26;
 const HISTORY_MAX = 60;
 /** Angle (degrees) within which a drawn wall is snapped flat to horizontal/vertical. */
 const WALL_AXIS_SNAP_DEG = 10;
@@ -414,21 +414,7 @@ export class FloorplanCardEditor extends LitElement {
 
   /** Nearest existing wall endpoint within ENDPOINT_SNAP, or null. */
   private _nearestCorner(rawX: number, rawY: number): { x: number; y: number } | null {
-    let best: { x: number; y: number } | null = null;
-    let bestDist = ENDPOINT_SNAP;
-    for (const w of this._floor().walls) {
-      for (const e of [
-        { x: w.x1, y: w.y1 },
-        { x: w.x2, y: w.y2 },
-      ]) {
-        const d = Math.hypot(rawX - e.x, rawY - e.y);
-        if (d < bestDist) {
-          bestDist = d;
-          best = { x: e.x, y: e.y };
-        }
-      }
-    }
-    return best;
+    return nearestCorner(this._floor().walls, rawX, rawY, ENDPOINT_SNAP);
   }
 
   /** Snap a raw point to a nearby existing wall endpoint, else to the snap step. */
@@ -436,29 +422,24 @@ export class FloorplanCardEditor extends LitElement {
     return this._nearestCorner(rawX, rawY) ?? { x: this._snap(rawX), y: this._snap(rawY) };
   }
 
-  /**
-   * Snap a wall's moving endpoint while drawing. Existing corners win (so rooms
-   * close/continue); otherwise, unless free-draw is on, apply "gravity" toward
-   * horizontal/vertical relative to the start point. The position itself snaps
-   * to the configured snap step (which is the grid by default, or nothing when
-   * Snap is Off) — "straighten" only governs the H/V alignment, not snapping.
-   */
+  /** See {@link snapWallEnd}: corners win, then axis gravity, then the snap step. */
   private _snapWallEnd(
     x1: number,
     y1: number,
     rawX: number,
     rawY: number
   ): { x: number; y: number } {
-    if (this._freeWalls) return { x: this._snap(rawX), y: this._snap(rawY) };
-    const corner = this._nearestCorner(rawX, rawY);
-    if (corner) return corner;
-    const dx = rawX - x1;
-    const dy = rawY - y1;
-    const t = Math.tan((WALL_AXIS_SNAP_DEG * Math.PI) / 180);
-    // Sticky: align flat to an axis when close; the free coordinate snaps to step.
-    if (Math.abs(dy) <= Math.abs(dx) * t) return { x: this._snap(rawX), y: y1 }; // horizontal
-    if (Math.abs(dx) <= Math.abs(dy) * t) return { x: x1, y: this._snap(rawY) }; // vertical
-    return { x: this._snap(rawX), y: this._snap(rawY) };
+    return snapWallEnd(
+      this._floor().walls,
+      x1,
+      y1,
+      rawX,
+      rawY,
+      (v) => this._snap(v),
+      this._freeWalls,
+      WALL_AXIS_SNAP_DEG,
+      ENDPOINT_SNAP
+    );
   }
 
   // ---- config mutation + history ----------------------------------------
@@ -468,6 +449,10 @@ export class FloorplanCardEditor extends LitElement {
 
   private _emit(config: FloorplanCardConfig): void {
     this._config = config;
+    // Recompute here, not just in setConfig: real HA deep-equal-skips the
+    // setConfig echo of our own emission, so entities bound during the
+    // session would otherwise never enter the watched set.
+    this._watchedEntities = collectWatchedEntities(config);
     // Emit without the legacy flat arrays: `floors` is the source of truth,
     // and empty stubs would otherwise be persisted into the user's YAML.
     const out = { ...config };
@@ -524,16 +509,21 @@ export class FloorplanCardEditor extends LitElement {
 
   private _selectOne(sel: Sel): void {
     this._selection = [sel];
+    // Selection changes end any live-edit burst: re-selecting the same
+    // element later must start a new undo step, not extend the old one.
+    this._liveEditKey = null;
   }
 
   private _toggleSel(sel: Sel): void {
     this._selection = this._isSel(sel.kind, sel.id)
       ? this._selection.filter((s) => !(s.kind === sel.kind && s.id === sel.id))
       : [...this._selection, sel];
+    this._liveEditKey = null;
   }
 
   private _clearSel(): void {
     this._selection = [];
+    this._liveEditKey = null;
   }
 
   /** Pointer-driven selection: modifier toggles; plain click selects unless already in the set. */
@@ -568,8 +558,22 @@ export class FloorplanCardEditor extends LitElement {
     // Only react while the user is actually working in the editor — the event
     // must originate inside it (the canvas is focusable, so canvas work counts).
     // A window-level listener sees every key on the page; without this, keys
-    // leak in from HA UI stacked above (more-info dialog, quick-bar).
-    if (!path.includes(this)) return;
+    // leak in from HA UI stacked above (more-info dialog, quick-bar). The
+    // deliberate cost: shortcuts are dead until the first click inside the
+    // editor after the dialog opens.
+    if (!path.includes(this)) {
+      // While fullscreen the workspace owns the screen: an Escape that fires
+      // from `body` (focus dropped after a blur or a dead-space click) must
+      // collapse it rather than reach — and close — HA's dialog hidden
+      // underneath. A dialog stacked above us is unaffected: it takes focus,
+      // and the focusin guard has already collapsed fullscreen by then.
+      if (this._fullscreen && ev.key === "Escape") {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._fullscreen = false;
+      }
+      return;
+    }
     // Don't hijack keys while typing in a field / picker.
     const typing = path.some((el) => {
       const node = el as HTMLElement;
@@ -591,13 +595,20 @@ export class FloorplanCardEditor extends LitElement {
       if (ev.key === "Escape" && this._fullscreen) {
         ev.preventDefault();
         ev.stopPropagation();
-        (path[0] as HTMLElement | undefined)?.blur?.();
+        // Move focus to the canvas (not a bare blur, which would strand focus
+        // on `body` and route the next Escape around the editor entirely).
+        this._canvasWrap?.focus();
       }
       return;
     }
 
     const mod = ev.ctrlKey || ev.metaKey;
     const key = ev.key.toLowerCase();
+    // While a gesture is live, any keyboard mutation (paste, delete, nudge,
+    // undo…) would interleave with the drag's emits and history snapshot —
+    // ignore them all; Escape below still cancels the gesture itself.
+    const gestureActive = !!(this._drag || this._draft || this._draftTracker || this._marquee);
+    if (gestureActive && ev.key !== "Escape" && !(mod && key === "c")) return;
     if (mod && key === "c") {
       if (this._selection.length) {
         ev.preventDefault();
@@ -622,15 +633,12 @@ export class FloorplanCardEditor extends LitElement {
     // Undo / redo — the toolbar buttons exist, but the keyboard is what
     // everyone reaches for first. Ctrl/Cmd+Z, Shift for redo, plus Ctrl+Y.
     if (mod && key === "z") {
-      // Mid-gesture undo would emit on top of the restored config — ignore.
-      if (this._drag || this._draft || this._draftTracker || this._marquee) return;
       ev.preventDefault();
       if (ev.shiftKey) this._redo();
       else this._undo();
       return;
     }
     if (mod && key === "y") {
-      if (this._drag || this._draft || this._draftTracker || this._marquee) return;
       ev.preventDefault();
       this._redo();
       return;
@@ -776,8 +784,9 @@ export class FloorplanCardEditor extends LitElement {
 
   /**
    * Abort any in-progress gesture. A moved drag is rolled back to the exact
-   * pre-drag config (restoring wall-snap angle changes too) and its history
-   * snapshot is dropped — a canceled drag leaves no trace in undo.
+   * pre-drag config (restoring wall-snap angle changes too) and its own
+   * history snapshot — matched by identity, in case something else pushed in
+   * between — is dropped, so a canceled drag leaves no trace in undo.
    */
   private _cancelGesture(): void {
     this._gesturePointer = null;
@@ -786,10 +795,9 @@ export class FloorplanCardEditor extends LitElement {
     this._marquee = null;
     const drag = this._drag;
     this._drag = null;
-    if (drag?.moved) {
-      const prev = this._history[this._history.length - 1];
-      this._history = this._history.slice(0, -1);
-      if (prev) this._emit(prev);
+    if (drag?.moved && drag.snapshot) {
+      this._history = this._history.filter((c) => c !== drag.snapshot);
+      this._emit(drag.snapshot);
     }
   }
 
@@ -875,6 +883,7 @@ export class FloorplanCardEditor extends LitElement {
       }
       const hits = this._elementsInRect(m);
       this._selection = this._marqueeAdd ? this._mergeSel(this._selection, hits) : hits;
+      this._liveEditKey = null;
       return;
     }
     if (this._drag) {
@@ -885,22 +894,7 @@ export class FloorplanCardEditor extends LitElement {
 
   /** All active-floor elements whose center lies inside the marquee rect. */
   private _elementsInRect(m: Marquee): Sel[] {
-    const minX = Math.min(m.x0, m.x1);
-    const maxX = Math.max(m.x0, m.x1);
-    const minY = Math.min(m.y0, m.y1);
-    const maxY = Math.max(m.y0, m.y1);
-    const inside = (x: number, y: number) => x >= minX && x <= maxX && y >= minY && y <= maxY;
-    const f = this._floor();
-    const out: Sel[] = [];
-    for (const w of f.walls)
-      if (inside((w.x1 + w.x2) / 2, (w.y1 + w.y2) / 2)) out.push({ kind: "wall", id: w.id });
-    for (const o of f.openings) if (inside(o.x, o.y)) out.push({ kind: "opening", id: o.id });
-    for (const it of f.items) if (inside(it.x, it.y)) out.push({ kind: "item", id: it.id });
-    for (const t of f.texts) if (inside(t.x, t.y)) out.push({ kind: "text", id: t.id });
-    for (const fu of f.furniture) if (inside(fu.x, fu.y)) out.push({ kind: "furniture", id: fu.id });
-    for (const tr of f.trackers ?? [])
-      if (inside(tr.x + tr.w / 2, tr.y + tr.h / 2)) out.push({ kind: "tracker", id: tr.id });
-    return out;
+    return elementsInRect(this._floor(), m);
   }
 
   // ---- dragging existing elements ----------------------------------------
@@ -954,13 +948,17 @@ export class FloorplanCardEditor extends LitElement {
 
   private _applyDrag(ev: PointerEvent): void {
     const drag = this._drag!;
-    // First actual movement: snapshot for undo now, not at pointerdown, so a
-    // plain selection click doesn't spam history or wipe the redo stack.
+    const p = this._toVirtual(ev, false);
+    // First *effective* movement: snapshot for undo now, not at pointerdown,
+    // so a plain selection click — including the ~1px jitter real clicks and
+    // taps produce — doesn't spam history or wipe the redo stack. Threshold
+    // matches the marquee's click-vs-drag test.
     if (!drag.moved) {
+      if (Math.hypot(p.x - drag.start.x, p.y - drag.start.y) <= 4) return;
       drag.moved = true;
       this._pushHistory();
+      drag.snapshot = this._history[this._history.length - 1];
     }
-    const p = this._toVirtual(ev, false);
     const f = this._floor();
 
     // Single wall endpoint handle: snaps to nearby wall corners.
@@ -1008,35 +1006,7 @@ export class FloorplanCardEditor extends LitElement {
 
   /** Translate every snapshotted element by (dx, dy). */
   private _applyDelta(dx: number, dy: number, orig: Map<string, OrigPos>): Partial<Floor> {
-    const f = this._floor();
-    return {
-      walls: f.walls.map((w) => {
-        const o = orig.get(`wall:${w.id}`);
-        return o && o.kind === "wall"
-          ? { ...w, x1: o.x1 + dx, y1: o.y1 + dy, x2: o.x2 + dx, y2: o.y2 + dy }
-          : w;
-      }),
-      openings: f.openings.map((el) => {
-        const o = orig.get(`opening:${el.id}`);
-        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
-      }),
-      items: f.items.map((el) => {
-        const o = orig.get(`item:${el.id}`);
-        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
-      }),
-      texts: f.texts.map((el) => {
-        const o = orig.get(`text:${el.id}`);
-        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
-      }),
-      furniture: f.furniture.map((el) => {
-        const o = orig.get(`furniture:${el.id}`);
-        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
-      }),
-      trackers: (f.trackers ?? []).map((el) => {
-        const o = orig.get(`tracker:${el.id}`);
-        return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
-      }),
-    };
+    return applyDelta(this._floor(), dx, dy, orig);
   }
 
   // ---- overlay drag for items & texts (HTML, not SVG) --------------------
@@ -2171,16 +2141,8 @@ export class FloorplanCardEditor extends LitElement {
 
   private _renderItemOverlay(it: FloorItem, c: FloorplanCardConfig): TemplateResult {
     const selected = this._isSel("item", it.id);
-    // Same icon precedence as the live card: config override → entity's
-    // explicit icon → device_class-implied icon ("show as") → kind default.
     const st = it.entity ? this.hass?.states[it.entity] : undefined;
-    const stateOn =
-      st?.state === "on" || st?.state === "open" || st?.state === "home" || st?.state === "playing";
-    const icon =
-      it.icon ??
-      (st?.attributes?.icon as string | undefined) ??
-      entityDefaultIcon(it.entity, st?.attributes?.device_class as string | undefined, stateOn) ??
-      defaultIcon(it.kind);
+    const icon = resolveItemIcon(it, st);
     const label = it.name || it.entity || it.kind;
     const size = it.size ?? DEFAULT_ITEM_SIZE;
     const showIcon = it.showIcon ?? true;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1382,6 +1382,17 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * Every new pointer interaction ends the current live-edit burst, so two
+   * separate drags of the same slider (or two picker sessions on the same
+   * color field) become two undo steps instead of silently merging into one.
+   * Canvas gestures stop propagation before reaching this, but they snapshot
+   * history themselves. `_liveEditKey` is non-reactive — no render triggered.
+   */
+  private _onEditorPointerDown = (): void => {
+    this._liveEditKey = null;
+  };
+
+  /**
    * Live variants for continuous controls (sliders, color pickers, typing):
    * one undo snapshot per edit burst — keyed by element and fields — then
    * plain emits, instead of a full-config clone per input event.
@@ -1678,6 +1689,7 @@ export class FloorplanCardEditor extends LitElement {
       <div
         class="editor ${this._fullscreen ? "fullscreen" : ""}"
         popover=${this._fullscreen ? "manual" : nothing}
+        @pointerdown=${this._onEditorPointerDown}
       >
         ${this._floorMenuOpen || this._addMenuOpen
           ? html`<div

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
   FURNITURE_DEFAULT_SIZE,
+  configsEqual,
   emptyConfig,
   getFloors,
   gridPercentToSnap,
@@ -129,6 +130,8 @@ interface Drag {
   orig: Map<string, OrigPos>;
   /** Set when dragging a single wall endpoint handle. */
   endpoint?: 1 | 2;
+  /** Set once the drag actually moved something (history snapshots lazily). */
+  moved?: boolean;
 }
 
 interface Marquee {
@@ -196,19 +199,29 @@ export class FloorplanCardEditor extends LitElement {
   @query(".canvas-wrap") private _canvasWrap?: HTMLElement;
 
   private _drag: Drag | null = null;
+  /** Pointer driving the current gesture; others are ignored while it's active. */
+  private _gesturePointer: number | null = null;
   /** True when the active marquee should add to (rather than replace) the selection. */
   private _marqueeAdd = false;
   private _clipboard: Clipboard | null = null;
   private _onKeyDown = (ev: KeyboardEvent) => this._handleKeyDown(ev);
+  private _onFocusIn = (ev: FocusEvent) => {
+    // While the fullscreen popover is up, anything that pulls focus outside the
+    // editor (Tab past the last control, a dialog opening above) lands on UI
+    // hidden behind the top layer. Collapse instead of leaving the user blind.
+    if (this._fullscreen && !ev.composedPath().includes(this)) this._fullscreen = false;
+  };
 
   public connectedCallback(): void {
     super.connectedCallback();
     // Capture phase so HA's dialog can't swallow the arrow keys before we see them.
     window.addEventListener("keydown", this._onKeyDown, true);
+    window.addEventListener("focusin", this._onFocusIn);
   }
 
   public disconnectedCallback(): void {
     window.removeEventListener("keydown", this._onKeyDown, true);
+    window.removeEventListener("focusin", this._onFocusIn);
     super.disconnectedCallback();
   }
 
@@ -232,6 +245,14 @@ export class FloorplanCardEditor extends LitElement {
         base.defaultFloor && floors.some((f) => f.id === base.defaultFloor)
           ? base.defaultFloor
           : floors[0].id;
+    }
+    // A setConfig that isn't the echo of our own emission is an external change
+    // (YAML-tab edit, a different card loaded into the dialog): stale undo/redo
+    // snapshots would silently revert it, so drop them.
+    if (this._lastEmitted && config !== this._lastEmitted && !configsEqual(config, this._lastEmitted)) {
+      this._history = [];
+      this._future = [];
+      this._liveEditKey = null;
     }
   }
 
@@ -411,16 +432,24 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- config mutation + history ----------------------------------------
 
+  /** The config most recently dispatched, to recognize HA's setConfig echo. */
+  private _lastEmitted?: FloorplanCardConfig;
+
   private _emit(config: FloorplanCardConfig): void {
     this._config = config;
+    this._lastEmitted = config;
     this.dispatchEvent(
       new CustomEvent("config-changed", { detail: { config }, bubbles: true, composed: true })
     );
   }
 
-  private _pushHistory(): void {
+  /** Key of the in-progress live-edit burst (one history snapshot per burst). */
+  private _liveEditKey: string | null = null;
+
+  private _pushHistory(burstKey: string | null = null): void {
     this._history = [...this._history, structuredClone(this._config)].slice(-HISTORY_MAX);
     this._future = [];
+    this._liveEditKey = burstKey;
   }
 
   /** Discrete change: snapshot for undo, then emit. */
@@ -430,6 +459,7 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   private _undo(): void {
+    this._liveEditKey = null;
     if (!this._history.length) return;
     this._future = [structuredClone(this._config), ...this._future];
     const prev = this._history[this._history.length - 1];
@@ -439,6 +469,7 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   private _redo(): void {
+    this._liveEditKey = null;
     if (!this._future.length) return;
     this._history = [...this._history, structuredClone(this._config)];
     const next = this._future[0];
@@ -496,21 +527,37 @@ export class FloorplanCardEditor extends LitElement {
     // so ignore the event unless this editor is actually visible.
     const checkVisibility = (this as { checkVisibility?: () => boolean }).checkVisibility;
     if (checkVisibility && !checkVisibility.call(this)) return;
-    // Don't hijack keys while typing in a field / picker.
     const path = ev.composedPath();
-    if (
-      path.some((el) => {
-        const tag = (el as HTMLElement).tagName?.toLowerCase();
-        return (
-          tag === "input" ||
-          tag === "textarea" ||
-          tag === "select" ||
-          tag === "ha-entity-picker" ||
-          tag === "ha-icon-picker"
-        );
-      })
-    )
+    // Only react while the user is actually working in the editor — the event
+    // must originate inside it (the canvas is focusable, so canvas work counts).
+    // A window-level listener sees every key on the page; without this, keys
+    // leak in from HA UI stacked above (more-info dialog, quick-bar).
+    if (!path.includes(this)) return;
+    // Don't hijack keys while typing in a field / picker.
+    const typing = path.some((el) => {
+      const node = el as HTMLElement;
+      const tag = node.tagName?.toLowerCase();
+      return (
+        tag === "input" ||
+        tag === "textarea" ||
+        tag === "select" ||
+        tag === "ha-entity-picker" ||
+        tag === "ha-icon-picker" ||
+        node.isContentEditable === true
+      );
+    });
+    if (typing) {
+      // While fullscreen, Escape must never fall through to HA's dialog — it
+      // would close it underneath the top-layer workspace (and a dirty config
+      // pops an invisible confirm behind it). First Esc leaves the field; the
+      // next one runs the normal cascade below.
+      if (ev.key === "Escape" && this._fullscreen) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        (path[0] as HTMLElement | undefined)?.blur?.();
+      }
       return;
+    }
 
     const mod = ev.ctrlKey || ev.metaKey;
     const key = ev.key.toLowerCase();
@@ -538,12 +585,15 @@ export class FloorplanCardEditor extends LitElement {
     // Undo / redo — the toolbar buttons exist, but the keyboard is what
     // everyone reaches for first. Ctrl/Cmd+Z, Shift for redo, plus Ctrl+Y.
     if (mod && key === "z") {
+      // Mid-gesture undo would emit on top of the restored config — ignore.
+      if (this._drag || this._draft || this._draftTracker || this._marquee) return;
       ev.preventDefault();
       if (ev.shiftKey) this._redo();
       else this._undo();
       return;
     }
     if (mod && key === "y") {
+      if (this._drag || this._draft || this._draftTracker || this._marquee) return;
       ev.preventDefault();
       this._redo();
       return;
@@ -560,12 +610,10 @@ export class FloorplanCardEditor extends LitElement {
         this._addMenuOpen = false;
         return;
       }
-      if (this._draft || this._draftTracker || this._marquee) {
+      if (this._draft || this._draftTracker || this._marquee || this._drag) {
         ev.preventDefault();
         ev.stopPropagation();
-        this._draft = null;
-        this._draftTracker = null;
-        this._marquee = null;
+        this._cancelGesture();
       } else if (this._selection.length) {
         ev.preventDefault();
         ev.stopPropagation();
@@ -656,6 +704,9 @@ export class FloorplanCardEditor extends LitElement {
 
   private _onCanvasDown(ev: PointerEvent): void {
     if (ev.button !== 0) return;
+    // One gesture at a time: a second touch must not hijack the state machine.
+    if (this._gesturePointer !== null) return;
+    this._canvasWrap?.focus();
     const raw = this._toVirtual(ev, false);
 
     if (this._tool === "wall") {
@@ -663,6 +714,7 @@ export class FloorplanCardEditor extends LitElement {
         ? { x: this._snap(raw.x), y: this._snap(raw.y) }
         : this._snapWallPoint(raw.x, raw.y);
       this._draft = { x1: s.x, y1: s.y, x2: s.x, y2: s.y };
+      this._gesturePointer = ev.pointerId;
       this._capturePointer(ev);
       return;
     }
@@ -674,16 +726,55 @@ export class FloorplanCardEditor extends LitElement {
       const x = this._snap(raw.x);
       const y = this._snap(raw.y);
       this._draftTracker = { x0: x, y0: y, x1: x, y1: y };
+      this._gesturePointer = ev.pointerId;
       this._capturePointer(ev);
       return;
     }
     // Select tool, empty canvas: start a marquee (rubber-band) selection.
     this._marqueeAdd = ev.shiftKey || ev.ctrlKey || ev.metaKey;
     this._marquee = { x0: raw.x, y0: raw.y, x1: raw.x, y1: raw.y };
+    this._gesturePointer = ev.pointerId;
     this._capturePointer(ev);
   }
 
+  /**
+   * Abort any in-progress gesture. A moved drag is rolled back to the exact
+   * pre-drag config (restoring wall-snap angle changes too) and its history
+   * snapshot is dropped — a canceled drag leaves no trace in undo.
+   */
+  private _cancelGesture(): void {
+    this._gesturePointer = null;
+    this._draft = null;
+    this._draftTracker = null;
+    this._marquee = null;
+    const drag = this._drag;
+    this._drag = null;
+    if (drag?.moved) {
+      const prev = this._history[this._history.length - 1];
+      this._history = this._history.slice(0, -1);
+      if (prev) this._emit(prev);
+    }
+  }
+
+  private _onPointerCancel(ev: PointerEvent): void {
+    if (this._gesturePointer !== null && ev.pointerId !== this._gesturePointer) return;
+    this._cancelGesture();
+  }
+
+  /** True when this event belongs to a pointer other than the gesture's. */
+  private _foreignPointer(ev: PointerEvent): boolean {
+    return this._gesturePointer !== null && ev.pointerId !== this._gesturePointer;
+  }
+
   private _onCanvasMove(ev: PointerEvent): void {
+    if (this._foreignPointer(ev)) return;
+    // A gesture with no buttons held means pointerup never reached us
+    // (alt-tab, dialog retarget) — treat it as canceled instead of letting
+    // the element chase the hovering mouse.
+    if (ev.buttons === 0 && (this._drag || this._draft || this._draftTracker || this._marquee)) {
+      this._cancelGesture();
+      return;
+    }
     if (this._tool === "wall" && this._draft) {
       const raw = this._toVirtual(ev, false);
       const s = this._snapWallEnd(this._draft.x1, this._draft.y1, raw.x, raw.y);
@@ -708,6 +799,8 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   private _onCanvasUp(ev: PointerEvent): void {
+    if (this._foreignPointer(ev)) return;
+    this._gesturePointer = null;
     if (this._tool === "wall" && this._draft) {
       const d = this._draft;
       this._draft = null;
@@ -778,6 +871,8 @@ export class FloorplanCardEditor extends LitElement {
   private _startDrag(ev: PointerEvent, sel: Sel, endpoint?: 1 | 2): void {
     if (this._tool !== "select") return;
     ev.stopPropagation();
+    if (this._gesturePointer !== null) return;
+    this._canvasWrap?.focus();
     // Endpoint handles always operate on that single wall.
     if (endpoint) this._selectOne(sel);
     else this._selectForPointer(ev, sel);
@@ -787,7 +882,7 @@ export class FloorplanCardEditor extends LitElement {
       orig: this._snapshotSelection(),
       endpoint,
     };
-    this._pushHistory();
+    this._gesturePointer = ev.pointerId;
     this._capturePointer(ev);
   }
 
@@ -822,6 +917,12 @@ export class FloorplanCardEditor extends LitElement {
 
   private _applyDrag(ev: PointerEvent): void {
     const drag = this._drag!;
+    // First actual movement: snapshot for undo now, not at pointerdown, so a
+    // plain selection click doesn't spam history or wipe the redo stack.
+    if (!drag.moved) {
+      drag.moved = true;
+      this._pushHistory();
+    }
     const p = this._toVirtual(ev, false);
     const f = this._floor();
 
@@ -906,22 +1007,33 @@ export class FloorplanCardEditor extends LitElement {
   private _onOverlayDown(ev: PointerEvent, sel: OverlaySel): void {
     if (this._tool !== "select") return;
     ev.stopPropagation();
+    // preventDefault suppresses native mousedown focusing, so focus explicitly.
     ev.preventDefault();
+    if (this._gesturePointer !== null) return;
+    this._canvasWrap?.focus();
     this._selectForPointer(ev, sel);
     this._drag = {
       primary: sel,
       start: this._toVirtual(ev, false),
       orig: this._snapshotSelection(),
     };
-    this._pushHistory();
+    this._gesturePointer = ev.pointerId;
     this._capturePointer(ev, ev.currentTarget as Element);
   }
 
   private _onOverlayMove(ev: PointerEvent): void {
+    if (this._foreignPointer(ev)) return;
+    if (ev.buttons === 0 && this._drag) {
+      // Missed pointerup (see _onCanvasMove) — cancel rather than chase.
+      this._cancelGesture();
+      return;
+    }
     if (this._drag) this._applyDrag(ev);
   }
 
   private _onOverlayUp(ev: PointerEvent): void {
+    if (this._foreignPointer(ev)) return;
+    this._gesturePointer = null;
     if (this._drag) {
       this._drag = null;
       this._releasePointer(ev, ev.currentTarget as Element);
@@ -1260,6 +1372,61 @@ export class FloorplanCardEditor extends LitElement {
 
   private _patchConfig(partial: Partial<FloorplanCardConfig>): void {
     this._commit({ ...this._config, ...partial });
+  }
+
+  /**
+   * Live variants for continuous controls (sliders, color pickers, typing):
+   * one undo snapshot per edit burst — keyed by element and fields — then
+   * plain emits, instead of a full-config clone per input event.
+   */
+  private _beginLive(kind: string, id: string, partial: object): void {
+    const key = `${kind}:${id}:${Object.keys(partial).sort().join(",")}`;
+    if (this._liveEditKey !== key) this._pushHistory(key);
+  }
+
+  private _updateOpeningLive(id: string, partial: Partial<Opening>): void {
+    this._beginLive("opening", id, partial);
+    this._emitFloor({
+      openings: this._floor().openings.map((o) => (o.id === id ? { ...o, ...partial } : o)),
+    });
+  }
+
+  private _updateItemLive(id: string, partial: Partial<FloorItem>): void {
+    this._beginLive("item", id, partial);
+    this._emitFloor({
+      items: this._floor().items.map((it) => (it.id === id ? { ...it, ...partial } : it)),
+    });
+  }
+
+  private _updateTextLive(id: string, partial: Partial<FloorText>): void {
+    this._beginLive("text", id, partial);
+    this._emitFloor({
+      texts: this._floor().texts.map((t) => (t.id === id ? { ...t, ...partial } : t)),
+    });
+  }
+
+  private _updateFurnitureLive(id: string, partial: Partial<Furniture>): void {
+    this._beginLive("furniture", id, partial);
+    this._emitFloor({
+      furniture: this._floor().furniture.map((f) => (f.id === id ? { ...f, ...partial } : f)),
+    });
+  }
+
+  private _updateTrackerLive(id: string, partial: Partial<Tracker>): void {
+    this._beginLive("tracker", id, partial);
+    this._emitFloor({
+      trackers: (this._floor().trackers ?? []).map((t) => (t.id === id ? { ...t, ...partial } : t)),
+    });
+  }
+
+  private _patchConfigLive(partial: Partial<FloorplanCardConfig>): void {
+    this._beginLive("config", "", partial);
+    this._emit({ ...this._config, ...partial });
+  }
+
+  private _patchFloorLive(partial: Partial<Floor>): void {
+    this._beginLive("floor", this._activeFloorId, partial);
+    this._emitFloor(partial);
   }
 
   // ---- rendering ----------------------------------------------------------
@@ -1634,7 +1801,7 @@ export class FloorplanCardEditor extends LitElement {
 
         <div class="workspace">
         <div class="canvas-outer">
-        <div class="canvas-wrap" @wheel=${this._onCanvasWheel}>
+        <div class="canvas-wrap" tabindex="0" @wheel=${this._onCanvasWheel}>
           <div class="stage" style="aspect-ratio: ${c.width} / ${c.height}; width:${this._zoom * 100}%;">
             <svg
               viewBox="0 0 ${c.width} ${c.height}"
@@ -1643,6 +1810,7 @@ export class FloorplanCardEditor extends LitElement {
               @pointerdown=${this._onCanvasDown}
               @pointermove=${this._onCanvasMove}
               @pointerup=${this._onCanvasUp}
+              @pointercancel=${this._onPointerCancel}
             >
               <rect
                 x="0"
@@ -1971,6 +2139,7 @@ export class FloorplanCardEditor extends LitElement {
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "item", id: it.id })}
         @pointermove=${this._onOverlayMove}
         @pointerup=${this._onOverlayUp}
+        @pointercancel=${this._onPointerCancel}
       >
         ${visual}
         <span class="ilabel">${label}</span>
@@ -1990,6 +2159,7 @@ export class FloorplanCardEditor extends LitElement {
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "text", id: t.id })}
         @pointermove=${this._onOverlayMove}
         @pointerup=${this._onOverlayUp}
+        @pointercancel=${this._onPointerCancel}
       >
         ${t.text || "…"}
       </div>
@@ -2073,7 +2243,8 @@ export class FloorplanCardEditor extends LitElement {
           <input
             type="color"
             .value=${this._config.background ?? "#ffffff"}
-            @input=${(e: Event) => this._patchConfig({ background: (e.target as HTMLInputElement).value })}
+            @input=${(e: Event) =>
+              this._patchConfigLive({ background: (e.target as HTMLInputElement).value })}
           />
           <input
             type="text"
@@ -2103,7 +2274,7 @@ export class FloorplanCardEditor extends LitElement {
                 step="0.05"
                 .value=${String(this._floor()?.imageOpacity ?? 1)}
                 @input=${(e: Event) =>
-                  this._commitFloor({
+                  this._patchFloorLive({
                     imageOpacity: Number((e.target as HTMLInputElement).value),
                   })}
               />
@@ -2119,7 +2290,11 @@ export class FloorplanCardEditor extends LitElement {
    * cleared field — `Number("")` is 0 but `Number("abc")`/partial input is
    * NaN, which previously got stored and broke the element's transform.
    */
-  private _renderAngleRow(value: number, apply: (angle: number) => void): TemplateResult {
+  private _renderAngleRow(
+    value: number,
+    apply: (angle: number) => void,
+    applyLive: (angle: number) => void = apply
+  ): TemplateResult {
     const current = Math.round(value);
     return html`
       <div class="row">
@@ -2129,7 +2304,7 @@ export class FloorplanCardEditor extends LitElement {
           min="0"
           max="360"
           .value=${String(value)}
-          @input=${(e: Event) => apply(Number((e.target as HTMLInputElement).value))}
+          @input=${(e: Event) => applyLive(Number((e.target as HTMLInputElement).value))}
         />
         <input
           class="num"
@@ -2315,7 +2490,9 @@ export class FloorplanCardEditor extends LitElement {
                   type="color"
                   .value=${o.activeColor ?? "#03a9f4"}
                   @input=${(e: Event) =>
-                    this._updateOpening(o.id, { activeColor: (e.target as HTMLInputElement).value })}
+                    this._updateOpeningLive(o.id, {
+                      activeColor: (e.target as HTMLInputElement).value,
+                    })}
                 />
                 <input
                   type="text"
@@ -2328,7 +2505,11 @@ export class FloorplanCardEditor extends LitElement {
                 />
               </div>`
           : nothing}
-        ${this._renderAngleRow(o.angle, (angle) => this._updateOpening(o.id, { angle }))}
+        ${this._renderAngleRow(
+          o.angle,
+          (angle) => this._updateOpening(o.id, { angle }),
+          (angle) => this._updateOpeningLive(o.id, { angle })
+        )}
       `;
     }
 
@@ -2399,7 +2580,7 @@ export class FloorplanCardEditor extends LitElement {
             step="2"
             .value=${String(it.size ?? DEFAULT_ITEM_SIZE)}
             @input=${(e: Event) =>
-              this._updateItem(it.id, { size: Number((e.target as HTMLInputElement).value) })}
+              this._updateItemLive(it.id, { size: Number((e.target as HTMLInputElement).value) })}
           />
           <input
             class="num"
@@ -2413,7 +2594,11 @@ export class FloorplanCardEditor extends LitElement {
               })}
           />
         </div>
-        ${this._renderAngleRow(it.angle ?? 0, (angle) => this._updateItem(it.id, { angle }))}
+        ${this._renderAngleRow(
+          it.angle ?? 0,
+          (angle) => this._updateItem(it.id, { angle }),
+          (angle) => this._updateItemLive(it.id, { angle })
+        )}
         <div class="row">
           <label>Display</label>
           <select
@@ -2436,7 +2621,9 @@ export class FloorplanCardEditor extends LitElement {
                   type="color"
                   .value=${it.rippleColor ?? "#03a9f4"}
                   @input=${(e: Event) =>
-                    this._updateItem(it.id, { rippleColor: (e.target as HTMLInputElement).value })}
+                    this._updateItemLive(it.id, {
+                      rippleColor: (e.target as HTMLInputElement).value,
+                    })}
                 />
                 <input
                   type="text"
@@ -2457,7 +2644,7 @@ export class FloorplanCardEditor extends LitElement {
                   step="4"
                   .value=${String(it.rippleSize ?? DEFAULT_RIPPLE_SIZE)}
                   @input=${(e: Event) =>
-                    this._updateItem(it.id, {
+                    this._updateItemLive(it.id, {
                       rippleSize: Number((e.target as HTMLInputElement).value),
                     })}
                 />
@@ -2507,7 +2694,7 @@ export class FloorplanCardEditor extends LitElement {
             type="text"
             .value=${t.text}
             @input=${(e: Event) =>
-              this._updateText(t.id, { text: (e.target as HTMLInputElement).value })}
+              this._updateTextLive(t.id, { text: (e.target as HTMLInputElement).value })}
           />
         </div>
         <div class="row">
@@ -2518,7 +2705,7 @@ export class FloorplanCardEditor extends LitElement {
             max="80"
             .value=${String(t.size ?? DEFAULT_TEXT_SIZE)}
             @input=${(e: Event) =>
-              this._updateText(t.id, { size: Number((e.target as HTMLInputElement).value) })}
+              this._updateTextLive(t.id, { size: Number((e.target as HTMLInputElement).value) })}
           />
           <input
             class="num"
@@ -2538,7 +2725,7 @@ export class FloorplanCardEditor extends LitElement {
             type="color"
             .value=${t.color ?? "#000000"}
             @input=${(e: Event) =>
-              this._updateText(t.id, { color: (e.target as HTMLInputElement).value })}
+              this._updateTextLive(t.id, { color: (e.target as HTMLInputElement).value })}
           />
           <input
             type="text"
@@ -2548,7 +2735,11 @@ export class FloorplanCardEditor extends LitElement {
               this._updateText(t.id, { color: (e.target as HTMLInputElement).value || undefined })}
           />
         </div>
-        ${this._renderAngleRow(t.angle ?? 0, (angle) => this._updateText(t.id, { angle }))}
+        ${this._renderAngleRow(
+          t.angle ?? 0,
+          (angle) => this._updateText(t.id, { angle }),
+          (angle) => this._updateTextLive(t.id, { angle })
+        )}
       `;
     }
 
@@ -2587,14 +2778,18 @@ export class FloorplanCardEditor extends LitElement {
               this._updateFurniture(f.id, { h: Number((e.target as HTMLInputElement).value) || f.h })}
           />
         </div>
-        ${this._renderAngleRow(f.angle ?? 0, (angle) => this._updateFurniture(f.id, { angle }))}
+        ${this._renderAngleRow(
+          f.angle ?? 0,
+          (angle) => this._updateFurniture(f.id, { angle }),
+          (angle) => this._updateFurnitureLive(f.id, { angle })
+        )}
         <div class="row">
           <label>Color</label>
           <input
             type="color"
             .value=${f.color ?? "#9e9e9e"}
             @input=${(e: Event) =>
-              this._updateFurniture(f.id, { color: (e.target as HTMLInputElement).value })}
+              this._updateFurnitureLive(f.id, { color: (e.target as HTMLInputElement).value })}
           />
           <input
             type="text"
@@ -2655,14 +2850,18 @@ export class FloorplanCardEditor extends LitElement {
               this._updateTracker(tr.id, { y: Number((e.target as HTMLInputElement).value) })}
           />
         </div>
-        ${this._renderAngleRow(tr.angle ?? 0, (angle) => this._updateTracker(tr.id, { angle }))}
+        ${this._renderAngleRow(
+          tr.angle ?? 0,
+          (angle) => this._updateTracker(tr.id, { angle }),
+          (angle) => this._updateTrackerLive(tr.id, { angle })
+        )}
         <div class="row">
           <label>Color</label>
           <input
             type="color"
             .value=${tr.color ?? "#03a9f4"}
             @input=${(e: Event) =>
-              this._updateTracker(tr.id, { color: (e.target as HTMLInputElement).value })}
+              this._updateTrackerLive(tr.id, { color: (e.target as HTMLInputElement).value })}
           />
           <input
             type="text"
@@ -2683,7 +2882,7 @@ export class FloorplanCardEditor extends LitElement {
             step="1"
             .value=${String(tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE)}
             @input=${(e: Event) =>
-              this._updateTracker(tr.id, {
+              this._updateTrackerLive(tr.id, {
                 dotSize: Number((e.target as HTMLInputElement).value),
               })}
           />
@@ -3084,6 +3283,15 @@ export class FloorplanCardEditor extends LitElement {
     button[disabled] {
       opacity: 0.4;
       cursor: not-allowed;
+    }
+    /* The canvas is focusable so keyboard shortcuts only fire while working in
+       the editor; only show the ring for keyboard focus, not pointer clicks. */
+    .canvas-wrap:focus {
+      outline: none;
+    }
+    .canvas-wrap:focus-visible {
+      outline: 2px solid var(--primary-color, #03a9f4);
+      outline-offset: -2px;
     }
     .canvas-wrap {
       border: 1px solid var(--divider-color, #ccc);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -140,6 +140,8 @@ interface Drag {
   moved?: boolean;
   /** The exact history entry this drag pushed, so cancel can remove it by identity. */
   snapshot?: FloorplanCardConfig;
+  /** The redo stack as it stood before the drag's history push cleared it. */
+  priorFuture?: FloorplanCardConfig[];
 }
 
 type Marquee = Rect;
@@ -798,6 +800,9 @@ export class FloorplanCardEditor extends LitElement {
     if (drag?.moved && drag.snapshot) {
       this._history = this._history.filter((c) => c !== drag.snapshot);
       this._emit(drag.snapshot);
+      // The push at first movement cleared the redo stack; a canceled drag
+      // must be a complete no-op, so put it back.
+      this._future = drag.priorFuture ?? [];
     }
   }
 
@@ -956,6 +961,7 @@ export class FloorplanCardEditor extends LitElement {
     if (!drag.moved) {
       if (Math.hypot(p.x - drag.start.x, p.y - drag.start.y) <= 4) return;
       drag.moved = true;
+      drag.priorFuture = this._future;
       this._pushHistory();
       drag.snapshot = this._history[this._history.length - 1];
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, svg, nothing, type TemplateResult } from "lit";
+import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state, query } from "lit/decorators.js";
 import type {
   HomeAssistant,
@@ -183,7 +183,15 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _addMenuOpen = false;
   /** Project section expanded? Collapsed by default — page settings are touched rarely. */
   @state() private _projectOpen = false;
+  /**
+   * Expanded (fullscreen) editing. HA renders the card config editor in a
+   * narrow dialog (~480–560px), which is cramped for a visual canvas editor.
+   * When true the `.editor` root is promoted to the top layer so the canvas
+   * gets real room and the element/project sections dock beside it.
+   */
+  @state() private _fullscreen = false;
 
+  @query(".editor") private _editorEl?: HTMLElement;
   @query("svg") private _svg?: SVGSVGElement;
   @query(".canvas-wrap") private _canvasWrap?: HTMLElement;
 
@@ -255,6 +263,28 @@ export class FloorplanCardEditor extends LitElement {
 
   protected firstUpdated(): void {
     void this._ensurePickers();
+  }
+
+  /**
+   * Promote the expanded editor into the top layer. `position: fixed` alone is
+   * not enough: HA's edit dialog puts a `transform` on its surface to offset
+   * the safe areas, and any transform makes that surface the containing block
+   * for fixed descendants — so a "full-viewport" overlay would fill the narrow
+   * dialog instead. A popover escapes it. Collapsing drops the attribute, which
+   * hides the popover on its own. Browsers without the API keep the fixed
+   * fallback, which is already correct on the mobile dialog (transform: none).
+   */
+  protected updated(changed: PropertyValues): void {
+    if (!changed.has("_fullscreen") || !this._fullscreen) return;
+    const el = this._editorEl;
+    if (!el?.isConnected || typeof el.showPopover !== "function") return;
+    if (!el.matches(":popover-open")) {
+      try {
+        el.showPopover();
+      } catch {
+        // Top layer unavailable — the fixed-position styles still apply.
+      }
+    }
   }
 
   /**
@@ -540,6 +570,12 @@ export class FloorplanCardEditor extends LitElement {
         ev.preventDefault();
         ev.stopPropagation();
         this._clearSel();
+      } else if (this._fullscreen) {
+        // Nothing left to cancel — collapse the full-screen workspace before
+        // letting a further Escape reach (and close) HA's edit dialog.
+        ev.preventDefault();
+        ev.stopPropagation();
+        this._fullscreen = false;
       }
       return;
     }
@@ -1465,7 +1501,10 @@ export class FloorplanCardEditor extends LitElement {
       !floor.furniture.length &&
       !(floor.trackers ?? []).length;
     return html`
-      <div class="editor">
+      <div
+        class="editor ${this._fullscreen ? "fullscreen" : ""}"
+        popover=${this._fullscreen ? "manual" : nothing}
+      >
         ${this._floorMenuOpen || this._addMenuOpen
           ? html`<div
               class="pop-backdrop"
@@ -1494,6 +1533,21 @@ export class FloorplanCardEditor extends LitElement {
                 </button>`
             )}
           </div>
+
+          <span class="divider"></span>
+
+          <!-- Expand: break out of HA's narrow config dialog into a full-screen
+               workspace. Kept next to the tools so it's reachable even when the
+               toolbar wraps at dialog width. -->
+          <button
+            class=${this._fullscreen ? "active expand-toggle" : "expand-toggle"}
+            aria-pressed=${this._fullscreen}
+            title=${this._fullscreen ? "Exit full screen (Esc)" : "Edit full screen — more room for the canvas"}
+            @click=${() => this._toggleFullscreen()}
+          >
+            <ha-icon icon=${this._fullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}></ha-icon>
+            ${this._fullscreen ? "Exit" : "Expand"}
+          </button>
 
           <span class="divider"></span>
 
@@ -1578,6 +1632,7 @@ export class FloorplanCardEditor extends LitElement {
 
         ${this._renderContextBar()}
 
+        <div class="workspace">
         <div class="canvas-outer">
         <div class="canvas-wrap" @wheel=${this._onCanvasWheel}>
           <div class="stage" style="aspect-ratio: ${c.width} / ${c.height}; width:${this._zoom * 100}%;">
@@ -1664,10 +1719,21 @@ export class FloorplanCardEditor extends LitElement {
         </div>
         </div>
 
-        ${this._renderElementEdit()}
-        ${this._renderPanel()}
+        <div class="side">
+          ${this._renderElementEdit()}
+          ${this._renderPanel()}
+        </div>
+        </div>
       </div>
     `;
+  }
+
+  /** Toggle the full-screen workspace. */
+  private _toggleFullscreen(): void {
+    this._fullscreen = !this._fullscreen;
+    // Any open toolbar popover would be orphaned by the layout change.
+    this._floorMenuOpen = false;
+    this._addMenuOpen = false;
   }
 
   /** The "+ Add" popover: device, text, then every furniture type as its real glyph. */
@@ -2807,6 +2873,89 @@ export class FloorplanCardEditor extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 8px;
+    }
+    /* Full-screen workspace, shown as a popover so the top layer lifts it clear
+       of HA's edit dialog (whose surface is transformed — see updated()). The
+       resets undo the UA popover defaults: fit-content size, auto margins, a
+       solid border and padding. z-index and the fixed position only matter to
+       the fallback path, where the dialog sets --dialog-z-index: 6. */
+    .editor.fullscreen {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      width: auto;
+      height: auto;
+      max-width: none;
+      max-height: none;
+      margin: 0;
+      border: none;
+      padding: 12px;
+      box-sizing: border-box;
+      color: inherit;
+      background: var(--card-background-color, #fff);
+      overflow: hidden;
+    }
+    .editor.fullscreen::backdrop {
+      background: rgba(0, 0, 0, 0.6);
+    }
+    /* Toolbar-icon button (Expand/Exit) — match the gear button's icon+label
+       alignment so it reads as part of the toolbar. */
+    .expand-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+    }
+    /* Below the two toolbars: the canvas and the element/project sections.
+       Stacked at dialog width; split into canvas + docked side panel when
+       expanded so the extra width isn't wasted. */
+    .workspace {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-width: 0;
+    }
+    .side {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      min-width: 0;
+    }
+    .editor.fullscreen .workspace {
+      flex-direction: row;
+      align-items: stretch;
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+    .editor.fullscreen .canvas-outer {
+      flex: 1 1 auto;
+      min-width: 0;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
+    .editor.fullscreen .canvas-wrap {
+      flex: 1 1 auto;
+      min-height: 0;
+      height: auto;
+      resize: none;
+    }
+    /* Docked inspector — fixed, scrollable column beside the canvas. */
+    .editor.fullscreen .side {
+      flex: 0 0 340px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding-right: 2px;
+    }
+    /* At real dialog width the side panel can drop below instead of squeezing
+       the canvas to nothing. */
+    @media (max-width: 900px) {
+      .editor.fullscreen .workspace {
+        flex-direction: column;
+      }
+      .editor.fullscreen .side {
+        flex: 0 0 auto;
+        max-height: 40vh;
+      }
     }
     .toolbar {
       display: flex;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -162,6 +162,25 @@ const HISTORY_MAX = 60;
 /** Angle (degrees) within which a drawn wall is snapped flat to horizontal/vertical. */
 const WALL_AXIS_SNAP_DEG = 10;
 
+/**
+ * True when the event's composed path sits in a form field / picker — keys
+ * typed there belong to the field, not the canvas.
+ */
+function isTypingPath(path: EventTarget[]): boolean {
+  return path.some((el) => {
+    const node = el as HTMLElement;
+    const tag = node.tagName?.toLowerCase();
+    return (
+      tag === "input" ||
+      tag === "textarea" ||
+      tag === "select" ||
+      tag === "ha-entity-picker" ||
+      tag === "ha-icon-picker" ||
+      node.isContentEditable === true
+    );
+  });
+}
+
 @customElement("easy-floorplan-card-editor")
 export class FloorplanCardEditor extends LitElement {
   private static _nextWallMaskId = 0;
@@ -211,6 +230,21 @@ export class FloorplanCardEditor extends LitElement {
   private _marqueeAdd = false;
   private _clipboard: Clipboard | null = null;
   private _onKeyDown = (ev: KeyboardEvent) => this._handleKeyDown(ev);
+  private _onHostKeyDown = (ev: KeyboardEvent) => {
+    // Bubble-phase backstop for Escape typed in a form field while fullscreen.
+    // The capture listener above lets those through so an open picker/select
+    // overlay can close itself and absorb the key; one that bubbles this far
+    // was declined by every overlay, and the host sits below HA's dialog in
+    // the bubble path — contain it here or the dialog closes underneath the
+    // top-layer workspace (and a dirty config pops an invisible confirm
+    // behind it). Park focus on the canvas (not a bare blur, which would
+    // strand focus on `body`) so the next Escape runs the normal cascade.
+    if (ev.key !== "Escape" || !this._fullscreen) return;
+    if (!isTypingPath(ev.composedPath())) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    this._canvasWrap?.focus();
+  };
   private _onFocusIn = (ev: FocusEvent) => {
     // While the fullscreen popover is up, anything that pulls focus outside the
     // editor (Tab past the last control, a dialog opening above) lands on UI
@@ -222,11 +256,15 @@ export class FloorplanCardEditor extends LitElement {
     super.connectedCallback();
     // Capture phase so HA's dialog can't swallow the arrow keys before we see them.
     window.addEventListener("keydown", this._onKeyDown, true);
+    // Bubble phase on the host: fires only after the editor's own form
+    // overlays had their chance to absorb the key (see _onHostKeyDown).
+    this.addEventListener("keydown", this._onHostKeyDown);
     window.addEventListener("focusin", this._onFocusIn);
   }
 
   public disconnectedCallback(): void {
     window.removeEventListener("keydown", this._onKeyDown, true);
+    this.removeEventListener("keydown", this._onHostKeyDown);
     window.removeEventListener("focusin", this._onFocusIn);
     super.disconnectedCallback();
   }
@@ -576,33 +614,14 @@ export class FloorplanCardEditor extends LitElement {
       }
       return;
     }
-    // Don't hijack keys while typing in a field / picker.
-    const typing = path.some((el) => {
-      const node = el as HTMLElement;
-      const tag = node.tagName?.toLowerCase();
-      return (
-        tag === "input" ||
-        tag === "textarea" ||
-        tag === "select" ||
-        tag === "ha-entity-picker" ||
-        tag === "ha-icon-picker" ||
-        node.isContentEditable === true
-      );
-    });
-    if (typing) {
-      // While fullscreen, Escape must never fall through to HA's dialog — it
-      // would close it underneath the top-layer workspace (and a dirty config
-      // pops an invisible confirm behind it). First Esc leaves the field; the
-      // next one runs the normal cascade below.
-      if (ev.key === "Escape" && this._fullscreen) {
-        ev.preventDefault();
-        ev.stopPropagation();
-        // Move focus to the canvas (not a bare blur, which would strand focus
-        // on `body` and route the next Escape around the editor entirely).
-        this._canvasWrap?.focus();
-      }
-      return;
-    }
+    // Don't hijack keys while typing in a field / picker. Escape is not
+    // swallowed here even in fullscreen: HA's pickers hold focus while their
+    // dropdown is open and close it on their own Escape (absorbing the
+    // event), so a capture-phase swallow starves them and leaves an orphaned
+    // dropdown that focus can't escape. Escapes no overlay absorbs are
+    // contained by the bubble-phase host listener (_onHostKeyDown) before
+    // they can reach — and close — HA's dialog.
+    if (isTypingPath(path)) return;
 
     const mod = ev.ctrlKey || ev.metaKey;
     const key = ev.key.toLowerCase();

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -25,6 +25,7 @@ import {
   entityDefaultIcon,
   itemStateText,
   hassRenderInputsChanged,
+  collectWatchedEntities,
 } from "./render";
 import type { Opening } from "./types";
 
@@ -43,7 +44,18 @@ export class FloorplanCard extends LitElement {
   private _watchedEntities: Set<string> = new Set();
 
   public setConfig(config: FloorplanCardConfig): void {
-    if (!config) throw new Error("Invalid configuration");
+    // Cheap shape assertions so malformed YAML surfaces as HA's error card
+    // instead of a render crash deep inside the SVG.
+    if (!config || typeof config !== "object") throw new Error("Invalid configuration");
+    const raw = config as Record<string, unknown>;
+    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers", "floors"]) {
+      if (raw[key] !== undefined && !Array.isArray(raw[key]))
+        throw new Error(`Invalid configuration: "${key}" must be a list`);
+    }
+    for (const key of ["width", "height", "grid"]) {
+      if (raw[key] !== undefined && typeof raw[key] !== "number")
+        throw new Error(`Invalid configuration: "${key}" must be a number`);
+    }
     this._config = {
       ...config,
       width: config.width ?? DEFAULT_WIDTH,
@@ -54,26 +66,7 @@ export class FloorplanCard extends LitElement {
       texts: config.texts ?? [],
       furniture: config.furniture ?? [],
     };
-    this._watchedEntities = this._collectWatchedEntities(this._config);
-  }
-
-  /** Every entity id whose state can change what this card draws (all floors). */
-  private _collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
-    const ids = new Set<string>();
-    for (const f of getFloors(c)) {
-      for (const o of f.openings) if (o.entity) ids.add(o.entity);
-      for (const it of f.items) {
-        if (it.entity) ids.add(it.entity);
-        if (it.secondaryEntity) ids.add(it.secondaryEntity);
-      }
-      for (const tr of f.trackers) {
-        for (const s of [tr.xSensor, tr.ySensor]) {
-          if (s?.entity) ids.add(s.entity);
-          if (s?.presence?.entity) ids.add(s.presence.entity);
-        }
-      }
-    }
-    return ids;
+    this._watchedEntities = collectWatchedEntities(this._config);
   }
 
   /**
@@ -98,7 +91,14 @@ export class FloorplanCard extends LitElement {
   }
 
   public static getStubConfig(): Partial<FloorplanCardConfig> {
-    return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT, walls: [], openings: [], items: [] };
+    // Minimal on purpose: the editor migrates to the floors model on first
+    // edit, and defaults (width/height/grid) backfill in setConfig.
+    return {};
+  }
+
+  /** Sections-view sizing (grid rows ≈ 56px): room for the 5:3 default canvas. */
+  public static getGridOptions() {
+    return { columns: 12, rows: 8, min_columns: 6, min_rows: 4 };
   }
 
   private _isOn(item: FloorItem): boolean {
@@ -367,7 +367,7 @@ export class FloorplanCard extends LitElement {
     }
     .floor-switcher button.active {
       background: var(--primary-color, #03a9f4);
-      color: #fff;
+      color: var(--text-primary-color, #fff);
       border-color: var(--primary-color, #03a9f4);
     }
     svg {
@@ -440,8 +440,8 @@ export class FloorplanCard extends LitElement {
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     }
     .item.on .badge {
-      background: var(--state-light-active-color, #fdd835);
-      border-color: var(--state-light-active-color, #fdd835);
+      background: var(--state-light-active-color, var(--state-active-color, #fdd835));
+      border-color: var(--state-light-active-color, var(--state-active-color, #fdd835));
       color: var(--text-primary-color, #212121);
     }
     ha-icon {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -21,11 +21,11 @@ import {
   renderFurniture,
   renderTracker,
   trackerSensorReading,
-  defaultIcon,
-  entityDefaultIcon,
   itemStateText,
   hassRenderInputsChanged,
   collectWatchedEntities,
+  isEntityOn,
+  resolveItemIcon,
 } from "./render";
 import type { Opening } from "./types";
 
@@ -102,8 +102,7 @@ export class FloorplanCard extends LitElement {
   }
 
   private _isOn(item: FloorItem): boolean {
-    const st = this.hass?.states[item.entity]?.state;
-    return st === "on" || st === "open" || st === "home" || st === "playing";
+    return isEntityOn(this.hass?.states[item.entity]?.state);
   }
 
   /** How far open an opening should be drawn (0..1), from its entity (or default). */
@@ -119,18 +118,7 @@ export class FloorplanCard extends LitElement {
   }
 
   private _itemIcon(item: FloorItem): string {
-    // Precedence: config override → entity's explicit icon → the icon implied
-    // by its device_class ("show as", issue #29) → the generic kind default.
-    if (item.icon) return item.icon;
-    const st = this.hass?.states[item.entity];
-    if (st?.attributes?.icon) return st.attributes.icon;
-    return (
-      entityDefaultIcon(
-        item.entity,
-        st?.attributes?.device_class as string | undefined,
-        this._isOn(item)
-      ) ?? defaultIcon(item.kind)
-    );
+    return resolveItemIcon(item, this.hass?.states[item.entity]);
   }
 
   private _label(item: FloorItem): string {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -98,8 +98,12 @@ export class FloorplanCard extends LitElement {
     return {};
   }
 
-  /** Sections-view sizing (grid rows ≈ 56px): room for the 5:3 default canvas. */
-  public static getGridOptions() {
+  /**
+   * Sections-view sizing (grid rows ≈ 56px): room for the 5:3 default canvas.
+   * An instance method — HA calls it on the card element (getConfigElement /
+   * getStubConfig are the static ones, called before any instance exists).
+   */
+  public getGridOptions() {
     return { columns: 12, rows: 8, min_columns: 6, min_rows: 4 };
   }
 

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -48,12 +48,14 @@ export class FloorplanCard extends LitElement {
     // instead of a render crash deep inside the SVG.
     if (!config || typeof config !== "object") throw new Error("Invalid configuration");
     const raw = config as Record<string, unknown>;
+    // A key with an empty YAML value ("trackers:") parses to null — treat it
+    // as unset like the ?? defaults always have, not as malformed.
     for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers", "floors"]) {
-      if (raw[key] !== undefined && !Array.isArray(raw[key]))
+      if (raw[key] != null && !Array.isArray(raw[key]))
         throw new Error(`Invalid configuration: "${key}" must be a list`);
     }
     for (const key of ["width", "height", "grid"]) {
-      if (raw[key] !== undefined && typeof raw[key] !== "number")
+      if (raw[key] != null && typeof raw[key] !== "number")
         throw new Error(`Invalid configuration: "${key}" must be a number`);
     }
     this._config = {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -19,6 +19,8 @@ import {
   itemStateText,
   hassRenderInputsChanged,
   collectWatchedEntities,
+  isEntityOn,
+  resolveItemIcon,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -482,6 +484,25 @@ describe("hassRenderInputsChanged", () => {
   it("ignores entities the plan does not watch", () => {
     const next = { ...base(), states: { [TEMP]: tempState, [HUMIDITY]: { state: "50.0" } } };
     expect(hassRenderInputsChanged(base(), next, watched)).toBe(false);
+  });
+});
+
+describe("isEntityOn / resolveItemIcon", () => {
+  it("treats on/open/home/playing as on", () => {
+    for (const s of ["on", "open", "home", "playing"]) expect(isEntityOn(s)).toBe(true);
+    for (const s of ["off", "closed", "idle", undefined]) expect(isEntityOn(s)).toBe(false);
+  });
+
+  it("resolves icon precedence: override → entity icon → device_class → kind default", () => {
+    const item = { entity: "binary_sensor.a", kind: "sensor" as const };
+    expect(resolveItemIcon({ ...item, icon: "mdi:override" }, undefined)).toBe("mdi:override");
+    expect(
+      resolveItemIcon(item, { state: "on", attributes: { icon: "mdi:from-entity" } })
+    ).toBe("mdi:from-entity");
+    expect(
+      resolveItemIcon(item, { state: "on", attributes: { device_class: "door" } })
+    ).toBe(entityDefaultIcon("binary_sensor.a", "door", true));
+    expect(resolveItemIcon(item, undefined)).toBe(defaultIcon("sensor"));
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -18,8 +18,9 @@ import {
   entityStateText,
   itemStateText,
   hassRenderInputsChanged,
+  collectWatchedEntities,
 } from "./render";
-import type { Opening, RenderHass } from "./types";
+import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
 describe("snapToWall", () => {
   const hWall = { x1: 0, y1: 0, x2: 100, y2: 0 }; // horizontal
@@ -481,5 +482,47 @@ describe("hassRenderInputsChanged", () => {
   it("ignores entities the plan does not watch", () => {
     const next = { ...base(), states: { [TEMP]: tempState, [HUMIDITY]: { state: "50.0" } } };
     expect(hassRenderInputsChanged(base(), next, watched)).toBe(false);
+  });
+});
+
+describe("collectWatchedEntities", () => {
+  it("collects opening, item, secondary, and tracker entities across floors", () => {
+    const cfg = {
+      floors: [
+        {
+          id: "f1",
+          name: "F1",
+          walls: [],
+          texts: [],
+          furniture: [],
+          openings: [{ id: "o1", type: "door", x: 0, y: 0, entity: "cover.door" }],
+          items: [
+            { id: "i1", kind: "light", x: 0, y: 0, entity: "light.a", secondaryEntity: "sensor.b" },
+          ],
+          trackers: [
+            {
+              id: "t1",
+              x: 0,
+              y: 0,
+              w: 10,
+              h: 10,
+              xSensor: { entity: "sensor.x", min: 0, max: 5, presence: { entity: "binary_sensor.p" } },
+            },
+          ],
+        },
+      ],
+    } as unknown as FloorplanCardConfig;
+    const got = collectWatchedEntities(cfg);
+    for (const id of ["cover.door", "light.a", "sensor.b", "sensor.x", "binary_sensor.p"]) {
+      expect(got.has(id)).toBe(true);
+    }
+  });
+
+  it("skips unset entities and handles a legacy flat config", () => {
+    const got = collectWatchedEntities({
+      items: [{ id: "i", kind: "light", x: 0, y: 0, entity: "light.legacy" }],
+    } as unknown as FloorplanCardConfig);
+    expect(got.has("light.legacy")).toBe(true);
+    expect(got.size).toBe(1);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
-import type { Opening, ItemKind, Furniture, Tracker, RenderHass } from "./types";
-import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, trackerAxisFraction } from "./types";
+import type { FloorplanCardConfig, Opening, ItemKind, Furniture, Tracker, RenderHass } from "./types";
+import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, getFloors, trackerAxisFraction } from "./types";
 
 export const WALL_THICKNESS = 8;
 
@@ -43,6 +43,25 @@ export function hassRenderInputsChanged(
     if (prev.states[id] !== next.states[id]) return true;
   }
   return false;
+}
+
+/** Every entity id whose state can change what a plan draws (all floors). */
+export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
+  const ids = new Set<string>();
+  for (const f of getFloors(c)) {
+    for (const o of f.openings) if (o.entity) ids.add(o.entity);
+    for (const it of f.items) {
+      if (it.entity) ids.add(it.entity);
+      if (it.secondaryEntity) ids.add(it.secondaryEntity);
+    }
+    for (const tr of f.trackers) {
+      for (const s of [tr.xSensor, tr.ySensor]) {
+        if (s?.entity) ids.add(s.entity);
+        if (s?.presence?.entity) ids.add(s.presence.entity);
+      }
+    }
+  }
+  return ids;
 }
 
 /** State text for an item: primary entity, plus secondary (e.g. humidity) when set. */

--- a/src/render.ts
+++ b/src/render.ts
@@ -185,6 +185,31 @@ export function entityDefaultIcon(
   return undefined;
 }
 
+/** Whether an entity state renders as "active" on the plan. */
+export function isEntityOn(state: string | undefined): boolean {
+  return state === "on" || state === "open" || state === "home" || state === "playing";
+}
+
+/**
+ * Icon precedence shared by card and editor: config override → entity's
+ * explicit icon → device_class-implied icon ("show as") → the kind default.
+ */
+export function resolveItemIcon(
+  item: { entity: string; kind: ItemKind; icon?: string },
+  st: { state: string; attributes: Record<string, unknown> } | undefined,
+): string {
+  if (item.icon) return item.icon;
+  const attrIcon = st?.attributes?.icon as string | undefined;
+  if (attrIcon) return attrIcon;
+  return (
+    entityDefaultIcon(
+      item.entity,
+      st?.attributes?.device_class as string | undefined,
+      isEntityOn(st?.state),
+    ) ?? defaultIcon(item.kind)
+  );
+}
+
 /** Infer a sensible item kind from an entity id's domain. */
 export function kindFromEntity(entity: string): ItemKind {
   const domain = entity.split(".")[0];

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -10,6 +10,7 @@ import {
   trackerPresenceDetected,
   haFloorsOf,
   uid,
+  configsEqual,
 } from "./types";
 import type { FloorplanCardConfig, TrackerSensor } from "./types";
 
@@ -271,5 +272,28 @@ describe("uid", () => {
   it("prefixes the id and stays unique", () => {
     expect(uid("wall")).toMatch(/^wall_/);
     expect(uid("x")).not.toBe(uid("x"));
+  });
+});
+
+describe("configsEqual", () => {
+  it("treats missing key and undefined value as equal", () => {
+    expect(configsEqual({ a: 1, b: undefined }, { a: 1 })).toBe(true);
+  });
+
+  it("compares nested arrays/objects structurally", () => {
+    expect(configsEqual({ f: [{ x: 1 }] }, { f: [{ x: 1 }] })).toBe(true);
+    expect(configsEqual({ f: [{ x: 1 }] }, { f: [{ x: 2 }] })).toBe(false);
+  });
+
+  it("detects added/removed keys and length changes", () => {
+    expect(configsEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(configsEqual({ f: [1] }, { f: [1, 2] })).toBe(false);
+  });
+
+  it("handles primitives and nulls", () => {
+    expect(configsEqual(1, 1)).toBe(true);
+    expect(configsEqual(null, null)).toBe(true);
+    expect(configsEqual(null, {})).toBe(false);
+    expect(configsEqual("a", "b")).toBe(false);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,9 +339,9 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   floors?: Floor[];
   /** Id of the floor shown first. Falls back to the first floor. */
   defaultFloor?: string;
-  walls: Wall[];
-  openings: Opening[];
-  items: FloorItem[];
+  walls?: Wall[];
+  openings?: Opening[];
+  items?: FloorItem[];
   texts?: FloorText[];
   furniture?: Furniture[];
   trackers?: Tracker[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,26 @@ export function uid(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
 }
 
+/**
+ * Structural equality for JSON-shaped config data. A missing key and an
+ * `undefined` value compare equal, because a YAML round-trip through HA's
+ * dialog drops undefined-valued keys.
+ */
+export function configsEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => configsEqual(v, b[i]));
+  }
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  const ra = a as Record<string, unknown>;
+  const rb = b as Record<string, unknown>;
+  for (const k of new Set([...Object.keys(ra), ...Object.keys(rb)])) {
+    if (!configsEqual(ra[k], rb[k])) return false;
+  }
+  return true;
+}
+
 /** A fresh, empty floor (optionally seeded with walls). */
 export function makeFloor(name: string, walls: Wall[] = []): Floor {
   return {


### PR DESCRIPTION
## Problem

Two things, tackled together because the second was found while building the first:

1. HA renders a card's config editor in a ~480–560px dialog — far too cramped for a visual canvas editor. There's barely room to draw walls, the toolbar wraps, and the Element/Project sections push the canvas even shorter.
2. A full audit of the editor (four independent review passes: HA-norms, overlay/fullscreen integration, Lit lifecycle/state, structure/a11y) turned up a set of pre-existing correctness gaps worth fixing while in here.

## Change

Four self-contained commits:

**1. `feat(editor)`: full-screen edit mode.** An **Expand / Exit** toggle in the toolbar lifts the whole editor out of the narrow dialog into a full-viewport workspace, with the Element/Project sections docked in a scrollable side panel beside the canvas. Shown as a manual **popover** rather than a fixed overlay: HA's dialog surface carries a `transform`, which makes it the containing block for `position: fixed` descendants — a "full-viewport" overlay would fill the same narrow dialog it exists to escape. The top layer is unaffected. Browsers without the Popover API keep the fixed-position fallback. Esc collapses fullscreen only after cancelling drafts/selection first, and still closes HA's dialog when there's nothing left to cancel.

**2. `fix(editor)`: input correctness.** Keyboard shortcuts now only fire when the event originates inside the editor (the canvas is focusable) — previously the window-capture listener swallowed Escape/Ctrl+Z/Delete from HA dialogs stacked above (e.g. more-info). While fullscreen, focus leaving the editor collapses the workspace and field-Escape refocuses the canvas, so the key can never invisibly close HA's dialog underneath the top layer. Undo history snapshots once per real gesture or edit burst instead of per pointerdown/keystroke (selection clicks no longer wipe redo), and external YAML-tab edits invalidate stale history. Pointer gestures are cancel-safe: bound to their pointer, `pointercancel`/missed pointerups roll back cleanly, Esc cancels an active drag.

**3. `fix(card,editor)`: HA-norms alignment.** The editor skips re-renders on hass ticks that can't change the plan (same watched-entity gating the card already had, now shared). Emitted configs no longer bake empty legacy `walls: []`-style arrays into the user's YAML. The card validates config shape (HA error card instead of a render crash), gains `getGridOptions()` for sections view, and `getStubConfig()` is minimal. Entity fields fall back to a plain input when `ha-entity-picker` is unavailable and upgrade in place. Theme-safe colors (`--text-primary-color` on primary, state-active fallback chain) and an accessible name for the add-floor button.

**4. `refactor(editor)`: tested geometry.** The endpoint-snapping, axis-gravity, marquee hit-testing, and group-translation math moves verbatim into `editor-geometry.ts` with the editor's first unit tests. The entity on-state predicate and item icon precedence — previously drifting copies in card and editor — are shared via `render.ts`.

## Verification

- `npm run typecheck`, `npm run build`, `npm test` — 123 tests pass (20 new: geometry, config equality, watched entities, shared icon logic).
- A 19-check Playwright pass driving the real editor in the dev harness: fullscreen expand/exit/Esc lifecycle, focus containment, undo discipline (selection clicks don't push history; typing bursts and slider drags are one undo step; mid-drag Esc rolls back exactly), keyboard scoping (Delete with focus outside the editor does nothing), emitted-config shape, and picker fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMzXLjqWUr9QCeArktZqBw
