### PR TITLE
Areas: one name field that autocompletes HA areas, instead of two

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ automatically to the card and screen size.
   dishwasher, water heater, air handler, bathtub, vanity, sectional, fish tank,
   piano, hot tub.
 - **Areas** — trace a room's outline point-by-point (points snap to wall corners and to
-  neighboring areas' corners) to get a colored, named room polygon. Link an area to a
-  Home Assistant area to name it automatically and scope the entity picker, for any
-  device dropped inside it, to that HA area's entities.
+  neighboring areas' corners) to get a colored, named room polygon. Naming a room after
+  one of your Home Assistant areas (the name field autocompletes against them) links the
+  two, which scopes the entity picker — for any device dropped inside it — to that HA
+  area's entities, and can bulk-add every device in the area.
 - **Live position tracker** — draw a rectangular tracked area and bind one or two
   orthogonal distance sensors (e.g. mmWave / radar). The card linearly maps each
   sensor's `[min, max]` reading to the rectangle's edges and animates a pulsating
@@ -311,12 +312,14 @@ device into one.
    discards the whole outline.
 4. With the area selected, the **Element** section offers:
    - **Name** and **Show name** — a label centered on the room; toggle it off if you'd
-     rather keep the plan uncluttered.
+     rather keep the plan uncluttered. The name field autocompletes against your Home
+     Assistant areas, and **naming the room after one links it**: a **Linked** badge
+     appears next to the field, and the options below unlock. Any other text is just a
+     label. Picking from the list adopts the HA area's exact spelling, so typing
+     "living room" still shows as "Living Room" on the plan. To keep a name but drop the
+     link, click the **×** on the Linked badge.
    - **Fill opacity** and a **color** picker — the translucent fill that makes the room
      stand out (falls back to the theme primary color).
-   - **HA area** — link the polygon to one of your Home Assistant areas. Linking names
-     the polygon after it (rename afterwards if you like; the link sticks either way) —
-     once **Filter entities** is on (below) it also turns on entity filtering (next point).
    - **Filter entities** — shown once an HA area is linked; a plain checkbox, on by
      default. Turn it off to keep the name link without narrowing the entity picker.
    - **Add all devices in this HA area** — shown once an HA area is linked; one click
@@ -614,8 +617,8 @@ trackers:
   is on. Mirrors the linked HA area's name when `haArea` is set.
 - `color` / `opacity` — the room's fill; `color` falls back to the theme primary color,
   `opacity` defaults to `0.25`.
