### PR TITLE
Rotate the displayed floorplan in 90° steps — closes #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Undo/redo buttons sit at the right of the tools row. Zoom controls live on the c
 itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button
 snaps back to 100%, and **Ctrl/Cmd+scroll** zooms from the keyboard/trackpad. The
 **Project** section (canvas size, grid, background) is collapsed by default — click its
-header to expand.
+header to expand. Its last row, **Rotate display**, turns the *live card* in 90° steps
+for portrait wall tablets — the editor keeps showing the plan as drawn, and icons and
+labels stay upright at any rotation.
 
 ## Elements
 
@@ -333,6 +335,7 @@ The editor writes this config for you; manual editing is optional.
 | `height`     | number   | `600`              | Virtual canvas height, in canvas units.      |
 | `grid`       | number   | `20`               | Gap between grid lines, in canvas units (so on a 1000-wide canvas, `20` ≈ 50 columns). A **smaller** number means a **finer** grid with more lines. |
 | `snap`       | number   | follows `grid`     | Snap step for placement / drag / nudge / wall drawing, in canvas units. Omit to snap to the visible grid; set `0` for free placement; set any other number for a custom step. The editor shows a custom step as a **percentage of the grid** (e.g. `50` % of a `20` grid is stored here as `10`), but the value here is always absolute. |
+| `rotation`   | number   | `0`                | Rotate the displayed card by `90`, `180` or `270` degrees — e.g. a landscape plan on a portrait wall tablet. Editing always shows the plan as drawn. Icons and labels stay upright. |
 | `background` | string   | card background    | Canvas background color (CSS / hex).         |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -10,6 +10,7 @@ import {
   trackerForm,
   wallForm,
   projectForm,
+  projectRotationForm,
   floorImageForm,
 } from "./editor-forms";
 import type { FormField } from "./editor-forms";
@@ -209,6 +210,22 @@ describe("wallForm / projectForm / floorImageForm", () => {
     const width = form.fields.find((x) => x.name === "width")!;
     expect(width.required).toBe(true);
     expect((width.selector.number as { min: number }).min).toBe(1);
+  });
+
+  it("rotation lives in its own bottom-row form, defaults to 0°, and patches as a number", () => {
+    const form = projectRotationForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
+    expect(form.fields.map((x) => x.name)).toEqual(["rotation"]);
+    expect(form.data.rotation).toBe("0");
+    // 0 comes back as undefined so an unrotated plan stays out of the YAML.
+    expect(form.toPatch({ rotation: "0" })).toEqual({ rotation: undefined });
+    expect(form.toPatch({ rotation: "90" })).toEqual({ rotation: 90 });
+    const rotated = projectRotationForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      rotation: 270,
+    } as FloorplanCardConfig);
+    expect(rotated.data.rotation).toBe("270");
   });
 
   it("image opacity appears only when an image is set", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_TEXT_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
 } from "./types";
-import { defaultIcon, openingMotion, sliderStyleOf } from "./render";
+import { defaultIcon, normalizePlanRotation, openingMotion, sliderStyleOf } from "./render";
 import { defaultItemAction } from "./actions";
 
 /** One ha-form schema item, extended with our label/helper (read by computeLabel). */
@@ -425,6 +425,30 @@ export function projectForm(c: FloorplanCardConfig): FormSpec {
     ],
     data: { title: c.title ?? "", width: c.width, height: c.height, grid: c.grid ?? DEFAULT_GRID },
     toPatch: identity,
