### PR TITLE
Floors: reorder from the editor + repair hand-edited ids — closes #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,14 @@ background):
 - **+ Add** — one popover for everything droppable: device, text, and all furniture
   types shown as their actual glyphs (pick a sofa by seeing a sofa). The new element is
   selected immediately so the **Element** section is ready for configuring it.
-- **floor** — switch floors with the dropdown, add one with **+**; rename and delete
-  live behind the gear button. The gear also offers an **HA floor** dropdown listing
-  your Home Assistant floors — linking one names the plan floor after it (rename
-  afterwards if you like; the link sticks either way).
+- **floor** — switch floors with the dropdown, add one with **+**; rename, **reorder**
+  (▲/▼ move the current floor up/down the list — the order of the dropdown and the
+  card's floor switcher) and delete live behind the gear button. The gear also offers
+  an **HA floor** dropdown listing your Home Assistant floors — linking one names the
+  plan floor after it (rename afterwards if you like; the link sticks either way).
+  Prefer the ▲/▼ buttons over reordering floor blocks in YAML: hand-editing easily
+  drops or duplicates floor `id`s (the card now repairs both, but edits made while
+  ids collide can land on the wrong floor).
 
 Undo/redo buttons sit at the right of the tools row. Zoom controls live on the canvas
 itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -30,6 +30,7 @@ import {
   gridPercentToSnap,
   makeFloor,
   haFloorsOf,
+  moveFloor,
   resolveSnap,
   snapToGridPercent,
   trackerPresenceDetected,
@@ -1445,6 +1446,16 @@ export class FloorplanCardEditor extends LitElement {
     this._clearSel();
   }
 
+  /**
+   * Move the active floor one step up/down the list (issue #66) — the safe
+   * alternative to reordering floor blocks by hand in YAML. Commits through
+   * history, so a mis-move is one Ctrl+Z away.
+   */
+  private _moveFloor(delta: -1 | 1): void {
+    const next = moveFloor(this._config.floors ?? [], this._activeFloorId, delta);
+    if (next) this._commit({ ...this._config, floors: next });
+  }
+
   private _renameFloor(id: string, name: string): void {
     this._commit({
       ...this._config,
@@ -2002,7 +2013,7 @@ export class FloorplanCardEditor extends LitElement {
             >
               ${floors.map(
                 (f) =>
-                  html`<option value=${f.id} ?selected=${f.id === this._activeFloorId}>${f.name}</option>`
+                  html`<option value=${f.id} .selected=${f.id === this._activeFloorId}>${f.name}</option>`
               )}
             </select>
             <button
@@ -2027,6 +2038,29 @@ export class FloorplanCardEditor extends LitElement {
             ${this._floorMenuOpen
               ? html`<div class="pop">
                   ${this._renderHaFloorRow(floor)}
+                  <!-- Reorder (issue #66): the safe alternative to cut-and-
+                       pasting floor blocks in YAML, which drops/duplicates
+                       ids. Position in this list is the switcher order. -->
+                  <div class="pop-row">
+                    <label>Order</label>
+                    <button
+                      aria-label="Move floor up"
+                      title="Move this floor up the list"
+                      ?disabled=${floors.length < 2 || floors[0]?.id === this._activeFloorId}
+                      @click=${() => this._moveFloor(-1)}
+                    >
+                      <ha-icon icon="mdi:arrow-up"></ha-icon>
+                    </button>
+                    <button
+                      aria-label="Move floor down"
+                      title="Move this floor down the list"
+                      ?disabled=${floors.length < 2 ||
+                      floors[floors.length - 1]?.id === this._activeFloorId}
+                      @click=${() => this._moveFloor(1)}
+                    >
+                      <ha-icon icon="mdi:arrow-down"></ha-icon>
+                    </button>
+                  </div>
                   <div class="pop-row">
                     <label>Rename</label>
                     <input

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -11,6 +11,7 @@ import {
   haFloorsOf,
   uid,
   configsEqual,
+  moveFloor,
 } from "./types";
 import type { FloorplanCardConfig, TrackerSensor } from "./types";
 
@@ -295,5 +296,56 @@ describe("configsEqual", () => {
     expect(configsEqual(null, null)).toBe(true);
     expect(configsEqual(null, {})).toBe(false);
     expect(configsEqual("a", "b")).toBe(false);
+  });
+});
+
+describe("floor id repair via getFloors (issue #66)", () => {
+  const floor = (id: string | undefined, name: string) =>
+    ({ id, name, walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [] });
+  const cfg = (floors: unknown[]) =>
+    ({ type: "t", width: 1000, height: 600, floors }) as unknown as FloorplanCardConfig;
+
+  it("leaves well-formed ids untouched (same order, same values)", () => {
+    const out = getFloors(cfg([floor("a", "A"), floor("b", "B")]));
+    expect(out.map((f) => f.id)).toEqual(["a", "b"]);
+  });
+
+  it("backfills missing ids deterministically by position", () => {
+    const out = getFloors(cfg([floor(undefined, "A"), floor(undefined, "B")]));
+    expect(out.map((f) => f.id)).toEqual(["floor_1", "floor_2"]);
+    // Stable: a second call yields the same ids, so lookups don't churn.
+    const again = getFloors(cfg([floor(undefined, "A"), floor(undefined, "B")]));
+    expect(again.map((f) => f.id)).toEqual(["floor_1", "floor_2"]);
+  });
+
+  it("de-duplicates copy-pasted ids, keeping the first occurrence", () => {
+    const out = getFloors(cfg([floor("a", "One"), floor("a", "Two"), floor("a", "Three")]));
+    expect(out[0]!.id).toBe("a");
+    expect(new Set(out.map((f) => f.id)).size).toBe(3);
+    // Names stay with their floors — only the colliding ids change.
+    expect(out.map((f) => f.name)).toEqual(["One", "Two", "Three"]);
+  });
+});
+
+describe("moveFloor (issue #66)", () => {
+  const floors = [
+    makeFloor("Basement"),
+    makeFloor("Ground"),
+    makeFloor("Roof"),
+  ].map((f, i) => ({ ...f, id: `f${i}` }));
+
+  it("moves a floor one step and leaves the input untouched", () => {
+    const up = moveFloor(floors, "f2", -1)!;
+    expect(up.map((f) => f.id)).toEqual(["f0", "f2", "f1"]);
+    const down = moveFloor(floors, "f0", 1)!;
+    expect(down.map((f) => f.id)).toEqual(["f1", "f0", "f2"]);
+    expect(floors.map((f) => f.id)).toEqual(["f0", "f1", "f2"]);
+  });
+
+  it("returns null at the ends and for unknown ids", () => {
+    expect(moveFloor(floors, "f0", -1)).toBeNull();
+    expect(moveFloor(floors, "f2", 1)).toBeNull();
+    expect(moveFloor(floors, "missing", 1)).toBeNull();
+    expect(moveFloor([], "f0", 1)).toBeNull();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -563,13 +563,51 @@ function normalizeFloor(f: Floor): Floor {
 }
 
 /**
+ * Repair missing / duplicated floor ids (issue #66). Hand-reordering floors
+ * in YAML is done by cut-and-paste, which routinely drops an `id:` line or
+ * pastes the same block twice. A missing id makes every by-id lookup miss
+ * (floor switching dead); a duplicated one is worse — the editor patches
+ * *every* floor sharing the id, so edits silently land on the wrong floor.
+ * Backfill deterministically from the position so the repair is stable
+ * across renders and persists on the next editor commit.
+ */
+function ensureFloorIds(floors: Floor[]): Floor[] {
+  const seen = new Set<string>();
+  return floors.map((f, i) => {
+    let id = f.id || `floor_${i + 1}`;
+    while (seen.has(id)) id = `${id}_${i + 1}`;
+    seen.add(id);
+    return id === f.id ? f : { ...f, id };
+  });
+}
+
+/**
+ * Reorder a floor one step up/down the list (issue #66), or null when the
+ * move is a no-op (unknown id, or already at that end).
+ */
+export function moveFloor(
+  floors: readonly Floor[],
+  id: string,
+  delta: -1 | 1
+): Floor[] | null {
+  const idx = floors.findIndex((f) => f.id === id);
+  const to = idx + delta;
+  if (idx < 0 || to < 0 || to >= floors.length) return null;
+  const next = [...floors];
+  const [f] = next.splice(idx, 1);
+  next.splice(to, 0, f!);
+  return next;
+}
+
+/**
  * Normalize a config into a list of floors. If `floors` is present and
  * non-empty each floor is returned with any missing element arrays
- * backfilled; otherwise the legacy flat arrays are wrapped into a single
- * floor so old single-floor configs keep rendering unchanged.
+ * backfilled and ids repaired ({@link ensureFloorIds}); otherwise the legacy
+ * flat arrays are wrapped into a single floor so old single-floor configs
+ * keep rendering unchanged.
  */
 export function getFloors(c: FloorplanCardConfig): Floor[] {
-  if (c.floors && c.floors.length) return c.floors.map(normalizeFloor);
+  if (c.floors && c.floors.length) return ensureFloorIds(c.floors.map(normalizeFloor));
   return [
     {
       id: "floor_main",


### PR DESCRIPTION
Issue #66 is two complaints in one — "editing the order of floors in YAML causes configuration errors" and "let me reorder floors without YAML". This PR does both.

## The feature: ▲/▼ in the floor gear
The floor gear popover gains an **Order** row: move the active floor up/down the list. Position in the list is what the editor dropdown and the card's floor switcher display, so the reporter's roof-stuck-in-the-basement is two clicks from the top. Buttons disable at the ends, the move commits through history (a mis-move is one Ctrl+Z away), and the logic is a pure, unit-tested `moveFloor()`.

## The bug: what hand-reordering actually breaks
Reordering floor blocks in YAML is cut-and-paste, and cut-and-paste routinely **drops or duplicates the `id:` line**. Reproduced both in the harness against main:

- **Duplicated id** (pasted a block twice): every editor commit patches **both** floors sharing the id — drawing a wall on "Roof" also draws it on "Basement", silently. This is the truly nasty one.
- **Missing id**: every by-id lookup misses — floor switching dies in the editor and the card.

`getFloors` now repairs both at the normalization boundary: missing ids backfill deterministically by position (`floor_1`, `floor_2`, …), collisions keep the first occurrence and suffix the rest. Deterministic-by-position means the repair is **stable across renders** (lookups don't churn) and persists into the YAML on the next editor commit.

Also fixed while here: the floor `<select>` bound `?selected` — the *default*-selection attribute — so after a reorder the browser's index-based live selection could point at the wrong floor. It now binds the `.selected` property.

## Verification
- `tsc` clean, **211/211 tests** (206 on main + 5: id repair incl. stability and name/id pairing, `moveFloor` moves/ends/unknown-id/immutability).
- Harness, the reporter's scenario end-to-end: Basement/Ground/Roof with Roof active → ▲ twice → `Roof, Basement, Ground`, ▲ now disabled at the top, ▼ was disabled at the bottom; Ctrl+Z ×2 restores the original order; the card's floor switcher renders in the new order. Duplicate-id config before/after: an edit used to land on **both** floors (`One:1 | Two:1`), now on exactly the edited one (`One:0 | Two:1`).

## Backwards compatibility
Well-formed configs pass through byte-identical (same ids, same order). Only configs that were already broken (missing/colliding ids) change — they get working ids, which is the repair. No schema additions.

Closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)