### PR TITLE
Items: attribute display + threshold label colors — closes #70, #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ By default it shows an icon badge:
   default); **Show name** adds the device's name — handy for a panel of look-alike
   buttons where a state would say nothing. Both together read `Name · state`, and
   **Label size** adjusts the line's font size.
+- **Attributes, not just states** — set **Attribute** to show an attribute instead
+  of the state (a climate's `current_temperature` rather than "heat"), and
+  **2nd attribute** for a second reading from the same device — so one climate
+  entity renders `21.5 °C · 45%`. Formatted by HA's own attribute formatter.
+- **Threshold colors** — `stateColor` (YAML) colors the label by value:
+
+  ```yaml
+  stateColor:
+    - above: 26
+      color: red
+    - above: 24
+      color: orange
+    - color: white   # default
+  ```
+
+  The highest matching `above` wins; non-numeric values use the default rule.
+  Colors go through the same injection allowlist as every other config color.
 - **No entity? Still on the map** — a device with no entity bound renders as a plain
   badge (its icon override or kind default), so hardware that has no Home Assistant
   entity — a dumb smoke detector, a wired doorbell — can still be marked on the plan.
@@ -418,6 +435,9 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `id`          | string                                 | —            | Unique id.                                             |
 | `entity`      | string                                 | —            | Entity id to bind. Optional: without one the device renders as a static badge. |
 | `secondaryEntity` | string                             | —            | Optional 2nd entity shown alongside (e.g. humidity).   |
+| `attribute`   | string                                 | —            | Show this attribute of `entity` instead of its state (e.g. `current_temperature`). |
+| `secondaryAttribute` | string                          | —            | Attribute for the 2nd reading — from `secondaryEntity`, or from `entity` when none. |
+| `stateColor`  | rule[]                                 | —            | Threshold colors for the label: `[{above: 26, color: red}, {color: white}]`. Highest matching `above` wins. |
 | `x`, `y`      | number                                 | —            | Position.                                              |
 | `kind`        | light/switch/sensor/binary_sensor/climate/cover/generic | inferred | Used for the default icon.            |
 | `icon`        | string                                 | entity icon  | Override mdi icon.                                     |

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -72,7 +72,12 @@ export function normalizeFormPatch(
   for (const field of fields) {
     if (!(field.name in patch)) continue;
     let v = patch[field.name];
-    if ("text" in field.selector || "icon" in field.selector || "entity" in field.selector) {
+    if (
+      "text" in field.selector ||
+      "icon" in field.selector ||
+      "entity" in field.selector ||
+      "attribute" in field.selector
+    ) {
       if (v === "" || v == null) v = field.required ? "" : undefined;
     } else if ("number" in field.selector) {
       const n = typeof v === "string" && v !== "" ? Number(v) : (v as number | undefined);
@@ -263,10 +268,22 @@ export function itemForm(it: FloorItem): FormSpec {
   const fields: FormField[] = [
     { name: "entity", label: "Entity", required: true, selector: { entity: {} } },
     {
+      name: "attribute",
+      label: "Attribute",
+      helper: "Show this attribute instead of the state (e.g. current_temperature)",
+      selector: { attribute: { entity_id: it.entity } },
+    },
+    {
       name: "secondaryEntity",
       label: "Second entity",
       helper: "Shown next to the primary state",
       selector: { entity: {} },
+    },
+    {
+      name: "secondaryAttribute",
+      label: "2nd attribute",
+      helper: "From the second entity, or this entity if none",
+      selector: { attribute: { entity_id: it.secondaryEntity || it.entity } },
     },
     { name: "icon", label: "Icon", selector: { icon: { placeholder: defaultIcon(it.kind) } } },
     { name: "name", label: "Name", selector: { text: {} } },
@@ -340,6 +357,8 @@ export function itemForm(it: FloorItem): FormSpec {
     data: {
       entity: it.entity,
       secondaryEntity: it.secondaryEntity ?? "",
+      attribute: it.attribute ?? "",
+      secondaryAttribute: it.secondaryAttribute ?? "",
       icon: it.icon ?? "",
       name: it.name ?? "",
       size: it.size ?? DEFAULT_ITEM_SIZE,

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, svg, nothing, type TemplateResult, type Property
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
-import { cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber } from "./css-safe";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -25,6 +25,7 @@ import {
   trackerSensorReading,
   entityIsActive,
   itemBadgeLabel,
+  resolveStateColor,
   itemLabelSize,
   hassRenderInputsChanged,
   collectWatchedEntities,
@@ -205,6 +206,13 @@ export class FloorplanCard extends LitElement {
     // Name/state composition lives in itemBadgeLabel, including #39's
     // no-entity guard (an unbound device gets no state line).
     const labelText = itemBadgeLabel(this.hass, item);
+    // Threshold color (issue #68), judged on the displayed value (attribute
+    // when set, else the state). cssColor gates the config string (#64).
+    const st = item.entity ? this.hass?.states[item.entity] : undefined;
+    const rawValue = item.attribute
+      ? (st?.attributes as Record<string, unknown> | undefined)?.[item.attribute]
+      : st?.state;
+    const labelColor = cssColor(resolveStateColor(item.stateColor, rawValue));
     const showIcon = item.showIcon ?? true;
     const display = item.display ?? "badge";
     const rippleColor = item.rippleColor ?? "var(--primary-color, #03a9f4)";
@@ -244,7 +252,9 @@ export class FloorplanCard extends LitElement {
         ${labelText
           ? html`<span
               class="label ${visual === nothing ? "inflow" : ""}"
-              style="font-size:${itemLabelSize(item.labelSize)}px;"
+              style="font-size:${itemLabelSize(item.labelSize)}px;${labelColor
+                ? `color:${labelColor};`
+                : ""}"
               >${labelText}</span
             >`
           : nothing}

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -24,6 +24,7 @@ import {
   entityStateText,
   itemStateText,
   itemBadgeLabel,
+  resolveStateColor,
   itemLabelSize,
   hassRenderInputsChanged,
   collectWatchedEntities,
@@ -1006,5 +1007,91 @@ describe("plan rotation (issue #33)", () => {
       }
     }
     expect(planRotationTransform(W, H, 0)).toBe("");
+  });
+});
+
+describe("itemStateText with attributes (issue #70)", () => {
+  const climate = () => {
+    const h = livingArea();
+    (h.states as Record<string, unknown>)["climate.home"] = {
+      entity_id: "climate.home",
+      state: "heat",
+      attributes: { current_temperature: 21.5, current_humidity: 45 },
+    };
+    return h;
+  };
+
+  it("attribute replaces the state as the primary reading", () => {
+    expect(itemStateText(climate(), { entity: "climate.home", attribute: "current_temperature" }))
+      .toBe("21.5");
+  });
+
+  it("secondaryAttribute without a second entity reads the same entity", () => {
+    expect(
+      itemStateText(climate(), {
+        entity: "climate.home",
+        attribute: "current_temperature",
+        secondaryAttribute: "current_humidity",
+      }),
+    ).toBe("21.5 · 45");
+  });
+
+  it("secondaryAttribute applies to secondaryEntity when both are set", () => {
+    expect(
+      itemStateText(climate(), {
+        entity: "climate.home",
+        secondaryEntity: TEMP,
+        secondaryAttribute: "unit_of_measurement",
+      }),
+    ).toBe("heat · °C");
+  });
+
+  it("uses HA's attribute formatter when the frontend provides it", () => {
+    const h = climate() as unknown as Record<string, unknown>;
+    h.formatEntityAttributeValue = (_s: unknown, a: string) => `fmt:${a}`;
+    expect(
+      itemStateText(h as never, { entity: "climate.home", attribute: "current_temperature" }),
+    ).toBe("fmt:current_temperature");
+  });
+
+  it("missing attribute renders the em dash", () => {
+    expect(itemStateText(climate(), { entity: "climate.home", attribute: "nope" })).toBe("—");
+  });
+});
+
+describe("resolveStateColor (issue #68)", () => {
+  const rules = [
+    { above: 26, color: "red" },
+    { above: 24, color: "orange" },
+    { color: "white" },
+  ];
+
+  it("highest matching threshold wins", () => {
+    expect(resolveStateColor(rules, "27.1")).toBe("red");
+    expect(resolveStateColor(rules, 25)).toBe("orange");
+    expect(resolveStateColor(rules, "20")).toBe("white");
+  });
+
+  it("boundary is strict: exactly the threshold falls through", () => {
+    expect(resolveStateColor(rules, 26)).toBe("orange");
+    expect(resolveStateColor(rules, 24)).toBe("white");
+  });
+
+  it("non-numeric values only match the default rule", () => {
+    expect(resolveStateColor(rules, "heat")).toBe("white");
+    expect(resolveStateColor(rules, undefined)).toBe("white");
+    expect(resolveStateColor([{ above: 24, color: "orange" }], "heat")).toBeUndefined();
+  });
+
+  it("rule order doesn't matter; malformed rules are skipped", () => {
+    expect(resolveStateColor([...rules].reverse(), 30)).toBe("red");
+    expect(
+      resolveStateColor([null, { above: "x" }, { above: 24, color: "orange" }] as never, 25),
+    ).toBe("orange");
+  });
+
+  it("no rules, no color", () => {
+    expect(resolveStateColor(undefined, 30)).toBeUndefined();
+    expect(resolveStateColor([], 30)).toBeUndefined();
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -5,6 +5,7 @@ import type {
   Opening,
   ItemKind,
   IconAnimation,
+  StateColorRule,
   Furniture,
   Tracker,
   RenderHass,
@@ -74,14 +75,79 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
   return ids;
 }
 
-/** State text for an item: primary entity, plus secondary (e.g. humidity) when set. */
+/**
+ * An entity attribute's value as HA would render it, or "—" when there is
+ * none (issue #70). Uses HA's `formatEntityAttributeValue` when the running
+ * frontend provides it (2023.9+); otherwise the raw value, stringified.
+ */
+export function entityAttributeText(
+  hass: RenderHass | undefined,
+  entityId: string | undefined,
+  attribute: string,
+): string {
+  if (!entityId || !hass) return NO_STATE;
+  const stateObj = hass.states[entityId];
+  if (!stateObj) return NO_STATE;
+  const fmt = (hass as { formatEntityAttributeValue?: (s: unknown, a: string) => string })
+    .formatEntityAttributeValue;
+  if (typeof fmt === "function") return fmt(stateObj, attribute);
+  const raw = (stateObj.attributes as Record<string, unknown>)?.[attribute];
+  return raw === undefined || raw === null || raw === "" ? NO_STATE : String(raw);
+}
+
+/**
+ * State text for an item: primary reading (state, or `attribute` of the
+ * entity — issue #70), plus a secondary one when configured. The secondary
+ * reading comes from `secondaryEntity` when set, else from the same entity —
+ * so one climate device can show `21.5 °C · 45%` from two attributes.
+ */
 export function itemStateText(
   hass: RenderHass | undefined,
-  item: { entity: string; secondaryEntity?: string },
+  item: {
+    entity: string;
+    attribute?: string;
+    secondaryEntity?: string;
+    secondaryAttribute?: string;
+  },
 ): string {
-  const primary = entityStateText(hass, item.entity);
-  if (!item.secondaryEntity) return primary;
-  return `${primary} · ${entityStateText(hass, item.secondaryEntity)}`;
+  const primary = item.attribute
+    ? entityAttributeText(hass, item.entity, item.attribute)
+    : entityStateText(hass, item.entity);
+  const secondaryEntity = item.secondaryEntity ?? (item.secondaryAttribute ? item.entity : undefined);
+  if (!secondaryEntity) return primary;
+  const secondary = item.secondaryAttribute
+    ? entityAttributeText(hass, secondaryEntity, item.secondaryAttribute)
+    : entityStateText(hass, secondaryEntity);
+  return `${primary} · ${secondary}`;
+}
+
+/**
+ * The threshold color for a value (issue #68), or undefined for "use the
+ * theme default". Highest matching `above` wins; a rule without `above` is
+ * the default. Non-numeric values (a climate saying "heat") only ever match
+ * the default rule. The returned color is config-supplied — callers MUST
+ * pass it through cssColor/cssColorOr before it reaches a style attribute.
+ */
+export function resolveStateColor(
+  rules: readonly StateColorRule[] | undefined,
+  raw: unknown,
+): string | undefined {
+  if (!rules?.length) return undefined;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  const numeric = typeof raw !== "boolean" && raw !== "" && raw != null && Number.isFinite(n);
+  let best: StateColorRule | undefined;
+  let fallback: string | undefined;
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object" || typeof rule.color !== "string") continue;
+    if (typeof rule.above === "number") {
+      if (numeric && n > rule.above && (!best || rule.above > (best.above ?? -Infinity))) {
+        best = rule;
+      }
+    } else if (fallback === undefined) {
+      fallback = rule.color;
+    }
+  }
+  return best?.color ?? fallback;
 }
 
 /** Default label font size (px) for an item's name/state line. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,35 @@ export interface FloorItem {
    * same element. The primary `entity` drives on/off state and click actions.
    */
   secondaryEntity?: string;
+  /**
+   * Show this attribute of `entity` instead of its state (issue #70) — e.g. a
+   * climate's `current_temperature` rather than "heat". Formatted through
+   * HA's own attribute formatter when available.
+   */
+  attribute?: string;
+  /**
+   * Attribute for the second reading. Applies to `secondaryEntity` when set,
+   * else to `entity` — so one climate device can show
+   * `current_temperature · current_humidity` without a second entity.
+   */
+  secondaryAttribute?: string;
+  /**
+   * Threshold colors for the label line (issue #68), highest matching `above`
+   * wins; an entry without `above` is the default. Evaluated against the
+   * displayed value (the attribute when `attribute` is set, else the state):
+   *
+   * ```yaml
+   * stateColor:
+   *   - above: 26
+   *     color: red
+   *   - above: 24
+   *     color: orange
+   *   - color: white
+   * ```
+   *
+   * Colors pass through the style-injection allowlist (#64) at render time.
+   */
+  stateColor?: StateColorRule[];
   x: number;
   y: number;
   kind: ItemKind;
@@ -172,6 +201,13 @@ export interface FloorItem {
 }
 
 export type ItemDisplay = "badge" | "ripple" | "iconRipple";
+
+/** One threshold rule for {@link FloorItem.stateColor}. */
+export interface StateColorRule {
+  /** Applies when the numeric value is strictly greater. Omit for the default rule. */
+  above?: number;
+  color: string;
+}
 
 export type IconAnimation = "auto" | "none" | "spin" | "pulse";
 


### PR DESCRIPTION
Both halves of "richer state display" in one PR — what the label shows (#70) and how it looks (#68).

## #70 — attributes, not just states
- **`attribute`**: show an attribute of the entity instead of its state — a climate renders `21.5` (current_temperature) instead of "heat".
- **`secondaryAttribute`**: a second reading, from `secondaryEntity` when set, else **from the same entity** — so one climate device shows `21.5 · 45` with zero extra entities. This generalizes the existing temperature+humidity pairing.
- Formatting goes through HA's own `formatEntityAttributeValue` when the frontend provides it (2023.9+), falling back to the raw value; missing attributes render the em dash like missing states always have.
- Editor: **Attribute** / **2nd attribute** fields using HA's attribute selector (scoped to the bound entity), degrading to plain inputs in the dev harness.

## #68 — threshold colors for the label
New `stateColor` rule list, exactly the shape the reporter proposed:

```yaml
stateColor:
  - above: 26
    color: red
  - above: 24
    color: orange
  - color: white   # default
```

Highest matching `above` wins (strict comparison; order-independent); a rule without `above` is the default; non-numeric values (a climate saying "heat") only ever match the default. Judged on the **displayed** value — the attribute when `attribute` is set, else the state. YAML-only for now: a rule-list form editor is a real UI project, noted as follow-up.

**Security**: rule colors are config strings landing in a `style` attribute — the exact surface #64/#65 closed — so they pass through `cssColor` at the sink. Verified: a rule with `color: "red;position:fixed"` produces *no* color styling at all.

## Verification
`tsc` clean, **361/361 tests** (attribute matrix incl. same-entity secondary and HA-formatter passthrough; `resolveStateColor` thresholds/boundaries/non-numeric/malformed-rule cases). Harness: one climate entity renders `21.5 · 45`; a temperature sensor's label steps white → orange → red as the live state crosses 24 and 26; the hostile rule color is rejected entirely.

## Backwards compatibility
All three fields absent = today's rendering exactly.

Closes #70. Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)