+  };
+}
+
+/**
+ * Display rotation (issue #33), a separate one-field form so the editor can
+ * render it as the very last Project row — it's a set-once option for wall
+ * tablets, not day-to-day editing, so it stays out of the way.
+ */
+export function projectRotationForm(c: FloorplanCardConfig): FormSpec {
+  return {
+    fields: [
+      {
+        name: "rotation",
+        label: "Rotate display",
+        helper: "Rotates the live card only — editing stays as drawn",
+        selector: dropdown(opt("0", "0°"), opt("90", "90°"), opt("180", "180°"), opt("270", "270°")),
+      },
+    ],
+    data: { rotation: String(normalizePlanRotation(c.rotation)) },
+    toPatch: (p) =>
+      "rotation" in p
+        ? // Stored as a number; 0 means "not rotated", so keep it out of the YAML.
+          { ...p, rotation: p.rotation === "0" ? undefined : Number(p.rotation) }
+        : p,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -73,6 +73,7 @@ import {
   normalizeFormPatch,
   openingForm,
   projectForm,
+  projectRotationForm,
   textForm,
   trackerForm,
   wallForm,
@@ -2485,6 +2486,9 @@ export class FloorplanCardEditor extends LitElement {
           if (live) this._patchFloorLive(patch as Partial<Floor>);
           else this._commitFloor(patch as Partial<Floor>);
         })}
+        ${this._renderForm(projectRotationForm(this._config), (patch) =>
+          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        )}
       </div>
     `;
   }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -26,6 +26,11 @@ import {
   hassRenderInputsChanged,
   collectWatchedEntities,
   resolveItemIcon,
+  normalizePlanRotation,
+  rotatedCanvasSize,
+  rotatePlanPoint,
+  planRotationTransform,
+  type PlanRotation,
 } from "./render";
 import type { Opening } from "./types";
 import { actionForGesture, executeAction, hasAction } from "./actions";
@@ -54,7 +59,7 @@ export class FloorplanCard extends LitElement {
       if (raw[key] != null && !Array.isArray(raw[key]))
         throw new Error(`Invalid configuration: "${key}" must be a list`);
     }
-    for (const key of ["width", "height", "grid"]) {
+    for (const key of ["width", "height", "grid", "rotation"]) {
       if (raw[key] != null && typeof raw[key] !== "number")
         throw new Error(`Invalid configuration: "${key}" must be a number`);
     }
@@ -178,7 +183,7 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
-  private _renderItem(item: FloorItem, c: FloorplanCardConfig): TemplateResult {
+  private _renderItem(item: FloorItem, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
     const on = this._isOn(item);
     const showState = item.showState ?? item.kind === "sensor";
     const showIcon = item.showIcon ?? true;
@@ -198,10 +203,14 @@ export class FloorplanCard extends LitElement {
       visual = this._renderBadge(item);
     }
 
+    // Rotated frame: the overlay is HTML, so each anchor is remapped instead
+    // of transformed — badges and labels stay upright at any rotation.
+    const p = rotatePlanPoint(item.x, item.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
     return html`
       <div
         class="item ${on ? "on" : "off"}"
-        style="left:${(item.x / c.width) * 100}%; top:${(item.y / c.height) * 100}%;"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;"
         title=${this._label(item)}
         role="button"
         tabindex="0"
@@ -218,11 +227,13 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
-  private _renderText(t: FloorText, c: FloorplanCardConfig): TemplateResult {
+  private _renderText(t: FloorText, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
+    const p = rotatePlanPoint(t.x, t.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
     return html`
       <div
         class="text"
-        style="left:${(t.x / c.width) * 100}%; top:${(t.y / c.height) * 100}%;
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
                font-size:${t.size ?? DEFAULT_TEXT_SIZE}px;
                color:${t.color ?? "var(--primary-text-color)"};
                transform:translate(-50%,-50%) rotate(${t.angle ?? 0}deg);"
@@ -240,11 +251,17 @@ export class FloorplanCard extends LitElement {
       floors.find((f) => f.id === this._activeFloorId) ??
       floors.find((f) => f.id === c.defaultFloor) ??
       floors[0];
+    // Whole-plan display rotation (issue #33): the SVG rotates via one group
+    // transform below; the HTML overlay remaps per point in _renderItem /
+    // _renderText. Both must use the same mapping (rotatePlanPoint).
+    const rot = normalizePlanRotation(c.rotation);
+    const dims = rotatedCanvasSize(c.width, c.height, rot);
+    const rotTransform = planRotationTransform(c.width, c.height, rot);
     return html`
       <ha-card .header=${c.title ?? nothing}>
         <div
           class="stage"
-          style="aspect-ratio: ${c.width} / ${c.height}; background:${c.background ??
+          style="aspect-ratio: ${dims.w} / ${dims.h}; background:${c.background ??
           "var(--card-background-color, #fff)"};"
         >
 <!-- preserveAspectRatio="none" is correct here, and it took a wrong fix to
@@ -261,7 +278,8 @@ export class FloorplanCard extends LitElement {
                The real fix letterboxes both layers together -- wrap the svg and
                the overlay in one aspect-ratio box and centre it. Until then, do
                not "fix" this line. -->
-          <svg viewBox="0 0 ${c.width} ${c.height}" preserveAspectRatio="none">
+          <svg viewBox="0 0 ${dims.w} ${dims.h}" preserveAspectRatio="none">
+            <g transform=${rotTransform || nothing}>
             ${active.image
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
@@ -306,10 +324,11 @@ export class FloorplanCard extends LitElement {
                 yPresent: trackerPresenceDetected(this.hass?.states, tr.ySensor?.presence),
               })
             )}
+            </g>
           </svg>
           <div class="items">
-            ${active.texts.map((t) => this._renderText(t, c))}
-            ${active.items.filter((it) => it.entity).map((it) => this._renderItem(it, c))}
+            ${active.texts.map((t) => this._renderText(t, c, rot))}
+            ${active.items.filter((it) => it.entity).map((it) => this._renderItem(it, c, rot))}
           </div>
           ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
         </div>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -28,6 +28,10 @@ import {
   isEntityOn,
   entityIsActive,
   resolveItemIcon,
+  normalizePlanRotation,
+  rotatedCanvasSize,
+  rotatePlanPoint,
+  planRotationTransform,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -745,5 +749,77 @@ describe("entityIsActive — domains that never say \"on\"", () => {
     expect(entityDefaultIcon("lock.front", undefined, entityIsActive("lock.front", "locked"))).toBe(
       "mdi:lock",
     );
+  });
+});
+
+describe("plan rotation (issue #33)", () => {
+  const W = 1000;
+  const H = 600;
+
+  it("normalizes to the four supported steps, defaulting everything else to 0", () => {
+    expect(normalizePlanRotation(undefined)).toBe(0);
+    expect(normalizePlanRotation(90)).toBe(90);
+    expect(normalizePlanRotation(450)).toBe(90);
+    expect(normalizePlanRotation(-90)).toBe(270);
+    expect(normalizePlanRotation(360)).toBe(0);
+    expect(normalizePlanRotation(45)).toBe(0);
+    expect(normalizePlanRotation("90" as unknown)).toBe(0);
+    expect(normalizePlanRotation(Number.NaN)).toBe(0);
+  });
+
+  it("swaps the displayed canvas size for quarter turns only", () => {
+    expect(rotatedCanvasSize(W, H, 0)).toEqual({ w: W, h: H });
+    expect(rotatedCanvasSize(W, H, 90)).toEqual({ w: H, h: W });
+    expect(rotatedCanvasSize(W, H, 180)).toEqual({ w: W, h: H });
+    expect(rotatedCanvasSize(W, H, 270)).toEqual({ w: H, h: W });
+  });
+
+  it("maps corners of the plan onto corners of the rotated frame", () => {
+    // Top-left of the plan…
+    expect(rotatePlanPoint(0, 0, W, H, 0)).toEqual({ x: 0, y: 0 });
+    expect(rotatePlanPoint(0, 0, W, H, 90)).toEqual({ x: H, y: 0 }); // …top-right
+    expect(rotatePlanPoint(0, 0, W, H, 180)).toEqual({ x: W, y: H }); // …bottom-right
+    expect(rotatePlanPoint(0, 0, W, H, 270)).toEqual({ x: 0, y: W }); // …bottom-left
+    // An interior point keeps its distances to the edges it rotates onto.
+    expect(rotatePlanPoint(100, 50, W, H, 90)).toEqual({ x: H - 50, y: 100 });
+    expect(rotatePlanPoint(100, 50, W, H, 270)).toEqual({ x: 50, y: W - 100 });
+  });
+
+  it("rotating four quarter turns is the identity", () => {
+    let p = { x: 123, y: 456 };
+    let w = W;
+    let h = H;
+    for (let i = 0; i < 4; i++) {
+      p = rotatePlanPoint(p.x, p.y, w, h, 90);
+      [w, h] = [h, w];
+    }
+    expect(p).toEqual({ x: 123, y: 456 });
+  });
+
+  it("group transform matches the point mapping", () => {
+    // Apply the SVG transform math manually and compare with rotatePlanPoint.
+    const apply = (t: string, x: number, y: number) => {
+      const m = t.match(/translate\((-?\d+) (-?\d+)\) rotate\((-?\d+)\)/);
+      if (!m) return { x, y };
+      const [tx, ty, deg] = [Number(m[1]), Number(m[2]), Number(m[3])];
+      const rad = (deg * Math.PI) / 180;
+      return {
+        x: Math.round(tx + x * Math.cos(rad) - y * Math.sin(rad)) + 0,
+        y: Math.round(ty + x * Math.sin(rad) + y * Math.cos(rad)) + 0,
+      };
+    };
+    for (const rot of [90, 180, 270] as const) {
+      const t = planRotationTransform(W, H, rot);
+      for (const [x, y] of [
+        [0, 0],
+        [W, H],
+        [123, 456],
+      ]) {
+        expect(apply(t, x, y), `rot ${rot} point ${x},${y}`).toEqual(
+          rotatePlanPoint(x, y, W, H, rot),
+        );
+      }
+    }
+    expect(planRotationTransform(W, H, 0)).toBe("");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -624,6 +624,71 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     </g>`;
 }
 
+// ---- whole-plan rotation (issue #33) ---------------------------------------
+//
+// The card can display the plan rotated in 90° steps — a landscape plan on a
+// portrait wall tablet — without touching any stored coordinate. The SVG
+// layers rotate via one group transform; the HTML overlay (badges, labels,
+// text) is repositioned point-by-point instead, so icons and text stay
+// upright. The editor always shows the plan as drawn.
+
+export type PlanRotation = 0 | 90 | 180 | 270;
+
+/** Coerce a config `rotation` to a supported step; anything else means 0. */
+export function normalizePlanRotation(v: unknown): PlanRotation {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 0;
+  const r = ((v % 360) + 360) % 360;
+  return r === 90 || r === 180 || r === 270 ? r : 0;
+}
+
+/** Canvas size as displayed: 90°/270° swap width and height. */
+export function rotatedCanvasSize(
+  w: number,
+  h: number,
+  rot: PlanRotation
+): { w: number; h: number } {
+  return rot === 90 || rot === 270 ? { w: h, h: w } : { w, h };
+}
+
+/** Map a plan point into the rotated (displayed) frame. */
+export function rotatePlanPoint(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rot: PlanRotation
+): { x: number; y: number } {
+  switch (rot) {
+    case 90:
+      return { x: h - y, y: x };
+    case 180:
+      return { x: w - x, y: h - y };
+    case 270:
+      return { x: y, y: w - x };
+    default:
+      return { x, y };
+  }
+}
+
+/**
+ * SVG group transform realizing {@link rotatePlanPoint} for whole layers, or
+ * "" for the unrotated plan. Matches the point mapping exactly — the overlay
+ * (HTML, remapped per point) and the drawing (SVG, one transform) must land
+ * on the same pixels or badges drift off their walls.
+ */
+export function planRotationTransform(w: number, h: number, rot: PlanRotation): string {
+  switch (rot) {
+    case 90:
+      return `translate(${h} 0) rotate(90)`;
+    case 180:
+      return `translate(${w} ${h}) rotate(180)`;
+    case 270:
+      return `translate(0 ${w}) rotate(-90)`;
+    default:
+      return "";
+  }
+}
+
 /**
  * Build an SVG `<mask>` (white field with a black rect at each opening) that, when
  * applied to the wall layer, removes the wall pixels behind doors/windows so a gap

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,6 +389,13 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * absolute. Resolve with {@link resolveSnap}.
    */
   snap?: number;
+  /**
+   * Rotate the *displayed* card in 90° steps (issue #33), e.g. to show a
+   * landscape plan on a portrait wall tablet. Coordinates stay unrotated —
+   * the editor always shows the plan as drawn. Values other than
+   * 0/90/180/270 are normalized (see normalizePlanRotation).
+   */
+  rotation?: number;
   /** Canvas background color (CSS / hex). Falls back to the card background. */
   background?: string;
   /**


### PR DESCRIPTION
Implements #33: show a landscape plan on a portrait dashboard (or upside-down, for a wall tablet mounted that way) by rotating the **displayed card** in 90° increments.

## Design
- New top-level **`rotation: 0 | 90 | 180 | 270`** (anything else — 45, negatives, strings — normalizes to 0; negatives/overshoots wrap, so `-90` → 270).
- **Display-only**: no stored coordinate changes, the editor always shows the plan as drawn. Rotating back and forth is lossless by construction.
- **Icons and text stay upright.** Instead of CSS-rotating the whole card (which would tip every badge and label sideways), the SVG layers (walls, openings, furniture, trackers, background image) rotate through a single group transform while the HTML overlay (badges, state labels, text) is remapped point-by-point with the same mapping (`rotatePlanPoint`). A unit test proves the group transform and the point mapping are the same function, and a DOM check confirms it at the pixel level.
- 90°/270° swap the card's aspect ratio (`600 / 1000` instead of `1000 / 600`), so the card takes portrait space in the dashboard grid.
- Wall-gap masking, door swings/slides, tracker animations all ride inside the rotated group unchanged.

## UI (low priority, per the request)
**Rotate display** is the deliberate **last row of the Project section** — implemented as its own one-field form (`projectRotationForm`) so it sorts below the Background and floor-image rows rather than mid-form. Helper text: *"Rotates the live card only — editing stays as drawn."* Selecting 0° removes the key from the YAML.

## Verification
- `tsc` clean, **186/186 tests** (180 on main + 6 new: normalization incl. junk values, size swap, corner/interior point mapping for all four steps, four-quarter-turns-is-identity, transform ≡ point-mapping equivalence, form field/patch behavior).
- Harness: for an L-shaped test room with a door, a lit badge and a text label, all four rotations produce the expected viewBox/aspect/transform and overlay percentages; at 90° and 270° the SVG's own `getScreenCTM()` for the item's plan point matches the badge's DOM center to the decimal. Screenshot at 270° shows the portrait card with the door swung out of the (now-left) wall and the "Kitchen" label upright. Editor canvas stays `0 0 1000 600` while the card rotates; the dropdown round-trips 180 → 0 (key removed).

## Backwards compatibility
No schema break — absent `rotation` renders exactly as today. Nothing else in the config changes meaning.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)