### PR TITLE
Items: Show name toggle + adjustable label size — closes #61, #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ By default it shows an icon badge:
   still wins.
 - **Make it yours** — override the **icon** (with autocomplete + live preview), set a
   custom **name**, change the **size**, **rotate** it, or hide the icon entirely.
+- **Label line** — **Show state** displays the live value (sensors do this by
+  default); **Show name** adds the device's name — handy for a panel of look-alike
+  buttons where a state would say nothing. Both together read `Name · state`, and
+  **Label size** adjusts the line's font size.
 
 ### Presence ripples
 
@@ -400,7 +404,9 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `rippleColor` | string                                 | primary color| Ripple ring color (ripple modes).                     |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |
-| `showState`   | boolean                                | sensors only | Show the entity state label.                           |
+| `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
+| `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
+| `labelSize`   | number                                 | `12`         | Label line font size (px).                             |
 
 Clicking a `light`, `switch`, `cover`, `fan` or `input_boolean` toggles it; other
 domains open the more-info dialog.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -156,6 +156,23 @@ describe("itemForm", () => {
     ).toContain("rippleSize");
   });
 
+  it("offers Show name, and Label size only while a label line renders (#61, #59)", () => {
+    // A light shows no label by default → no size slider.
+    const light = itemForm(item);
+    expect(light.fields.map((x) => x.name)).toContain("showName");
+    expect(light.fields.map((x) => x.name)).not.toContain("labelSize");
+    // Sensors label by default; showName or showState also reveal the slider.
+    const sensor = itemForm({ ...item, entity: "sensor.a", kind: "sensor" } as FloorItem);
+    expect(sensor.fields.map((x) => x.name)).toContain("labelSize");
+    const namedLight = itemForm({ ...item, showName: true } as FloorItem);
+    expect(namedLight.fields.map((x) => x.name)).toContain("labelSize");
+    expect(namedLight.data.showName).toBe(true);
+    expect(namedLight.data.labelSize).toBe(12);
+    expect(
+      itemForm({ ...item, showName: true, labelSize: 20 } as FloorItem).data.labelSize
+    ).toBe(20);
+  });
+
   it("offers the three action fields with behavior-preserving defaults", () => {
     const fs = itemForm(item).fields;
     expect(fs.find((x) => x.name === "tap_action")!.selector).toEqual({

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_TEXT_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
 } from "./types";
-import { defaultIcon, openingMotion, sliderStyleOf } from "./render";
+import { DEFAULT_LABEL_SIZE, defaultIcon, openingMotion, sliderStyleOf } from "./render";
 import { defaultItemAction } from "./actions";
 
 /** One ha-form schema item, extended with our label/helper (read by computeLabel). */
@@ -283,6 +283,22 @@ export function itemForm(it: FloorItem): FormSpec {
     { name: "showIcon", label: "Show icon", selector: { boolean: {} } },
     { name: "showState", label: "Show state", selector: { boolean: {} } },
     {
+      name: "showName",
+      label: "Show name",
+      helper: "Adds the device's name to the label line",
+      selector: { boolean: {} },
+    }
+  );
+  // Label size only matters while a label line renders.
+  if (it.showName || (it.showState ?? it.kind === "sensor")) {
+    fields.push({
+      name: "labelSize",
+      label: "Label size",
+      selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
+    });
+  }
+  fields.push(
+    {
       name: "tap_action",
       label: "Tap action",
       selector: { ui_action: { default_action: defaultItemAction(it.entity).action } },
@@ -307,6 +323,8 @@ export function itemForm(it: FloorItem): FormSpec {
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       showIcon: it.showIcon ?? true,
       showState: it.showState ?? false,
+      showName: it.showName ?? false,
+      labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
       tap_action: it.tap_action,
       hold_action: it.hold_action,
       double_tap_action: it.double_tap_action,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2403,7 +2403,9 @@ export class FloorplanCardEditor extends LitElement {
         @pointercancel=${this._onPointerCancel}
       >
         ${visual}
-        <span class="ilabel">${label}</span>
+        <!-- The editor label always shows (identification while editing);
+             only its size previews the card's labelSize (issue #59). -->
+        <span class="ilabel" style="font-size:${it.labelSize ?? 11}px;">${label}</span>
       </div>
     `;
   }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -22,7 +22,8 @@ import {
   renderTracker,
   trackerSensorReading,
   entityIsActive,
-  itemStateText,
+  itemBadgeLabel,
+  DEFAULT_LABEL_SIZE,
   hassRenderInputsChanged,
   collectWatchedEntities,
   resolveItemIcon,
@@ -180,7 +181,7 @@ export class FloorplanCard extends LitElement {
 
   private _renderItem(item: FloorItem, c: FloorplanCardConfig): TemplateResult {
     const on = this._isOn(item);
-    const showState = item.showState ?? item.kind === "sensor";
+    const labelText = itemBadgeLabel(this.hass, item);
     const showIcon = item.showIcon ?? true;
     const display = item.display ?? "badge";
     const rippleColor = item.rippleColor ?? "var(--primary-color, #03a9f4)";
@@ -213,7 +214,11 @@ export class FloorplanCard extends LitElement {
         })}
       >
         ${visual}
-        ${showState ? html`<span class="label">${itemStateText(this.hass, item)}</span>` : nothing}
+        ${labelText
+          ? html`<span class="label" style="font-size:${item.labelSize ?? DEFAULT_LABEL_SIZE}px;"
+              >${labelText}</span
+            >`
+          : nothing}
       </div>
     `;
   }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -23,6 +23,7 @@ import {
   openingIsActive,
   entityStateText,
   itemStateText,
+  itemBadgeLabel,
   hassRenderInputsChanged,
   collectWatchedEntities,
   isEntityOn,
@@ -495,6 +496,50 @@ describe("itemStateText", () => {
     expect(itemStateText(livingArea(), { entity: TEMP, secondaryEntity: "sensor.gone" })).toBe(
       "17.9 °C · —",
     );
+  });
+});
+
+describe("itemBadgeLabel (issues #61, #59)", () => {
+  const named = () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).friendly_name = "Living Temp";
+    return h;
+  };
+
+  it("keeps the historic default: sensors show state, nothing else shows", () => {
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "sensor" })).toBe("17.9 °C");
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "light" })).toBe("");
+  });
+
+  it("showName renders the friendly name; a config name override wins", () => {
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "light", showName: true })).toBe(
+      "Living Temp",
+    );
+    expect(
+      itemBadgeLabel(named(), { entity: TEMP, kind: "light", showName: true, name: "Lamp" }),
+    ).toBe("Lamp");
+  });
+
+  it("falls back to the entity id when there is no friendly name", () => {
+    expect(itemBadgeLabel(livingArea(), { entity: TEMP, kind: "light", showName: true })).toBe(
+      TEMP,
+    );
+  });
+
+  it("name and state combine as one line", () => {
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "sensor", showName: true })).toBe(
+      "Living Temp · 17.9 °C",
+    );
+    expect(
+      itemBadgeLabel(named(), { entity: TEMP, kind: "light", showName: true, showState: true }),
+    ).toBe("Living Temp · 17.9 °C");
+  });
+
+  it("showState: false silences even a sensor; name alone still shows", () => {
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "sensor", showState: false })).toBe("");
+    expect(
+      itemBadgeLabel(named(), { entity: TEMP, kind: "sensor", showState: false, showName: true }),
+    ).toBe("Living Temp");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -82,6 +82,35 @@ export function itemStateText(
   return `${primary} · ${entityStateText(hass, item.secondaryEntity)}`;
 }
 
