### PR TITLE
Covers: roll-up opening glyph + safe default tap — closes #45, #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ A **device** binds a Home Assistant entity to a spot on the plan. Add one with
 **+ device**, then pick the entity in the **Element** section below the canvas.
 By default it shows an icon badge:
 
-- **Tap to act** — lights, switches, covers, fans and `input_boolean`s toggle on tap;
+- **Tap to act** — lights, switches, fans and `input_boolean`s toggle on tap;
+  covers open the more-info dialog instead (an accidental tap must not move a
+  shutter — set **Tap action** to *Toggle* to opt back in);
   any other entity opens its more-info dialog.
 - **Live look** — the badge highlights when the entity is "on". Turn on **Show state**
   to display the current value next to it, formatted exactly as Home Assistant would —
@@ -177,8 +179,9 @@ Select the opening and bind an **Entity** in the **Element** section below the c
 contact `binary_sensor` or a `cover` (Home Assistant's domain for anything that opens: doors,
 gates, garages, blinds, shades, shutters, curtains…) — to make the opening track its real
 state. When you bind an entity the card reads its HA **`device_class`** and sets a sensible
-`type`/`motion` for you (a `window` cover → a window; a `garage` roller → a sliding door);
-adjust either afterwards. Once bound, the opening tracks state:
+`type`/`motion` for you (a `window` cover → a window; a `blind` → a slider; a `garage`
+or `shutter` roller → a **roll-up**); adjust either afterwards. Once bound, the opening
+tracks state:
 
 - **Open / closed** — the opening is drawn open when the entity is `on` / `open`, closed
   otherwise. A door's leaf swings around its hinge; a window's two leaves swing outward
@@ -372,7 +375,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | ------------- | --------------------------- | ------------------------------------------------------ |
 | `id`          | string                      | Unique id.                                             |
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
-| `motion`      | `swing` \| `slide`          | How it moves. `swing` (default) hinged door / casement window; `slide` sliding panels. |
+| `motion`      | `swing` \| `slide` \| `roll` | How it moves. `swing` (default) hinged door / casement window; `slide` sliding panels; `roll` roll-up cover (garage / roller shutter) drawn as a slatted curtain that thins onto its track as it opens. |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -163,6 +163,30 @@ const hass = {
       state: "off",
       attributes: { friendly_name: "Door Lock", device_class: "lock" },
     },
