### PR TITLE
Streamline batch: five small fixes (#30 #37 #38 #39 #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ background):
 
 - **Select** — the default tool. Click an element to select it; Shift/Ctrl-click or drag
   a box to select several at once. Arrow keys nudge the selection (Shift+arrow jumps a
-  full grid cell); **Ctrl/Cmd+C/V/D** copy / paste / duplicate; **Ctrl/Cmd+Z** undoes
+  full grid cell); **Ctrl/Cmd+C/V/D** copy / paste / duplicate — pasting also works
+  across floors (copy, switch floor, paste); **Ctrl/Cmd+Z** undoes
   (**Shift+Z** or **Ctrl+Y** redoes); **Escape** cancels an in-progress draw or clears
   the selection. The **Element** section below the canvas names the selection
   (e.g. *Door · 60 units*) and carries its **duplicate** / **delete** buttons along
@@ -99,6 +100,10 @@ background):
   keeps walls horizontal/vertical and corner-snapped (turn it off to draw freely), and
   the **Snap** segmented control (`On` / `Off` / `Custom`) governs snapping for *all*
   tools — `Custom` lets you snap to a percentage of the grid (e.g. 50% = half a cell).
+  Rooms **stretch** instead of tearing: dragging a wall — or one of its corner
+  handles — carries every wall corner that touches it, so you can widen a room by
+  just pulling its wall. Hold **Alt** while dragging to detach and move only the
+  grabbed wall.
 - **Door / Window** — click to drop; it snaps onto the nearest wall. The context row
   shows a **Length** field for the *next* opening you place, so you can size doors and
   windows before placing them. Assign a sensor after placement (in the **Element**
@@ -117,9 +122,10 @@ background):
 
 Undo/redo buttons sit at the right of the tools row. Zoom controls live on the canvas
 itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button
-snaps back to 100%, and **Ctrl/Cmd+scroll** zooms from the keyboard/trackpad. The
-**Project** section (canvas size, grid, background) is collapsed by default — click its
-header to expand.
+snaps back to 100%, and **Ctrl/Cmd+scroll** zooms from the keyboard/trackpad. On touch
+screens, **pinch** directly on the canvas — it zooms just the plan (anchored between
+your fingers), not the whole editor. The **Project** section (canvas size, grid,
+background) is collapsed by default — click its header to expand.
 
 ## Elements
 
@@ -149,6 +155,10 @@ By default it shows an icon badge:
   still wins.
 - **Make it yours** — override the **icon** (with autocomplete + live preview), set a
   custom **name**, change the **size**, **rotate** it, or hide the icon entirely.
+- **No entity? Still on the map** — a device with no entity bound renders as a plain
+  badge (its icon override or kind default), so hardware that has no Home Assistant
+  entity — a dumb smoke detector, a wired doorbell — can still be marked on the plan.
+  It never highlights and tapping does nothing.
 
 ### Presence ripples
 
@@ -388,7 +398,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | Field         | Type                                   | Default      | Description                                            |
 | ------------- | -------------------------------------- | ------------ | ------------------------------------------------------ |
 | `id`          | string                                 | —            | Unique id.                                             |
-| `entity`      | string                                 | —            | Entity id to bind.                                     |
+| `entity`      | string                                 | —            | Entity id to bind. Optional: without one the device renders as a static badge. |
 | `secondaryEntity` | string                             | —            | Optional 2nd entity shown alongside (e.g. humidity).   |
 | `x`, `y`      | number                                 | —            | Position.                                              |
 | `kind`        | light/switch/sensor/binary_sensor/climate/cover/generic | inferred | Used for the default icon.            |

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { nearestCorner, snapWallEnd, elementsInRect, applyDelta } from "./editor-geometry";
+import {
+  nearestCorner,
+  snapWallEnd,
+  elementsInRect,
+  applyDelta,
+  attachedCorners,
+} from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
-import type { Floor } from "./types";
+import type { Floor, Wall } from "./types";
 
 const walls = [{ x1: 0, y1: 0, x2: 100, y2: 0 }];
 
