### PR TITLE
Add "area" concept to define areas/rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ device into one.
      once **Filter entities** is on (below) it also turns on entity filtering (next point).
    - **Filter entities** — shown once an HA area is linked; a plain checkbox, on by
      default. Turn it off to keep the name link without narrowing the entity picker.
+   - **Add all devices in this HA area** — shown once an HA area is linked; one click
+     drops a device for every entity registered to that HA area that isn't already
+     placed on this floor, laid out across the room so the new icons spread out instead
+     of stacking on top of each other. The button shows how many are pending and
+     disables itself once there's nothing left to add; click it again later (after
+     adding entities in Home Assistant) to top up.
 
 **Reshaping.** Drag anywhere inside the fill to move the whole room; drag a single corner
 handle to reshape it (each handle snaps the same way a freshly placed point does). There's

--- a/README.md
+++ b/README.md
@@ -315,8 +315,10 @@ device into one.
    - **Fill opacity** and a **color** picker — the translucent fill that makes the room
      stand out (falls back to the theme primary color).
    - **HA area** — link the polygon to one of your Home Assistant areas. Linking names
-     the polygon after it (rename afterwards if you like; the link sticks either way) and
-     turns on entity filtering (next point).
+     the polygon after it (rename afterwards if you like; the link sticks either way) —
+     once **Filter entities** is on (below) it also turns on entity filtering (next point).
+   - **Filter entities** — shown once an HA area is linked; a plain checkbox, on by
+     default. Turn it off to keep the name link without narrowing the entity picker.
 
 **Reshaping.** Drag anywhere inside the fill to move the whole room; drag a single corner
 handle to reshape it (each handle snaps the same way a freshly placed point does). There's
@@ -325,11 +327,12 @@ area's or a wall's corner doesn't drag together with it, only *snaps* there when
 or move it.
 
 **Entity filtering.** Drop a **device** (via **+ Add**) inside an area linked to an HA
-area, and that device's entity picker narrows to entities registered to that HA area —
-so you're not scrolling past your whole house to find the right light. The picker widens
-back up the moment you drag the device outside the polygon. Overlapping areas resolve by
-draw order: whichever area was drawn last wins for both the fill you see on top and which
-one a device is considered "inside".
+area (with **Filter entities** on), and that device's entity picker narrows to entities
+registered to that HA area — so you're not scrolling past your whole house to find the
+right light. The picker widens back up the moment you drag the device outside the polygon,
+or if you flip **Filter entities** off. Overlapping areas resolve by draw order: whichever
+area was drawn last wins for both the fill you see on top and which one a device is
+considered "inside".
 
 ```yaml
 areas:
@@ -597,7 +600,7 @@ trackers:
 
 ### Area
 
-`{ id, points, name?, showName?, color?, opacity?, haArea? }`
+`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities? }`
 
 - `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
   is implicitly closed from the last point back to the first.
@@ -606,8 +609,10 @@ trackers:
 - `color` / `opacity` — the room's fill; `color` falls back to the theme primary color,
   `opacity` defaults to `0.25`.
 - `haArea` — optional id of a linked Home Assistant area. Selecting one in the editor
-  names the polygon after it and scopes the entity picker, for any device placed inside
-  it, to that HA area's entities — see **Areas**.
+  names the polygon after it — see **Areas**.
+- `filterEntities` — with `haArea` set, scopes the entity picker (for any device placed
+  inside this polygon) to that HA area's entities. Default `true`; has no effect without
+  a linked `haArea`.
 
 ```yaml
 areas:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ automatically to the card and screen size.
   wardrobe, rug, plant, fridge, stove, sink, toilet, stairs, tv, washer, dryer,
   dishwasher, water heater, air handler, bathtub, vanity, sectional, fish tank,
   piano, hot tub.
+- **Areas** — trace a room's outline point-by-point (points snap to wall corners and to
+  neighboring areas' corners) to get a colored, named room polygon. Link an area to a
+  Home Assistant area to name it automatically and scope the entity picker, for any
+  device dropped inside it, to that HA area's entities.
 - **Live position tracker** — draw a rectangular tracked area and bind one or two
   orthogonal distance sensors (e.g. mmWave / radar). The card linearly maps each
   sensor's `[min, max]` reading to the rectangle's edges and animates a pulsating
@@ -114,6 +118,11 @@ background):
   sensors (X axis and/or Y axis) in the **Element** section to animate a live position
   marker inside the zone — see **Tracker**. The zone outline is visible only in the
   editor; the live card shows just the marker.
+- **Area** — click to place each corner of a room outline; points snap onto nearby wall
+  corners or another area's corners, and clicking back on the starting point closes the
+  shape (3+ points required; Backspace removes the last point while drawing, Escape
+  discards the whole outline). Once placed, drag anywhere inside the fill to move the
+  whole room, or drag a corner handle to reshape it — see **Areas**.
 - **+ Add** — one popover for everything droppable: device, text, and all furniture
   types shown as their actual glyphs (pick a sofa by seeing a sofa). The new element is
   selected immediately so the **Element** section is ready for configuring it.
@@ -140,8 +149,8 @@ rotation.
 
 Everything you place on the plan is an **element** you can select, move (freely or
 snapped to a grid), nudge with arrow keys, copy/paste, duplicate and delete. The element
-types are **devices**, **doors & windows**, **furniture**, **text** and **trackers** —
-and each floor holds its own set of them.
+types are **devices**, **doors & windows**, **furniture**, **text**, **areas** and
+**trackers** — and each floor holds its own set of them.
 
 ### Devices
 
@@ -288,6 +297,54 @@ openings:
 
 <img width="540" height="304" alt="door_window_demo" src="https://github.com/user-attachments/assets/091b3c89-5202-4025-8a0f-0fe867276be2" />
 
+### Areas
+
+An **area** is a colored, named room polygon you trace on top of your walls — handy for
+telling rooms apart at a glance, and for scoping which entities show up when you drop a
+device into one.
+
+1. Pick the **Area** tool from the toolbar.
+2. Click to place each corner of the room. Points snap onto nearby wall corners — and
+   onto other areas' corners, so adjoining rooms can share an exact boundary point.
+3. Once you've placed at least 3 points, click back on the **first** point to close the
+   shape. **Backspace** removes the last point while you're still drawing; **Escape**
+   discards the whole outline.
+4. With the area selected, the **Element** section offers:
+   - **Name** and **Show name** — a label centered on the room; toggle it off if you'd
+     rather keep the plan uncluttered.
+   - **Fill opacity** and a **color** picker — the translucent fill that makes the room
+     stand out (falls back to the theme primary color).
+   - **HA area** — link the polygon to one of your Home Assistant areas. Linking names
+     the polygon after it (rename afterwards if you like; the link sticks either way) and
+     turns on entity filtering (next point).
+
+**Reshaping.** Drag anywhere inside the fill to move the whole room; drag a single corner
+handle to reshape it (each handle snaps the same way a freshly placed point does). There's
+no cross-room "shared corner" dragging — a corner that happens to coincide with another
+area's or a wall's corner doesn't drag together with it, only *snaps* there when you place
+or move it.
+
+**Entity filtering.** Drop a **device** (via **+ Add**) inside an area linked to an HA
+area, and that device's entity picker narrows to entities registered to that HA area —
+so you're not scrolling past your whole house to find the right light. The picker widens
+back up the moment you drag the device outside the polygon. Overlapping areas resolve by
+draw order: whichever area was drawn last wins for both the fill you see on top and which
+one a device is considered "inside".
+
+```yaml
+areas:
+  - id: living_room
+    name: Living Room
+    haArea: living_room
+    color: "#26c6da"
+    opacity: 0.15
+    points:
+      - { x: 100, y: 100 }
+      - { x: 900, y: 100 }
+      - { x: 900, y: 500 }
+      - { x: 100, y: 500 }
+```
+
 ### Live position trackers
 
 A **tracker** turns one or two distance sensors into a live marker that moves around
@@ -397,14 +454,16 @@ The editor writes this config for you; manual editing is optional.
 | `items`      | Item[]   | `[]`               | Entity devices.                              |
 | `texts`      | Text[]   | `[]`               | Free text labels.                            |
 | `furniture`  | Furniture[]| `[]`             | Gray furniture/fixture diagrams.             |
+| `trackers`   | Tracker[]| `[]`               | Live position trackers (see **Tracker**).    |
+| `areas`      | Area[]   | `[]`               | Named room polygons (see **Area**).          |
 
-When `floors` is present each floor carries its own `walls`, `openings`, `items`, `texts`
-and `furniture`. The top-level arrays describe a single implicit floor and remain valid
-for backward compatibility.
+When `floors` is present each floor carries its own `walls`, `openings`, `items`, `texts`,
+`furniture`, `trackers` and `areas`. The top-level arrays describe a single implicit floor
+and remain valid for backward compatibility.
 
 ### Floor
 
-`{ id, name, short?, color?, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture }`
+`{ id, name, short?, color?, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture, trackers, areas }`
 — a named floor with its own elements. Use the **floor** controls in the editor toolbar
 to add, rename, switch and delete floors; the live card shows a floor switcher in the
 top-right when there is more than one.
@@ -417,7 +476,8 @@ config-color allowlist); and **Default** — which floor the live card opens on
 
 **`haFloor`** optionally stores the id of a linked Home Assistant floor (set from the
 editor's floor gear popover). Today the link auto-names the floor; it is kept in the
-config so future features (like area-based entity filtering) can build on it.
+config so other features (like the per-**Area** HA-area entity filtering above) can build
+on the same idea one level down.
 
 Set **`image`** to a background image URL (e.g. `/local/floorplan.png` or an external
 URL) to draw it behind the elements — handy for tracing over a real floor plan. It fills
@@ -535,6 +595,34 @@ trackers:
       presence: { entity: binary_sensor.radar_occupancy }
 ```
 
+### Area
+
+`{ id, points, name?, showName?, color?, opacity?, haArea? }`
+
+- `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
+  is implicitly closed from the last point back to the first.
+- `name` — display label, shown centered on the polygon when `showName` (default `true`)
+  is on. Mirrors the linked HA area's name when `haArea` is set.
+- `color` / `opacity` — the room's fill; `color` falls back to the theme primary color,
+  `opacity` defaults to `0.25`.
+- `haArea` — optional id of a linked Home Assistant area. Selecting one in the editor
+  names the polygon after it and scopes the entity picker, for any device placed inside
+  it, to that HA area's entities — see **Areas**.
+
+```yaml
+areas:
+  - id: living_room
+    name: Living Room
+    haArea: living_room
+    color: "#26c6da"
+    opacity: 0.15
+    points:
+      - { x: 100, y: 100 }
+      - { x: 900, y: 100 }
+      - { x: 900, y: 500 }
+      - { x: 100, y: 500 }
+```
+
 ### Example
 
 ```yaml
@@ -580,6 +668,17 @@ furniture:
   - { id: f1, type: sofa, x: 250, y: 420, w: 170, h: 72, angle: 0 }
 texts:
   - { id: t1, x: 500, y: 60, text: Living Room, size: 22 }
+areas:
+  - id: a1
+    name: Living Room
+    haArea: living_room
+    color: "#26c6da"
+    opacity: 0.15
+    points:
+      - { x: 100, y: 100 }
+      - { x: 900, y: 100 }
+      - { x: 900, y: 500 }
+      - { x: 100, y: 500 }
 trackers:
   - id: pet
     x: 120

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -273,7 +273,7 @@ const bgImage =
 // Start with a blank floor so you can draw a perimeter from scratch. Flip
 // START_WITH_DEMO to true to instead load a sample room (walls + door + window
 // over the background image) — handy for testing rendering of existing plans.