-- `haArea` — optional id of a linked Home Assistant area. Selecting one in the editor
-  names the polygon after it — see **Areas**.
+- `haArea` — optional id of a linked Home Assistant area. The editor sets this when the
+  polygon's `name` matches one of your HA areas — see **Areas**.
 - `filterEntities` — with `haArea` set, scopes the entity picker (for any device placed
   inside this polygon) to that HA area's entities. Default `true`; has no effect without
   a linked `haArea`.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -248,12 +248,18 @@ describe("areaForm", () => {
 
   it("data presents effective defaults (showName true, DEFAULT_AREA_OPACITY)", () => {
     const d = areaForm(area()).data;
-    expect(d).toMatchObject({ name: "", showName: true, opacity: 0.25 });
+    expect(d).toMatchObject({ showName: true, opacity: 0.25 });
   });
 
-  it("data reflects an explicit name/showName/opacity", () => {
+  it("data reflects an explicit showName/opacity", () => {
     const d = areaForm(area({ name: "Kitchen", showName: false, opacity: 0.5 })).data;
-    expect(d).toMatchObject({ name: "Kitchen", showName: false, opacity: 0.5 });
+    expect(d).toMatchObject({ showName: false, opacity: 0.5 });
+  });
+
+  it("omits name — it's a bespoke row (autocompletes against HA areas to link one)", () => {
+    const f = areaForm(area({ name: "Kitchen" }));
+    expect(f.fields.some((x) => x.name === "name")).toBe(false);
+    expect(f.data).not.toHaveProperty("name");
   });
 
   it("opacity field is a 0..1 slider", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -497,15 +497,15 @@ export function trackerForm(tr: Tracker): FormSpec {
 }
 
 /**
- * Name/visibility/opacity fields for an Area (a room polygon). Color and the
- * HA-area link are bespoke rows in the editor's selection editor, same as
- * every other color field / registry link in this file (see `textForm`'s
- * caller / `_renderHaFloorRow` in editor.ts).
+ * Visibility/opacity fields for an Area (a room polygon). Color and the
+ * name — which doubles as the HA-area link, so it needs a datalist of area
+ * names and an unlink affordance — are bespoke rows in the editor's selection
+ * editor, same as every other color field / registry link in this file (see
+ * `textForm`'s caller / `_renderHaFloorRow` in editor.ts).
  */
 export function areaForm(a: Area): FormSpec {
   return {
     fields: [
-      { name: "name", label: "Name", selector: { text: {} } },
       { name: "showName", label: "Show name", selector: { boolean: {} } },
       {
         name: "opacity",
@@ -514,7 +514,6 @@ export function areaForm(a: Area): FormSpec {
       },
     ],
     data: {
-      name: a.name ?? "",
       showName: a.showName ?? true,
       opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
     },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -35,6 +35,7 @@ import {
   makeFloor,
   haFloorsOf,
   haAreasOf,
+  matchHaAreaByName,
   entityIdsInHaArea,
   areaFiltersEntities,
   moveFloor,
@@ -1694,13 +1695,78 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
-   * Link an Area to a Home Assistant area (mirrors {@link _linkHaFloor}).
-   * Linking also names the Area after it — the point of the association —
-   * while a later manual rename sticks; unlinking keeps the current name.
+   * Commit the Area's name, which doubles as the HA-area link: one field, so
+   * typing (or picking from the datalist) a name that matches a Home Assistant
+   * area links to it, and any other text is just a free label and clears the
+   * link. Picking from the datalist adopts the HA area's exact spelling, so a
+   * case-insensitive match doesn't leave the plan labelled "living room".
+   *
+   * The link is never silent — {@link _renderAreaNameRow} shows a "Linked"
+   * chip whenever `haArea` is set, with its own unlink button for the one case
+   * this can't express: keeping the name while dropping the link.
    */
-  private _linkHaArea(id: string, haAreaId: string): void {
-    const ha = haAreasOf(this.hass).find((a) => a.area_id === haAreaId);
-    this._updateArea(id, { haArea: ha?.area_id, ...(ha ? { name: ha.name } : {}) });
+  private _commitAreaName(id: string, typed: string): void {
+    const name = typed.trim();
+    const ha = matchHaAreaByName(haAreasOf(this.hass), name);
+    this._updateArea(id, {
+      name: ha ? ha.name : name || undefined,
+      haArea: ha?.area_id,
+    });
+  }
+
+  /** Drop the HA-area link but keep the name the user sees on the plan. */
+  private _unlinkHaArea(id: string): void {
+    this._updateArea(id, { haArea: undefined });
+  }
+
+  /**
+   * The Area's single name field: a free-text input whose `<datalist>` offers
+   * every Home Assistant area, so naming a room after one links it (see
+   * {@link _commitAreaName}). A "Linked" chip — with an unlink button — makes
+   * the resulting association visible rather than implied by the text alone.
+   *
+   * Falls back to a plain input when `hass` exposes no area registry (older
+   * HA, the dev harness): the field still names the room, there's just nothing
+   * to autocomplete against.
+   */
+  private _renderAreaNameRow(a: Area): TemplateResult {
+    const haAreas = haAreasOf(this.hass);
+    const listId = `ha-areas-${a.id}`;
+    const linked = a.haArea ? haAreas.find((ha) => ha.area_id === a.haArea) : undefined;
+    return html`
+      <div class="row wide">
+        <label>Name</label>
+        <input
+          type="text"
+          list=${haAreas.length ? listId : nothing}
+          placeholder="Room name (or a Home Assistant area)"
+          .value=${a.name ?? ""}
+          @change=${(e: Event) =>
+            this._commitAreaName(a.id, (e.target as HTMLInputElement).value)}
+        />
+        ${haAreas.length
+          ? html`<datalist id=${listId}>
+              ${haAreas.map((ha) => html`<option value=${ha.name}></option>`)}
+            </datalist>`
+          : nothing}
+        ${a.haArea
+          ? html`<span class="ha-link-chip" title=${`Linked to the Home Assistant area "${linked?.name ?? a.haArea}"`}>
+                <ha-icon icon="mdi:link-variant"></ha-icon>Linked
+                <button
+                  class="unlink"
+                  title="Keep this name but unlink the Home Assistant area"
+                  @click=${() => this._unlinkHaArea(a.id)}
+                >
+                  <ha-icon icon="mdi:close"></ha-icon>
+                </button>
+              </span>`
+          : html`<span class="hint"
+              >${haAreas.length
+                ? "Matching a Home Assistant area's name links it."
+                : "No Home Assistant areas available."}</span
+            >`}
+      </div>
+    `;
   }
 
   /** Every entity in `area`'s linked HA area not already placed as an item on this floor. */
@@ -3219,9 +3285,9 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "area") {
       const a = (this._floor().areas ?? []).find((x) => x.id === sel.id);
       if (!a) return html`${nothing}`;
-      const haAreas = haAreasOf(this.hass);
       const pendingEntities = a.haArea ? this._pendingAreaEntities(a) : [];
       return html`
+        ${this._renderAreaNameRow(a)}
         ${this._renderForm(areaForm(a), (patch, live) =>
           this._applyElementPatch("area", a.id, patch, live)
         )}
@@ -3241,25 +3307,6 @@ export class FloorplanCardEditor extends LitElement {
               this._updateArea(a.id, { color: (e.target as HTMLInputElement).value || undefined })}
           />
         </div>
-        ${haAreas.length
-          ? html`<div class="row wide">
-              <label>HA area</label>
-              <select
-                .value=${a.haArea ?? ""}
-                @change=${(e: Event) =>
-                  this._linkHaArea(a.id, (e.target as HTMLSelectElement).value)}
-              >
-                <option value="" ?selected=${!a.haArea}>(not linked)</option>
-                ${haAreas.map(
-                  (ha) =>
-                    html`<option value=${ha.area_id} ?selected=${a.haArea === ha.area_id}>
-                      ${ha.name}
-                    </option>`
-                )}
-              </select>
-              <span class="hint">Names this room after the linked HA area.</span>
-            </div>`
-          : nothing}
         ${a.haArea
           ? html`<div class="row wide">
               <label>Filter entities</label>
@@ -4434,6 +4481,36 @@ export class FloorplanCardEditor extends LitElement {
       font-size: 13px;
       color: var(--secondary-text-color);
       line-height: 1.5;
+    }
+    /* "Linked" badge on the Area name row: the HA-area association is implied
+       by the name matching, so it needs to be visible somewhere. */
+    .ha-link-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 4px 2px 8px;
+      border-radius: 999px;
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      font-size: 12px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .ha-link-chip ha-icon {
+      --mdc-icon-size: 14px;
+    }
+    .ha-link-chip .unlink {
+      display: inline-flex;
+      align-items: center;
+      padding: 0;
+      border: none;
+      background: none;
+      color: inherit;
+      cursor: pointer;
+      opacity: 0.85;
+    }
+    .ha-link-chip .unlink:hover {
+      opacity: 1;
     }
   `;
 }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -10,6 +10,7 @@ import {
   trackerPresenceDetected,
   haFloorsOf,
   haAreasOf,
+  matchHaAreaByName,
   entityHaAreaId,
   entityIdsInHaArea,
   areaFiltersEntities,
@@ -305,6 +306,53 @@ describe("haAreasOf", () => {
     expect(
       haAreasOf({ areas: { x: { area_id: "x" }, ok: { area_id: "ok", name: "Ok" } } })
     ).toEqual([{ area_id: "ok", name: "Ok" }]);
+  });
+});
+
+describe("matchHaAreaByName", () => {
+  const areas = [
+    { area_id: "bedroom", name: "Bedroom" },
+    { area_id: "living_room", name: "Living Room" },
+  ];
+
+  it("matches an exact name", () => {
+    expect(matchHaAreaByName(areas, "Living Room")?.area_id).toBe("living_room");
+  });
+
+  it("matches case-insensitively and tolerates stray whitespace", () => {
+    expect(matchHaAreaByName(areas, "living room")?.area_id).toBe("living_room");
+    expect(matchHaAreaByName(areas, "  LIVING   ROOM ")?.area_id).toBe("living_room");
+  });
+
+  it("returns undefined for a free-text name that matches nothing", () => {
+    expect(matchHaAreaByName(areas, "Lounge")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/whitespace-only input", () => {
+    expect(matchHaAreaByName(areas, "")).toBeUndefined();
+    expect(matchHaAreaByName(areas, "   ")).toBeUndefined();
+    expect(matchHaAreaByName(areas, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when there are no HA areas at all", () => {
+    expect(matchHaAreaByName([], "Living Room")).toBeUndefined();
+  });
+
+  it("prefers the exact-case area when two names differ only by case", () => {
+    const dupes = [
+      { area_id: "lower", name: "office" },
+      { area_id: "title", name: "Office" },
+    ];
+    expect(matchHaAreaByName(dupes, "Office")?.area_id).toBe("title");
+    expect(matchHaAreaByName(dupes, "office")?.area_id).toBe("lower");
+  });
+
+  it("picks the first of two identically named areas (names can't disambiguate)", () => {
+    const dupes = [
+      { area_id: "bath_up", name: "Bathroom" },
+      { area_id: "bath_down", name: "Bathroom" },
+    ];
+    expect(matchHaAreaByName(dupes, "Bathroom")?.area_id).toBe("bath_up");
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,37 @@ export function haAreasOf(hass: unknown): HaAreaInfo[] {
 }
 
 /**
+ * Resolve a typed room name to a Home Assistant area, so the Area panel can
+ * offer one combined name-with-autocomplete field instead of a separate name
+ * box and HA-area dropdown: whatever the user types is the display name, and
+ * if it happens to name a real HA area we link to it too.
+ *
+ * Matching is exact first, then case-insensitive, then case-insensitive with
+ * surrounding whitespace collapsed — so "living  room" still finds "Living
+ * Room" — and returns `undefined` for free-text names that match nothing.
+ *
+ * NOTE: Home Assistant allows two areas to share a name (e.g. a "Bathroom" on
+ * each floor). Names therefore can't disambiguate them, and the first match in
+ * `haAreasOf` order (sorted by name, so effectively arbitrary between equals)
+ * wins. That ambiguity is inherent to naming an area by name; picking the
+ * other one means renaming it in HA.
+ */
+export function matchHaAreaByName(
+  areas: readonly HaAreaInfo[],
+  name: string | undefined
+): HaAreaInfo | undefined {
+  const raw = (name ?? "").trim();
+  if (!raw) return undefined;
+  const exact = areas.find((a) => a.name === raw);
+  if (exact) return exact;
+  const lower = raw.toLowerCase();
+  const ci = areas.find((a) => a.name.toLowerCase() === lower);
+  if (ci) return ci;
+  const loose = lower.replace(/\s+/g, " ");
+  return areas.find((a) => a.name.trim().toLowerCase().replace(/\s+/g, " ") === loose);
+}
+
+/**
  * The shape of `hass.entities`/`hass.devices` this card needs to resolve an
  * entity's effective Home Assistant area — the entity registry's own
  * `area_id` override, else its device's `area_id`. Neither is declared by


### PR DESCRIPTION
Follow-up to #83 / #25.

## What

The Area panel had a **Name** text box *and* a separate **HA area** dropdown, where picking an area overwrote the name. That's two controls for what is, in the common case, a single decision — you name the room after the HA area.

They're now **one field**. The name input autocompletes (native `<datalist>`) against your Home Assistant area registry, and naming a room after one of your areas links it. Any other text is just a label.

| before | after |
|---|---|
| `Name` (text) + `HA area` (select) | `Name` (autocomplete) + `🔗 Linked` badge |

## Keeping the link visible

The obvious risk of merging is that the association becomes invisible — "Living Room" typed by hand and picked from the list would look identical but behave differently (linking gates entity filtering and the bulk-add button). Two things address that:

- a **"Linked" chip** beside the field whenever `haArea` is set, naming the linked area in its tooltip;
- an **unlink button (×)** on that chip — the one intent a merged field can't otherwise express: *keep the name, drop the link*.

## Matching

Exact → case-insensitive → whitespace-tolerant, and it adopts the HA area's own spelling, so typing `living room` still renders as **Living Room** on the plan.

**Known limitation, inherent to naming an area by name:** HA allows duplicate area names (a "Bathroom" per floor). Names can't disambiguate those — the first match wins. Documented in the code and covered by a test.

Falls back to a plain text input when no area registry is available (older HA, the dev harness).

## Verified in the dev harness

| step | name | haArea | chip |
|---|---|---|---|
| initial | Living Room | `living_room` | ✅ |
| type `Lounge` | Lounge | *(cleared)* | — |
| type `Living Room` | Living Room | `living_room` | ✅ |
| type `living room` | **Living Room** | `living_room` | ✅ |
| type `  LIVING   ROOM  ` | **Living Room** | `living_room` | ✅ |
| click unlink × | Living Room | *(cleared)* | — |

Unlinking correctly hides the dependent **Filter entities** row and **Add all devices** button; re-typing the name restores both.

`npm test` **431 passed** (+8: 7 for the new `matchHaAreaByName`, 1 asserting `areaForm` no longer owns `name`), `npm run typecheck` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)