### PR TITLE
Windows: single-sash mode + external roller shutter layer — closes #73, #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,12 @@ tracks state:
 
 - **Open / closed** — the opening is drawn open when the entity is `on` / `open`, closed
   otherwise. A door's leaf swings around its hinge; a window's two leaves swing outward
-  from the middle. When closed the swing arc is hidden; as the opening moves, the arc
+  from the middle — or set **Sashes** to *Single* for a one-sash window (hinged at
+  either jamb via **Hinge**).
+- **Window + external shutter** — a window and its roller shutter share one wall gap:
+  bind the window's contact sensor as **Entity** and the shutter's `cover` as
+  **Shutter**. The sash and the slatted curtain render independently, so an open
+  window behind a closed shutter shows both truthfully. When closed the swing arc is hidden; as the opening moves, the arc
   **draws on**, tracing the path of the leaf edge — animated smoothly.
 - **Partial (position covers)** — if the bound `cover` reports a `current_position`
   (0–100), the opening is drawn **partly open** to match — a door swings partway, a
@@ -401,6 +406,8 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `id`          | string                      | Unique id.                                             |
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves. `swing` (default) hinged door / casement window; `slide` sliding panels; `roll` roll-up cover (garage / roller shutter) drawn as a slatted curtain that thins onto its track as it opens. |
+| `sash`        | `single` \| `double`        | Swing windows only: one full-width sash or the classic two leaves. Default `double`. |
+| `shutterEntity` | string                     | Windows only: a `cover` for an external roller shutter over the same gap — drawn as a slatted curtain layered on the sash, with its own open/closed state. |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -410,7 +410,16 @@ function setCoverPosition(entity: string, pos: number) {
 function refreshOpeningEmu(cfg: FloorplanCardConfig) {
   const host = document.getElementById("opening-emu")!;
   const pane = document.getElementById("opening-emu-pane")!;
-  const openings = (cfg.floors ?? []).flatMap((f) => f.openings ?? []).filter((o) => o.entity);
+  // One control per bound entity — including a window's external shutter
+  // (issue #74), which gets its own cover slider.
+  const openings = (cfg.floors ?? [])
+    .flatMap((f) => f.openings ?? [])
+    .flatMap((o) => {
+      const out: { type: string; entity: string }[] = [];
+      if (o.entity) out.push({ type: o.type, entity: o.entity });
+      if (o.shutterEntity) out.push({ type: `${o.type} shutter`, entity: o.shutterEntity });
+      return out;
+    });
   if (!openings.length) {
     pane.style.display = "none";
     host.replaceChildren();
@@ -421,7 +430,7 @@ function refreshOpeningEmu(cfg: FloorplanCardConfig) {
   const frag = document.createDocumentFragment();
   const seen = new Set<string>();
   for (const o of openings) {
-    const entity = o.entity!;
+    const entity = o.entity;
     if (seen.has(entity)) continue; // one control per entity, even if reused
     seen.add(entity);
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -281,3 +281,35 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(floorImageForm({} as Floor).fields.map((x) => x.name)).not.toContain("imageOpacity");
   });
 });
+
+describe("openingForm — sash and shutter (issues #73 / #74)", () => {
+  const win = { id: "w1", type: "window", x: 0, y: 0, length: 90, angle: 0 } as Opening;
+
+  it("swing windows offer Sashes; single sash reveals Hinge", () => {
+    const names = openingForm(win).fields.map((x) => x.name);
+    expect(names).toContain("sash");
+    expect(names).not.toContain("hinge"); // double: no single hinge
+    const single = openingForm({ ...win, sash: "single" } as Opening).fields.map((x) => x.name);
+    expect(single).toContain("hinge");
+    // doors and sliders don't get a sash field
+    expect(openingForm(door).fields.map((x) => x.name)).not.toContain("sash");
+    expect(
+      openingForm({ ...win, motion: "slide" } as Opening).fields.map((x) => x.name)
+    ).not.toContain("sash");
+  });
+
+  it("windows offer a Shutter cover picker; doors don't", () => {
+    const f = openingForm(win).fields.find((x) => x.name === "shutterEntity");
+    expect(f).toBeDefined();
+    expect(f!.selector).toEqual({ entity: { filter: [{ domain: "cover" }] } });
+    expect(openingForm(door).fields.map((x) => x.name)).not.toContain("shutterEntity");
+  });
+
+  it("patches map back to config shape (double stays out of the YAML)", () => {
+    const form = openingForm(win);
+    expect(form.toPatch({ sash: "single" })).toEqual({ sash: "single" });
+    expect(form.toPatch({ sash: "double" })).toEqual({ sash: undefined });
+    expect(form.data.sash).toBe("double");
+    expect(openingForm({ ...win, sash: "single" } as Opening).data.sash).toBe("single");
+  });
+});

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -29,6 +29,7 @@ import {
   normalizePlanRotation,
   openingMotion,
   sliderStyleOf,
+  windowSash,
 } from "./render";
 import { defaultItemAction } from "./actions";
 
@@ -186,7 +187,16 @@ export function openingForm(o: Opening): FormSpec {
     },
     { name: "length", label: "Length", required: true, selector: { number: { min: 1, mode: "box" } } },
   ];