@@ -104,5 +110,59 @@ describe("applyDelta", () => {
     const orig = new Map<string, OrigPos>([["opening:o", { kind: "pt", x: 10, y: 10 }]]);
     const out = applyDelta(f, 5, 5, orig);
     expect(out.openings![0]).toMatchObject({ x: 15, y: 15 });
+  });
+});
+
+describe("attachedCorners (issue #30: stretch-drag shared room corners)", () => {
+  // A closed rectangle drawn as four walls sharing corners.
+  const room: Wall[] = [
+    { id: "n", x1: 0, y1: 0, x2: 100, y2: 0 },
+    { id: "e", x1: 100, y1: 0, x2: 100, y2: 80 },
+    { id: "s", x1: 100, y1: 80, x2: 0, y2: 80 },
+    { id: "w", x1: 0, y1: 80, x2: 0, y2: 0 },
+  ];
+
+  it("endpoint drag: finds only the walls sharing the grabbed corner", () => {
+    // Grabbing the north wall's second endpoint (100, 0) — shared with east's first.
+    const out = attachedCorners(room, "n", 2);
+    expect(out).toEqual([{ id: "e", end: 1, which: 2, x0: 100, y0: 0 }]);
+  });
+
+  it("whole-wall drag: finds neighbors at both corners, tagged per corner", () => {
+    const out = attachedCorners(room, "n");
+    expect(out).toEqual([
+      { id: "e", end: 1, which: 2, x0: 100, y0: 0 },
+      { id: "w", end: 2, which: 1, x0: 0, y0: 0 },
+    ]);
+  });
+
+  it("tolerates near-coincident corners within the epsilon only", () => {
+    const sloppy: Wall[] = [
+      { id: "a", x1: 0, y1: 0, x2: 100, y2: 0 },
+      { id: "b", x1: 100.5, y1: 0.5, x2: 100, y2: 80 }, // ~0.7 away — attached
+      { id: "c", x1: 103, y1: 0, x2: 100, y2: 80 }, // 3 away — separate wall
+    ];
+    const out = attachedCorners(sloppy, "a", 2);
+    expect(out).toEqual([{ id: "b", end: 1, which: 2, x0: 100.5, y0: 0.5 }]);
+  });
+
+  it("returns undefined for a free-standing wall or unknown id", () => {
+    expect(attachedCorners(room, "missing")).toBeUndefined();
+    const lone: Wall[] = [
+      { id: "a", x1: 0, y1: 0, x2: 100, y2: 0 },
+      { id: "b", x1: 500, y1: 500, x2: 600, y2: 500 },
+    ];
+    expect(attachedCorners(lone, "a")).toBeUndefined();
+  });
+
+  it("can attach both endpoints of the same neighbor (duplicated wall)", () => {
+    const doubled: Wall[] = [
+      { id: "a", x1: 0, y1: 0, x2: 100, y2: 0 },
+      { id: "b", x1: 0, y1: 0, x2: 100, y2: 0 },
+    ];
+    expect(attachedCorners(doubled, "a")).toEqual([
+      { id: "b", end: 1, which: 1, x0: 0, y0: 0 },
+      { id: "b", end: 2, which: 2, x0: 100, y0: 0 },
+    ]);
   });
 });

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -26,6 +26,56 @@ type WallSegment = Pick<Wall, "x1" | "y1" | "x2" | "y2">;
 /** Snap distance (virtual units) for wall endpoints onto each other. */
 export const ENDPOINT_SNAP = 26;
 
