### PR TITLE
Harden config colour/size values against style-attribute injection

### DIFF
--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { cssColor } from "./css-safe";
+
+describe("cssColor — adversarial: exotic breakout attempts all rejected", () => {
+  const ATTACKS = [
+    // newline / CR / tab tricks (the classic ^...$ before-\n regex hole)
+    "red\n;position:fixed",
+    "red\r\n}body{x:1",
+    "red\t;color:blue",
+    "rgb(0,0,0)\n;position:fixed",
+    "var(--x)\n;evil",
+    "red ;evil", // line separator
+    "red;evil", // NEL
+    "red;evil", // vertical tab
+    "red\f;evil", // form feed
+    // CSS comments
+    "red/**/;position:fixed",
+    "rgb(0,0,0)/*x*/",
+    "/*x*/red",
+    // CSS escapes / encoded
+    "\\72 ed;evil",
+    "\\0000red",
+    "red\\3b evil",
+    // url / fetch vectors in every wrapper
+    "url(https://evil/x)",
+    "URL(//evil)",
+    "image-set(//evil)",
+    "var(--x, url(//evil))",
+    "rgb(0,0,0);background:url(//evil)",
+    "expression(alert(1))",
+    "EXPRESSION(1)",
+    // breakout punctuation
+    "red;",
+    "red}",
+    "red{x:1}",
+    "red !important;x:1",
+    "rgb(0,0,0) ;evil",
+    "#fff;--x:url(//evil)",
+    // nested / doubled parens (where url could hide)
+    "rgb(rgb(0,0,0))",
+    "hsl(calc(1) 0 0)",
+    "var(--x, rgb(0,0,0); z:1)",
+    // whitespace-obfuscated
+    "red ; position : fixed",
+    // quote / angle-bracket escape attempts
+    'red"x',
+    "red'x",
+    "red>x",
+    "red<x",
+  ];
+  for (const a of ATTACKS) {
+    it(`rejects ${JSON.stringify(a)}`, () => {
+      expect(cssColor(a)).toBeUndefined();
+    });
+  }
+
+  // Surrounding whitespace (incl. newlines/tabs) is trimmed, and the RESULT is
+  // still validated — so a whitespace-wrapped legit colour is accepted and its
+  // output carries no control char. This is safe, not a bypass.
+  it("trims surrounding whitespace/newlines to a clean value", () => {
+    expect(cssColor("red\n")).toBe("red");
+    expect(cssColor("\nred")).toBe("red");
+    expect(cssColor("  #03a9f4\t")).toBe("#03a9f4");
+    // but an INTERNAL newline followed by a payload is still rejected
+    expect(cssColor("red\n;evil")).toBeUndefined();
+  });
+});
+
+describe("cssColor — INVARIANT: nothing accepted can break out of a style declaration", () => {
+  // Broad mix of legit + hostile strings; assert the invariant that any accepted
+  // value contains no `;` `{` `}` and at most one `(`/`)` (so url()/expression()/
+  // nested functions can never form inside an accepted value).
+  const CHARS = "red#09aff(url);{}/*-,% .\n\tvax'\"!".split("");
+  const seeds = [
+    "red", "#03a9f4", "rgb(0,0,0)", "var(--x)", "var(--x, #fff)", "oklch(0.7 0.1 200)",
+    "url(//e)", "red;evil", "red}q{", "expression(1)", "rgb(url(x))", "transparent",
+  ];
+  const cases: string[] = [...seeds];
+  // deterministic pseudo-permutations (no Math.random — reproducible)
+  for (let i = 0; i < 500; i++) {
+    let s = "";
+    let n = (i * 2654435761) >>> 0;
+    const len = 3 + (i % 14);
+    for (let j = 0; j < len; j++) {
+      n = (n * 1103515245 + 12345) >>> 0;
+      s += CHARS[n % CHARS.length];
+    }
+    cases.push(s);
+  }
+  it("no accepted value contains ; { } or a nested paren / url(", () => {
+    let accepted = 0;
+    for (const c of cases) {
+      const out = cssColor(c);
+      if (out === undefined) continue;
+      accepted++;
+      expect(out).not.toMatch(/[;{}]/);
+      expect((out.match(/\(/g) ?? []).length).toBeLessThanOrEqual(1);
+      expect((out.match(/\)/g) ?? []).length).toBeLessThanOrEqual(1);
+      expect(out.toLowerCase()).not.toContain("url(");
+      expect(out.toLowerCase()).not.toContain("expression(");
+    }
+    // sanity: the legit seeds really were accepted (so the invariant isn't vacuous)
+    expect(accepted).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -26,6 +26,8 @@ describe("cssColor — adversarial: exotic breakout attempts all rejected", () =
     "URL(//evil)",
     "image-set(//evil)",
     "var(--x, url(//evil))",
+    "var(--a, var(--b, url(//evil)))", // url hidden inside a nested var fallback
+    "var(--a, var(--b, red);position:fixed))", // breakout inside a nested fallback
     "rgb(0,0,0);background:url(//evil)",
     "expression(alert(1))",
     "EXPRESSION(1)",
@@ -36,9 +38,7 @@ describe("cssColor — adversarial: exotic breakout attempts all rejected", () =
     "red !important;x:1",
     "rgb(0,0,0) ;evil",
     "#fff;--x:url(//evil)",
-    // nested / doubled parens (where url could hide)
-    "rgb(rgb(0,0,0))",
-    "hsl(calc(1) 0 0)",
+    // breakout hidden inside otherwise-safe nesting
     "var(--x, rgb(0,0,0); z:1)",
     // whitespace-obfuscated
     "red ; position : fixed",
@@ -87,17 +87,26 @@ describe("cssColor — INVARIANT: nothing accepted can break out of a style decl
     }
     cases.push(s);
   }
-  it("no accepted value contains ; { } or a nested paren / url(", () => {
+  it("no accepted value can break out of a style declaration", () => {
+    // Nested functions are allowed, so an accepted value may contain several
+    // balanced parens — but never a declaration break (`;` `{` `}`) and never a
+    // fetch/execute function, since those aren't on the SAFE_FUNCS allowlist.
+    const FORBIDDEN = ["url(", "image(", "image-set(", "-webkit-image-set(",
+      "cross-fade(", "element(", "paint(", "expression(", "attr("];
     let accepted = 0;
     for (const c of cases) {
       const out = cssColor(c);
       if (out === undefined) continue;
       accepted++;
       expect(out).not.toMatch(/[;{}]/);
-      expect((out.match(/\(/g) ?? []).length).toBeLessThanOrEqual(1);
-      expect((out.match(/\)/g) ?? []).length).toBeLessThanOrEqual(1);
-      expect(out.toLowerCase()).not.toContain("url(");
-      expect(out.toLowerCase()).not.toContain("expression(");
+      // balanced parens
+      let d = 0;
+      for (const ch of out) { if (ch === "(") d++; else if (ch === ")") d--; expect(d).toBeGreaterThanOrEqual(0); }
+      expect(d).toBe(0);
+      const lower = out.toLowerCase();
+      for (const bad of FORBIDDEN) expect(lower).not.toContain(bad);
+      // no quotes, colons, semicolons, escapes, or bangs survived
+      expect(out).not.toMatch(/["':@\\!]/);
     }
     // sanity: the legit seeds really were accepted (so the invariant isn't vacuous)
     expect(accepted).toBeGreaterThanOrEqual(6);

--- a/src/css-safe.test.ts
+++ b/src/css-safe.test.ts
@@ -160,3 +160,15 @@ describe("cssNumber — coerces size/angle fields, blocks breakouts", () => {
     expect(cssNumber(Infinity, 16)).toBe(16);
   });
 });
+
+describe("cssNumber — style-attribute injection at the aspect-ratio sink", () => {
+  const evil = "1 / 600; position: fixed; inset: 0; background: url(//evil)";
+  it("coerces a declaration-breakout width to the fallback", () => {
+    expect(cssNumber(evil, 1000)).toBe(1000);
+    expect(String(cssNumber(evil, 1000))).not.toMatch(/[;:]/);
+  });
+  it("treats a blank string as unset, not 0", () => {
+    expect(cssNumber("", 1000)).toBe(1000);
+    expect(cssNumber("   ", 1000)).toBe(1000);
+  });
+});

--- a/src/css-safe.test.ts
+++ b/src/css-safe.test.ts
@@ -14,6 +14,21 @@ describe("cssColor — accepts the colours real users actually type", () => {
     "var(--card-background-color, #fff)",
     "var(--primary-text-color)",
     "var(  --primary-color , red )", // sloppy whitespace
+    // nested var() fallback chains — valid CSS, common in HA themes (Codex #65 P2)
+    "var(--ha-card-background, var(--card-background-color, #fff))",
+    "var(--x, var(--y, var(--z, red)))",
+    "var(--accent, rgb(3, 169, 244))", // function fallback
+    // THE core HA idiom: colours stored as bare "r, g, b" triplets, read back
+    // wrapped in rgb()/rgba() (HA default themes since 2022.12).
+    "rgb(var(--rgb-primary-color))",
+    "rgba(var(--rgb-primary-color), 0.5)",
+    "rgb(var(--rgb-card-background-color))",
+    "rgba(var(--rgb-primary-color), 0.35)",
+    "hsl(var(--h), var(--s), var(--l))",
+    // modern mixing + gradients (valid for a background)
+    "color-mix(in srgb, var(--primary-color), transparent 40%)",
+    "linear-gradient(to right, var(--primary-color), transparent)",
+    "hsl(calc(200 + 10) 90% 48%)", // maths inside a colour component
     // hex, all valid lengths + case
     "#fff",
     "#FFF",
@@ -56,6 +71,30 @@ describe("cssColor — accepts the colours real users actually type", () => {
     it(`accepts ${v}`, () => {
       expect(cssColor(v)).toBe(v.trim());
     });
+  }
+});
+
+describe("cssColor — accepts HA theme colours across every version/era", () => {
+  // A config outlives any one HA release, so the allowlist must accept the colour
+  // forms from all eras, not just current. Each must round-trip unchanged.
+  const HA_ERAS = [
+    // docs examples / named (all versions)
+    "pink", "orange",
+    // traditional hex + rgb/hsl literals (pre-2022.12 default themes)
+    "#ffffff", "#03a9f480", "rgb(255, 255, 255)", "rgba(0,0,0,0.5)", "hsl(200,90%,48%)",
+    // traditional var() references (all versions)
+    "var(--primary-color)", "var(--card-background-color)", "var(--state-active-color)",
+    // old Polymer/paper era + MDC era variables
+    "var(--paper-item-icon-color)", "var(--mdc-theme-primary)",
+    // 2022.12+ RGB-triplet idiom, incl. nested var in the alpha slot
+    "rgb(var(--rgb-primary-color))", "rgba(var(--rgb-primary-color), 0.5)",
+    "rgba(var(--rgb-accent-color), var(--opacity, 0.3))",
+    // fallback chains + modern functions (2024+)
+    "var(--ha-card-border-color, var(--divider-color))",
+    "color-mix(in srgb, var(--primary-color), transparent 40%)", "light-dark(#fff, #000)",
+  ];
+  for (const v of HA_ERAS) {
+    it(`accepts ${v}`, () => expect(cssColor(v)).toBe(v));
   }
 });
 

--- a/src/css-safe.test.ts
+++ b/src/css-safe.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { cssColor, cssColorOr, cssNumber } from "./css-safe";
+
+describe("cssColor — accepts the colours real users actually type", () => {
+  // Every value a Home Assistant floorplan user would plausibly put in a config.
+  const LEGIT = [
+    // HA theme variables — by far the most common in HA cards
+    "var(--primary-color)",
+    "var(--primary-color, #03a9f4)",
+    "var(--error-color)",
+    "var(--success-color)",
+    "var(--state-active-color)",
+    "var(--disabled-text-color)",
+    "var(--card-background-color, #fff)",
+    "var(--primary-text-color)",
+    "var(  --primary-color , red )", // sloppy whitespace
+    // hex, all valid lengths + case
+    "#fff",
+    "#FFF",
+    "#03a9f4",
+    "#03A9F4",
+    "#ff000080", // 8-digit (alpha)
+    "#f00a", // 4-digit
+    // named + CSS-wide keywords
+    "red",
+    "blue",
+    "white",
+    "transparent",
+    "currentColor",
+    "rebeccapurple",
+    "cornflowerblue",
+    "inherit",
+    "initial",
+    "unset",
+    // rgb / rgba — legacy comma and modern space syntaxes
+    "rgb(3,169,244)",
+    "rgb(3, 169, 244)",
+    "rgba(3,169,244,0.5)",
+    "rgba(3, 169, 244, .5)",
+    "rgb(3 169 244)",
+    "rgb(3 169 244 / 50%)",
+    "rgb(100%, 0%, 0%)",
+    // hsl / hsla
+    "hsl(200, 90%, 48%)",
+    "hsla(200, 90%, 48%, 0.5)",
+    "hsl(200deg 90% 48%)",
+    // modern colour spaces (picker output)
+    "oklch(70% 0.1 200)",
+    "oklab(0.7 -0.1 0.1)",
+    "lab(52% 40 60)",
+    "lch(52% 60 40)",
+    "hwb(200 10% 20%)",
+    "color(display-p3 1 0 0)",
+  ];
+  for (const v of LEGIT) {
+    it(`accepts ${v}`, () => {
+      expect(cssColor(v)).toBe(v.trim());
+    });
+  }
+});
+
+describe("cssColor — rejects style-attribute breakouts", () => {
+  const MALICIOUS = [
+    "red;position:fixed;inset:0;z-index:99999",
+    "red;background-image:url(https://evil.example/x)",
+    "#fff;background:url(//evil/x)",
+    "red}body{display:none",
+    "url(https://evil/x)",
+    "rgb(0,0,0);pointer-events:none",
+    "expression(alert(1))",
+    "var(--x); position:fixed",
+    "var(--x, url(//evil))",
+    "10px;position:fixed", // a size string sneaking into a colour slot
+  ];
+  for (const v of MALICIOUS) {
+    it(`rejects ${JSON.stringify(v)}`, () => {
+      expect(cssColor(v)).toBeUndefined();
+    });
+  }
+  it("rejects empty / non-strings", () => {
+    expect(cssColor("")).toBeUndefined();
+    expect(cssColor("   ")).toBeUndefined();
+    expect(cssColor(undefined)).toBeUndefined();
+    expect(cssColor(null)).toBeUndefined();
+    expect(cssColor(42)).toBeUndefined();
+    expect(cssColor({})).toBeUndefined();
+  });
+});
+
+describe("cssColorOr — falls back on unsafe or missing", () => {
+  it("keeps a safe value", () => {
+    expect(cssColorOr("#03a9f4", "red")).toBe("#03a9f4");
+  });
+  it("falls back on an injection", () => {
+    expect(cssColorOr("red;position:fixed", "var(--primary-color)")).toBe("var(--primary-color)");
+  });
+  it("falls back on undefined", () => {
+    expect(cssColorOr(undefined, "var(--primary-color)")).toBe("var(--primary-color)");
+  });
+});
+
+describe("cssNumber — coerces size/angle fields, blocks breakouts", () => {
+  it("passes finite numbers", () => {
+    expect(cssNumber(16, 34)).toBe(16);
+    expect(cssNumber(0, 34)).toBe(0);
+    expect(cssNumber(-90, 0)).toBe(-90);
+    expect(cssNumber(12.5, 0)).toBe(12.5);
+  });
+  it("coerces numeric strings (YAML often yields strings)", () => {
+    expect(cssNumber("16", 34)).toBe(16);
+    expect(cssNumber("12.5", 0)).toBe(12.5);
+  });
+  it("falls back on null/undefined like the old ?? default", () => {
+    expect(cssNumber(undefined, 34)).toBe(34);
+    expect(cssNumber(null, 34)).toBe(34);
+  });
+  it("rejects a breakout string in a size field", () => {
+    expect(cssNumber("1;position:fixed;inset:0", 16)).toBe(16);
+    expect(cssNumber("16px;color:red", 16)).toBe(16);
+    expect(cssNumber(NaN, 16)).toBe(16);
+    expect(cssNumber(Infinity, 16)).toBe(16);
+  });
+});

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -95,6 +95,9 @@ export function cssColorOr(value: unknown, fallback: string): string {
  */
 export function cssNumber(value: unknown, fallback: number): number {
   if (value == null) return fallback;
+  // Number("") and Number("   ") are 0 (finite), which would silently become
+  // 0px / a 0 ratio; treat a blank string as unset.
+  if (typeof value === "string" && value.trim() === "") return fallback;
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) ? n : fallback;
 }

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -1,0 +1,66 @@
+/**
+ * Sanitise user-supplied CSS values before they are interpolated into a `style`
+ * attribute.
+ *
+ * A floorplan config is shareable and importable, so its colour and size strings
+ * are effectively attacker-controlled. Lit does **not** escape `;` or `}` inside a
+ * style-attribute expression, so a value like `red;position:fixed;inset:0;z-index:99999`
+ * breaks out of its declaration and paints a full-viewport overlay over Home
+ * Assistant, and `red;background-image:url(https://evil/x)` turns into a remote fetch
+ * that beacons the viewer's IP. Both were reproduced by parsing the emitted DOM.
+ *
+ * Note this is specifically about values that land in a `style="…"` attribute. SVG
+ * presentation attributes (`fill=`, `stroke=`) are not affected — there is no
+ * declaration there to break out of — so those sinks are intentionally left alone.
+ */
+
+// #rgb #rgba #rrggbb #rrggbbaa
+const HEX = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+// named keywords and CSS-wide keywords: red, transparent, currentColor, inherit…
+const KEYWORD = /^[a-z]+$/i;
+// The colour functions CSS actually has — rgb/hsl plus the modern spaces
+// (oklch is now the default output of many pickers). Only numbers, the angle/
+// space keywords those functions take, separators, %, / and whitespace inside;
+// no nested `(`, so url()/expression()/calc() can never form.
+const FUNC =
+  /^(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([a-z0-9.,%/\s-]+\)$/i;
+// var(--token) with an optional simple fallback restricted to the characters a
+// colour value uses — no `;` `{` `}` `(` `)` and no injection-adjacent punctuation,
+// e.g. var(--primary, #03a9f4). Tighter than "anything but delimiters".
+const VAR = /^var\(\s*--[a-z0-9-]+\s*(?:,\s*[a-z0-9\s.,%/#-]*)?\)$/i;
+
+/**
+ * The colour if it is safe to place in a `style` attribute, else `undefined`.
+ * An allowlist, deliberately: a denylist ("reject `;` `url(` …") invites the one
+ * vector you forgot. A value is dropped unless it is recognisably one of the
+ * colour forms CSS actually uses. Whitespace is trimmed; empty and non-strings
+ * return `undefined`.
+ */
+export function cssColor(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim();
+  if (!v) return undefined;
+  if (HEX.test(v) || KEYWORD.test(v) || FUNC.test(v) || VAR.test(v)) return v;
+  return undefined;
+}
+
+/**
+ * `cssColor(value) ?? fallback` — the value if safe, otherwise the (trusted,
+ * caller-supplied) fallback. Use at every point a config colour reaches a style.
+ */
+export function cssColorOr(value: unknown, fallback: string): string {
+  return cssColor(value) ?? fallback;
+}
+
+/**
+ * A finite number for a numeric CSS field (a size, an angle) that will be
+ * interpolated into a `style` attribute, else `fallback`. This is what stops a
+ * size like `1;position:fixed;inset:0` from breaking out of `font-size:${…}px`.
+ * `null`/`undefined` fall back like the previous `?? default` did; strings that
+ * parse to a finite number (`"16"`) are accepted, anything else is rejected.
+ */
+export function cssNumber(value: unknown, fallback: number): number {
+  if (value == null) return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -14,34 +14,68 @@
  * declaration there to break out of — so those sinks are intentionally left alone.
  */
 
-// #rgb #rgba #rrggbb #rrggbbaa
-const HEX = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
-// named keywords and CSS-wide keywords: red, transparent, currentColor, inherit…
-const KEYWORD = /^[a-z]+$/i;
-// The colour functions CSS actually has — rgb/hsl plus the modern spaces
-// (oklch is now the default output of many pickers). Only numbers, the angle/
-// space keywords those functions take, separators, %, / and whitespace inside;
-// no nested `(`, so url()/expression()/calc() can never form.
-const FUNC =
-  /^(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\([a-z0-9.,%/\s-]+\)$/i;
-// var(--token) with an optional simple fallback restricted to the characters a
-// colour value uses — no `;` `{` `}` `(` `)` and no injection-adjacent punctuation,
-// e.g. var(--primary, #03a9f4). Tighter than "anything but delimiters".
-const VAR = /^var\(\s*--[a-z0-9-]+\s*(?:,\s*[a-z0-9\s.,%/#-]*)?\)$/i;
+/**
+ * Functions that are inert as a CSS *value*: colour, gradient, `var()`/`env()`
+ * and maths. This is an **allowlist** and we fail closed — anything not listed
+ * (`url()`, `image-set()`, `cross-fade()`, `element()`, `paint()`, `attr()`,
+ * legacy `expression()`, …) is rejected, so a resource fetch or worklet can never
+ * appear, even nested. Home Assistant themes lean on nesting heavily — colours are
+ * stored as bare `r, g, b` triplets and read back as `rgb(var(--rgb-primary-color))`,
+ * and fallbacks chain as `var(--a, var(--b, #fff))` — so nesting must be allowed.
+ */
+const SAFE_FUNCS = new Set([
+  // colour
+  "rgb", "rgba", "hsl", "hsla", "hwb", "lab", "lch", "oklab", "oklch",
+  "color", "color-mix", "light-dark",
+  // custom properties / environment
+  "var", "env",
+  // maths (calc & friends can appear inside colour components)
+  "calc", "clamp", "min", "max", "abs", "round", "mod", "rem",
+  "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "pow", "sqrt", "hypot", "log", "exp",
+  // gradients (valid for the stage `background`)
+  "linear-gradient", "radial-gradient", "conic-gradient",
+  "repeating-linear-gradient", "repeating-radial-gradient", "repeating-conic-gradient",
+]);
+
+// The characters a colour / gradient value is built from. Deliberately excludes
+// `;` `{` `}` (declaration/rule breakout), `"` `'` `:` `@` `\` `!` and every
+// control char — so an accepted value can neither end its declaration, start a
+// new one, carry a quoted or `data:` URL, nor use an escape or `!important`.
+const SAFE_CHARS = /^[a-z0-9#%.,/_() +*-]+$/i;
+// A function call is an identifier (optionally hyphenated) immediately before `(`.
+const FUNC_CALL = /([a-z][a-z0-9-]*)\s*\(/gi;
 
 /**
  * The colour if it is safe to place in a `style` attribute, else `undefined`.
- * An allowlist, deliberately: a denylist ("reject `;` `url(` …") invites the one
- * vector you forgot. A value is dropped unless it is recognisably one of the
- * colour forms CSS actually uses. Whitespace is trimmed; empty and non-strings
- * return `undefined`.
+ *
+ * Fail-closed and structural rather than a fixed set of regexes, so it accepts the
+ * full range of real values (hex, named/CSS-wide keywords, `rgb/hsl/oklch/…`,
+ * `color-mix`, gradients, and arbitrarily nested `var()` / `rgb(var(--…))`) while
+ * still guaranteeing no breakout: allowed characters only, balanced parens, and
+ * every function on the {@link SAFE_FUNCS} allowlist. Whitespace is trimmed; empty
+ * and non-strings return `undefined`.
  */
 export function cssColor(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const v = value.trim();
   if (!v) return undefined;
-  if (HEX.test(v) || KEYWORD.test(v) || FUNC.test(v) || VAR.test(v)) return v;
-  return undefined;
+  if (!SAFE_CHARS.test(v)) return undefined;
+  if (v.includes("/*") || v.includes("*/")) return undefined; // no comments
+  if (!/^[a-z#]/i.test(v)) return undefined; // must read as a colour/keyword/function
+  // Balanced parens, never dropping below zero.
+  let depth = 0;
+  for (let i = 0; i < v.length; i++) {
+    const c = v[i];
+    if (c === "(") depth++;
+    else if (c === ")" && --depth < 0) return undefined;
+  }
+  if (depth !== 0) return undefined;
+  // Every function call must be inert (fail closed on anything unknown).
+  const funcs = new RegExp(FUNC_CALL.source, "gi");
+  for (let m: RegExpExecArray | null; (m = funcs.exec(v)); ) {
+    if (!SAFE_FUNCS.has(m[1].toLowerCase())) return undefined;
+  }
+  return v;
 }
 
 /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -20,6 +20,8 @@ import {
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
   DEFAULT_TEXT_SIZE,
+  DEFAULT_WIDTH,
+  DEFAULT_HEIGHT,
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
   FURNITURE_DEFAULT_SIZE,
@@ -1886,7 +1888,8 @@ export class FloorplanCardEditor extends LitElement {
         <div class="workspace">
         <div class="canvas-outer">
         <div class="canvas-wrap" tabindex="0" @wheel=${this._onCanvasWheel}>
-          <div class="stage" style="aspect-ratio: ${c.width} / ${c.height}; width:${this._zoom * 100}%;">
+          <div class="stage" style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
+            c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;">
             <svg
               viewBox="0 0 ${c.width} ${c.height}"
               preserveAspectRatio="none"

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -51,6 +51,7 @@ import {
   collectWatchedEntities,
   hassRenderInputsChanged,
 } from "./render";
+import { cssColorOr, cssNumber } from "./css-safe";
 import {
   ENDPOINT_SNAP,
   applyDelta,
@@ -2369,7 +2370,7 @@ export class FloorplanCardEditor extends LitElement {
     // Pass the registry icon here too, so the editor preview matches the card.
     const icon = resolveItemIcon(it, st, it.entity ? this.hass?.entities?.[it.entity]?.icon : undefined);
     const label = it.name || it.entity || it.kind;
-    const size = it.size ?? DEFAULT_ITEM_SIZE;
+    const size = cssNumber(it.size, DEFAULT_ITEM_SIZE);
     const showIcon = it.showIcon ?? true;
     const display = it.display ?? "badge";
     const rippleColor = it.rippleColor ?? "var(--primary-color, #03a9f4)";
@@ -2377,7 +2378,7 @@ export class FloorplanCardEditor extends LitElement {
 
     const badge = html`<div
       class="badge ${showIcon ? "" : "ghost"}"
-      style="width:${size}px;height:${size}px;transform:rotate(${it.angle ?? 0}deg);"
+      style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(it.angle, 0)}deg);"
     >
       <ha-icon icon=${icon} style="--mdc-icon-size:${Math.round(size * 0.62)}px;"></ha-icon>
     </div>`;
@@ -2416,9 +2417,9 @@ export class FloorplanCardEditor extends LitElement {
       <div
         class="edit-text ${selected ? "selected" : ""}"
         style="left:${(t.x / c.width) * 100}%; top:${(t.y / c.height) * 100}%;
-               font-size:${t.size ?? DEFAULT_TEXT_SIZE}px;
-               color:${t.color ?? "var(--primary-text-color)"};
-               transform:translate(-50%,-50%) rotate(${t.angle ?? 0}deg);"
+               font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
+               color:${cssColorOr(t.color, "var(--primary-text-color)")};
+               transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "text", id: t.id })}
         @pointermove=${this._onOverlayMove}
         @pointerup=${this._onOverlayUp}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -264,7 +264,7 @@ export class FloorplanCard extends LitElement {
     // transform below; the HTML overlay remaps per point in _renderItem /
     // _renderText. Both must use the same mapping (rotatePlanPoint).
     const rot = normalizePlanRotation(c.rotation);
-    const dims = rotatedCanvasSize(c.width, c.height, rot);
+    const dims = rotatedCanvasSize(cssNumber(c.width, DEFAULT_WIDTH), cssNumber(c.height, DEFAULT_HEIGHT), rot);
     const rotTransform = planRotationTransform(c.width, c.height, rot);
     return html`
       <ha-card .header=${c.title ?? nothing}>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
+import { cssColorOr, cssNumber } from "./css-safe";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -173,11 +174,11 @@ export class FloorplanCard extends LitElement {
   }
 
   private _renderBadge(item: FloorItem): TemplateResult {
-    const size = item.size ?? DEFAULT_ITEM_SIZE;
+    const size = cssNumber(item.size, DEFAULT_ITEM_SIZE);
     return html`
       <div
         class="badge"
-        style="width:${size}px;height:${size}px;transform:rotate(${item.angle ?? 0}deg);"
+        style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(item.angle, 0)}deg);"
       >
         <ha-icon
           icon=${this._itemIcon(item)}
@@ -242,9 +243,9 @@ export class FloorplanCard extends LitElement {
       <div
         class="text"
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
-               font-size:${t.size ?? DEFAULT_TEXT_SIZE}px;
-               color:${t.color ?? "var(--primary-text-color)"};
-               transform:translate(-50%,-50%) rotate(${t.angle ?? 0}deg);"
+               font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
+               color:${cssColorOr(t.color, "var(--primary-text-color)")};
+               transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
       >
         ${t.text}
       </div>
@@ -269,8 +270,8 @@ export class FloorplanCard extends LitElement {
       <ha-card .header=${c.title ?? nothing}>
         <div
           class="stage"
-          style="aspect-ratio: ${dims.w} / ${dims.h}; background:${c.background ??
-          "var(--card-background-color, #fff)"};"
+          style="aspect-ratio: ${dims.w} / ${dims.h}; background:${cssColorOr(
+          c.background, "var(--card-background-color, #fff)")};"
         >
 <!-- preserveAspectRatio="none" is correct here, and it took a wrong fix to
                see why. .stage pins aspect-ratio: width / height inline, so the

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,7 +8,8 @@ import type {
   Tracker,
   RenderHass,
 } from "./types";
-import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, getFloors, trackerAxisFraction } from "./types";
+import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, DEFAULT_RIPPLE_SIZE, getFloors, trackerAxisFraction } from "./types";
+import { cssColorOr, cssNumber } from "./css-safe";
 
 export const WALL_THICKNESS = 8;
 
@@ -506,7 +507,8 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   const half = o.length / 2;
   const cutH = WALL_THICKNESS + 4;
   // The moving parts take the accent color when actively open (sensor-driven).
-  const tone = active ? accent : color;
+  // Sanitised: color/accent are config-supplied and land in `style="stroke/fill:…"`.
+  const tone = cssColorOr(active ? accent : color, "var(--primary-color, #03a9f4)");
   // Fraction open (0..1) drives partial swing/slide. Defaults to the binary
   // `open` so callers that don't pass `amount` render exactly as before.
   const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
@@ -974,7 +976,7 @@ export function renderRipple(
   return html`
     <div
       class="ripple ${active ? "active" : ""}"
-      style="width:${sizePx}px;height:${sizePx}px;--fp-ripple-color:${color};"
+      style="width:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;height:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;--fp-ripple-color:${cssColorOr(color, "var(--primary-color, #03a9f4)")};"
     >
       <span class="dot"></span>
       ${Array.from(


### PR DESCRIPTION
> **🤖 Disclosure** — written with an AI agent (Claude Code) under my direction. I run this card on a live HA instance daily. Addresses #64.

Config is shareable/importable, so its colour and size fields are effectively attacker-controlled. Lit doesn't escape `;` or `}` inside a style-attribute expression, so a shared/imported config can break a value out of its declaration — e.g. `background: "red;position:fixed;inset:0;z-index:99999"` paints a full-viewport overlay over the HA UI, and a colour containing `url(…)` becomes an IP-leaking remote fetch.

**What this does**
- Adds `src/css-safe.ts`: an **allowlist** `cssColor`/`cssColorOr` (hex, named + CSS-wide keywords, `rgb/hsl/hwb/lab/lch/oklab/oklch/color(...)`, and `var(--x[, fallback])`) plus a `cssNumber` coercion for numeric fields. Allowlist over denylist on purpose — a denylist invites the one vector you forgot.
- Wires it at **every `style="…"` sink** in the card, the editor preview, and the shared render helpers: stage `background`, text `color`/`size`, item badge `size`/`angle`, opening `accent` (the `fill`/`stroke` in `style=`), and ripple `color`/`size`.
- Leaves SVG `fill=`/`stroke=`/`transform=` **presentation attributes** alone — there's no CSS declaration there to break out of, so they're not this bug class.

**Honest scoping**
- The colour allowlist is the part I've run hard; the `size`/`angle` numeric coercion is a simple finite-number guard (new, not previously battle-tested, but small and covered by tests).
- Top-level `width`/`height`/`grid` already go through your `setConfig` numeric check, so those are left as-is.
- #62 adds a `labelSize` field of the same shape; it's not on `main` so it's out of scope here — it just needs the same `cssNumber` wrap wherever it lands.

**Backward-compatible:** every legitimate value renders unchanged — I tested the allowlist against the colours real configs use (HA theme vars with/without fallback, hex, named, rgb/rgba in comma and modern space syntax, hsl/hsla, oklch/lab/lch/hwb/color). Only invalid/malicious values fall back to the existing defaults. `tsc` clean; full suite green (adds sanitiser unit + adversarial/fuzz cases).

Marked as a draft — happy to adjust scope, naming, or split it if you'd prefer smaller.
