### PR TITLE
Animate device icons while active (fan spins, playback pulses) — closes #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ By default it shows an icon badge:
   still wins.
 - **Make it yours** — override the **icon** (with autocomplete + live preview), set a
   custom **name**, change the **size**, **rotate** it, or hide the icon entirely.
+- **Icons that move** — while an entity is active its icon can animate, the way
+  Home Assistant's own Tile card does it: by default a running **fan spins** and a
+  playing **media player** or cleaning **vacuum pulses**. The **Animate icon**
+  dropdown per device switches to `none`, or forces `spin` / `pulse` on any entity
+  (a spinning icon still only plays while the entity is actually active — an
+  unavailable fan never spins). Respects the OS *reduced motion* preference.
 
 ### Presence ripples
 
@@ -397,6 +403,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
 | `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn.                               |
+| `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. |
 | `rippleColor` | string                                 | primary color| Ripple ring color (ripple modes).                     |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -163,6 +163,19 @@ const hass = {
       state: "off",
       attributes: { friendly_name: "Door Lock", device_class: "lock" },
     },
+    // Icon-animation demo (issue #48): a running fan spins, a playing media
+    // player pulses. Flip their states in the console via setHassBinary /
+    // baseStates to watch the animation start and stop.
+    "fan.ceiling_fan": {
+      entity_id: "fan.ceiling_fan",
+      state: "on",
+      attributes: { friendly_name: "Ceiling Fan" },
+    },
+    "media_player.living_tv": {
+      entity_id: "media_player.living_tv",
+      state: "playing",
+      attributes: { friendly_name: "Living Room TV" },
+    },
     [SENSOR_TEMPERATURE]: {
       entity_id: SENSOR_TEMPERATURE,
       state: "17.94",

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -156,6 +156,19 @@ describe("itemForm", () => {
     ).toContain("rippleSize");
   });
 