+    // Roll-up covers (issue #45): binding either to an opening infers
+    // motion "roll" from the device_class (garage → door, shutter → window)
+    // and the opening emulator below offers a 0–100 position slider that
+    // drives the curtain. The garage one ships pre-bound in the demo floor.
+    "cover.garage_door": {
+      entity_id: "cover.garage_door",
+      state: "closed",
+      attributes: {
+        friendly_name: "Garage Door",
+        device_class: "garage",
+        current_position: 0,
+        supported_features: 15,
+      },
+    },
+    "cover.bedroom_shutter": {
+      entity_id: "cover.bedroom_shutter",
+      state: "closed",
+      attributes: {
+        friendly_name: "Bedroom Shutter",
+        device_class: "shutter",
+        current_position: 0,
+        supported_features: 15,
+      },
+    },
     [SENSOR_TEMPERATURE]: {
       entity_id: SENSOR_TEMPERATURE,
       state: "17.94",
@@ -226,6 +250,18 @@ const demoFloor = {
   openings: [
     { id: "o1", type: "window" as const, x: 500, y: 100, length: 140, angle: 0 },
     { id: "o2", type: "door" as const, x: 500, y: 500, length: 90, angle: 0 },
+    // Roll-up demo (issue #45): a garage door on the east wall, pre-bound so
+    // the emulator's position slider drives the slatted curtain immediately.
+    {
+      id: "o3",
+      type: "door" as const,
+      motion: "roll" as const,
+      x: 900,
+      y: 300,
+      length: 140,
+      angle: 90,
+      entity: "cover.garage_door",
+    },
   ],
   // A temperature reading paired with humidity — both stored at two decimals but
   // configured to display one, so the badge should read "17.9 °C · 49.3%".

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -30,12 +30,18 @@ const makeHass = () => {
 
 describe("defaultItemAction", () => {
   it("toggles controllable domains, more-info otherwise", () => {
-    for (const e of ["light.a", "switch.a", "cover.a", "fan.a", "input_boolean.a"]) {
+    for (const e of ["light.a", "switch.a", "fan.a", "input_boolean.a"]) {
       expect(defaultItemAction(e)).toEqual({ action: "toggle" });
     }
     expect(defaultItemAction("sensor.a")).toEqual({ action: "more-info" });
     expect(defaultItemAction("binary_sensor.a")).toEqual({ action: "more-info" });
     expect(defaultItemAction(undefined)).toEqual({ action: "more-info" });
+  });
+
+  it("covers open more-info, never a blind toggle (issue #47)", () => {
+    // A tap that physically moves a shutter is too destructive for a default;
+    // tap_action: toggle remains available as an explicit opt-in.
+    expect(defaultItemAction("cover.shutter")).toEqual({ action: "more-info" });
   });
 });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,7 +1,13 @@
 import type { ActionConfig, HomeAssistant } from "./types";
 
-/** Domains where a bare tap toggles instead of opening more-info (legacy card behavior). */
-const TOGGLE_DOMAINS = new Set(["light", "switch", "cover", "fan", "input_boolean"]);
+/**
+ * Domains where a bare tap toggles instead of opening more-info (legacy card
+ * behavior). `cover` is deliberately absent (issue #47): an accidental tap on
+ * a shutter icon used to physically move the shutter — real hardware, slow to
+ * undo. Covers now open more-info like HA's Tile card; users who want the old
+ * behavior set `tap_action: { action: toggle }` on the item.
+ */
+const TOGGLE_DOMAINS = new Set(["light", "switch", "fan", "input_boolean"]);
 
 /** The action an item performs when no tap_action is configured. */
 export function defaultItemAction(entity: string | undefined): ActionConfig {

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -113,6 +113,22 @@ describe("openingForm", () => {
     expect(bi.fields.map((x) => x.name)).not.toContain("slide");
   });
 
+  it("roll-up opening hides swing and slide fields (issue #45)", () => {
+    const motionField = openingForm(door).fields.find((x) => x.name === "motion")!;
+    const opts = (motionField.selector as { select: { options: { value: string }[] } }).select
+      .options.map((o) => o.value);
+    expect(opts).toEqual(["swing", "slide", "roll"]);
+    const roll = openingForm({ ...door, motion: "roll" } as Opening).fields.map((x) => x.name);
+    expect(roll).not.toContain("hinge");
+    expect(roll).not.toContain("opens");
+    expect(roll).not.toContain("slide");
+    expect(roll).not.toContain("style");
+    expect(openingForm(door).toPatch({ motion: "roll" })).toEqual({
+      motion: "roll",
+      sliderStyle: undefined,
+    });
+  });
+
   it("invert only offered with an entity; entity filter targets covers and binary_sensors", () => {
     expect(openingForm(door).fields.map((x) => x.name)).not.toContain("invert");
     const bound = openingForm({ ...door, entity: "cover.x" } as Opening);

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -169,7 +169,15 @@ export function openingForm(o: Opening): FormSpec {
   const style = sliderStyleOf(o);
   const fields: FormField[] = [
     { name: "type", label: "Type", selector: dropdown(opt("door", "Door"), opt("window", "Window")) },
-    { name: "motion", label: "Motion", selector: dropdown(opt("swing", "Swing"), opt("slide", "Slide")) },
+    {
+      name: "motion",
+      label: "Motion",
+      selector: dropdown(
+        opt("swing", "Swing"),
+        opt("slide", "Slide"),
+        opt("roll", "Roll up (garage / shutter)")
+      ),
+    },
     { name: "length", label: "Length", required: true, selector: { number: { min: 1, mode: "box" } } },
   ];
   if (o.type === "door" && motion === "swing") {
@@ -230,8 +238,8 @@ export function openingForm(o: Opening): FormSpec {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(patch)) {
         if (k === "motion") {
-          out.motion = v === "slide" ? "slide" : undefined;
-          // sliderStyle only applies while sliding — drop it when switching back.
+          out.motion = v === "slide" || v === "roll" ? v : undefined;
+          // sliderStyle only applies while sliding — drop it when switching away.
           if (v !== "slide") out.sliderStyle = undefined;
         } else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
         else if (k === "opens") out.flipV = v === "other" || undefined;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2302,10 +2302,10 @@ export class FloorplanCardEditor extends LitElement {
         ${renderOpening(o, {
           color: selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
           open: openingDefaultOpen(o),
-          // Draw sliding openings partly open in the editor so the slide
-          // direction and panel style are visible — a closed slider looks
-          // symmetric, which would make the Slide / Style controls appear inert.
-          amount: openingMotion(o) === "slide" ? 0.55 : undefined,
+          // Draw sliding / rolling openings partly open in the editor so the
+          // motion is visible — closed, both look like a plain band, which
+          // would make the Motion / Slide / Style controls appear inert.
+          amount: openingMotion(o) !== "swing" ? 0.55 : undefined,
         })}
       </g>`;
   }
@@ -3119,6 +3119,12 @@ export class FloorplanCardEditor extends LitElement {
     }
     .fp-door-arc {
       transition: stroke-dashoffset 0.5s ease, stroke 0.5s ease;
+    }
+    /* Roll-up curtain: scaleY must shrink onto the band's own centerline
+       (the track), not the SVG origin. */
+    .fp-roll-curtain {
+      transform-box: fill-box;
+      transform-origin: center;
     }
     .wall-hit {
       stroke: transparent;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -420,6 +420,15 @@ export class FloorplanCard extends LitElement {
     .fp-slide-panel rect {
       transition: fill 0.5s ease;
     }
+    /* Roll-up curtain (garage / roller shutter): thins onto the track line. */
+    .fp-roll-curtain {
+      transform-box: fill-box;
+      transform-origin: center;
+      transition: transform 0.5s ease;
+    }
+    .fp-roll-curtain rect {
+      transition: fill 0.5s ease;
+    }
     .items {
       position: absolute;
       inset: 0;

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -91,3 +91,33 @@ describe("renderOpening — sliding window", () => {
     expect(win).not.toContain("height=2.5"); // not a solid door panel
   });
 });
+
+describe("renderOpening — roll-up cover (issue #45)", () => {
+  it("closed: full-thickness slatted curtain on the track", () => {
+    const closed = svgOf({ type: "door", motion: "roll" }, { open: false });
+    expect(closed).toContain("fp-roll-curtain");
+    expect(closed).toContain("scaleY(1)");
+    expect(closed).toContain("height=5"); // curtain band, thicker than any panel
+  });
+
+  it("open: the curtain collapses onto the track line", () => {
+    expect(svgOf({ type: "door", motion: "roll" }, { open: true })).toContain("scaleY(0)");
+  });
+
+  it("partial position thins the curtain proportionally", () => {
+    expect(svgOf({ type: "door", motion: "roll" }, { amount: 0.6 })).toContain("scaleY(0.4)");
+  });
+
+  it("draws slat ticks so it reads as a shutter, not a slab", () => {
+    // length 90 → ~8 slats → 7 interior ticks.
+    const closed = svgOf({ type: "door", motion: "roll" }, { open: false });
+    expect(closed.match(/var\(--card-background-color, #fff\)/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("nothing travels along the wall — no slide panels, no swing arc", () => {
+    const s = svgOf({ type: "door", motion: "roll" }, { amount: 0.5 });
+    expect(s).not.toContain("fp-slide-panel");
+    expect(s).not.toContain("fp-door-arc");
+    expect(s).not.toContain("fp-door-leaf");
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -87,6 +87,19 @@ describe("openingMotion", () => {
     expect(openingMotion({ type: "door" } as Opening)).toBe("swing");
     expect(openingMotion({ type: "door", motion: "slide" } as Opening)).toBe("slide");
     expect(openingMotion({ type: "window", motion: "slide" } as Opening)).toBe("slide");
+    expect(openingMotion({ type: "door", motion: "roll" } as Opening)).toBe("roll");
+  });
+});
+
+describe("roll-up openings (issue #45)", () => {
+  it("draw closed by default, like sliders", () => {
+    expect(openingDefaultOpen({ type: "door", motion: "roll" } as Opening)).toBe(false);
+    expect(openingDefaultOpen({ type: "window", motion: "roll" } as Opening)).toBe(false);
+  });
+  it("have no slider panel arrangement", () => {
+    expect(sliderStyleOf({ type: "door", motion: "roll", sliderStyle: "bypass" } as Opening)).toBe(
+      "single",
+    );
   });
 });
 
@@ -126,10 +139,14 @@ describe("openingFromDeviceClass", () => {
     expect(openingFromDeviceClass("shade")).toEqual({ type: "window", motion: "slide" });
     expect(openingFromDeviceClass("curtain")).toEqual({ type: "window", motion: "slide" });
   });
-  it("maps door-like device classes to a door, sliding for rollers", () => {
+  it("maps door-like device classes to a door", () => {
     expect(openingFromDeviceClass("door")).toEqual({ type: "door", motion: undefined });
-    expect(openingFromDeviceClass("garage")).toEqual({ type: "door", motion: "slide" });
     expect(openingFromDeviceClass("gate")).toEqual({ type: "door", motion: undefined });
+  });
+  it("garage doors and roller shutters roll up (issue #45)", () => {
+    expect(openingFromDeviceClass("garage")).toEqual({ type: "door", motion: "roll" });
+    expect(openingFromDeviceClass("garage_door")).toEqual({ type: "door", motion: "roll" });
+    expect(openingFromDeviceClass("shutter")).toEqual({ type: "window", motion: "roll" });
   });
   it("defaults unknown / missing device classes to a swing door", () => {
     expect(openingFromDeviceClass(undefined)).toEqual({ type: "door", motion: undefined });

--- a/src/render.ts
+++ b/src/render.ts
@@ -306,7 +306,7 @@ export function kindFromEntity(entity: string): ItemKind {
  * How an opening moves — `swing` (hinged door / casement window) or `slide`
  * (panels travelling along the wall). Defaults to `swing`.
  */
-export function openingMotion(o: Opening): "swing" | "slide" {
+export function openingMotion(o: Opening): "swing" | "slide" | "roll" {
   return o.motion ?? "swing";
 }
 
@@ -342,30 +342,30 @@ export function sliderStyleOf(o: Opening): "single" | "bypass" | "biparting" {
 
 /** HA `cover` / `binary_sensor` device classes that read as a window (glass). */
 const WINDOW_DEVICE_CLASSES = new Set(["window", "blind", "shade", "shutter", "curtain", "awning"]);
-/** Device classes that roll / slide rather than swing. */
-const SLIDING_DEVICE_CLASSES = new Set([
-  "garage",
-  "garage_door",
-  "blind",
-  "shade",
-  "shutter",
-  "curtain",
-]);
+/** Device classes whose panels travel along the wall. */
+const SLIDING_DEVICE_CLASSES = new Set(["blind", "shade", "curtain"]);
+/** Device classes whose curtain rolls up out of the floor plane (issue #45). */
+const ROLLING_DEVICE_CLASSES = new Set(["garage", "garage_door", "shutter"]);
 
 /**
  * Default opening `type` and `motion` inferred from a bound entity's HA
  * `device_class` (mirrors how HA itself picks icons/behaviour from it). Window-
- * like classes render as a window; rolling/sliding classes default to `slide`.
- * Unknown / missing classes fall back to a swing door. `motion: undefined`
- * means swing (the default).
+ * like classes render as a window; blinds/shades/curtains default to `slide`;
+ * garage doors and roller shutters to `roll`. Unknown / missing classes fall
+ * back to a swing door. `motion: undefined` means swing (the default).
  */
 export function openingFromDeviceClass(deviceClass: string | undefined): {
   type: Opening["type"];
-  motion: "slide" | undefined;
+  motion: "slide" | "roll" | undefined;
 } {
+  const dc = deviceClass ?? "";
   return {
-    type: WINDOW_DEVICE_CLASSES.has(deviceClass ?? "") ? "window" : "door",
-    motion: SLIDING_DEVICE_CLASSES.has(deviceClass ?? "") ? "slide" : undefined,
+    type: WINDOW_DEVICE_CLASSES.has(dc) ? "window" : "door",
+    motion: ROLLING_DEVICE_CLASSES.has(dc)
+      ? "roll"
+      : SLIDING_DEVICE_CLASSES.has(dc)
+        ? "slide"
+        : undefined,
   };
 }
 
@@ -535,6 +535,36 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
           </g>
         </g>
       `;
+  } else if (openingMotion(o) === "roll") {
+    // Roll-up cover — garage door, roller shutter (issues #45 / #47). Unlike a
+    // slider nothing travels along the wall: the curtain leaves the floor
+    // plane, so the slatted band thins toward the track line as it opens and
+    // vanishes fully open, leaving jambs + track. Distinct at a glance from
+    // both the giant swing leaf and the slide panel.
+    const bandT = 5;
+    const slats = Math.max(3, Math.round(o.length / 12));
+    const ticks: SVGTemplateResult[] = [];
+    for (let i = 1; i < slats; i++) {
+      const x = -half + (o.length * i) / slats;
+      ticks.push(
+        svg`<line x1=${x} y1=${-bandT / 2} x2=${x} y2=${bandT / 2}
+              stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
+      );
+    }
+    body = svg`
+        <!-- jambs -->
+        <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <!-- track: stays when the curtain is up so the gap still reads as an opening -->
+        <line x1=${-half} y1="0" x2=${half} y2="0"
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <g class="fp-roll-curtain" style="transform:scaleY(${1 - amt});">
+          <rect x=${-half} y=${-bandT / 2} width=${o.length} height=${bandT}
+                style="fill:${tone};" />
+          ${ticks}
+        </g>`;
   } else if (openingMotion(o) === "slide") {
     // A sliding door / window: panel(s) sit in the opening and travel *along* the
     // wall. Closed, they fill the gap; open, they slide aside (single), stack

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,9 +51,11 @@ export interface Opening {
   /**
    * How the opening moves. `swing` (default) is a hinged door / casement window;
    * `slide` is a sliding door / sliding window whose panel(s) travel along the
-   * wall (see {@link sliderStyle}).
+   * wall (see {@link sliderStyle}); `roll` is a roll-up cover — garage door,
+   * roller shutter — whose slatted curtain leaves the floor plane (issue #45),
+   * drawn thinning toward the track line as it opens.
    */
-  motion?: "swing" | "slide";
+  motion?: "swing" | "slide" | "roll";
   x: number;
   y: number;
   /** Length along the wall, in virtual units. */


### PR DESCRIPTION
The two cover complaints in one PR, since they're the same story from two angles: covers were drawn like doors (#45) and tapped like lights (#47).

## #45 — a real representation for garage doors and roller shutters
New opening **`motion: "roll"`**. Where a slider's panel travels along the wall, a roll-up cover leaves the floor plane — so the glyph is a **slatted curtain that thins onto its track line** as the cover opens: closed = full-thickness band with slat ticks, 50 % = half-thickness, open = just jambs and a faint track marking the gap. Reads instantly differently from the giant swing leaf the reporter was stuck with, and from the slide panel.

- Partial `cover` positions render proportionally (`scaleY(1 − position)`, 0.5 s transition like the other openings).
- **Device-class inference**: binding a `garage`, `garage_door` or `shutter` cover now sets Roll up automatically ( previously garage inferred *slide*); `blind`/`shade`/`curtain` stay sliders. The Motion dropdown gains **Roll up (garage / shutter)**, and roll hides the hinge/slide/style rows that don't apply.
- The editor previews roll openings partly open (like sliders) so the motion is visible while configuring.

## #47 — tapping a cover icon no longer moves the cover
A bare tap on a cover **item** used to fire `toggle` — the reporter's shutters physically closed from a stray tap. Cover items now default to **more-info**, matching HA's own Tile card. `tap_action: { action: toggle }` remains a one-line opt-in (the #44 action editor exposes it as a dropdown). Deliberately unchanged: clicking the **opening symbol** on the plan still toggles its cover — that's a large, explicit target that exists precisely to operate the cover.

## Verification
- `tsc` clean, **190/190 tests** (180 on main + 10: device-class matrix, motion/default-open/slider-style behavior for roll, glyph structure incl. slat count and absence of slide/swing artifacts at partial amounts, form field visibility + `toPatch`, cover tap default).
- Harness: a `cover.garage` at positions 0/50/100 renders `scaleY(1)` / `scaleY(0.5)` / `scaleY(0)` with 9 slat ticks on a 120-unit opening; tapping the cover item fires `hass-more-info` for `cover.garage` with **zero** service calls; editor Motion dropdown offers Roll up, selecting it patches `motion: "roll"` and clears `sliderStyle`, and the canvas previews the half-rolled curtain (`transform-box: fill-box` confirmed so it collapses onto the track, not the SVG origin).

## Backwards compatibility
- Existing configs render unchanged (`roll` is new; no stored value is reinterpreted). Newly *bound* garage/shutter entities infer roll instead of slide — existing openings keep whatever motion they have.
- **Behavior change to note in the release**: cover item taps now open more-info instead of toggling. This is the point of #47, but anyone relying on tap-to-toggle covers needs the one-line `tap_action` opt-in (README updated).

Closes #45. Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Repro in the dev harness (no Home Assistant needed)

The branch now ships mock roll-up covers so anyone can exercise the feature locally:

```
npm install && npx vite
# open http://localhost:5173/dev/
```

**Interactive path (zero code edits):**
1. Draw a wall, drop a **Door** on it.
2. In the **Element** section, set **Entity** to `cover.garage_door` (or `cover.bedroom_shutter`).
3. The editor infers **Motion: Roll up** from the device_class on its own — watch the Motion dropdown flip.
4. An **opening emulator** panel appears below with a 0–100 position slider for the cover; drag it and the slatted curtain thins/thickens on the live card (`scaleY(1)` closed → `scaleY(0.4)` at 60 → `scaleY(0)` open, with the 0.5 s transition).

**Demo-floor path:** flip `START_WITH_DEMO` to `true` in `dev/dev.ts` — the sample room now includes a garage door pre-bound to `cover.garage_door` on the east wall, so the slider is live immediately on load.

The tap-safety half (#47) is reproducible the same way: add a **device** bound to `cover.garage_door` and tap its badge — the mock `hass` logs show no `callService`, and a `hass-more-info` event fires instead.
