### PR TITLE
Floors: default-floor picker, switcher accents, short labels — issue #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,10 +376,16 @@ for backward compatibility.
 
 ### Floor
 
-`{ id, name, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture }`
+`{ id, name, short?, color?, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture }`
 — a named floor with its own elements. Use the **floor** controls in the editor toolbar
 to add, rename, switch and delete floors; the live card shows a floor switcher in the
 top-right when there is more than one.
+
+The floor gear popover also sets (issue #67): **Short** — an abbreviation shown on the
+card's switcher button (`GF`, `1st`…) while the full name stays as its tooltip;
+**Color** — an accent for that button while its floor is active (goes through the
+config-color allowlist); and **Default** — which floor the live card opens on
+(stored as the top-level `defaultFloor`).
 
 **`haFloor`** optionally stores the id of a linked Home Assistant floor (set from the
 editor's floor gear popover). Today the link auto-names the floor; it is kept in the

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2041,6 +2041,55 @@ export class FloorplanCardEditor extends LitElement {
                         this._renameFloor(this._activeFloorId, (e.target as HTMLInputElement).value)}
                     />
                   </div>
+                  <!-- Issue #67: switcher-button label, per-floor accent, and
+                       which floor the live card opens on. -->
+                  <div class="pop-row">
+                    <label>Short</label>
+                    <input
+                      type="text"
+                      maxlength="8"
+                      placeholder="e.g. GF"
+                      title="Short label for the card's floor-switcher button"
+                      .value=${floor?.short ?? ""}
+                      @change=${(e: Event) =>
+                        this._commitFloor({
+                          short: (e.target as HTMLInputElement).value.trim() || undefined,
+                        })}
+                    />
+                  </div>
+                  <div class="pop-row">
+                    <label>Color</label>
+                    <input
+                      type="color"
+                      title="Accent for this floor's switcher button while active"
+                      .value=${floor?.color ?? "#03a9f4"}
+                      @input=${(e: Event) =>
+                        this._commitFloor({ color: (e.target as HTMLInputElement).value })}
+                    />
+                    <button
+                      aria-label="Clear floor color"
+                      title="Back to the theme color"
+                      ?disabled=${!floor?.color}
+                      @click=${() => this._commitFloor({ color: undefined })}
+                    >
+                      <ha-icon icon="mdi:water-off-outline"></ha-icon>
+                    </button>
+                  </div>
+                  <div class="pop-row">
+                    <label>Default</label>
+                    <input
+                      type="checkbox"
+                      title="Open the live card on this floor"
+                      .checked=${this._config.defaultFloor === this._activeFloorId}
+                      @change=${(e: Event) =>
+                        this._commit({
+                          ...this._config,
+                          defaultFloor: (e.target as HTMLInputElement).checked
+                            ? this._activeFloorId
+                            : undefined,
+                        })}
+                    />
+                  </div>
                   <button
                     class="danger pop-action"
                     ?disabled=${floors.length <= 1}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, svg, nothing, type TemplateResult, type Property
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
-import { cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber } from "./css-safe";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -381,19 +381,24 @@ export class FloorplanCard extends LitElement {
   private _renderFloorSwitcher(floors: Floor[], active: Floor): TemplateResult {
     return html`
       <div class="floor-switcher">
-        ${floors.map(
-          (f) => html`
+        ${floors.map((f) => {
+          // Per-floor accent (issue #67): applied only while active so the
+          // resting buttons stay theme-neutral. cssColor gates the config
+          // string; no custom color falls back to the theme primary.
+          const accent = f.id === active.id ? cssColor(f.color) : undefined;
+          return html`
             <button
               class=${f.id === active.id ? "active" : ""}
               title=${f.name}
+              style=${accent ? `background:${accent};border-color:${accent};` : nothing}
               @click=${() => {
                 this._activeFloorId = f.id;
               }}
             >
-              ${f.name}
+              ${f.short || f.name}
             </button>
-          `
-        )}
+          `;
+        })}
       </div>
     `;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -382,6 +382,17 @@ export interface Floor {
    */
   haFloor?: string;
   /**
+   * Short label for the card's floor-switcher button (issue #67), e.g. "GF" —
+   * the full `name` stays as the tooltip. Falls back to `name`.
+   */
+  short?: string;
+  /**
+   * Accent color for this floor's switcher button while active (issue #67).
+   * Passes through the style-injection allowlist (#64). Falls back to the
+   * theme primary color.
+   */
+  color?: string;
+  /**
    * Optional background image URL (e.g. `/local/floorplan.png` or an external
    * URL) drawn behind the elements — handy for tracing over a real floor plan.
    * It fills the virtual canvas, so match the canvas width/height to the image


### PR DESCRIPTION
Items **1, 3 and 4** of #67 (item 2 — reordering — is already open as #69). Three new rows in the floor gear popover:

- **Default** — a checkbox marking which floor the live card opens on. The `defaultFloor` config has existed since multi-floor landed and the card already honors it; it just never had UI. Checking a floor writes `defaultFloor: <id>`; unchecking clears it (back to first-floor behavior).
- **Color** — a per-floor accent applied to that floor's switcher button *while active* (resting buttons stay theme-neutral, so the switcher doesn't turn into a rainbow). Stored as `Floor.color`; passes through #64's `cssColor` at the sink — a hostile config color produces no styling at all (verified).
- **Short** — an abbreviation (`GF`, `2F`, max 8 chars) shown on the switcher button, exactly the reporter's title/abbreviation split: the button shows the short form, the full `name` stays as its tooltip. Empty = falls back to the name, unchanged from today.

## Verification
`tsc` clean, **351/351 tests**, build clean. Harness round-trip: setting Short/Color/Default through the gear rows lands `short: "2F"`, `color: "#9c27b0"`, `defaultFloor: "f2"` in the config; a **fresh card** opens on floor 2, its button reads "2F" with tooltip "Upstairs" and computed background `rgb(156, 39, 176)`; swapping in `color: "red;position:fixed"` renders no style attribute.

## Notes
- Expect a **small merge conflict with #69** — both add rows to the same gear popover. Whichever lands second, I'll resolve (adjacent-line union).
- No schema break: all fields optional; absent = today's rendering.

Addresses #67 (with #69 covering its item 2 — between the two, the issue can close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)