+  it("offers the icon-animation dropdown defaulting to auto", () => {
+    const f = itemForm(item).fields.find((x) => x.name === "iconAnimation");
+    expect(f).toBeDefined();
+    const opts = (f!.selector as { select: { options: { value: string }[] } }).select.options.map(
+      (o) => o.value
+    );
+    expect(opts).toEqual(["auto", "none", "spin", "pulse"]);
+    expect(itemForm(item).data.iconAnimation).toBe("auto");
+    expect(itemForm({ ...item, iconAnimation: "spin" } as FloorItem).data.iconAnimation).toBe(
+      "spin"
+    );
+  });
+
   it("offers the three action fields with behavior-preserving defaults", () => {
     const fs = itemForm(item).fields;
     expect(fs.find((x) => x.name === "tap_action")!.selector).toEqual({

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -271,6 +271,17 @@ export function itemForm(it: FloorItem): FormSpec {
         opt("iconRipple", "Icon + ripple")
       ),
     },
+    {
+      name: "iconAnimation",
+      label: "Animate icon",
+      helper: "Plays only while the entity is active",
+      selector: dropdown(
+        opt("auto", "Auto (fan spins, playback pulses)"),
+        opt("none", "None"),
+        opt("spin", "Spin"),
+        opt("pulse", "Pulse")
+      ),
+    },
   ];
   if (display !== "badge") {
     fields.push({
@@ -304,6 +315,7 @@ export function itemForm(it: FloorItem): FormSpec {
       size: it.size ?? DEFAULT_ITEM_SIZE,
       angle: it.angle ?? 0,
       display,
+      iconAnimation: it.iconAnimation ?? "auto",
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       showIcon: it.showIcon ?? true,
       showState: it.showState ?? false,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -47,6 +47,7 @@ import {
   trackerSensorReading,
   kindFromEntity,
   resolveItemIcon,
+  resolveIconAnimation,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -2373,11 +2374,19 @@ export class FloorplanCardEditor extends LitElement {
     const rippleColor = it.rippleColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
+    // Live preview: the icon animates exactly when the card would animate it
+    // (entity currently active), so the "Animate icon" dropdown shows its
+    // effect without leaving the editor.
+    const anim = resolveIconAnimation(it, st?.state);
     const badge = html`<div
       class="badge ${showIcon ? "" : "ghost"}"
       style="width:${size}px;height:${size}px;transform:rotate(${it.angle ?? 0}deg);"
     >
-      <ha-icon icon=${icon} style="--mdc-icon-size:${Math.round(size * 0.62)}px;"></ha-icon>
+      <ha-icon
+        class=${anim ? `anim-${anim}` : ""}
+        icon=${icon}
+        style="--mdc-icon-size:${Math.round(size * 0.62)}px;"
+      ></ha-icon>
     </div>`;
 
     // Editor always previews the ripple animated so its effect is visible.
@@ -3535,6 +3544,36 @@ export class FloorplanCardEditor extends LitElement {
     }
     ha-icon {
       --mdc-icon-size: 22px;
+    }
+    /* Icon motion while the entity is active (issue #48) — matches the card. */
+    ha-icon.anim-spin {
+      animation: fp-icon-spin 2s linear infinite;
+    }
+    ha-icon.anim-pulse {
+      animation: fp-icon-pulse 1.6s ease-in-out infinite;
+    }
+    @keyframes fp-icon-spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+    @keyframes fp-icon-pulse {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.4;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      ha-icon.anim-spin,
+      ha-icon.anim-pulse {
+        animation: none;
+      }
     }
     .ilabel {
       font-size: 11px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -26,6 +26,7 @@ import {
   hassRenderInputsChanged,
   collectWatchedEntities,
   resolveItemIcon,
+  resolveIconAnimation,
 } from "./render";
 import type { Opening } from "./types";
 import { actionForGesture, executeAction, hasAction } from "./actions";
@@ -165,12 +166,17 @@ export class FloorplanCard extends LitElement {
 
   private _renderBadge(item: FloorItem): TemplateResult {
     const size = item.size ?? DEFAULT_ITEM_SIZE;
+    // Animation goes on the inner ha-icon, not the badge: the badge carries
+    // the user's `angle` rotation, and a spin on the same element would
+    // overwrite it.
+    const anim = resolveIconAnimation(item, this.hass?.states[item.entity]?.state);
     return html`
       <div
         class="badge"
         style="width:${size}px;height:${size}px;transform:rotate(${item.angle ?? 0}deg);"
       >
         <ha-icon
+          class=${anim ? `anim-${anim}` : ""}
           icon=${this._itemIcon(item)}
           style="--mdc-icon-size:${Math.round(size * 0.62)}px;"
         ></ha-icon>
@@ -454,6 +460,36 @@ export class FloorplanCard extends LitElement {
     }
     ha-icon {
       --mdc-icon-size: 22px;
+    }
+    /* Icon motion while the entity is active (issue #48). */
+    ha-icon.anim-spin {
+      animation: fp-icon-spin 2s linear infinite;
+    }
+    ha-icon.anim-pulse {
+      animation: fp-icon-pulse 1.6s ease-in-out infinite;
+    }
+    @keyframes fp-icon-spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+    @keyframes fp-icon-pulse {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.4;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      ha-icon.anim-spin,
+      ha-icon.anim-pulse {
+        animation: none;
+      }
     }
     .label {
       font-size: 12px;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -28,6 +28,7 @@ import {
   isEntityOn,
   entityIsActive,
   resolveItemIcon,
+  resolveIconAnimation,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -745,5 +746,46 @@ describe("entityIsActive — domains that never say \"on\"", () => {
     expect(entityDefaultIcon("lock.front", undefined, entityIsActive("lock.front", "locked"))).toBe(
       "mdi:lock",
     );
+  });
+});
+
+describe("resolveIconAnimation (issue #48)", () => {
+  it("auto: a running fan spins, playback and a cleaning vacuum pulse", () => {
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, "on")).toBe("spin");
+    expect(resolveIconAnimation({ entity: "media_player.tv" }, "playing")).toBe("pulse");
+    expect(resolveIconAnimation({ entity: "vacuum.robo" }, "cleaning")).toBe("pulse");
+  });
+
+  it("auto: everything else stays still, even when active", () => {
+    expect(resolveIconAnimation({ entity: "light.a" }, "on")).toBeUndefined();
+    expect(resolveIconAnimation({ entity: "switch.a" }, "on")).toBeUndefined();
+  });
+
+  it("never animates an inactive entity — including forced spin/pulse", () => {
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, "off")).toBeUndefined();
+    expect(
+      resolveIconAnimation({ entity: "light.a", iconAnimation: "spin" }, "off"),
+    ).toBeUndefined();
+    expect(
+      resolveIconAnimation({ entity: "media_player.tv", iconAnimation: "pulse" }, "paused"),
+    ).toBeUndefined();
+  });
+
+  it("fail-closed: unavailable/unknown/missing state never animates", () => {
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, "unavailable")).toBeUndefined();
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, "unknown")).toBeUndefined();
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, undefined)).toBeUndefined();
+    expect(resolveIconAnimation({}, "on")).toBeUndefined();
+  });
+
+  it("explicit spin/pulse override the domain default while active", () => {
+    expect(resolveIconAnimation({ entity: "light.a", iconAnimation: "spin" }, "on")).toBe("spin");
+    expect(resolveIconAnimation({ entity: "fan.ceiling", iconAnimation: "pulse" }, "on")).toBe(
+      "pulse",
+    );
+  });
+
+  it("none disables the domain default", () => {
+    expect(resolveIconAnimation({ entity: "fan.ceiling", iconAnimation: "none" }, "on")).toBeUndefined();
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -4,6 +4,7 @@ import type {
   SectionalHand,
   Opening,
   ItemKind,
+  IconAnimation,
   Furniture,
   Tracker,
   RenderHass,
@@ -224,6 +225,35 @@ export function entityIsActive(entityId: string | undefined, state: string | und
   const domain = entityId?.split(".")[0] ?? "";
   const active = ACTIVE_STATES[domain];
   return active ? active.has(state) : isEntityOn(state);
+}
+
+/**
+ * Domains whose icons move by default while active (issue #48), mirroring the
+ * feel of HA's own Tile card: a running fan spins; playback and a working
+ * vacuum breathe. Everything else stays still unless the config asks.
+ */
+const AUTO_ICON_ANIMATION: Record<string, "spin" | "pulse"> = {
+  fan: "spin",
+  media_player: "pulse",
+  vacuum: "pulse",
+};
+
+/**
+ * Which animation an item's icon should play right now, or undefined for
+ * none. Shared by card and editor. Never animates an inactive (or
+ * unavailable) entity — including when the config forces "spin"/"pulse": a
+ * spinning fan icon is a claim that the fan is running, so it obeys the same
+ * fail-closed rule as the active highlight ({@link entityIsActive}).
+ */
+export function resolveIconAnimation(
+  item: { entity?: string; iconAnimation?: IconAnimation },
+  state: string | undefined,
+): "spin" | "pulse" | undefined {
+  const mode = item.iconAnimation ?? "auto";
+  if (mode === "none") return undefined;
+  if (!entityIsActive(item.entity, state)) return undefined;
+  if (mode === "spin" || mode === "pulse") return mode;
+  return AUTO_ICON_ANIMATION[item.entity?.split(".")[0] ?? ""];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,13 @@ export interface FloorItem {
   angle?: number;
   /** How the device is drawn. Default "badge". */
   display?: ItemDisplay;
+  /**
+   * Animate the icon while the entity is active (issue #48). "auto" (the
+   * default) applies HA-like defaults per domain — a running fan spins, a
+   * playing media player pulses; "spin"/"pulse" force that animation (still
+   * only while active); "none" disables it.
+   */
+  iconAnimation?: IconAnimation;
   /** Ripple ring color (CSS/hex). Falls back to the primary color. */
   rippleColor?: string;
   /** Max ripple ring diameter in pixels. Default 80. */
@@ -146,6 +153,8 @@ export interface FloorItem {
 }
 
 export type ItemDisplay = "badge" | "ripple" | "iconRipple";
+
+export type IconAnimation = "auto" | "none" | "spin" | "pulse";
 
 /**
  * A Lovelace action (tap/hold/double_tap). Typed loosely on purpose: HA has


### PR DESCRIPTION
Implements #48 the way Home Assistant itself animates icons: HA exposes no animation API — its Tile card simply applies CSS keyframes to the icon while the entity is active — so this card now does the same.

## What you get
- **Auto defaults (zero config), matching HA's feel**: a running `fan` **spins**, a playing `media_player` and a cleaning `vacuum` **pulse**. Everything else stays still.
- **Per-device control**: new **Animate icon** dropdown in the element editor (`iconAnimation: auto | none | spin | pulse`) — force a spin/pulse on any entity, or switch it off.
- **Fail-closed, like the active highlight**: an animation is a claim the device is running, so it *only* plays while `entityIsActive` says so — a forced `spin` on an off/`unavailable`/`unknown` entity stays still.
- **Live in the editor too**: the canvas preview animates exactly when the card would, so the dropdown's effect is visible while editing.
- Details: the keyframes ride the inner `ha-icon`, not the badge, so they compose with the user's `angle` rotation; `prefers-reduced-motion: reduce` disables all of it (as HA's frontend does).

## Implementation
- `resolveIconAnimation(item, state)` — pure, shared by card and editor (`src/render.ts`), driven by a small `AUTO_ICON_ANIMATION` domain map.
- `FloorItem.iconAnimation` (`src/types.ts`) — absent field = today's behavior for every domain except the three animated ones; set `none` to restore stillness there.
- Editor form field in `src/editor-forms.ts`; keyframes + reduced-motion guard in both stylesheets.
- Dev harness: `fan.ceiling_fan` (on) and `media_player.living_tv` (playing) mocks.

## Verification
- `tsc` clean, **187/187 tests** (180 on main + 7 new: resolver matrix incl. fail-closed cases, form field/data defaults), build 183.5 kB.
- Harness, computed styles: fan → `fp-icon-spin 2s`, TV → `fp-icon-pulse 1.6s`, forced `spin` on a light animates, `none` on a fan doesn't; identical results in card and editor overlays. Scrubbing the animation clock shows the transform sweep 0°→90°→180° and opacity dip to 0.4; flipping the fan to `off` removes the class live. Editor dropdown round-trips (`none` → `spin` persists to config).

## Backwards compatibility
No schema break. The only visible change without config is that fans / media players / vacuums that are *active* now move; `iconAnimation: none` opts any device out.

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)