-const START_WITH_DEMO = true;
+const START_WITH_DEMO = false;
 
 const demoFloor = {
   id: "f1",

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -119,10 +119,31 @@ import "../src/index";
 const SENSOR_TEMPERATURE = "sensor.living_area_temperature";
 const SENSOR_HUMIDITY = "sensor.living_area_humidity";
 
-/** Stand-in for HA's entity registry — the only place display precision lives. */
-const entityRegistry: Record<string, { entity_id: string; display_precision?: number }> = {
+/**
+ * Stand-in for HA's entity registry — display precision, plus (for the Area
+ * ⇄ HA-area device filtering feature) each entity's `device_id`. Paired with
+ * `deviceRegistry` below so `light.living_room` resolves to the "Living Room"
+ * HA area and `fan.ceiling_fan` resolves to no area at all, giving the demo
+ * both a filtered and an unfiltered case to compare in the editor.
+ */
+const entityRegistry: Record<
+  string,
+  { entity_id: string; display_precision?: number; device_id?: string }
+> = {
   [SENSOR_TEMPERATURE]: { entity_id: SENSOR_TEMPERATURE, display_precision: 1 },
   [SENSOR_HUMIDITY]: { entity_id: SENSOR_HUMIDITY, display_precision: 1 },
+  "light.living_room": { entity_id: "light.living_room", device_id: "dev_living_light" },
+  "fan.ceiling_fan": { entity_id: "fan.ceiling_fan" },
+};
+
+/** Stand-in for HA's device registry — just enough for area resolution. */
+const deviceRegistry: Record<string, { area_id?: string }> = {
+  dev_living_light: { area_id: "living_room" },
+};
+
+/** Stand-in for HA's area registry (Area ⇄ HA-area linking). */
+const areaRegistry: Record<string, { area_id: string; name: string }> = {
+  living_room: { area_id: "living_room", name: "Living Room" },
 };
 
 /** Approximates HA's own formatter: registry precision, then HA's unit spacing. */
@@ -212,6 +233,7 @@ const hass = {
     },
   },
   entities: entityRegistry,
+  devices: deviceRegistry,
   locale: { language: "en" },
   themes: { darkMode: false },
   // HA floor registry mock so the editor's "HA floor" link (issue #24) is
@@ -221,6 +243,10 @@ const hass = {
     upstairs: { floor_id: "upstairs", name: "Upstairs", level: 1 },
     basement: { floor_id: "basement", name: "Basement", level: -1 },
   },
+  // HA area registry mock so the editor's "HA area" link (Area feature) is
+  // exercisable outside HA. `light.living_room` and `fan.ceiling_fan` are the
+  // two devices to try dragging in/out of the demo room's Area polygon.
+  areas: areaRegistry,
   callService: (...args: unknown[]) => console.log("[mock hass] callService", ...args),
   formatEntityState: mockFormatEntityState,
   localize: (k: string) => k,
@@ -247,7 +273,7 @@ const bgImage =
 // Start with a blank floor so you can draw a perimeter from scratch. Flip
 // START_WITH_DEMO to true to instead load a sample room (walls + door + window
 // over the background image) — handy for testing rendering of existing plans.
-const START_WITH_DEMO = false;
+const START_WITH_DEMO = true;
 
 const demoFloor = {
   id: "f1",
@@ -287,10 +313,33 @@ const demoFloor = {
       y: 300,
       kind: "sensor" as const,
     },
+    // Sits inside the "Living Room" Area below, whose linked HA area (via
+    // deviceRegistry/areaRegistry) scopes its entity picker — drag it outside
+    // the polygon to watch the picker widen back up.
+    { id: "i2", entity: "light.living_room", x: 220, y: 180, kind: "light" as const },
   ],
   texts: [],
   furniture: [],
   trackers: [],
+  // Area demo: the whole room, linked to the mock "living_room" HA area so
+  // the entity-filtering behavior (light.living_room in, fan.ceiling_fan out)
+  // is exercisable without a real Home Assistant instance.
+  areas: [
+    {
+      id: "a1",
+      name: "Living Room",
+      haArea: "living_room",
+      showName: true,
+      color: "#26c6da",
+      opacity: 0.15,
+      points: [
+        { x: 100, y: 100 },
+        { x: 900, y: 100 },
+        { x: 900, y: 500 },
+        { x: 100, y: 500 },
+      ],
+    },
+  ],
 };
 
 const emptyFloor = {
@@ -302,6 +351,7 @@ const emptyFloor = {
   texts: [],
   furniture: [],
   trackers: [],
+  areas: [],
 };
 
 const config: FloorplanCardConfig = {

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -122,9 +122,12 @@ const SENSOR_HUMIDITY = "sensor.living_area_humidity";
 /**
  * Stand-in for HA's entity registry — display precision, plus (for the Area
  * ⇄ HA-area device filtering feature) each entity's `device_id`. Paired with
- * `deviceRegistry` below so `light.living_room` resolves to the "Living Room"
- * HA area and `fan.ceiling_fan` resolves to no area at all, giving the demo
- * both a filtered and an unfiltered case to compare in the editor.
+ * `deviceRegistry` below so `light.living_room` and `media_player.living_tv`
+ * resolve to the "Living Room" HA area (the former is already placed on the
+ * demo floor, the latter isn't — so the Area panel's "Add all devices in
+ * this HA area" button has something to add out of the box) while
+ * `fan.ceiling_fan` resolves to no area at all, for a filtered-vs-unfiltered
+ * comparison in the editor.
  */
 const entityRegistry: Record<
   string,
@@ -133,12 +136,14 @@ const entityRegistry: Record<
   [SENSOR_TEMPERATURE]: { entity_id: SENSOR_TEMPERATURE, display_precision: 1 },
   [SENSOR_HUMIDITY]: { entity_id: SENSOR_HUMIDITY, display_precision: 1 },
   "light.living_room": { entity_id: "light.living_room", device_id: "dev_living_light" },
+  "media_player.living_tv": { entity_id: "media_player.living_tv", device_id: "dev_living_tv" },
   "fan.ceiling_fan": { entity_id: "fan.ceiling_fan" },
 };
 
 /** Stand-in for HA's device registry — just enough for area resolution. */
 const deviceRegistry: Record<string, { area_id?: string }> = {
   dev_living_light: { area_id: "living_room" },
+  dev_living_tv: { area_id: "living_room" },
 };
 
 /** Stand-in for HA's area registry (Area ⇄ HA-area linking). */

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -12,9 +12,10 @@ import {
   projectForm,
   projectRotationForm,
   floorImageForm,
+  areaForm,
 } from "./editor-forms";
 import type { FormField } from "./editor-forms";
-import type { Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
+import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
 
 const fields: FormField[] = [
   { name: "name", label: "Name", selector: { text: {} } },
@@ -223,6 +224,47 @@ describe("itemForm", () => {
     expect(d.showState).toBe(false);
     expect(d.display).toBe("badge");
     expect(d.angle).toBe(0);
+  });
+
+  it("scopes the entity/secondaryEntity pickers to areaEntities when given", () => {
+    const unscoped = itemForm(item);
+    expect(unscoped.fields.find((x) => x.name === "entity")!.selector).toEqual({ entity: {} });
+    const scoped = itemForm(item, ["light.kitchen", "switch.kitchen"]);
+    expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({
+      entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
+    });
+    expect(scoped.fields.find((x) => x.name === "secondaryEntity")!.selector).toEqual({
+      entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
+    });
+  });
+});
+
+describe("areaForm", () => {
+  const area = (extra: Partial<Area> = {}): Area => ({
+    id: "a",
+    points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }],
+    ...extra,
+  });
+
+  it("data presents effective defaults (showName true, DEFAULT_AREA_OPACITY)", () => {
+    const d = areaForm(area()).data;
+    expect(d).toMatchObject({ name: "", showName: true, opacity: 0.25 });
+  });
+
+  it("data reflects an explicit name/showName/opacity", () => {
+    const d = areaForm(area({ name: "Kitchen", showName: false, opacity: 0.5 })).data;
+    expect(d).toMatchObject({ name: "Kitchen", showName: false, opacity: 0.5 });
+  });
+
+  it("opacity field is a 0..1 slider", () => {
+    const f = areaForm(area()).fields.find((x) => x.name === "opacity")!;
+    expect(f.selector).toEqual({ number: { min: 0, max: 1, step: 0.05, mode: "slider" } });
+  });
+
+  it("clamps an out-of-range opacity patch via normalizeFormPatch", () => {
+    const fields = areaForm(area()).fields;
+    expect(normalizeFormPatch({ opacity: 5 }, fields)).toEqual({ opacity: 1 });
+    expect(normalizeFormPatch({ opacity: -1 }, fields)).toEqual({ opacity: 0 });
   });
 });
 

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -6,6 +6,7 @@
  * effects (device-class inference, grid/snap rescale).
  */
 import type {
+  Area,
   Floor,
   FloorItem,
   FloorText,
@@ -17,6 +18,7 @@ import type {
   Wall,
 } from "./types";
 import {
+  DEFAULT_AREA_OPACITY,
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
   DEFAULT_RIPPLE_SIZE,
@@ -290,10 +292,19 @@ export function openingForm(o: Opening): FormSpec {
   };
 }
 
-export function itemForm(it: FloorItem): FormSpec {
+/**
+ * When `it` sits inside a Home Assistant area-linked {@link Area} on the
+ * plan, `areaEntities` narrows the `entity`/`secondaryEntity` pickers to
+ * that HA area's entities. `include_entities` on the entity selector is the
+ * assumed-but-unverified `<ha-form>` equivalent of `ha-entity-picker`'s own
+ * `.includeEntities` property — see areas.md decision #5.
+ */
+export function itemForm(it: FloorItem, areaEntities?: string[]): FormSpec {
   const display = it.display ?? "badge";
+  const entitySelector = (): Record<string, unknown> =>
+    areaEntities ? { entity: { include_entities: areaEntities } } : { entity: {} };
   const fields: FormField[] = [
-    { name: "entity", label: "Entity", required: true, selector: { entity: {} } },
+    { name: "entity", label: "Entity", required: true, selector: entitySelector() },
     {
       name: "attribute",
       label: "Attribute",
@@ -304,7 +315,7 @@ export function itemForm(it: FloorItem): FormSpec {
       name: "secondaryEntity",
       label: "Second entity",
       helper: "Shown next to the primary state",
-      selector: { entity: {} },
+      selector: entitySelector(),
     },
     {
       name: "secondaryAttribute",
@@ -480,6 +491,32 @@ export function trackerForm(tr: Tracker): FormSpec {
       y: Math.round(tr.y),
       angle: tr.angle ?? 0,
       dotSize: tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE,
+    },
+    toPatch: identity,
+  };
+}
+
+/**
+ * Name/visibility/opacity fields for an Area (a room polygon). Color and the
+ * HA-area link are bespoke rows in the editor's selection editor, same as
+ * every other color field / registry link in this file (see `textForm`'s
+ * caller / `_renderHaFloorRow` in editor.ts).
+ */
+export function areaForm(a: Area): FormSpec {
+  return {
+    fields: [
+      { name: "name", label: "Name", selector: { text: {} } },
+      { name: "showName", label: "Show name", selector: { boolean: {} } },
+      {
+        name: "opacity",
+        label: "Fill opacity",
+        selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
+      },
+    ],
+    data: {
+      name: a.name ?? "",
+      showName: a.showName ?? true,
+      opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
     },
     toPatch: identity,
   };

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from "vitest";
 import {
   nearestCorner,
+  nearestAreaSnapPoint,
+  pointInPolygon,
+  areaContainingPoint,
   snapWallEnd,
   elementsInRect,
   applyDelta,
   attachedCorners,
 } from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
-import type { Floor, Wall } from "./types";
+import type { Area, Floor, Wall } from "./types";
 
 const walls = [{ x1: 0, y1: 0, x2: 100, y2: 0 }];
 
@@ -164,5 +167,116 @@ describe("attachedCorners (issue #30: stretch-drag shared room corners)", () => 
       { id: "b", end: 1, which: 1, x0: 0, y0: 0 },
       { id: "b", end: 2, which: 2, x0: 100, y0: 0 },
     ]);
+  });
+});
+
+describe("pointInPolygon", () => {
+  const square = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ];
+
+  it("detects points inside/outside a convex quad", () => {
+    expect(pointInPolygon(square, 5, 5)).toBe(true);
+    expect(pointInPolygon(square, 50, 50)).toBe(false);
+  });
+
+  it("handles a concave (L-shaped) polygon", () => {
+    // An L: a 10x10 square with its top-right 5x5 quadrant notched out.
+    const L = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 5 },
+      { x: 5, y: 5 },
+      { x: 5, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    expect(pointInPolygon(L, 2, 2)).toBe(true); // main body
+    expect(pointInPolygon(L, 8, 8)).toBe(false); // inside the notched-out corner
+    expect(pointInPolygon(L, 8, 2)).toBe(true); // the lower-right arm
+  });
+
+  it("rejects a point clearly outside the bounding box", () => {
+    expect(pointInPolygon(square, -100, -100)).toBe(false);
+  });
+});
+
+describe("areaContainingPoint", () => {
+  const a1: Area = {
+    id: "a1",
+    points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }],
+  };
+  const a2: Area = {
+    id: "a2",
+    points: [{ x: 5, y: 5 }, { x: 15, y: 5 }, { x: 15, y: 15 }, { x: 5, y: 15 }],
+  };
+
+  it("finds the area containing a point, else undefined", () => {
+    expect(areaContainingPoint({ areas: [a1] }, 3, 3)?.id).toBe("a1");
+    expect(areaContainingPoint({ areas: [a1] }, 50, 50)).toBeUndefined();
+  });
+
+  it("overlapping areas: last-drawn (array order) wins", () => {
+    expect(areaContainingPoint({ areas: [a1, a2] }, 7, 7)?.id).toBe("a2");
+    expect(areaContainingPoint({ areas: [a2, a1] }, 7, 7)?.id).toBe("a1");
+  });
+});
+
+describe("nearestAreaSnapPoint", () => {
+  it("matches a wall corner", () => {
+    expect(nearestAreaSnapPoint({ walls, areas: [] }, 3, 4, 26)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("matches another area's vertex", () => {
+    const areas: Area[] = [{ id: "a1", points: [{ x: 50, y: 50 }, { x: 60, y: 50 }, { x: 60, y: 60 }] }];
+    expect(nearestAreaSnapPoint({ walls: [], areas }, 52, 51, 26)).toEqual({ x: 50, y: 50 });
+  });
+
+  it("ignores the excluded vertex, falling back to the next-closest candidate", () => {
+    const a: Area = { id: "a1", points: [{ x: 50, y: 50 }, { x: 53, y: 50 }] };
+    const f = { walls: [], areas: [a] };
+    expect(nearestAreaSnapPoint(f, 51, 50, 26)).toEqual({ x: 50, y: 50 });
+    expect(nearestAreaSnapPoint(f, 51, 50, 26, { areaId: "a1", vertexIndex: 0 })).toEqual({
+      x: 53,
+      y: 50,
+    });
+  });
+
+  it("returns null when nothing is within range", () => {
+    expect(nearestAreaSnapPoint({ walls: [], areas: [] }, 500, 500, 26)).toBeNull();
+  });
+});
+
+describe("elementsInRect (area case)", () => {
+  it("selects an Area by its centroid", () => {
+    const f = {
+      ...floor,
+      areas: [
+        { id: "a1", points: [{ x: 0, y: 0 }, { x: 20, y: 0 }, { x: 20, y: 20 }, { x: 0, y: 20 }] },
+      ],
+    } as unknown as Floor;
+    const hits = elementsInRect(f, { x0: 0, y0: 0, x1: 60, y1: 60 });
+    expect(hits).toContainEqual({ kind: "area", id: "a1" });
+  });
+});
+
+describe("applyDelta (area case)", () => {
+  it("translates every vertex of a snapshotted area", () => {
+    const f = {
+      ...floor,
+      areas: [{ id: "a1", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] }],
+    } as unknown as Floor;
+    const orig = new Map<string, OrigPos>([
+      [
+        "area:a1",
+        { kind: "polygon", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] },
+      ],
+    ]);
+    const out = applyDelta(f, 5, 5, orig);
+    expect(out.areas![0]).toMatchObject({
+      points: [{ x: 5, y: 5 }, { x: 15, y: 5 }, { x: 15, y: 15 }],
+    });
   });
 });

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -4,6 +4,7 @@ import {
   nearestAreaSnapPoint,
   pointInPolygon,
   areaContainingPoint,
+  layoutPointsInPolygon,
   snapWallEnd,
   elementsInRect,
   applyDelta,
@@ -246,6 +247,72 @@ describe("nearestAreaSnapPoint", () => {
 
   it("returns null when nothing is within range", () => {
     expect(nearestAreaSnapPoint({ walls: [], areas: [] }, 500, 500, 26)).toBeNull();
+  });
+});
+
+describe("layoutPointsInPolygon", () => {
+  const square = [
+    { x: 0, y: 0 },
+    { x: 100, y: 0 },
+    { x: 100, y: 100 },
+    { x: 0, y: 100 },
+  ];
+
+  it("returns [] for a non-positive count", () => {
+    expect(layoutPointsInPolygon(square, 0)).toEqual([]);
+    expect(layoutPointsInPolygon(square, -1)).toEqual([]);
+  });
+
+  it("places a single point at the centroid", () => {
+    expect(layoutPointsInPolygon(square, 1)).toEqual([{ x: 50, y: 50 }]);
+  });
+
+  it("returns exactly `count` distinct points, all inside the polygon", () => {
+    const pts = layoutPointsInPolygon(square, 6);
+    expect(pts).toHaveLength(6);
+    for (const p of pts) expect(pointInPolygon(square, p.x, p.y)).toBe(true);
+    // Distinct positions — the whole point is to not stack them.
+    const uniq = new Set(pts.map((p) => `${p.x},${p.y}`));
+    expect(uniq.size).toBe(6);
+  });
+
+  it("spreads points out rather than clumping in one corner", () => {
+    const pts = layoutPointsInPolygon(square, 4);
+    const xs = pts.map((p) => p.x);
+    const ys = pts.map((p) => p.y);
+    // A 4-point spread across a square should use a meaningful fraction of
+    // both axes, not huddle in a small sub-region.
+    expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(20);
+    expect(Math.max(...ys) - Math.min(...ys)).toBeGreaterThan(20);
+  });
+
+  it("keeps every point inside a concave (L-shaped) polygon, avoiding the notch", () => {
+    const L = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 50 },
+      { x: 50, y: 50 },
+      { x: 50, y: 100 },
+      { x: 0, y: 100 },
+    ];
+    const pts = layoutPointsInPolygon(L, 8);
+    expect(pts).toHaveLength(8);
+    for (const p of pts) expect(pointInPolygon(L, p.x, p.y)).toBe(true);
+  });
+
+  it("still returns exactly `count` points when far more are requested than the room can grid-fit", () => {
+    const tiny = [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      { x: 4, y: 4 },
+      { x: 0, y: 4 },
+    ];
+    const pts = layoutPointsInPolygon(tiny, 20);
+    expect(pts).toHaveLength(20);
+    for (const p of pts) {
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+    }
   });
 });
 

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -171,6 +171,66 @@ export function areaContainingPoint(f: Pick<Floor, "areas">, x: number, y: numbe
 }
 
 /**
+ * Evenly distribute `count` points across the interior of `polygon` — used to
+ * auto-place a batch of new elements (e.g. every entity in a linked HA area)
+ * without stacking them on top of each other. Lays a grid over the polygon's
+ * bounding box, sized to `count` and the box's aspect ratio, and keeps only
+ * the cell centers that actually fall inside the (possibly concave) polygon;
+ * if too few land inside on the first pass — a narrow or oddly-shaped room —
+ * the grid is retried at higher density up to a cap. More hits than needed
+ * are evenly subsampled down to `count` rather than just taking the first
+ * `count` found, so the result stays spread out instead of clumping wherever
+ * the scan happened to pass first. Any shortfall past the density cap (a
+ * sliver-shaped room, or `count` far exceeding what it could ever hold
+ * legibly) is padded with points ringed around the centroid — accepting some
+ * overlap is better than throwing.
+ */
+export function layoutPointsInPolygon(polygon: readonly AreaPoint[], count: number): AreaPoint[] {
+  if (count <= 0) return [];
+  const centroid = polygonCentroid(polygon);
+  if (count === 1) return [centroid];
+
+  const xs = polygon.map((p) => p.x);
+  const ys = polygon.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const w = Math.max(maxX - minX, 1);
+  const h = Math.max(maxY - minY, 1);
+
+  for (let density = 1; density <= 8; density++) {
+    const n = count * density;
+    const cols = Math.max(1, Math.round(Math.sqrt((n * w) / h)));
+    const rows = Math.max(1, Math.ceil(n / cols));
+    const stepX = w / (cols + 1);
+    const stepY = h / (rows + 1);
+    const candidates: AreaPoint[] = [];
+    for (let r = 1; r <= rows; r++) {
+      for (let c = 1; c <= cols; c++) {
+        const x = minX + c * stepX;
+        const y = minY + r * stepY;
+        if (pointInPolygon(polygon, x, y)) candidates.push({ x, y });
+      }
+    }
+    if (candidates.length >= count) {
+      return Array.from(
+        { length: count },
+        (_, i) => candidates[Math.floor((i * candidates.length) / count)]!
+      );
+    }
+  }
+
+  // Fallback: ring the remainder around the centroid so points at least
+  // separate a little instead of landing exactly on top of each other.
+  return Array.from({ length: count }, (_, i) => {
+    const angle = (i / count) * Math.PI * 2;
+    const ring = Math.min(w, h) * 0.15 * (1 + Math.floor(i / 6));
+    return { x: centroid.x + Math.cos(angle) * ring, y: centroid.y + Math.sin(angle) * ring };
+  });
+}
+
+/**
  * Snap a wall's moving endpoint while drawing. Existing corners win (so rooms
  * close/continue); otherwise, unless free-draw is on, apply "gravity" toward
  * horizontal/vertical relative to the start point. The position itself snaps

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -1,7 +1,8 @@
-import type { Floor, Wall } from "./types";
+import type { Area, AreaPoint, Floor, Wall } from "./types";
+import { polygonCentroid } from "./render";
 
 /** Element kinds addressable by the editor's selection model. */