+/** Default label font size (px) for an item's name/state line. */
+export const DEFAULT_LABEL_SIZE = 12;
+
+/**
+ * The label line under an item's badge, or "" for none: the name (issue #61)
+ * and/or the state, per the item's toggles. `showState` keeps its historic
+ * default (sensors only); `showName` defaults off. Both together read
+ * "Name · state".
+ */
+export function itemBadgeLabel(
+  hass: RenderHass | undefined,
+  item: {
+    entity: string;
+    secondaryEntity?: string;
+    name?: string;
+    kind: ItemKind;
+    showName?: boolean;
+    showState?: boolean;
+  },
+): string {
+  const parts: string[] = [];
+  if (item.showName) {
+    const friendly = hass?.states[item.entity]?.attributes?.friendly_name as string | undefined;
+    parts.push(item.name || friendly || item.entity);
+  }
+  if (item.showState ?? item.kind === "sensor") parts.push(itemStateText(hass, item));
+  return parts.join(" · ");
+}
+
 /** Default mdi icon per item kind, used when neither config nor entity supplies one. */
 export function defaultIcon(kind: ItemKind): string {
   switch (kind) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,14 @@ export interface FloorItem {
   name?: string;
   /** Show the entity state next to the icon. */
   showState?: boolean;
+  /**
+   * Show the device's name in the label line (issue #61) — the `name`
+   * override, else the entity's friendly name. Combines with `showState` as
+   * "Name · state". Default false.
+   */
+  showName?: boolean;
+  /** Label line font size in pixels (issue #59). Default 12. */
+  labelSize?: number;
   /** Show the icon badge. When false only the state/label shows. Default true. */
   showIcon?: boolean;
   /** Badge diameter in pixels. Default 34. */


### PR DESCRIPTION
Two small label asks in one PR, since they touch the same line of UI:

## #61 — Show name
New **Show name** toggle per device (`showName`). The label line shows the device's name — the config `name` override, else the entity's friendly name, else the entity id. Built for the reporter's case: a panel of identical button icons where a state label says nothing and text elements are a spacing chore. Combines with **Show state** as `Name · state`; sensors keep their state-shown-by-default behavior, and `showState: false` still silences a sensor while leaving the name.

## #59 — Label size
New **Label size** slider (`labelSize`, default 12px, range 8–40). Shown in the editor only while a label line actually renders (name or state on), and the editor canvas label previews the chosen size live. *Note to reporter:* #59's wording was terse — I read it as "the device label text size isn't editable"; if the ask was actually about label rotation or something else, say so on the issue and we'll follow up.

## Implementation
- `itemBadgeLabel(hass, item)` — one pure helper (`src/render.ts`) builds the label line from both toggles; the card renders whatever it returns, so name/state composition is unit-tested rather than templated.
- `FloorItem.showName` / `FloorItem.labelSize` in types; editor form fields with conditional visibility; README (Devices bullet + item table).

## Verification
- `tsc` clean, **186/186 tests** (180 on main + 6: label composition matrix incl. fallback chain and silenced-sensor case, form field visibility/data defaults).
- Harness: light with `showName` shows "Living Room"; sensor with `showName` shows "Living Area Temperature · 17.9 °C" (HA display precision intact); `name: "Custom Label"` override wins; `labelSize: 20` lands as inline 20px; item with neither toggle renders no label element at all. Editor: "Show name" checkbox commits, the Label size row appears only after a label line exists, and dragging the slider to 18 updates both config and the canvas preview live.

## Backwards compatibility
No schema break; both fields absent = today's rendering exactly.

Closes #61. Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)