+/**
+ * Corners of different walls at most this far apart count as the same room
+ * corner for stretch-dragging (issue #30). Kept tight so only genuinely
+ * shared corners travel together — walls that merely pass near each other
+ * don't get grabbed.
+ */
+export const CORNER_ATTACH_EPS = 0.75;
+
+/** An endpoint of another wall that shares a corner with a dragged wall. */
+export interface AttachedCorner {
+  id: string;
+  /** Which endpoint of the attached wall coincides. */
+  end: 1 | 2;
+  /** Which endpoint of the dragged wall it follows. */
+  which: 1 | 2;
+  /** Position at drag start (for whole-wall translation). */
+  x0: number;
+  y0: number;
+}
+
+/**
+ * Endpoints of other walls sharing a corner with the grabbed wall (issue
+ * #30): dragging a corner or a whole wall stretches the room instead of
+ * tearing it open. Scans only the grabbed endpoint's corner for an
+ * endpoint-handle drag; both corners for a whole-wall drag.
+ */
+export function attachedCorners(
+  walls: readonly Wall[],
+  wallId: string,
+  endpoint?: 1 | 2,
+  eps = CORNER_ATTACH_EPS
+): AttachedCorner[] | undefined {
+  const w = walls.find((x) => x.id === wallId);
+  if (!w) return undefined;
+  const anchors: { x: number; y: number; which: 1 | 2 }[] = [];
+  if (endpoint !== 2) anchors.push({ x: w.x1, y: w.y1, which: 1 });
+  if (endpoint !== 1) anchors.push({ x: w.x2, y: w.y2, which: 2 });
+  const attached: AttachedCorner[] = [];
+  for (const other of walls) {
+    if (other.id === w.id) continue;
+    for (const end of [1, 2] as const) {
+      const px = end === 1 ? other.x1 : other.x2;
+      const py = end === 1 ? other.y1 : other.y2;
+      const a = anchors.find((an) => Math.hypot(px - an.x, py - an.y) <= eps);
+      if (a) attached.push({ id: other.id, end, which: a.which, x0: px, y0: py });
+    }
+  }
+  return attached.length ? attached : undefined;
+}
+
 /** Nearest existing wall endpoint within `maxDist`, or null. */
 export function nearestCorner(
   walls: readonly WallSegment[],

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state, query } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import type {
   HomeAssistant,
   FloorplanCardConfig,
@@ -47,6 +48,7 @@ import {
   trackerSensorReading,
   kindFromEntity,
   resolveItemIcon,
+  itemIconSize,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -54,9 +56,11 @@ import {
 import {
   ENDPOINT_SNAP,
   applyDelta,
+  attachedCorners,
   elementsInRect,
   nearestCorner,
   snapWallEnd,
+  type AttachedCorner,
   type OrigPos,
   type Rect,
   type Sel,
@@ -114,6 +118,12 @@ interface Drag {
   orig: Map<string, OrigPos>;
   /** Set when dragging a single wall endpoint handle. */
   endpoint?: 1 | 2;
+  /**
+   * Endpoints of *other* walls that coincide with the dragged wall's
+   * corner(s) and stretch along with it (issue #30). Hold Alt to detach and
+   * move just the grabbed wall.
+   */
+  attached?: AttachedCorner[];
   /** Set once the drag actually moved something (history snapshots lazily). */
   moved?: boolean;
   /** The exact history entry this drag pushed, so cancel can remove it by identity. */
@@ -205,6 +215,10 @@ export class FloorplanCardEditor extends LitElement {
   @query(".canvas-wrap") private _canvasWrap?: HTMLElement;
 
   private _drag: Drag | null = null;
+  /** Live touch points on the canvas wrap, for pinch-zoom (issue #38). */
+  private _pinchPts = new Map<number, { x: number; y: number }>();
+  /** Pinch baseline: finger distance, zoom, and centroid (content coords) at pinch start. */
+  private _pinch: { d0: number; z0: number; cx: number; cy: number } | null = null;
   /** Pointer driving the current gesture; others are ignored while it's active. */
   private _gesturePointer: number | null = null;
   /** True when the active marquee should add to (rather than replace) the selection. */
@@ -333,7 +347,71 @@ export class FloorplanCardEditor extends LitElement {
         void customElements.whenDefined(tag).then(() => this.requestUpdate());
       }
     }
+    // Pinch-zoom (issue #38): capture phase, because element handlers on the
+    // canvas (item badges, endpoint handles) stopPropagation and would hide a
+    // finger that lands on them from the pinch tracker.
+    const wrap = this._canvasWrap;
+    if (wrap) {
+      wrap.addEventListener("pointerdown", this._onWrapPointerDown, { capture: true });
+      wrap.addEventListener("pointermove", this._onWrapPointerMove, { capture: true });
+      wrap.addEventListener("pointerup", this._onWrapPointerEnd, { capture: true });
+      wrap.addEventListener("pointercancel", this._onWrapPointerEnd, { capture: true });
+      // Safari routes trackpad/touch pinch through proprietary gesture events
+      // and zooms the whole page (the entire visual editor) unless they're
+      // canceled — touch-action does not cover this path.
+      for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+        wrap.addEventListener(type, (e: Event) => e.preventDefault());
+      }
+    }
   }
+
+  // ---- pinch-zoom on the canvas (issue #38) -------------------------------
+
+  private _onWrapPointerDown = (ev: PointerEvent): void => {
+    if (ev.pointerType !== "touch") return;
+    this._pinchPts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (this._pinchPts.size !== 2) return;
+    // A second finger turns the gesture into a pinch: abort any draw/drag so
+    // the canvas doesn't draw a wall while the user is only trying to zoom.
+    this._cancelGesture();
+    const wrap = this._canvasWrap;
+    const rect = wrap?.getBoundingClientRect();
+    const [a, b] = [...this._pinchPts.values()];
+    this._pinch = {
+      d0: Math.max(Math.hypot(b.x - a.x, b.y - a.y), 1),
+      z0: this._zoom,
+      cx: (a.x + b.x) / 2 - (rect?.left ?? 0) + (wrap?.scrollLeft ?? 0),
+      cy: (a.y + b.y) / 2 - (rect?.top ?? 0) + (wrap?.scrollTop ?? 0),
+    };
+    ev.stopPropagation();
+  };
+
+  private _onWrapPointerMove = (ev: PointerEvent): void => {
+    if (!this._pinch || !this._pinchPts.has(ev.pointerId)) return;
+    this._pinchPts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (this._pinchPts.size < 2) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    const [a, b] = [...this._pinchPts.values()];
+    const pinch = this._pinch;
+    this._setZoom(pinch.z0 * (Math.hypot(b.x - a.x, b.y - a.y) / pinch.d0));
+    // Keep the content point under the fingers stationary: the stage scales
+    // with _zoom on the next render, so re-derive the scroll offset after it.
+    void this.updateComplete.then(() => {
+      const wrap = this._canvasWrap;
+      if (!wrap || this._pinch !== pinch) return;
+      const rect = wrap.getBoundingClientRect();
+      const scale = this._zoom / pinch.z0;
+      wrap.scrollLeft = pinch.cx * scale - ((a.x + b.x) / 2 - rect.left);
+      wrap.scrollTop = pinch.cy * scale - ((a.y + b.y) / 2 - rect.top);
+    });
+  };
+
+  private _onWrapPointerEnd = (ev: PointerEvent): void => {
+    if (ev.pointerType !== "touch") return;
+    this._pinchPts.delete(ev.pointerId);
+    if (this._pinchPts.size < 2) this._pinch = null;
+  };
 
   /**
    * Promote the expanded editor into the top layer. `position: fixed` alone is
@@ -450,6 +528,33 @@ export class FloorplanCardEditor extends LitElement {
   /** Snap a raw point to a nearby existing wall endpoint, else to the snap step. */
   private _snapWallPoint(rawX: number, rawY: number): { x: number; y: number } {
     return this._nearestCorner(rawX, rawY) ?? { x: this._snap(rawX), y: this._snap(rawY) };
+  }
+
+  /**
+   * Like {@link _snapWallPoint}, but ignores endpoints in `moving` (keys
+   * `${wallId}:${end}`) — the corner cluster being dragged must not attract
+   * itself.
+   */
+  private _snapWallPointExcluding(
+    rawX: number,
+    rawY: number,
+    moving: ReadonlySet<string>
+  ): { x: number; y: number } {
+    let best: { x: number; y: number } | null = null;
+    let bestDist = ENDPOINT_SNAP;
+    for (const w of this._floor().walls) {
+      for (const end of [1, 2] as const) {
+        if (moving.has(`${w.id}:${end}`)) continue;
+        const x = end === 1 ? w.x1 : w.x2;
+        const y = end === 1 ? w.y1 : w.y2;
+        const d = Math.hypot(rawX - x, rawY - y);
+        if (d < bestDist) {
+          bestDist = d;
+          best = { x, y };
+        }
+      }
+    }
+    return best ?? { x: this._snap(rawX), y: this._snap(rawY) };
   }
 
   /** See {@link snapWallEnd}: corners win, then axis gravity, then the snap step. */
@@ -927,8 +1032,14 @@ export class FloorplanCardEditor extends LitElement {
       orig: this._snapshotSelection(),
       endpoint,
     };
+    if (sel.kind === "wall") this._drag.attached = this._attachedCorners(sel.id, endpoint);
     this._gesturePointer = ev.pointerId;
     this._capturePointer(ev);
+  }
+
+  /** See {@link attachedCorners}: shared room corners that stretch with this wall. */
+  private _attachedCorners(wallId: string, endpoint?: 1 | 2): Drag["attached"] {
+    return attachedCorners(this._floor().walls, wallId, endpoint);
   }
 
   /** Capture the start positions of every selected element on the active floor. */
@@ -976,14 +1087,31 @@ export class FloorplanCardEditor extends LitElement {
     }
     const f = this._floor();
 
-    // Single wall endpoint handle: snaps to nearby wall corners.
+    // Single wall endpoint handle: snaps to nearby wall corners. Coincident
+    // corners of other walls travel along (Alt detaches), so dragging a room
+    // corner stretches the room (issue #30).
     if (drag.endpoint) {
-      const target = this._snapWallPoint(p.x, p.y);
+      const attach = ev.altKey ? [] : (drag.attached ?? []);
+      // The moving cluster must not be a snap candidate for itself — the
+      // dragged corner would stick to its own last emitted position.
+      const moving = new Set<string>([
+        `${drag.primary.id}:${drag.endpoint}`,
+        ...attach.map((a) => `${a.id}:${a.end}`),
+      ]);
+      const target = this._snapWallPointExcluding(p.x, p.y, moving);
       const walls = f.walls.map((w) => {
-        if (w.id !== drag.primary.id) return w;
-        return drag.endpoint === 1
-          ? { ...w, x1: target.x, y1: target.y }
-          : { ...w, x2: target.x, y2: target.y };
+        let out = w;
+        if (w.id === drag.primary.id)
+          out = drag.endpoint === 1
+            ? { ...out, x1: target.x, y1: target.y }
+            : { ...out, x2: target.x, y2: target.y };
+        for (const a of attach) {
+          if (a.id !== w.id) continue;
+          out = a.end === 1
+            ? { ...out, x1: target.x, y1: target.y }
+            : { ...out, x2: target.x, y2: target.y };
+        }
+        return out;
       });
       this._emitFloor({ walls });
       return;
@@ -1016,7 +1144,24 @@ export class FloorplanCardEditor extends LitElement {
     const refY = ref.kind === "wall" ? ref.y1 : ref.y;
     const dx = this._snap(refX + (p.x - drag.start.x)) - refX;
     const dy = this._snap(refY + (p.y - drag.start.y)) - refY;
-    this._emitFloor(this._applyDelta(dx, dy, drag.orig));
+    let patch = this._applyDelta(dx, dy, drag.orig);
+    // Whole-wall drag: shared corners of neighboring walls follow (issue #30),
+    // unless Alt detaches or the neighbor is itself part of the selection
+    // (then it already translated with the group).
+    if (drag.attached?.length && !ev.altKey) {
+      const walls = (patch.walls ?? f.walls).map((w) => {
+        let out = w;
+        for (const a of drag.attached!) {
+          if (a.id !== w.id || drag.orig.has(`wall:${a.id}`)) continue;
+          out = a.end === 1
+            ? { ...out, x1: a.x0 + dx, y1: a.y0 + dy }
+            : { ...out, x2: a.x0 + dx, y2: a.y0 + dy };
+        }
+        return out;
+      });
+      patch = { ...patch, walls };
+    }
+    this._emitFloor(patch);
   }
 
   /** Translate every snapshotted element by (dx, dy). */
@@ -1826,7 +1971,15 @@ export class FloorplanCardEditor extends LitElement {
           <!-- Floor — switch + add inline; rename/delete behind the gear -->
           <span class="floors pop-wrap">
             <label>floor</label>
-            <select @change=${(e: Event) => this._switchFloor((e.target as HTMLSelectElement).value)}>
+            <select
+              @change=${(e: Event) => {
+                this._switchFloor((e.target as HTMLSelectElement).value);
+                // Hand focus back to the canvas: while the <select> keeps it,
+                // isTypingPath swallows every shortcut — most visibly Ctrl+V
+                // after a cross-floor copy (issue #37).
+                this._canvasWrap?.focus();
+              }}
+            >
               ${floors.map(
                 (f) =>
                   html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>${f.name}</option>`
@@ -1909,8 +2062,19 @@ export class FloorplanCardEditor extends LitElement {
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
-              ${floor.openings.map((o) => this._renderOpeningSel(o))}
-              ${(floor.trackers ?? []).map((tr) => this._renderTrackerSel(tr))}
+              ${repeat(
+                // Keyed by id: switching floors must create fresh DOM. Reused
+                // nodes would CSS-transition from the previous floor's opening
+                // state — a window briefly plays a door swing (issue #50).
+                floor.openings,
+                (o) => o.id,
+                (o) => this._renderOpeningSel(o)
+              )}
+              ${repeat(
+                floor.trackers ?? [],
+                (tr) => tr.id,
+                (tr) => this._renderTrackerSel(tr)
+              )}
               ${
                 this._draftTracker
                   ? svg`<rect class="tracker-draft"
@@ -2377,7 +2541,7 @@ export class FloorplanCardEditor extends LitElement {
       class="badge ${showIcon ? "" : "ghost"}"
       style="width:${size}px;height:${size}px;transform:rotate(${it.angle ?? 0}deg);"
     >
-      <ha-icon icon=${icon} style="--mdc-icon-size:${Math.round(size * 0.62)}px;"></ha-icon>
+      <ha-icon icon=${icon} style="--mdc-icon-size:${itemIconSize(size)}px;"></ha-icon>
     </div>`;
 
     // Editor always previews the ripple animated so its effect is visible.
@@ -3537,6 +3701,13 @@ export class FloorplanCardEditor extends LitElement {
       --mdc-icon-size: 22px;
     }
     .ilabel {
+      /* Out of flow, hanging below the badge: the label must not change the
+         element's box, so badges anchor on (x, y) whether or not a label
+         renders — icons stay aligned (issue #34) and match the card. */
+      position: absolute;
+      top: calc(100% + 2px);
+      left: 50%;
+      transform: translateX(-50%);
       font-size: 11px;
       line-height: 1;
       padding: 1px 4px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
 import {
   DEFAULT_WIDTH,
@@ -26,6 +27,7 @@ import {
   hassRenderInputsChanged,
   collectWatchedEntities,
   resolveItemIcon,
+  itemIconSize,
 } from "./render";
 import type { Opening } from "./types";
 import { actionForGesture, executeAction, hasAction } from "./actions";
@@ -172,7 +174,7 @@ export class FloorplanCard extends LitElement {
       >
         <ha-icon
           icon=${this._itemIcon(item)}
-          style="--mdc-icon-size:${Math.round(size * 0.62)}px;"
+          style="--mdc-icon-size:${itemIconSize(size)}px;"
         ></ha-icon>
       </div>
     `;
@@ -180,7 +182,8 @@ export class FloorplanCard extends LitElement {
 
   private _renderItem(item: FloorItem, c: FloorplanCardConfig): TemplateResult {
     const on = this._isOn(item);
-    const showState = item.showState ?? item.kind === "sensor";
+    // No entity, no state line — the badge alone marks the device (issue #39).
+    const showState = !!item.entity && (item.showState ?? item.kind === "sensor");
     const showIcon = item.showIcon ?? true;
     const display = item.display ?? "badge";
     const rippleColor = item.rippleColor ?? "var(--primary-color, #03a9f4)";
@@ -213,7 +216,11 @@ export class FloorplanCard extends LitElement {
         })}
       >
         ${visual}
-        ${showState ? html`<span class="label">${itemStateText(this.hass, item)}</span>` : nothing}
+        ${showState
+          ? html`<span class="label ${visual === nothing ? "inflow" : ""}"
+              >${itemStateText(this.hass, item)}</span
+            >`
+          : nothing}
       </div>
     `;
   }
@@ -275,7 +282,14 @@ export class FloorplanCard extends LitElement {
                       class="wall" stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
               )}
             </g>
-            ${active.openings.map((o) => {
+            ${repeat(
+              // Keyed by id: switching floors must create fresh DOM nodes.
+              // Unkeyed, Lit morphs floor A's openings into floor B's, and the
+              // 0.5s leaf/panel transitions animate the leftover state — a
+              // window briefly plays a door swing (issue #50).
+              active.openings,
+              (o) => o.id,
+              (o) => {
               const amount = this._openingAmount(o);
               const symbol = renderOpening(o, {
                 color: "var(--primary-text-color)",
@@ -297,7 +311,10 @@ export class FloorplanCard extends LitElement {
                         transform="rotate(${o.angle} ${o.x} ${o.y})" />
                 </g>`;
             })}
-            ${(active.trackers ?? []).map((tr) =>
+            ${repeat(
+              active.trackers ?? [],
+              (tr) => tr.id,
+              (tr) =>
               renderTracker(tr, {
                 editing: false,
                 xReading: trackerSensorReading(this.hass?.states, tr.xSensor?.entity),
@@ -309,7 +326,14 @@ export class FloorplanCard extends LitElement {
           </svg>
           <div class="items">
             ${active.texts.map((t) => this._renderText(t, c))}
-            ${active.items.filter((it) => it.entity).map((it) => this._renderItem(it, c))}
+            ${repeat(
+              // No entity filter: devices that exist physically but have no HA
+              // entity still deserve their badge (issue #39). Keyed by id so a
+              // floor switch builds fresh DOM (see the openings comment).
+              active.items,
+              (it) => it.id,
+              (it) => this._renderItem(it, c)
+            )}
           </div>
           ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
         </div>
@@ -456,6 +480,13 @@ export class FloorplanCard extends LitElement {
       --mdc-icon-size: 22px;
     }
     .label {
+      /* Out of flow, hanging below the badge: the state line must not change
+         the item's box, so the badge — not the badge+label column — centers
+         on (x, y). Items with and without a state stay aligned (issue #34). */
+      position: absolute;
+      top: calc(100% + 2px);
+      left: 50%;
+      transform: translateX(-50%);
       font-size: 12px;
       line-height: 1;
       padding: 1px 4px;
@@ -463,6 +494,12 @@ export class FloorplanCard extends LitElement {
       background: var(--card-background-color, #fff);
       color: var(--primary-text-color);
       white-space: nowrap;
+    }
+    /* Label-only items (showIcon: false) have no badge to hang under — let
+       the label itself be the box so it centers on (x, y) as before. */
+    .label.inflow {
+      position: static;
+      transform: none;
     }
     .text {
       position: absolute;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -28,6 +28,7 @@ import {
   isEntityOn,
   entityIsActive,
   resolveItemIcon,
+  itemIconSize,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -745,5 +746,38 @@ describe("entityIsActive — domains that never say \"on\"", () => {
     expect(entityDefaultIcon("lock.front", undefined, entityIsActive("lock.front", "locked"))).toBe(
       "mdi:lock",
     );
+  });
+});
+
+describe("resolveItemIcon without an entity (issue #39)", () => {
+  it("falls back to the kind default when no entity is bound", () => {
+    expect(resolveItemIcon({ entity: "", kind: "sensor" }, undefined)).toBe(
+      defaultIcon("sensor"),
+    );
+    expect(resolveItemIcon({ kind: "light" }, undefined)).toBe(defaultIcon("light"));
+  });
+
+  it("still honors an explicit icon override", () => {
+    expect(resolveItemIcon({ entity: "", kind: "sensor", icon: "mdi:smoke-detector" }, undefined)).toBe(
+      "mdi:smoke-detector",
+    );
+  });
+});
+
+describe("itemIconSize (issue #39: off-center glyphs at small sizes)", () => {
+  it("keeps the familiar 22px icon for the 34px default badge", () => {
+    expect(itemIconSize(34)).toBe(22);
+  });
+
+  it("matches the badge's parity so centering slack is a whole pixel per side", () => {
+    for (const badge of [16, 18, 20, 24, 28, 34, 48]) {
+      expect((badge - itemIconSize(badge)) % 2, `badge ${badge}`).toBe(0);
+    }
+    // 18px badge: naive round(18 * 0.62) = 11 leaves a half-pixel; we want 12.
+    expect(itemIconSize(18)).toBe(12);
+  });
+
+  it("never collapses below 2px", () => {
+    expect(itemIconSize(1)).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -265,10 +265,13 @@ export function entityDefaultIcon(
  * "on" (lock/vacuum/camera) reach their active icons here too.
  */
 export function resolveItemIcon(
-  item: { entity: string; kind: ItemKind; icon?: string },
+  item: { entity?: string; kind: ItemKind; icon?: string },
   st: { state: string; attributes: Record<string, unknown> } | undefined,
 ): string {
   if (item.icon) return item.icon;
+  // No entity bound (issue #39: devices that exist physically but not in HA):
+  // nothing to derive from, fall straight through to the kind default.
+  if (!item.entity) return defaultIcon(item.kind);
   const attrIcon = st?.attributes?.icon as string | undefined;
   if (attrIcon) return attrIcon;
   return (
@@ -278,6 +281,20 @@ export function resolveItemIcon(
       entityIsActive(item.entity, st?.state),
     ) ?? defaultIcon(item.kind)
   );
+}
+
+/**
+ * Icon size for an item badge, shared by card and editor. ~62% of the badge,
+ * nudged to the badge's parity so the flex-centering slack on each side is a
+ * whole pixel — an 11px icon in an 18px badge sits on a half-pixel and the
+ * glyph renders visibly off-center at small sizes (issue #39). The 34px
+ * default badge still gets its familiar 22px icon.
+ */
+export function itemIconSize(badgeSize: number): number {
+  const b = Math.round(badgeSize);
+  let s = Math.round(b * 0.62);
+  if (s % 2 !== b % 2) s += 1;
+  return Math.max(2, s);
 }
 
 /** Infer a sensible item kind from an entity id's domain. */


### PR DESCRIPTION
One PR for the small missing-feature / bug batch. Each fix is independent and verified in the dev harness; unit suite is at 191 after rebasing on main.

> **Note:** this PR originally also fixed #34, but @amadeobriones' #41 landed the same fix first (and better documented — see its measured before/after) — so that part now belongs to #41. This branch has been rebased on top: it keeps #41's version, extends its `gap: 2px` cleanup to the editor, and adds the editor-side counterpart (the canvas `.ilabel` now anchors the same way, so icons sit identically while editing and viewing).

## What's fixed

### #37 — copy/paste between floors
Paste itself always worked cross-floor; the bug was focus. Switching floors happens through a `<select>`, which **keeps keyboard focus**, and the editor's typing guard (correctly) swallows shortcuts while a form control is focused — so the Ctrl+V after switching floors died silently. The floor switcher now hands focus back to the canvas. Verified end-to-end with real key events: copy on floor 1 → switch via the select → Ctrl+V pastes onto floor 2.

### #38 — zoom on small devices
The canvas now has real **pinch-to-zoom**: two fingers zoom the plan (centroid-anchored, clamped to the existing 50–300%), and a second finger landing mid-draw cancels the draw instead of leaving a stray wall. Listeners are capture-phase on the canvas wrap so a finger on a badge or handle still counts. Safari's proprietary `gesturestart/change/end` events are canceled — that's the path that zoomed the entire visual editor.

### #39 — devices without an entity
The card filtered out items with no `entity`, so unbound hardware vanished at runtime (it already showed in the editor). They now render as a static badge: icon override or kind default, never highlighted, tap does nothing, no state line. Also from this issue: the icon glyph is now sized to match the badge's pixel parity (shared `itemIconSize`), so e.g. an 18px badge gets a 12px icon (whole-pixel centering) instead of an 11px one sitting on a half-pixel. The default 34px badge keeps its familiar 22px icon. Reconciled with #42: icon precedence is config icon → (no entity → kind default) → registry icon → attribute icon → derived.

### #50 — windows briefly animating like doors on floor switch
Openings were rendered unkeyed, so Lit **reused DOM nodes across floors**: floor B's window inherited floor A's door/window node and the 0.5s leaf/panel transition animated the leftover transform — the flash in the issue's video, and why only *some* windows did it (only those landing on a reused slot). Openings and trackers now render via `repeat()` keyed by id in both card and editor; a floor switch builds fresh nodes, which never transition on first paint.

### #30 — stretch/shrink rooms
Dragging a wall, or one of its corner handles, now carries every **coincident corner** of neighboring walls (tolerance 0.75 units — corner-snapped rooms match exactly), so pulling a wall stretches the room instead of tearing it open. **Alt-drag detaches** the grabbed wall. Group drags are consistent: selected walls translate once, shared corners outside the selection follow. Bonus fix that fell out: corner snapping now excludes the corner being dragged, removing the 26-unit "dead zone" stickiness endpoint drags used to have. Logic lives in `editor-geometry.attachedCorners` with unit tests.

## Verification
- `tsc` clean, **191/191 tests**, vite build 190.9 kB (re-run after the rebase onto #41 + #42).
- Dev harness, all five: cross-floor paste via real keydowns; synthetic 2-finger pinch (zoom 1 → 2 on a 2× spread, gesture canceled, clean teardown); door→window floor switch creates fresh DOM; three items (labeled sensor / bare light / entity-less 18px smoke detector) render with identical badge centers and a 12px icon; corner drag pulls the attached wall, whole-wall drag stretches both neighbors, Alt detaches, undo restores exactly.
- Post-rebase note for reviewers: the auto-merge with #41 silently **duplicated** the `.label` CSS block (no conflict marker); deduplicated in the merge commit, keeping #41's copy.

## Backwards compatibility
No config schema changes. Entity-less items previously hidden at runtime will now appear (that's the point of #39 — but it is a visible change for anyone who left orphaned items in their config). Icon size changes by ±1px at non-default badge sizes.

Closes #30, closes #37, closes #38, closes #39, closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)