-  if (o.type === "door" && motion === "swing") {
+  if (o.type === "window" && motion === "swing") {
+    fields.push({
+      name: "sash",
+      label: "Sashes",
+      helper: "Single = one full-width sash (issue #73)",
+      selector: dropdown(opt("double", "Double (two leaves)"), opt("single", "Single sash")),
+    });
+  }
+  // Hinge applies to anything with ONE hinged leaf: doors, and single-sash windows.
+  if (motion === "swing" && (o.type === "door" || windowSash(o) === "single")) {
     fields.push({
       name: "hinge",
       label: "Hinge",
@@ -224,6 +234,14 @@ export function openingForm(o: Opening): FormSpec {
     helper: "Type and motion follow the entity's device class",
     selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
   });
+  if (o.type === "window") {
+    fields.push({
+      name: "shutterEntity",
+      label: "Shutter",
+      helper: "External roller shutter over this window (a cover)",
+      selector: { entity: { filter: [{ domain: "cover" }] } },
+    });
+  }
   if (o.entity) fields.push({ name: "invert", label: "Invert", selector: { boolean: {} } });
   fields.push(angleField());
   return {
@@ -236,7 +254,9 @@ export function openingForm(o: Opening): FormSpec {
       opens: o.flipV ? "other" : "this",
       slide: o.flipH ? "right" : "left",
       style,
+      sash: windowSash(o),
       entity: o.entity ?? "",
+      shutterEntity: o.shutterEntity ?? "",
       invert: o.invert ?? false,
       angle: o.angle,
     },
@@ -247,7 +267,8 @@ export function openingForm(o: Opening): FormSpec {
           out.motion = v === "slide" || v === "roll" ? v : undefined;
           // sliderStyle only applies while sliding — drop it when switching away.
           if (v !== "slide") out.sliderStyle = undefined;
-        } else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
+        } else if (k === "sash") out.sash = v === "single" ? "single" : undefined;
+        else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
         else if (k === "opens") out.flipV = v === "other" || undefined;
         else if (k === "style") out.sliderStyle = v === "single" ? undefined : v;
         else if (k === "invert") out.invert = v || undefined;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2495,6 +2495,9 @@ export class FloorplanCardEditor extends LitElement {
           // motion is visible — closed, both look like a plain band, which
           // would make the Motion / Slide / Style controls appear inert.
           amount: openingMotion(o) !== "swing" ? 0.55 : undefined,
+          // Shutter previewed half-rolled so the layer is visible while
+          // configuring, whatever the live state.
+          shutter: o.shutterEntity ? { amount: 0.55 } : undefined,
         })}
       </g>`;
   }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -19,6 +19,8 @@ import {
   resolveOpeningAmount,
   openingIsActive,
   openingClickAction,
+  shutterAmount,
+  shutterActive,
   renderRipple,
   renderFurniture,
   renderTracker,
@@ -327,12 +329,20 @@ export class FloorplanCard extends LitElement {
               (o, i) => o.id || i,
               (o) => {
               const amount = this._openingAmount(o);
+              const shutterState = o.shutterEntity
+                ? this.hass?.states[o.shutterEntity]
+                : undefined;
               const symbol = renderOpening(o, {
                 color: "var(--primary-text-color)",
                 open: amount > 0,
                 amount,
                 active: this._openingActive(o),
                 accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
+                // External roller shutter layer (issue #74). No entity bound
+                // yet → previewed shut, like a static plan.
+                shutter: o.shutterEntity
+                  ? { amount: shutterAmount(shutterState), active: shutterActive(shutterState) }
+                  : undefined,
               });
               if (!o.entity) return symbol;
               // Entity-bound openings are tappable — a transparent rect over the

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -121,3 +121,51 @@ describe("renderOpening — roll-up cover (issue #45)", () => {
     expect(s).not.toContain("fp-door-leaf");
   });
 });
+
+describe("renderOpening — single-sash window (issue #73)", () => {
+  const single = { type: "window", sash: "single" } as Partial<Opening>;
+
+  it("draws one full-width sash and one arc instead of two casement leaves", () => {
+    const s = svgOf(single, { open: true });
+    expect(s.match(/fp-door-leaf/g)?.length).toBe(1);
+    expect(s).not.toContain("fp-leaf-r");
+    expect(s.match(/fp-door-arc/g)?.length).toBe(1);
+    expect(s).toContain("width=90"); // sash spans the full opening
+  });
+
+  it("double stays the historic two-leaf look (default unchanged)", () => {
+    const d = svgOf({ type: "window" }, { open: true });
+    expect(d).toContain("fp-door-leaf");
+    expect(d).toContain("fp-leaf-r");
+    expect(svgOf({ type: "window", sash: "double" } as Partial<Opening>, { open: true })).toContain(
+      "fp-leaf-r",
+    );
+  });
+
+  it("hinge follows flipH via the mirror wrapper", () => {
+    expect(svgOf({ ...single, flipH: true })).toContain("scale(-1 1)");
+  });
+});
+
+describe("renderOpening — external shutter layer (issue #74)", () => {
+  it("layers the roll curtain over the window body", () => {
+    const s = svgOf({ type: "window" }, { open: true, shutter: { amount: 0.25 } });
+    expect(s).toContain("fp-roll-curtain");
+    expect(s).toContain("scaleY(0.75)"); // 1 - amount
+    expect(s).toContain("fp-leaf-r"); // the window itself still renders
+  });
+
+  it("no shutter style, no curtain (existing windows unchanged)", () => {
+    expect(svgOf({ type: "window" }, { open: true })).not.toContain("fp-roll-curtain");
+  });
+
+  it("shutter accent is independent of the window's active state", () => {
+    const s = svgOf({ type: "window" }, {
+      open: false,
+      active: false,
+      accent: "#ff0000",
+      shutter: { amount: 0.5, active: true },
+    });
+    expect(s).toContain("#ff0000"); // curtain wears the accent while the sash doesn't
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -8,6 +8,9 @@ import {
   openingMirror,
   sliderStyleOf,
   openingFromDeviceClass,
+  windowSash,
+  shutterAmount,
+  shutterActive,
   openingClickAction,
   resolveOpeningOpen,
   resolveOpeningAmount,
@@ -1006,5 +1009,59 @@ describe("plan rotation (issue #33)", () => {
       }
     }
     expect(planRotationTransform(W, H, 0)).toBe("");
+  });
+});
+
+describe("windowSash (issue #73)", () => {
+  it("defaults to double; single only for swing windows", () => {
+    expect(windowSash({ type: "window" } as Opening)).toBe("double");
+    expect(windowSash({ type: "window", sash: "single" } as Opening)).toBe("single");
+    expect(windowSash({ type: "door", sash: "single" } as Opening)).toBe("double");
+    expect(windowSash({ type: "window", motion: "slide", sash: "single" } as Opening)).toBe(
+      "double",
+    );
+  });
+});
+
+describe("shutterAmount / shutterActive (issue #74)", () => {
+  const st = (state: string, pos?: number) =>
+    ({ state, attributes: pos === undefined ? {} : { current_position: pos } });
+
+  it("position wins, clamped to 0..1", () => {
+    expect(shutterAmount(st("open", 50))).toBe(0.5);
+    expect(shutterAmount(st("open", 120))).toBe(1);
+    expect(shutterAmount(st("closed", 0))).toBe(0);
+  });
+
+  it("falls back to open-ish states without a position", () => {
+    expect(shutterAmount(st("open"))).toBe(1);
+    expect(shutterAmount(st("opening"))).toBe(1);
+    expect(shutterAmount(st("closed"))).toBe(0);
+  });
+
+  it("fails closed on an outage or missing state", () => {
+    expect(shutterAmount(undefined)).toBe(0);
+    expect(shutterAmount(st("unavailable", 80))).toBe(0);
+    expect(shutterActive(st("unknown"))).toBe(false);
+  });
+
+  it("active while (partly) open or in transit", () => {
+    expect(shutterActive(st("open", 40))).toBe(true);
+    expect(shutterActive(st("closing", 0))).toBe(true);
+    expect(shutterActive(st("closed", 0))).toBe(false);
+  });
+});
+
+describe("collectWatchedEntities includes shutter entities (issue #74)", () => {
+  it("watches shutterEntity alongside the opening entity", () => {
+    const cfg = {
+      type: "t", width: 1000, height: 600,
+      floors: [{ id: "f", name: "F", walls: [], items: [], texts: [], furniture: [], trackers: [],
+        openings: [{ id: "o", type: "window", x: 0, y: 0, length: 90, angle: 0,
+          entity: "binary_sensor.win", shutterEntity: "cover.shutter" }] }],
+    } as unknown as FloorplanCardConfig;
+    const ids = collectWatchedEntities(cfg);
+    expect(ids.has("binary_sensor.win")).toBe(true);
+    expect(ids.has("cover.shutter")).toBe(true);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -59,7 +59,10 @@ export function hassRenderInputsChanged(
 export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
   const ids = new Set<string>();
   for (const f of getFloors(c)) {
-    for (const o of f.openings) if (o.entity) ids.add(o.entity);
+    for (const o of f.openings) {
+      if (o.entity) ids.add(o.entity);
+      if (o.shutterEntity) ids.add(o.shutterEntity);
+    }
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);
       if (it.secondaryEntity) ids.add(it.secondaryEntity);
@@ -440,6 +443,45 @@ export function sliderStyleOf(o: Opening): "single" | "bypass" | "biparting" {
   return openingMotion(o) === "slide" ? (o.sliderStyle ?? "single") : "single";
 }
 
+/**
+ * Sash count for a swing window (issue #73): `double` (the historic look) or
+ * `single`. Only meaningful for `type: "window"` with swing motion — doors
+ * and sliding/rolling openings always resolve to `double` (ignored).
+ */
+export function windowSash(o: Opening): "single" | "double" {
+  return o.type === "window" && openingMotion(o) === "swing" ? (o.sash ?? "double") : "double";
+}
+
+/**
+ * How far open an external roller shutter is drawn, 0..1 (issue #74). Cover
+ * position when published, else open-ish states = 1. Fails closed on an
+ * outage — a stale "open" shutter is worse than drawing it shut.
+ */
+export function shutterAmount(
+  state: { state: string; attributes?: Record<string, unknown> } | undefined,
+): number {
+  if (!state || isSensorOutage(state.state)) return 0;
+  const pos = state.attributes?.current_position;
+  if (typeof pos === "number" && Number.isFinite(pos)) {
+    return Math.max(0, Math.min(1, pos / 100));
+  }
+  return state.state === "open" || state.state === "opening" || state.state === "closing" ||
+    state.state === "on"
+    ? 1
+    : 0;
+}
+
+/**
+ * Whether the shutter layer wears the accent — drawn (partly) open or still in
+ * transit, matching {@link openingIsActive}'s "active = open" semantics.
+ */
+export function shutterActive(
+  state: { state: string; attributes?: Record<string, unknown> } | undefined,
+): boolean {
+  if (!state || isSensorOutage(state.state)) return false;
+  return shutterAmount(state) > 0 || state.state === "opening" || state.state === "closing";
+}
+
 /** HA `cover` / `binary_sensor` device classes that read as a window (glass). */
 const WINDOW_DEVICE_CLASSES = new Set(["window", "blind", "shade", "shutter", "curtain", "awning"]);
 /** Device classes whose panels travel along the wall. */
@@ -568,6 +610,30 @@ export function openingIsActive(
   return openingInMotion(state.state) || resolveOpeningAmount(o, state) > 0;
 }
 
+/**
+ * The slatted roll curtain (band + slat ticks) scaled by how far open, shared
+ * by roll-up openings and the window shutter layer (issue #74). Centered on
+ * the track line; callers draw their own jambs/track.
+ */
+function rollCurtain(length: number, tone: string, amt: number): SVGTemplateResult {
+  const half = length / 2;
+  const bandT = 5;
+  const slats = Math.max(3, Math.round(length / 12));
+  const ticks: SVGTemplateResult[] = [];
+  for (let i = 1; i < slats; i++) {
+    const x = -half + (length * i) / slats;
+    ticks.push(
+      svg`<line x1=${x} y1=${-bandT / 2} x2=${x} y2=${bandT / 2}
+            stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
+    );
+  }
+  return svg`<g class="fp-roll-curtain" style="transform:scaleY(${1 - amt});">
+      <rect x=${-half} y=${-bandT / 2} width=${length} height=${bandT}
+            style="fill:${tone};" />
+      ${ticks}
+    </g>`;
+}
+
 /** Style options for {@link renderOpening}. */
 export interface OpeningStyle {
   /** Base color of the jambs / leaf / swing arc. */
@@ -584,6 +650,12 @@ export interface OpeningStyle {
   active?: boolean;
   /** Accent color used while `active` (default the HA primary color). */
   accent?: string;
+  /**
+   * External roller shutter layered over the opening (issue #74): how far
+   * open (0..1, see {@link shutterAmount}) and whether it wears the accent.
+   * Rendered as the roll curtain on top of the sash.
+   */
+  shutter?: { amount: number; active?: boolean };
 }
 
 /**
@@ -605,7 +677,29 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
 
   let body: SVGTemplateResult;
-  if (o.type === "window" && openingMotion(o) === "swing") {
+  if (o.type === "window" && openingMotion(o) === "swing" && windowSash(o) === "single") {
+    // One casement sash hinged at the left jamb (issue #73) — the window
+    // counterpart of the door leaf: full-width sash, quarter-circle arc that
+    // draws on as it opens. flipH (via the mirror wrapper below) moves the
+    // hinge to the other jamb.
+    const arcLen = (Math.PI / 2) * o.length;
+    body = svg`
+        <!-- jambs -->
+        <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <path class="fp-door-arc"
+              d="M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}"
+              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
+              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
+        <g transform="translate(${-half} 0)">
+          <g class="fp-door-leaf" style="transform:rotate(${-90 * amt}deg);">
+            <rect x="0" y="-1.25" width=${o.length} height="2.5" style="fill:${tone};" />
+          </g>
+        </g>
+      `;
+  } else if (o.type === "window" && openingMotion(o) === "swing") {
     // Two casement leaves hinged at each jamb. Closed, they meet in the middle
     // along the wall; open, they swing outward (up) like double doors, each
     // tracing a quarter-circle arc (radius = half) that draws on as it opens.
@@ -642,16 +736,6 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     // plane, so the slatted band thins toward the track line as it opens and
     // vanishes fully open, leaving jambs + track. Distinct at a glance from
     // both the giant swing leaf and the slide panel.
-    const bandT = 5;
-    const slats = Math.max(3, Math.round(o.length / 12));
-    const ticks: SVGTemplateResult[] = [];
-    for (let i = 1; i < slats; i++) {
-      const x = -half + (o.length * i) / slats;
-      ticks.push(
-        svg`<line x1=${x} y1=${-bandT / 2} x2=${x} y2=${bandT / 2}
-              stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
-      );
-    }
     body = svg`
         <!-- jambs -->
         <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
@@ -661,11 +745,7 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <!-- track: stays when the curtain is up so the gap still reads as an opening -->
         <line x1=${-half} y1="0" x2=${half} y2="0"
               stroke=${color} stroke-width="0.75" opacity="0.6" />
-        <g class="fp-roll-curtain" style="transform:scaleY(${1 - amt});">
-          <rect x=${-half} y=${-bandT / 2} width=${o.length} height=${bandT}
-                style="fill:${tone};" />
-          ${ticks}
-        </g>`;
+        ${rollCurtain(o.length, tone, amt)}`;
   } else if (openingMotion(o) === "slide") {
     // A sliding door / window: panel(s) sit in the opening and travel *along* the
     // wall. Closed, they fill the gap; open, they slide aside (single), stack
@@ -749,6 +829,13 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   // Orientation mirrors are applied as a single scale wrapper inside the
   // place-into-position transform, so the base symbol (drawn once, centered at
   // the origin) reflects into any of the four hinge/swing orientations.
+  // External shutter layer (issue #74): the roll curtain rides on top of the
+  // sash so a shut shutter visibly covers an open window. Its own
+  // active/accent state is independent of the window's.
+  if (style.shutter) {
+    const shutterTone = style.shutter.active ? accent : color;
+    body = svg`${body}${rollCurtain(o.length, cssColorOr(shutterTone, "var(--primary-color, #03a9f4)"), style.shutter.amount)}`;
+  }
   const { sx, sy } = openingMirror(o);
   return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">
       <g transform="scale(${sx} ${sy})">${body}</g>

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,20 @@ export interface Opening {
    */
   flipV?: boolean;
   /**
+   * Swing windows only: how many sashes. `double` (the default, today's look)
+   * draws two casement leaves meeting in the middle; `single` draws one sash
+   * hinged at a jamb (issue #73) — `flipH` picks which jamb. Ignored for
+   * doors and for sliding / rolling openings.
+   */
+  sash?: "single" | "double";
+  /**
+   * Windows only: a `cover` entity for an external roller shutter sharing the
+   * same wall gap (issue #74). Drawn as a slatted roll curtain layered over
+   * the sash — `entity` keeps driving the window itself, so an open window
+   * behind a closed shutter renders both truthfully.
+   */
+  shutterEntity?: string;
+  /**
    * Sliding openings only (`motion: "slide"`): how the panels are arranged.
    * - `single` (default) — one panel slides aside into the wall.
    * - `bypass` — two panels on parallel tracks; one slides behind the other


### PR DESCRIPTION
Two window asks in one PR — same subsystem, same glyphs.

## #73 — single-sash windows
Swing windows always drew **two** casement leaves; single-sash windows had no honest representation (the reporter fakes them with doors). New **Sashes** dropdown on swing windows: *Double* (default — byte-identical to today) or *Single* — one full-width sash with its swing arc, hinged at either jamb via the **Hinge** field (which now appears for single-sash windows, not just doors).

## #74 — window + external roller shutter in one gap
New **Shutter** field on windows (`shutterEntity`, cover-filtered): the roll curtain from #45 layers **over** the sash in the same wall gap, driven by its own entity with its own accent state. The window's `entity` keeps driving the sash — so an open window behind a shut shutter draws both truthfully (verified: leaves swung open under a full-height curtain). Fail-closed like every other entity binding: an `unavailable` shutter draws shut.

Implementation notes: the curtain body was extracted into a shared `rollCurtain()` used by both the roll-up opening and the shutter layer; `shutterAmount`/`shutterActive` are pure and mirror `resolveOpeningAmount`/`openingIsActive` semantics; shutter colors pass through #65's `cssColorOr`; `collectWatchedEntities` includes shutters so state changes re-render; the dev-harness opening emulator grows a position slider per shutter.

## Verification
`tsc` clean, **366/366 tests** (single/double glyph structure, hinge mirroring, shutter layering/independence, `shutterAmount`/`shutterActive` matrix incl. outage fail-closed, watched-entity coverage, form field visibility + patches). Harness: single-sash window renders one leaf + one arc; shutter at position 40 → `scaleY(0.6)` curtain; shutter to 0 → full curtain **while the open window's leaves stay swung underneath**.

## Backwards compatibility
No stored value reinterpreted; absent `sash`/`shutterEntity` render exactly as today.

Closes #73. Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)