-export type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker";
+export type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker" | "area";
 
 export interface Sel {
   kind: SelKind;
@@ -11,7 +12,8 @@ export interface Sel {
 /** Snapshot of an element's position at drag start, for group translation. */
 export type OrigPos =
   | { kind: "wall"; x1: number; y1: number; x2: number; y2: number }
-  | { kind: "pt"; x: number; y: number };
+  | { kind: "pt"; x: number; y: number }
+  | { kind: "polygon"; points: AreaPoint[] };
 
 /** A rectangle described by two opposite corners (any orientation). */
 export interface Rect {
@@ -76,6 +78,25 @@ export function attachedCorners(
   return attached.length ? attached : undefined;
 }
 
+/** Closest of `points` to `(rawX, rawY)` within `maxDist`, or null. */
+function nearestOf(
+  points: readonly AreaPoint[],
+  rawX: number,
+  rawY: number,
+  maxDist: number
+): AreaPoint | null {
+  let best: AreaPoint | null = null;
+  let bestDist = maxDist;
+  for (const p of points) {
+    const d = Math.hypot(rawX - p.x, rawY - p.y);
+    if (d < bestDist) {
+      bestDist = d;
+      best = { x: p.x, y: p.y };
+    }
+  }
+  return best;
+}
+
 /** Nearest existing wall endpoint within `maxDist`, or null. */
 export function nearestCorner(
   walls: readonly WallSegment[],
@@ -83,21 +104,70 @@ export function nearestCorner(
   rawY: number,
   maxDist: number
 ): { x: number; y: number } | null {
-  let best: { x: number; y: number } | null = null;
-  let bestDist = maxDist;
-  for (const w of walls) {
-    for (const e of [
-      { x: w.x1, y: w.y1 },
-      { x: w.x2, y: w.y2 },
-    ]) {
-      const d = Math.hypot(rawX - e.x, rawY - e.y);
-      if (d < bestDist) {
-        bestDist = d;
-        best = { x: e.x, y: e.y };
-      }
-    }
+  const corners = walls.flatMap((w) => [
+    { x: w.x1, y: w.y1 },
+    { x: w.x2, y: w.y2 },
+  ]);
+  return nearestOf(corners, rawX, rawY, maxDist);
+}
+
+/**
+ * Nearest point within `maxDist` among every wall endpoint and every Area
+ * vertex on the floor — used both while drawing a new Area polygon and while
+ * dragging an existing vertex, so adjacent rooms (or a room and a wall) can
+ * share an exact boundary point. `exclude` drops one specific vertex from the
+ * candidate set — the one currently being moved, so it never snaps to its own
+ * pre-drag position.
+ */
+export function nearestAreaSnapPoint(
+  f: { walls: readonly WallSegment[]; areas?: readonly Area[] },
+  rawX: number,
+  rawY: number,
+  maxDist: number,
+  exclude?: { areaId: string; vertexIndex: number }
+): AreaPoint | null {
+  const corners = f.walls.flatMap((w) => [
+    { x: w.x1, y: w.y1 },
+    { x: w.x2, y: w.y2 },
+  ]);
+  const vertices = (f.areas ?? []).flatMap((a) =>
+    a.points
+      .filter((_, i) => !(exclude && exclude.areaId === a.id && exclude.vertexIndex === i))
+      .map((p) => ({ x: p.x, y: p.y }))
+  );
+  return nearestOf([...corners, ...vertices], rawX, rawY, maxDist);
+}
+
+/**
+ * Ray-casting point-in-polygon test. Points exactly on an edge may resolve
+ * either way (not a documented guarantee) — the caller only needs an
+ * approximate "did this land inside the room" answer, not exact edge
+ * semantics.
+ */
+export function pointInPolygon(points: readonly AreaPoint[], x: number, y: number): boolean {
+  let inside = false;
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const pi = points[i]!;
+    const pj = points[j]!;
+    const intersects =
+      pi.y > y !== pj.y > y && x < ((pj.x - pi.x) * (y - pi.y)) / (pj.y - pi.y) + pi.x;
+    if (intersects) inside = !inside;
   }
-  return best;
+  return inside;
+}
+
+/**
+ * The topmost (last-drawn) Area whose polygon contains `(x, y)`, or undefined
+ * when none does. Overlapping areas resolve by array order — later elements
+ * paint over earlier ones, the same implicit tie-break the rest of the editor
+ * uses (e.g. marquee/click hit-testing).
+ */
+export function areaContainingPoint(f: Pick<Floor, "areas">, x: number, y: number): Area | undefined {
+  const areas = f.areas ?? [];
+  for (let i = areas.length - 1; i >= 0; i--) {
+    if (pointInPolygon(areas[i]!.points, x, y)) return areas[i];
+  }
+  return undefined;
 }
 
 /**
@@ -146,6 +216,10 @@ export function elementsInRect(f: Floor, m: Rect): Sel[] {
   for (const fu of f.furniture) if (inside(fu.x, fu.y)) out.push({ kind: "furniture", id: fu.id });
   for (const tr of f.trackers ?? [])
     if (inside(tr.x + tr.w / 2, tr.y + tr.h / 2)) out.push({ kind: "tracker", id: tr.id });
+  for (const a of f.areas ?? []) {
+    const c = polygonCentroid(a.points);
+    if (inside(c.x, c.y)) out.push({ kind: "area", id: a.id });
+  }
   return out;
 }
 
@@ -177,6 +251,12 @@ export function applyDelta(f: Floor, dx: number, dy: number, orig: Map<string, O
     trackers: (f.trackers ?? []).map((el) => {
       const o = orig.get(`tracker:${el.id}`);
       return o && o.kind === "pt" ? { ...el, x: o.x + dx, y: o.y + dy } : el;
+    }),
+    areas: (f.areas ?? []).map((el) => {
+      const o = orig.get(`area:${el.id}`);
+      return o && o.kind === "polygon"
+        ? { ...el, points: o.points.map((p) => ({ x: p.x + dx, y: p.y + dy })) }
+        : el;
     }),
   };
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -71,6 +71,7 @@ import {
   areaContainingPoint,
   attachedCorners,
   elementsInRect,
+  layoutPointsInPolygon,
   nearestAreaSnapPoint,
   nearestCorner,
   snapWallEnd,
@@ -1702,6 +1703,40 @@ export class FloorplanCardEditor extends LitElement {
     this._updateArea(id, { haArea: ha?.area_id, ...(ha ? { name: ha.name } : {}) });
   }
 
+  /** Every entity in `area`'s linked HA area not already placed as an item on this floor. */
+  private _pendingAreaEntities(area: Area): string[] {
+    if (!area.haArea) return [];
+    const existing = new Set(this._floor().items.map((it) => it.entity));
+    return entityIdsInHaArea(this.hass, area.haArea).filter((id) => !existing.has(id));
+  }
+
+  /**
+   * Add a device for every entity registered to `area`'s linked HA area that
+   * isn't already placed as an item on this floor, laid out across the
+   * polygon's interior (`layoutPointsInPolygon`) so the new icons spread out
+   * instead of stacking on top of each other.
+   */
+  private _addAreaEntities(area: Area): void {
+    const toAdd = this._pendingAreaEntities(area);
+    if (!toAdd.length) return;
+    const positions = layoutPointsInPolygon(area.points, toAdd.length);
+    const newItems: FloorItem[] = toAdd.map((entity, i) => {
+      const kind = kindFromEntity(entity);
+      return {
+        id: uid("item"),
+        entity,
+        x: Math.round(positions[i]!.x),
+        y: Math.round(positions[i]!.y),
+        kind,
+        showState: kind === "sensor",
+        showIcon: true,
+        size: DEFAULT_ITEM_SIZE,
+      };
+    });
+    this._commitFloor({ items: [...this._floor().items, ...newItems] });
+    this._selection = newItems.map((it) => ({ kind: "item" as const, id: it.id }));
+  }
+
   /** Patch a single field on one of a tracker's sensor sub-objects (X / Y axis). */
   private _updateTrackerSensor(
     id: string,
@@ -3185,6 +3220,7 @@ export class FloorplanCardEditor extends LitElement {
       const a = (this._floor().areas ?? []).find((x) => x.id === sel.id);
       if (!a) return html`${nothing}`;
       const haAreas = haAreasOf(this.hass);
+      const pendingEntities = a.haArea ? this._pendingAreaEntities(a) : [];
       return html`
         ${this._renderForm(areaForm(a), (patch, live) =>
           this._applyElementPatch("area", a.id, patch, live)
@@ -3239,6 +3275,22 @@ export class FloorplanCardEditor extends LitElement {
                 >Scope the entity picker, for devices placed inside this room, to this HA
                 area's entities.</span
               >
+            </div>`
+          : nothing}
+        ${a.haArea
+          ? html`<div class="row wide">
+              <button
+                ?disabled=${!pendingEntities.length}
+                title=${pendingEntities.length
+                  ? `Add ${pendingEntities.length} device${pendingEntities.length === 1 ? "" : "s"} from this HA area, spread out across the room`
+                  : "Every entity in this HA area is already placed on this floor"}
+                @click=${() => this._addAreaEntities(a)}
+              >
+                <ha-icon icon="mdi:shape-square-plus"></ha-icon>
+                Add all devices in this HA area${pendingEntities.length
+                  ? ` (${pendingEntities.length})`
+                  : ""}
+              </button>
             </div>`
           : nothing}
         <p class="hint">

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -15,6 +15,8 @@ import type {
   ItemKind,
   Tracker,
   TrackerSensor,
+  Area,
+  AreaPoint,
 } from "./types";
 import {
   DEFAULT_CUSTOM_PERCENT,
@@ -32,6 +34,8 @@ import {
   gridPercentToSnap,
   makeFloor,
   haFloorsOf,
+  haAreasOf,
+  entityIdsInHaArea,
   moveFloor,
   resolveSnap,
   snapToGridPercent,
@@ -48,6 +52,7 @@ import {
   renderRipple,
   renderFurniture,
   renderTracker,
+  renderArea,
   trackerSensorReading,
   kindFromEntity,
   resolveItemIcon,
@@ -62,8 +67,10 @@ import { cssColorOr, cssNumber } from "./css-safe";
 import {
   ENDPOINT_SNAP,
   applyDelta,
+  areaContainingPoint,
   attachedCorners,
   elementsInRect,
+  nearestAreaSnapPoint,
   nearestCorner,
   snapWallEnd,
   type AttachedCorner,
@@ -75,6 +82,7 @@ import {
 import {
   FURNITURE_LABELS,
   FURNITURE_TYPES,
+  areaForm,
   diffFormValue,
   floorImageForm,
   furnitureForm,
@@ -94,7 +102,7 @@ import {
 const formLabel = (s: FormField): string => s.label;
 const formHelper = (s: FormField): string | undefined => s.helper;
 
-type Tool = "select" | "wall" | "door" | "window" | "tracker";
+type Tool = "select" | "wall" | "door" | "window" | "tracker" | "area";
 type OverlaySel = { kind: "item" | "text"; id: string };
 
 /** Toolbar metadata per tool: mdi icon + label (icons make the modes scannable). */
@@ -104,6 +112,7 @@ const TOOL_META: Record<Tool, { icon: string; label: string }> = {
   door: { icon: "mdi:door", label: "Door" },
   window: { icon: "mdi:window-closed-variant", label: "Window" },
   tracker: { icon: "mdi:crosshairs-gps", label: "Tracker" },
+  area: { icon: "mdi:vector-polygon", label: "Area" },
 };
 
 /** Icon shown in the Element header per selected element kind. */
@@ -114,6 +123,7 @@ const SEL_KIND_ICON: Record<SelKind, string> = {
   text: "mdi:format-text",
   furniture: "mdi:sofa-outline",
   tracker: "mdi:crosshairs-gps",
+  area: "mdi:floor-plan",
 };
 
 interface Drag {
@@ -125,6 +135,8 @@ interface Drag {
   orig: Map<string, OrigPos>;
   /** Set when dragging a single wall endpoint handle. */
   endpoint?: 1 | 2;
+  /** Set when dragging a single Area vertex handle (index into its `points`). */
+  areaVertex?: number;
   /**
    * Endpoints of *other* walls that coincide with the dragged wall's
    * corner(s) and stretch along with it (issue #30). Hold Alt to detach and
@@ -149,6 +161,7 @@ interface Clipboard {
   texts: FloorText[];
   furniture: Furniture[];
   trackers: Tracker[];
+  areas: Area[];
 }
 
 /** Snap distance (virtual units) for openings onto walls. */
@@ -195,6 +208,13 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _draft: { x1: number; y1: number; x2: number; y2: number } | null = null;
   /** While dragging the Tracker tool, the rectangle being drawn (top-left corner + opposite corner). */
   @state() private _draftTracker: { x0: number; y0: number; x1: number; y1: number } | null = null;
+  /**
+   * While the Area tool is active, the polygon being built up click by click.
+   * Closed by clicking back on `points[0]` once at least 3 points are placed.
+   */
+  @state() private _draftArea: { points: AreaPoint[] } | null = null;
+  /** Live cursor position while drawing an Area, for the rubber-band preview segment. */
+  @state() private _areaHover: AreaPoint | null = null;
   /** When true, walls are drawn freely (no horizontal/vertical or corner gravity). */
   @state() private _freeWalls = false;
   /** Default length applied to a freshly placed door/window. User-editable from the context bar. */
@@ -556,6 +576,25 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * Snap a raw point for Area drawing/editing: nearby wall corner or another
+   * Area's vertex wins (so adjacent rooms can share an exact boundary point),
+   * else the grid/snap step. `exclude` drops one vertex from the candidate
+   * set — the one currently being dragged, so it can't snap to itself.
+   */
+  private _snapAreaPoint(
+    rawX: number,
+    rawY: number,
+    exclude?: { areaId: string; vertexIndex: number }
+  ): AreaPoint {
+    return (
+      nearestAreaSnapPoint(this._floor(), rawX, rawY, ENDPOINT_SNAP, exclude) ?? {
+        x: this._snap(rawX),
+        y: this._snap(rawY),
+      }
+    );
+  }
+
+  /**
    * Like {@link _snapWallPoint}, but ignores endpoints in `moving` (keys
    * `${wallId}:${end}`) — the corner cluster being dragged must not attract
    * itself.
@@ -616,7 +655,7 @@ export class FloorplanCardEditor extends LitElement {
     // Emit without the legacy flat arrays: `floors` is the source of truth,
     // and empty stubs would otherwise be persisted into the user's YAML.
     const out = { ...config };
-    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers"] as const) {
+    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers", "areas"] as const) {
       if (!out[key]?.length) delete out[key];
     }
     this._lastEmitted = out;
@@ -748,7 +787,22 @@ export class FloorplanCardEditor extends LitElement {
     // While a gesture is live, any keyboard mutation (paste, delete, nudge,
     // undo…) would interleave with the drag's emits and history snapshot —
     // ignore them all; Escape below still cancels the gesture itself.
-    const gestureActive = !!(this._drag || this._draft || this._draftTracker || this._marquee);
+    const gestureActive = !!(
+      this._drag ||
+      this._draft ||
+      this._draftTracker ||
+      this._draftArea ||
+      this._marquee
+    );
+    // Backspace pops the last placed vertex instead of deleting a selected
+    // element while an Area draft is in progress (checked ahead of the
+    // gestureActive bail so it isn't swallowed by that guard).
+    if (ev.key === "Backspace" && this._draftArea?.points.length) {
+      ev.preventDefault();
+      const pts = this._draftArea.points.slice(0, -1);
+      this._draftArea = pts.length ? { points: pts } : null;
+      return;
+    }
     if (gestureActive && ev.key !== "Escape" && !(mod && key === "c")) return;
     if (mod && key === "c") {
       if (this._selection.length) {
@@ -796,7 +850,7 @@ export class FloorplanCardEditor extends LitElement {
         this._addMenuOpen = false;
         return;
       }
-      if (this._draft || this._draftTracker || this._marquee || this._drag) {
+      if (this._draft || this._draftTracker || this._draftArea || this._marquee || this._drag) {
         ev.preventDefault();
         ev.stopPropagation();
         this._cancelGesture();
@@ -845,6 +899,7 @@ export class FloorplanCardEditor extends LitElement {
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
     const trIds = this._idsOfKind("tracker");
+    const aIds = this._idsOfKind("area");
     this._commitFloor({
       walls: f.walls.map((w) =>
         wIds.has(w.id) ? { ...w, x1: w.x1 + dx, y1: w.y1 + dy, x2: w.x2 + dx, y2: w.y2 + dy } : w
@@ -857,6 +912,9 @@ export class FloorplanCardEditor extends LitElement {
       ),
       trackers: (f.trackers ?? []).map((tr) =>
         trIds.has(tr.id) ? { ...tr, x: tr.x + dx, y: tr.y + dy } : tr
+      ),
+      areas: (f.areas ?? []).map((a) =>
+        aIds.has(a.id) ? { ...a, points: a.points.map((p) => ({ x: p.x + dx, y: p.y + dy })) } : a
       ),
     });
   }
@@ -916,6 +974,25 @@ export class FloorplanCardEditor extends LitElement {
       this._capturePointer(ev);
       return;
     }
+    if (this._tool === "area") {
+      // Discrete clicks, like door/window — no drag capture/gesture pointer.
+      const pt = this._snapAreaPoint(raw.x, raw.y);
+      if (!this._draftArea) {
+        this._draftArea = { points: [pt] };
+        return;
+      }
+      const pts = this._draftArea.points;
+      const first = pts[0]!;
+      if (pts.length >= 3 && Math.hypot(pt.x - first.x, pt.y - first.y) <= ENDPOINT_SNAP) {
+        this._finishArea();
+        return;
+      }
+      const last = pts[pts.length - 1]!;
+      if (pt.x !== last.x || pt.y !== last.y) {
+        this._draftArea = { points: [...pts, pt] };
+      }
+      return;
+    }
     // Select tool, empty canvas: start a marquee (rubber-band) selection.
     this._marqueeAdd = ev.shiftKey || ev.ctrlKey || ev.metaKey;
     this._marquee = { x0: raw.x, y0: raw.y, x1: raw.x, y1: raw.y };
@@ -933,6 +1010,8 @@ export class FloorplanCardEditor extends LitElement {
     this._gesturePointer = null;
     this._draft = null;
     this._draftTracker = null;
+    this._draftArea = null;
+    this._areaHover = null;
     this._marquee = null;
     const drag = this._drag;
     this._drag = null;
@@ -977,6 +1056,11 @@ export class FloorplanCardEditor extends LitElement {
         x1: this._snap(raw.x),
         y1: this._snap(raw.y),
       };
+      return;
+    }
+    if (this._tool === "area" && this._draftArea) {
+      const raw = this._toVirtual(ev, false);
+      this._areaHover = this._snapAreaPoint(raw.x, raw.y);
       return;
     }
     if (this._marquee) {
@@ -1043,19 +1127,20 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- dragging existing elements ----------------------------------------
 
-  private _startDrag(ev: PointerEvent, sel: Sel, endpoint?: 1 | 2): void {
+  private _startDrag(ev: PointerEvent, sel: Sel, endpoint?: 1 | 2, areaVertex?: number): void {
     if (this._tool !== "select") return;
     ev.stopPropagation();
     if (this._gesturePointer !== null) return;
     this._canvasWrap?.focus();
-    // Endpoint handles always operate on that single wall.
-    if (endpoint) this._selectOne(sel);
+    // Endpoint/vertex handles always operate on that single element.
+    if (endpoint || areaVertex != null) this._selectOne(sel);
     else this._selectForPointer(ev, sel);
     this._drag = {
       primary: sel,
       start: this._toVirtual(ev, false),
       orig: this._snapshotSelection(),
       endpoint,
+      areaVertex,
     };
     if (sel.kind === "wall") this._drag.attached = this._attachedCorners(sel.id, endpoint);
     this._gesturePointer = ev.pointerId;
@@ -1087,6 +1172,9 @@ export class FloorplanCardEditor extends LitElement {
       } else if (s.kind === "furniture") {
         const fu = f.furniture.find((x) => x.id === s.id);
         if (fu) m.set(`furniture:${fu.id}`, { kind: "pt", x: fu.x, y: fu.y });
+      } else if (s.kind === "area") {
+        const a = (f.areas ?? []).find((x) => x.id === s.id);
+        if (a) m.set(`area:${a.id}`, { kind: "polygon", points: a.points.map((p) => ({ ...p })) });
       } else {
         // tracker — stored by top-left corner.
         const tr = (f.trackers ?? []).find((x) => x.id === s.id);
@@ -1142,6 +1230,23 @@ export class FloorplanCardEditor extends LitElement {
       return;
     }
 
+    // Single Area vertex handle: reshape just that point, snapping to nearby
+    // wall corners / other areas' vertices (decision #1/#4 in areas.md). Like
+    // the wall-endpoint branch above, this positions absolutely against the
+    // live floor data rather than a delta off the pre-drag snapshot, and has
+    // no "stretch neighboring corners" step — a vertex only ever moves alone.
+    if (drag.primary.kind === "area" && drag.areaVertex != null) {
+      const idx = drag.areaVertex;
+      const target = this._snapAreaPoint(p.x, p.y, { areaId: drag.primary.id, vertexIndex: idx });
+      const areas = (f.areas ?? []).map((a) =>
+        a.id === drag.primary.id
+          ? { ...a, points: a.points.map((pt, i) => (i === idx ? target : pt)) }
+          : a
+      );
+      this._emitFloor({ areas });
+      return;
+    }
+
     // Single opening: keep the wall-snapping (and angle alignment) behavior.
     if (this._selection.length === 1 && drag.primary.kind === "opening") {
       const orig = drag.orig.get(`opening:${drag.primary.id}`);
@@ -1165,8 +1270,10 @@ export class FloorplanCardEditor extends LitElement {
     // derived from the primary element's reference point.
     const ref = drag.orig.get(`${drag.primary.kind}:${drag.primary.id}`);
     if (!ref) return;
-    const refX = ref.kind === "wall" ? ref.x1 : ref.x;
-    const refY = ref.kind === "wall" ? ref.y1 : ref.y;
+    // Any fixed vertex works as the delta-tracking reference for a whole-
+    // polygon (Area) drag — every point moves by the same delta regardless.
+    const refX = ref.kind === "wall" ? ref.x1 : ref.kind === "polygon" ? ref.points[0]!.x : ref.x;
+    const refY = ref.kind === "wall" ? ref.y1 : ref.kind === "polygon" ? ref.points[0]!.y : ref.y;
     const dx = this._snap(refX + (p.x - drag.start.x)) - refX;
     const dy = this._snap(refY + (p.y - drag.start.y)) - refY;
     let patch = this._applyDelta(dx, dy, drag.orig);
@@ -1305,6 +1412,17 @@ export class FloorplanCardEditor extends LitElement {
     this._tool = "select";
   }
 
+  /** Close the in-progress Area draft into a committed polygon and select it. */
+  private _finishArea(): void {
+    if (!this._draftArea || this._draftArea.points.length < 3) return;
+    const area: Area = { id: uid("area"), points: this._draftArea.points, showName: true };
+    this._commitFloor({ areas: [...(this._floor().areas ?? []), area] });
+    this._selection = [{ kind: "area", id: area.id }];
+    this._draftArea = null;
+    this._areaHover = null;
+    this._tool = "select";
+  }
+
   private _addText(): void {
     const t: FloorText = {
       id: uid("text"),
@@ -1327,6 +1445,7 @@ export class FloorplanCardEditor extends LitElement {
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
     const trIds = this._idsOfKind("tracker");
+    const aIds = this._idsOfKind("area");
     this._commitFloor({
       walls: f.walls.filter((w) => !wIds.has(w.id)),
       openings: f.openings.filter((o) => !oIds.has(o.id)),
@@ -1334,6 +1453,7 @@ export class FloorplanCardEditor extends LitElement {
       texts: f.texts.filter((t) => !tIds.has(t.id)),
       furniture: f.furniture.filter((fu) => !fIds.has(fu.id)),
       trackers: (f.trackers ?? []).filter((tr) => !trIds.has(tr.id)),
+      areas: (f.areas ?? []).filter((a) => !aIds.has(a.id)),
     });
     this._clearSel();
   }
@@ -1349,6 +1469,7 @@ export class FloorplanCardEditor extends LitElement {
     const tIds = this._idsOfKind("text");
     const fIds = this._idsOfKind("furniture");
     const trIds = this._idsOfKind("tracker");
+    const aIds = this._idsOfKind("area");
     this._clipboard = structuredClone({
       walls: f.walls.filter((w) => wIds.has(w.id)),
       openings: f.openings.filter((o) => oIds.has(o.id)),
@@ -1356,6 +1477,7 @@ export class FloorplanCardEditor extends LitElement {
       texts: f.texts.filter((t) => tIds.has(t.id)),
       furniture: f.furniture.filter((fu) => fIds.has(fu.id)),
       trackers: (f.trackers ?? []).filter((tr) => trIds.has(tr.id)),
+      areas: (f.areas ?? []).filter((a) => aIds.has(a.id)),
     });
   }
 
@@ -1405,6 +1527,11 @@ export class FloorplanCardEditor extends LitElement {
       x: tr.x + off,
       y: tr.y + off,
     }));
+    const newAreas: Area[] = (cb.areas ?? []).map((a) => ({
+      ...a,
+      id: uid("area"),
+      points: a.points.map((p) => ({ x: p.x + off, y: p.y + off })),
+    }));
     this._commitFloor({
       walls: [...f.walls, ...newWalls],
       openings: [...f.openings, ...newOpenings],
@@ -1412,6 +1539,7 @@ export class FloorplanCardEditor extends LitElement {
       texts: [...f.texts, ...newTexts],
       furniture: [...f.furniture, ...newFurn],
       trackers: [...(f.trackers ?? []), ...newTrackers],
+      areas: [...(f.areas ?? []), ...newAreas],
     });
     this._selection = [
       ...newWalls.map((w) => ({ kind: "wall" as const, id: w.id })),
@@ -1420,6 +1548,7 @@ export class FloorplanCardEditor extends LitElement {
       ...newTexts.map((t) => ({ kind: "text" as const, id: t.id })),
       ...newFurn.map((fu) => ({ kind: "furniture" as const, id: fu.id })),
       ...newTrackers.map((tr) => ({ kind: "tracker" as const, id: tr.id })),
+      ...newAreas.map((a) => ({ kind: "area" as const, id: a.id })),
     ];
     this._tool = "select";
   }
@@ -1556,6 +1685,22 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
+  private _updateArea(id: string, partial: Partial<Area>): void {
+    this._commitFloor({
+      areas: (this._floor().areas ?? []).map((a) => (a.id === id ? { ...a, ...partial } : a)),
+    });
+  }
+
+  /**
+   * Link an Area to a Home Assistant area (mirrors {@link _linkHaFloor}).
+   * Linking also names the Area after it — the point of the association —
+   * while a later manual rename sticks; unlinking keeps the current name.
+   */
+  private _linkHaArea(id: string, haAreaId: string): void {
+    const ha = haAreasOf(this.hass).find((a) => a.area_id === haAreaId);
+    this._updateArea(id, { haArea: ha?.area_id, ...(ha ? { name: ha.name } : {}) });
+  }
+
   /** Patch a single field on one of a tracker's sensor sub-objects (X / Y axis). */
   private _updateTrackerSensor(
     id: string,
@@ -1632,6 +1777,13 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
+  private _updateAreaLive(id: string, partial: Partial<Area>): void {
+    this._beginLive("area", id, partial);
+    this._emitFloor({
+      areas: (this._floor().areas ?? []).map((a) => (a.id === id ? { ...a, ...partial } : a)),
+    });
+  }
+
   private _patchConfigLive(partial: Partial<FloorplanCardConfig>): void {
     this._beginLive("config", "", partial);
     this._emit({ ...this._config, ...partial });
@@ -1651,7 +1803,7 @@ export class FloorplanCardEditor extends LitElement {
 
   /** Route a form patch to the right per-kind update helper (commit or burst). */
   private _applyElementPatch(
-    kind: "opening" | "item" | "text" | "furniture" | "tracker" | "wall",
+    kind: "opening" | "item" | "text" | "furniture" | "tracker" | "wall" | "area",
     id: string,
     patch: Record<string, unknown>,
     live: boolean
@@ -1680,6 +1832,10 @@ export class FloorplanCardEditor extends LitElement {
       case "wall":
         if (live) this._updateWallLive(id, patch);
         else this._updateWall(id, patch);
+        break;
+      case "area":
+        if (live) this._updateAreaLive(id, patch);
+        else this._updateArea(id, patch);
         break;
     }
   }
@@ -1733,6 +1889,11 @@ export class FloorplanCardEditor extends LitElement {
         if (!fu) return "Furniture";
         const label = FURNITURE_LABELS[fu.type];
         return `${label.charAt(0).toUpperCase()}${label.slice(1)} · ${Math.round(fu.w)}×${Math.round(fu.h)}`;
+      }
+      case "area": {
+        const a = (f.areas ?? []).find((x) => x.id === sel.id);
+        if (!a) return "Area";
+        return `Area · ${a.name || `${a.points.length}-point`}`;
       }
       default: {
         const tr = (f.trackers ?? []).find((x) => x.id === sel.id);
@@ -1799,6 +1960,18 @@ export class FloorplanCardEditor extends LitElement {
           >Drag on the canvas to draw the tracked area; bind one or two
           distance sensors in the Element editor.</span
         >
+      `;
+    } else if (t === "area") {
+      label = "Area";
+      const n = this._draftArea?.points.length ?? 0;
+      body = html`
+        <span class="ctx-hint">
+          ${n === 0
+            ? "Click to start a room outline; points snap to nearby corners."
+            : n < 3
+              ? `${n} point${n === 1 ? "" : "s"} placed — click to add more (3+ to close).`
+              : `${n} points placed — click the first point to close the room, or keep adding.`}
+        </span>
       `;
     } else if (t === "door" || t === "window") {
       label = t === "door" ? "Door" : "Window";
@@ -1921,7 +2094,8 @@ export class FloorplanCardEditor extends LitElement {
       !floor.items.length &&
       !floor.texts.length &&
       !floor.furniture.length &&
-      !(floor.trackers ?? []).length;
+      !(floor.trackers ?? []).length &&
+      !(floor.areas ?? []).length;
     return html`
       <div
         class="editor ${this._fullscreen ? "fullscreen" : ""}"
@@ -1940,7 +2114,7 @@ export class FloorplanCardEditor extends LitElement {
         <div class="toolbar">
           <!-- Tools — modes; exactly one is active at a time -->
           <div class="seg" role="group" aria-label="Tool">
-            ${(["select", "wall", "door", "window", "tracker"] as Tool[]).map(
+            ${(["select", "wall", "door", "window", "tracker", "area"] as Tool[]).map(
               (t) => html`
                 <button
                   class=${this._tool === t ? "active" : ""}
@@ -1950,6 +2124,8 @@ export class FloorplanCardEditor extends LitElement {
                     this._tool = t;
                     this._draft = null;
                     this._draftTracker = null;
+                    this._draftArea = null;
+                    this._areaHover = null;
                   }}
                 >
                   <ha-icon icon=${TOOL_META[t].icon}></ha-icon>${TOOL_META[t].label}
@@ -2167,6 +2343,11 @@ export class FloorplanCardEditor extends LitElement {
                             preserveAspectRatio="none" opacity=${floor.imageOpacity ?? 1} />`
                 : nothing}
               ${this._renderGrid()}
+              ${repeat(
+                floor.areas ?? [],
+                (a, i) => a.id || i,
+                (a) => this._renderAreaSel(a)
+              )}
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
@@ -2201,6 +2382,7 @@ export class FloorplanCardEditor extends LitElement {
                               stroke-width=${WALL_THICKNESS} />`
                   : nothing
               }
+              ${this._renderAreaDraft()}
               ${
                 this._marquee
                   ? svg`<rect x=${Math.min(this._marquee.x0, this._marquee.x1)}
@@ -2217,7 +2399,7 @@ export class FloorplanCardEditor extends LitElement {
             </div>
           </div>
         </div>
-        ${floorEmpty && !this._draft && !this._draftTracker
+        ${floorEmpty && !this._draft && !this._draftTracker && !this._draftArea
           ? html`<div class="empty-hint">
               <div>
                 <b>Draw your first room:</b> pick the <b>Wall</b> tool and drag on the canvas.<br />
@@ -2374,13 +2556,17 @@ export class FloorplanCardEditor extends LitElement {
       </div>`;
     }
     if ("entity" in sel) {
-      const filter = (sel.entity as { filter?: { domain?: string[] }[] }).filter;
+      const entitySel = sel.entity as {
+        filter?: { domain?: string[] }[];
+        include_entities?: string[];
+      };
       return html`<div class="row wide">
         <label>${f.label}</label>
         ${this._renderEntityPicker(
           String(value ?? ""),
           (v) => this._applyFallback(spec, f, v, false, apply),
-          filter?.[0]?.domain
+          entitySel.filter?.[0]?.domain,
+          entitySel.include_entities
         )}
       </div>`;
     }
@@ -2412,13 +2598,15 @@ export class FloorplanCardEditor extends LitElement {
   private _renderEntityPicker(
     value: string,
     onChange: (entity: string) => void,
-    includeDomains?: string[]
+    includeDomains?: string[],
+    includeEntities?: string[]
   ): TemplateResult {
     if (customElements.get("ha-entity-picker")) {
       return html`<ha-entity-picker
         .hass=${this.hass}
         .value=${value}
         .includeDomains=${includeDomains}
+        .includeEntities=${includeEntities}
         allow-custom-entity
         @value-changed=${(e: CustomEvent) => onChange((e.detail.value as string) ?? "")}
       ></ha-entity-picker>`;
@@ -2637,6 +2825,67 @@ export class FloorplanCardEditor extends LitElement {
       </g>`;
   }
 
+  /**
+   * A committed Area: the translucent fill (shared with the live card),
+   * a transparent hit-polygon for click-to-select and whole-shape drag, and
+   * — while selected — a heavier outline plus one draggable handle per
+   * vertex (decision #1 in areas.md: vertices reshape independently, with
+   * no cross-element corner-stretch).
+   */
+  private _renderAreaSel(a: Area): TemplateResult {
+    const selected = this._isSel("area", a.id);
+    const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
+    return svg`
+      <g class="area-hit ${selected ? "selected" : ""}">
+        ${renderArea(a)}
+        <polygon points=${pts} class="area-hit-shape"
+                 @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "area", id: a.id })} />
+        ${selected ? svg`<polygon points=${pts} class="area-outline" />` : nothing}
+        ${
+          selected
+            ? a.points.map(
+                (p, i) => svg`
+                  <circle cx=${p.x} cy=${p.y} r="7" class="handle"
+                          @pointerdown=${(e: PointerEvent) =>
+                            this._startDrag(e, { kind: "area", id: a.id }, undefined, i)} />`
+              )
+            : nothing
+        }
+      </g>`;
+  }
+
+  /**
+   * The in-progress Area draft: committed vertices as dots, straight segments
+   * between them, and — while a live pointer position is known — a dashed
+   * "rubber band" segment from the last vertex to the cursor. Once 3+ points
+   * are down the starting vertex is drawn larger/hollow so it's visually
+   * obvious that clicking it closes the polygon (see `_onCanvasDown`).
+   */
+  private _renderAreaDraft(): TemplateResult | typeof nothing {
+    const draft = this._draftArea;
+    if (!draft) return nothing;
+    const pts = draft.points;
+    const line = pts.map((p) => `${p.x},${p.y}`).join(" ");
+    const last = pts[pts.length - 1]!;
+    const canClose = pts.length >= 3;
+    const hover = this._areaHover;
+    return svg`
+      <g class="area-draft">
+        ${pts.length > 1 ? svg`<polyline points=${line} class="area-draft-line" />` : nothing}
+        ${
+          hover
+            ? svg`<line x1=${last.x} y1=${last.y} x2=${hover.x} y2=${hover.y}
+                        class="area-draft-hover" />`
+            : nothing
+        }
+        ${pts.map((p, i) =>
+          i === 0 && canClose
+            ? svg`<circle cx=${p.x} cy=${p.y} r="9" class="area-draft-start" />`
+            : svg`<circle cx=${p.x} cy=${p.y} r="5" class="area-draft-point" />`
+        )}
+      </g>`;
+  }
+
   private _renderItemOverlay(it: FloorItem, c: FloorplanCardConfig): TemplateResult {
     const selected = this._isSel("item", it.id);
     const st = it.entity ? this.hass?.states[it.entity] : undefined;
@@ -2834,8 +3083,16 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "item") {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
+      // A device placed inside an Area linked to a Home Assistant area (issue
+      // TBD) gets its entity pickers scoped to that HA area — recomputed on
+      // every render from the device's live x/y, so it tracks the device as
+      // it's dragged in/out of the polygon, even before the form reopens.
+      const containingArea = areaContainingPoint(this._floor(), it.x, it.y);
+      const areaEntities = containingArea?.haArea
+        ? entityIdsInHaArea(this.hass, containingArea.haArea)
+        : undefined;
       return html`
-        ${this._renderForm(itemForm(it), (patch, live) => {
+        ${this._renderForm(itemForm(it, areaEntities), (patch, live) => {
           // Any entity change re-derives the item kind (icon defaults etc.) —
           // including clearing it, which resets kind to "generic".
           if ("entity" in patch && typeof patch.entity === "string") {
@@ -2919,6 +3176,58 @@ export class FloorplanCardEditor extends LitElement {
               })}
           />
         </div>
+      `;
+    }
+
+    if (sel.kind === "area") {
+      const a = (this._floor().areas ?? []).find((x) => x.id === sel.id);
+      if (!a) return html`${nothing}`;
+      const haAreas = haAreasOf(this.hass);
+      return html`
+        ${this._renderForm(areaForm(a), (patch, live) =>
+          this._applyElementPatch("area", a.id, patch, live)
+        )}
+        <div class="row">
+          <label>Color</label>
+          <input
+            type="color"
+            .value=${a.color ?? "#03a9f4"}
+            @input=${(e: Event) =>
+              this._updateAreaLive(a.id, { color: (e.target as HTMLInputElement).value })}
+          />
+          <input
+            type="text"
+            placeholder="(primary)"
+            .value=${a.color ?? ""}
+            @change=${(e: Event) =>
+              this._updateArea(a.id, { color: (e.target as HTMLInputElement).value || undefined })}
+          />
+        </div>
+        ${haAreas.length
+          ? html`<div class="row wide">
+              <label>HA area</label>
+              <select
+                .value=${a.haArea ?? ""}
+                @change=${(e: Event) =>
+                  this._linkHaArea(a.id, (e.target as HTMLSelectElement).value)}
+              >
+                <option value="" ?selected=${!a.haArea}>(not linked)</option>
+                ${haAreas.map(
+                  (ha) =>
+                    html`<option value=${ha.area_id} ?selected=${a.haArea === ha.area_id}>
+                      ${ha.name}
+                    </option>`
+                )}
+              </select>
+              <span class="hint"
+                >Devices placed inside this room will be filtered to this HA area's
+                entities.</span
+              >
+            </div>`
+          : nothing}
+        <p class="hint">
+          Drag inside the fill to move the whole room; drag a vertex handle to reshape it.
+        </p>
       `;
     }
 
@@ -3356,7 +3665,8 @@ export class FloorplanCardEditor extends LitElement {
     svg.wall,
     svg.door,
     svg.window,
-    svg.tracker {
+    svg.tracker,
+    svg.area {
       cursor: crosshair;
     }
     .grid {
@@ -3745,6 +4055,50 @@ export class FloorplanCardEditor extends LitElement {
       stroke: var(--primary-color, #03a9f4);
       stroke-width: 1.5;
       stroke-dasharray: 6 4;
+      pointer-events: none;
+    }
+    .area-hit {
+      cursor: move;
+    }
+    .area-hit-shape {
+      /* Transparent fill turns the whole polygon into a pointer target for
+         the whole-shape drag, without covering the translucent room fill
+         drawn underneath by renderArea. */
+      fill: transparent;
+      stroke: none;
+      pointer-events: all;
+    }
+    .area-outline {
+      fill: none;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 2;
+      pointer-events: none;
+    }
+    .area-draft-line {
+      fill: none;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 2;
+      stroke-dasharray: 6 4;
+      pointer-events: none;
+    }
+    .area-draft-hover {
+      fill: none;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 1.5;
+      stroke-dasharray: 3 4;
+      opacity: 0.7;
+      pointer-events: none;
+    }
+    .area-draft-point {
+      fill: var(--primary-color, #03a9f4);
+      stroke: var(--card-background-color, #fff);
+      stroke-width: 1.5;
+      pointer-events: none;
+    }
+    .area-draft-start {
+      fill: var(--card-background-color, #fff);
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 2;
       pointer-events: none;
     }
     .tracker-draft {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -36,6 +36,7 @@ import {
   haFloorsOf,
   haAreasOf,
   entityIdsInHaArea,
+  areaFiltersEntities,
   moveFloor,
   resolveSnap,
   snapToGridPercent,
@@ -3083,13 +3084,14 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "item") {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
-      // A device placed inside an Area linked to a Home Assistant area (issue
-      // TBD) gets its entity pickers scoped to that HA area — recomputed on
-      // every render from the device's live x/y, so it tracks the device as
-      // it's dragged in/out of the polygon, even before the form reopens.
+      // A device placed inside an Area linked to a Home Assistant area gets
+      // its entity pickers scoped to that HA area, unless the area's own
+      // "Filter entities" toggle turns that off — recomputed on every render
+      // from the device's live x/y, so it tracks the device as it's dragged
+      // in/out of the polygon, even before the form reopens.
       const containingArea = areaContainingPoint(this._floor(), it.x, it.y);
-      const areaEntities = containingArea?.haArea
-        ? entityIdsInHaArea(this.hass, containingArea.haArea)
+      const areaEntities = areaFiltersEntities(containingArea)
+        ? entityIdsInHaArea(this.hass, containingArea!.haArea!)
         : undefined;
       return html`
         ${this._renderForm(itemForm(it, areaEntities), (patch, live) => {
@@ -3219,9 +3221,23 @@ export class FloorplanCardEditor extends LitElement {
                     </option>`
                 )}
               </select>
+              <span class="hint">Names this room after the linked HA area.</span>
+            </div>`
+          : nothing}
+        ${a.haArea
+          ? html`<div class="row wide">
+              <label>Filter entities</label>
+              <input
+                type="checkbox"
+                .checked=${a.filterEntities ?? true}
+                @change=${(e: Event) =>
+                  this._updateArea(a.id, {
+                    filterEntities: (e.target as HTMLInputElement).checked,
+                  })}
+              />
               <span class="hint"
-                >Devices placed inside this room will be filtered to this HA area's
-                entities.</span
+                >Scope the entity picker, for devices placed inside this room, to this HA
+                area's entities.</span
               >
             </div>`
           : nothing}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
-import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor } from "./types";
+import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor, Area } from "./types";
 import { cssColor, cssColorOr, cssNumber } from "./css-safe";
 import {
   DEFAULT_WIDTH,
@@ -24,6 +24,8 @@ import {
   renderRipple,
   renderFurniture,
   renderTracker,
+  renderArea,
+  polygonCentroid,
   trackerSensorReading,
   entityIsActive,
   itemBadgeLabel,
@@ -63,7 +65,7 @@ export class FloorplanCard extends LitElement {
     const raw = config as Record<string, unknown>;
     // A key with an empty YAML value ("trackers:") parses to null — treat it
     // as unset like the ?? defaults always have, not as malformed.
-    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers", "floors"]) {
+    for (const key of ["walls", "openings", "items", "texts", "furniture", "trackers", "areas", "floors"]) {
       if (raw[key] != null && !Array.isArray(raw[key]))
         throw new Error(`Invalid configuration: "${key}" must be a list`);
     }
@@ -264,6 +266,21 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
+  private _renderAreaLabel(a: Area, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult | typeof nothing {
+    if (!a.name || (a.showName ?? true) === false) return nothing;
+    const centroid = polygonCentroid(a.points);
+    const p = rotatePlanPoint(centroid.x, centroid.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
+    return html`
+      <div
+        class="area-label"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;"
+      >
+        ${a.name}
+      </div>
+    `;
+  }
+
   private _renderText(t: FloorText, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
     const p = rotatePlanPoint(t.x, t.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
@@ -321,6 +338,7 @@ export class FloorplanCard extends LitElement {
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
+            ${active.areas?.map((a) => renderArea(a))}
             ${active.furniture.map((f) => renderFurniture(f))}
             ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
             <g mask=${`url(#${this._wallMaskId})`}>
@@ -382,6 +400,7 @@ export class FloorplanCard extends LitElement {
             </g>
           </svg>
           <div class="items">
+            ${active.areas?.map((a) => this._renderAreaLabel(a, c, rot))}
             ${active.texts.map((t) => this._renderText(t, c, rot))}
             ${repeat(
               // No entity filter: devices that exist physically but have no HA
@@ -617,6 +636,22 @@ export class FloorplanCard extends LitElement {
       white-space: nowrap;
       font-weight: 500;
       line-height: 1;
+    }
+    .area-label {
+      position: absolute;
+      pointer-events: none;
+      white-space: nowrap;
+      transform: translate(-50%, -50%);
+      font-weight: 600;
+      font-size: 14px;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      line-height: 1;
+      color: var(--primary-text-color);
+      opacity: 0.7;
+      text-shadow:
+        0 1px 2px var(--card-background-color, #fff),
+        0 -1px 2px var(--card-background-color, #fff);
     }
     .stack {
       position: relative;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -40,6 +40,8 @@ import {
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
+  polygonCentroid,
+  renderArea,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -1174,5 +1176,51 @@ describe("collectWatchedEntities includes shutter entities (issue #74)", () => {
     const ids = collectWatchedEntities(cfg);
     expect(ids.has("binary_sensor.win")).toBe(true);
     expect(ids.has("cover.shutter")).toBe(true);
+  });
+});
+
+describe("polygonCentroid", () => {
+  it("averages the vertices", () => {
+    const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+    expect(polygonCentroid(square)).toEqual({ x: 5, y: 5 });
+  });
+
+  it("returns the origin for an empty polygon", () => {
+    expect(polygonCentroid([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("renderArea", () => {
+  /** Flatten a Lit template back to markup (see the fishTank glyph test above). */
+  const flatten = (node: unknown): string => {
+    if (node == null || node === false) return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+  const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+
+  it("emits the vertex points and the default fill/opacity", () => {
+    const markup = flatten(renderArea({ id: "a", points: square }));
+    expect(markup).toContain("points=0,0 10,0 10,10 0,10");
+    expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
+    expect(markup).toContain("fill-opacity=0.25");
+  });
+
+  it("honors a custom color and opacity", () => {
+    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000", opacity: 0.6 }));
+    expect(markup).toContain("fill=#ff0000");
+    expect(markup).toContain("fill-opacity=0.6");
+  });
+
+  it("falls back to the default color for an unsafe value (css-safe gate)", () => {
+    const markup = flatten(
+      renderArea({ id: "a", points: square, color: "red;position:fixed;inset:0" })
+    );
+    expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
+    expect(markup).not.toContain("position:fixed");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,9 +8,18 @@ import type {
   StateColorRule,
   Furniture,
   Tracker,
+  Area,
+  AreaPoint,
   RenderHass,
 } from "./types";
-import { FURNITURE_COLOR, DEFAULT_TRACKER_DOT_SIZE, DEFAULT_RIPPLE_SIZE, getFloors, trackerAxisFraction } from "./types";
+import {
+  FURNITURE_COLOR,
+  DEFAULT_TRACKER_DOT_SIZE,
+  DEFAULT_RIPPLE_SIZE,
+  DEFAULT_AREA_OPACITY,
+  getFloors,
+  trackerAxisFraction,
+} from "./types";
 import { cssColorOr, cssNumber } from "./css-safe";
 
 export const WALL_THICKNESS = 8;
@@ -999,6 +1008,31 @@ export function renderWallMask(
         })}
       </mask>
     </defs>`;
+}
+
+/**
+ * Arithmetic-mean centroid of a polygon's vertices. Not an exact
+ * center-of-mass for a non-convex shape, but that precision isn't needed
+ * here — it's only used for name-label placement and marquee/click
+ * hit-testing (see `elementsInRect` in editor-geometry.ts).
+ */
+export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: number } {
+  if (!points.length) return { x: 0, y: 0 };
+  const sum = points.reduce((s, p) => ({ x: s.x + p.x, y: s.y + p.y }), { x: 0, y: 0 });
+  return { x: sum.x / points.length, y: sum.y / points.length };
+}
+
+/**
+ * A room's translucent fill polygon. Drawn with no stroke — the walls drawn
+ * on top of it already imply an outline, so a second one would double it up.
+ * `color`/`opacity` are config-supplied style values, so they go through the
+ * same injection allowlist as every other color/number field (see css-safe.ts).
+ */
+export function renderArea(a: Area): SVGTemplateResult {
+  const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
+  return svg`<polygon points=${pts}
+                       fill=${cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
+                       fill-opacity=${cssNumber(a.opacity, DEFAULT_AREA_OPACITY)} />`;
 }
 
 /**

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -9,6 +9,9 @@ import {
   trackerAxisFraction,
   trackerPresenceDetected,
   haFloorsOf,
+  haAreasOf,
+  entityHaAreaId,
+  entityIdsInHaArea,
   uid,
   configsEqual,
   moveFloor,
@@ -192,6 +195,15 @@ describe("getFloors", () => {
     expect(floors[0].walls).toEqual(c.walls);
   });
 
+  it("wraps legacy top-level areas into the implicit floor", () => {
+    const c = {
+      ...emptyConfig("x"),
+      areas: [{ id: "a1", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] }],
+    } as FloorplanCardConfig;
+    const [f] = getFloors(c);
+    expect(f.areas).toEqual(c.areas);
+  });
+
   it("treats an empty floors array as legacy (wraps flat arrays)", () => {
     const c = { ...emptyConfig("x"), floors: [] } as FloorplanCardConfig;
     expect(getFloors(c)).toHaveLength(1);
@@ -218,6 +230,7 @@ describe("getFloors", () => {
     expect(f.texts).toEqual([]);
     expect(f.furniture).toEqual([]);
     expect(f.trackers).toEqual([]);
+    expect(f.areas).toEqual([]);
   });
 
   it("preserves extra floor fields (image, opacity) while backfilling", () => {
@@ -266,6 +279,79 @@ describe("haFloorsOf", () => {
     expect(haFloorsOf({ floors: { x: { floor_id: "x" }, ok: { floor_id: "ok", name: "Ok" } } })).toEqual([
       { floor_id: "ok", name: "Ok" },
     ]);
+  });
+});
+
+describe("haAreasOf", () => {
+  it("lists HA areas sorted by name", () => {
+    const hass = {
+      areas: {
+        kitchen: { area_id: "kitchen", name: "Kitchen" },
+        bedroom: { area_id: "bedroom", name: "Bedroom" },
+      },
+    };
+    expect(haAreasOf(hass).map((a) => a.area_id)).toEqual(["bedroom", "kitchen"]);
+  });
+
+  it("returns [] for hass objects without an area registry (older HA, dev harness)", () => {
+    expect(haAreasOf({})).toEqual([]);
+    expect(haAreasOf(undefined)).toEqual([]);
+    expect(haAreasOf(null)).toEqual([]);
+    expect(haAreasOf({ areas: "bogus" })).toEqual([]);
+  });
+
+  it("drops malformed registry entries", () => {
+    expect(
+      haAreasOf({ areas: { x: { area_id: "x" }, ok: { area_id: "ok", name: "Ok" } } })
+    ).toEqual([{ area_id: "ok", name: "Ok" }]);
+  });
+});
+
+describe("entityHaAreaId / entityIdsInHaArea", () => {
+  const hass = {
+    entities: {
+      // Entity-level override wins over its device's area.
+      "light.override": { device_id: "dev1", area_id: "office" },
+      // No override -> falls back to the device's area.
+      "light.by_device": { device_id: "dev1" },
+      // Device with no area, no entity override -> unresolved.
+      "light.orphan_device": { device_id: "dev2" },
+      // No device_id at all -> unresolved.
+      "light.no_device": {},
+    },
+    devices: {
+      dev1: { area_id: "living_room" },
+      dev2: {},
+    },
+  };
+
+  it("prefers the entity's own area_id override", () => {
+    expect(entityHaAreaId(hass, "light.override")).toBe("office");
+  });
+
+  it("falls back to the device's area when the entity has no override", () => {
+    expect(entityHaAreaId(hass, "light.by_device")).toBe("living_room");
+  });
+
+  it("returns undefined when neither the entity nor its device has an area", () => {
+    expect(entityHaAreaId(hass, "light.orphan_device")).toBeUndefined();
+    expect(entityHaAreaId(hass, "light.no_device")).toBeUndefined();
+  });
+
+  it("returns undefined for an entity with no registry entry at all", () => {
+    expect(entityHaAreaId(hass, "light.missing")).toBeUndefined();
+    expect(entityHaAreaId(undefined, "light.missing")).toBeUndefined();
+  });
+
+  it("entityIdsInHaArea collects every entity resolving to that area", () => {
+    expect(entityIdsInHaArea(hass, "living_room")).toEqual(["light.by_device"]);
+    expect(entityIdsInHaArea(hass, "office")).toEqual(["light.override"]);
+    expect(entityIdsInHaArea(hass, "nonexistent")).toEqual([]);
+  });
+
+  it("entityIdsInHaArea returns [] without an entity registry", () => {
+    expect(entityIdsInHaArea({}, "living_room")).toEqual([]);
+    expect(entityIdsInHaArea(undefined, "living_room")).toEqual([]);
   });
 });
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -12,6 +12,7 @@ import {
   haAreasOf,
   entityHaAreaId,
   entityIdsInHaArea,
+  areaFiltersEntities,
   uid,
   configsEqual,
   moveFloor,
@@ -352,6 +353,25 @@ describe("entityHaAreaId / entityIdsInHaArea", () => {
   it("entityIdsInHaArea returns [] without an entity registry", () => {
     expect(entityIdsInHaArea({}, "living_room")).toEqual([]);
     expect(entityIdsInHaArea(undefined, "living_room")).toEqual([]);
+  });
+});
+
+describe("areaFiltersEntities", () => {
+  it("filters by default once an HA area is linked", () => {
+    expect(areaFiltersEntities({ haArea: "living_room" })).toBe(true);
+  });
+
+  it("respects an explicit filterEntities: false", () => {
+    expect(areaFiltersEntities({ haArea: "living_room", filterEntities: false })).toBe(false);
+  });
+
+  it("an explicit filterEntities: true has no effect without a linked haArea", () => {
+    expect(areaFiltersEntities({ filterEntities: true })).toBe(false);
+  });
+
+  it("returns false for an unlinked area or undefined", () => {
+    expect(areaFiltersEntities({})).toBe(false);
+    expect(areaFiltersEntities(undefined)).toBe(false);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,11 +412,28 @@ export interface Area {
   opacity?: number;
   /**
    * Optional link to a Home Assistant area (its registry `area_id`). Selecting
-   * one names this Area after it (same convention as {@link Floor.haFloor})
-   * and scopes the entity picker, for devices placed inside this polygon, to
-   * entities registered to that HA area.
+   * one names this Area after it (same convention as {@link Floor.haFloor}).
+   * Whether it also scopes the entity picker is controlled by
+   * {@link filterEntities}.
    */
   haArea?: string;
+  /**
+   * With `haArea` linked, scope the entity picker (for devices placed inside
+   * this polygon) to that HA area's entities. Default true. Has no effect
+   * without a linked `haArea`.
+   */
+  filterEntities?: boolean;
+}
+
+/**
+ * Whether a device inside `area` should have its entity picker scoped to the
+ * linked HA area's entities: only once an HA area is actually linked, and
+ * only while {@link Area.filterEntities} hasn't been turned off (defaults on).
+ */
+export function areaFiltersEntities(
+  area: Pick<Area, "haArea" | "filterEntities"> | undefined
+): boolean {
+  return !!area?.haArea && (area.filterEntities ?? true);
 }
 
 export const DEFAULT_AREA_OPACITY = 0.25;

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,6 +386,41 @@ export interface TrackerPresence {
   invert?: boolean;
 }
 
+/** A vertex of an {@link Area} polygon, in virtual canvas units. */
+export interface AreaPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * A named room polygon, drawn point-by-point in the editor and closed by
+ * clicking back on the starting vertex. Distinct from a {@link Floor} (a
+ * whole level/story) the same way Home Assistant's own "area" (room) sits
+ * inside a "floor" — see {@link Area.haArea}.
+ */
+export interface Area {
+  id: string;
+  /** Vertices in drawing order, virtual canvas units. Implicitly closed (last -> first). */
+  points: AreaPoint[];
+  /** Display name. Mirrors the linked HA area's name when `haArea` is set. */
+  name?: string;
+  /** Show the name label on the plan, centered on the polygon. Default true. */
+  showName?: boolean;
+  /** Fill color. Falls back to the theme primary color. */
+  color?: string;
+  /** Fill opacity, 0-1. Default {@link DEFAULT_AREA_OPACITY}. */
+  opacity?: number;
+  /**
+   * Optional link to a Home Assistant area (its registry `area_id`). Selecting
+   * one names this Area after it (same convention as {@link Floor.haFloor})
+   * and scopes the entity picker, for devices placed inside this polygon, to
+   * entities registered to that HA area.
+   */
+  haArea?: string;
+}
+
+export const DEFAULT_AREA_OPACITY = 0.25;
+
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 
 export const DEFAULT_ITEM_SIZE = 34;
@@ -463,6 +498,7 @@ export interface Floor {
   texts: FloorText[];
   furniture: Furniture[];
   trackers: Tracker[];
+  areas: Area[];
 }
 
 export interface FloorplanCardConfig extends LovelaceCardConfig {
@@ -507,6 +543,7 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   texts?: FloorText[];
   furniture?: Furniture[];
   trackers?: Tracker[];
+  areas?: Area[];
 }
 
 export const DEFAULT_WIDTH = 1000;
@@ -571,6 +608,58 @@ export function haFloorsOf(hass: unknown): HaFloorInfo[] {
     .sort((a, b) => (a.level ?? 0) - (b.level ?? 0) || a.name.localeCompare(b.name));
 }
 
+/** A Home Assistant area-registry entry (the subset this card uses). */
+export interface HaAreaInfo {
+  area_id: string;
+  name: string;
+}
+
+/**
+ * List the Home Assistant areas from a `hass` object, sorted by name. Mirrors
+ * {@link haFloorsOf} exactly: `custom-card-helpers`' HomeAssistant type predates
+ * `hass.areas` too, and older HA / the dev harness simply yield `[]`.
+ */
+export function haAreasOf(hass: unknown): HaAreaInfo[] {
+  const areas = (hass as { areas?: Record<string, HaAreaInfo> } | null | undefined)?.areas;
+  if (!areas || typeof areas !== "object") return [];
+  return Object.values(areas)
+    .filter((a): a is HaAreaInfo => !!a && typeof a.area_id === "string" && typeof a.name === "string")
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The shape of `hass.entities`/`hass.devices` this card needs to resolve an
+ * entity's effective Home Assistant area — the entity registry's own
+ * `area_id` override, else its device's `area_id`. Neither is declared by
+ * `custom-card-helpers`, so callers take `hass: unknown` like {@link haFloorsOf}.
+ */
+interface HaRegistryHass {
+  entities?: Record<string, { device_id?: string | null; area_id?: string | null } | undefined>;
+  devices?: Record<string, { area_id?: string | null } | undefined>;
+}
+
+/**
+ * The effective Home Assistant area for an entity: its own registry override
+ * when set, else the area of the device it belongs to. `undefined` when
+ * neither resolves (no registry entry, or unassigned to any area).
+ */
+export function entityHaAreaId(hass: unknown, entityId: string): string | undefined {
+  const h = hass as HaRegistryHass | null | undefined;
+  const ent = h?.entities?.[entityId];
+  if (!ent) return undefined;
+  if (ent.area_id) return ent.area_id;
+  const dev = ent.device_id ? h?.devices?.[ent.device_id] : undefined;
+  return dev?.area_id ?? undefined;
+}
+
+/** Every entity id (out of the entity registry) whose effective HA area is `areaId`. */
+export function entityIdsInHaArea(hass: unknown, areaId: string): string[] {
+  const h = hass as HaRegistryHass | null | undefined;
+  const entities = h?.entities;
+  if (!entities || typeof entities !== "object") return [];
+  return Object.keys(entities).filter((id) => entityHaAreaId(hass, id) === areaId);
+}
+
 export function emptyConfig(type: string): FloorplanCardConfig {
   return {
     type,
@@ -583,6 +672,7 @@ export function emptyConfig(type: string): FloorplanCardConfig {
     texts: [],
     furniture: [],
     trackers: [],
+    areas: [],
   };
 }
 
@@ -621,6 +711,7 @@ export function makeFloor(name: string, walls: Wall[] = []): Floor {
     texts: [],
     furniture: [],
     trackers: [],
+    areas: [],
   };
 }
 
@@ -639,6 +730,7 @@ function normalizeFloor(f: Floor): Floor {
     texts: f.texts ?? [],
     furniture: f.furniture ?? [],
     trackers: f.trackers ?? [],
+    areas: f.areas ?? [],
   };
 }
 
@@ -698,6 +790,7 @@ export function getFloors(c: FloorplanCardConfig): Floor[] {
       texts: c.texts ?? [],
       furniture: c.furniture ?? [],
       trackers: c.trackers ?? [],
+      areas: c.areas ?? [],
     },
   ];
 }


### PR DESCRIPTION
Adds the concept of "areas" to define areas/rooms. Areas can be colored, have a name (which can be shown or hidden on the floor plan), and additionally be linked to HA areas. They will then follow the name of the area, and devices placed inside can have their entity list automatically filtered (optional).

Full disclosure: I'm a backend guy and no good with TypeScript and UI, so this is 100% written by Claude. Feel free to decline, modify or use in any way you see fit.