### PR TITLE
Areas: use ha-combo-box for the name field, and stop squeezing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,9 +737,10 @@ npm run serve      # opens /dev/ on the Vite dev server with HMR
 This mounts the **real** `easy-floorplan-card-editor` and `easy-floorplan-card`
 side-by-side in a plain HTML page with:
 
-- a minimal `hass` mock + tiny `<ha-card>` and `<ha-icon>` stubs so the card
-  renders outside HA — the entity / icon pickers are already feature-detected
-  inside the editor and fall back to plain inputs;
+- a minimal `hass` mock + tiny `<ha-card>`, `<ha-icon>`, `<ha-entity-picker>` and
+  `<ha-combo-box>` stubs so the card renders outside HA — the pickers are
+  feature-detected inside the editor and fall back to plain inputs, but stubbing
+  them means the harness drives the same branch a real HA install does;
 - a `config-changed` round-trip between the editor and the live preview, so
   edits in the editor instantly update the card (matching how HA wires it);
 - a **Tracker emulator** panel that appears whenever the current config has

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -6,10 +6,12 @@
  *
  * Run with: `npm run serve` (opens /dev/ on the Vite dev server).
  *
- * A few HA-provided custom elements are stubbed below: <ha-card>, <ha-icon> and
- * <ha-entity-picker>. The icon picker already falls back to a plain input in the
- * editor when unregistered, but the entity picker does not, so we stub it here
- * so Sensor / entity fields are usable outside HA.
+ * A few HA-provided custom elements are stubbed below: <ha-card>, <ha-icon>,
+ * <ha-entity-picker> and <ha-combo-box>. The icon picker already falls back to a
+ * plain input in the editor when unregistered, but the entity picker does not,
+ * so we stub it here so Sensor / entity fields are usable outside HA. The combo
+ * box has a fallback too, but stubbing it means the harness exercises the same
+ * branch HA does (the Area name field) instead of only the fallback.
  */
 import type { FloorplanCardConfig, Tracker, TrackerSensor } from "../src/types";
 
@@ -106,6 +108,77 @@ if (!customElements.get("ha-entity-picker")) {
     }
   }
   customElements.define("ha-entity-picker", HaEntityPickerStub);
+}
+
+if (!customElements.get("ha-combo-box")) {
+  // Same story as ha-entity-picker: inside HA this is a filter-as-you-type
+  // dropdown, and it's what the Area name field uses. Without a stub the field
+  // would silently fall back to its <input list> path here, so the harness
+  // would never exercise the code that actually runs in HA. A native
+  // input+datalist is close enough to drive it: free text (allow-custom-value)
+  // plus suggestions, emitting the same `value-changed`.
+  class HaComboBoxStub extends HTMLElement {
+    private _value = "";
+    private _items: Array<Record<string, unknown>> = [];
+    private _input?: HTMLInputElement;
+    private _list?: HTMLDataListElement;
+    set value(v: string) {
+      this._value = v ?? "";
+      if (this._input) this._input.value = this._value;
+    }
+    get value(): string {
+      return this._value;
+    }
+    set items(v: Array<Record<string, unknown>>) {
+      this._items = Array.isArray(v) ? v : [];
+      this._syncOptions();
+    }
+    set placeholder(v: string) {
+      if (this._input) this._input.placeholder = v ?? "";
+    }
+    /** `hass` is accepted and ignored — the real component uses it for i18n. */
+    set hass(_v: unknown) {}
+    private _labelPath(): string {
+      return this.getAttribute("item-label-path") || "name";
+    }
+    private _syncOptions() {
+      if (!this._list) return;
+      const path = this._labelPath();
+      this._list.replaceChildren(
+        ...this._items.map((it) => {
+          const opt = document.createElement("option");
+          opt.value = String(it[path] ?? "");
+          return opt;
+        }),
+      );
+    }
+    connectedCallback() {
+      if (this._input) return;
+      const id = `ha-combo-box-stub-${Math.random().toString(36).slice(2)}`;
+      const input = document.createElement("input");
+      input.type = "text";
+      input.setAttribute("list", id);
+      input.value = this._value;
+      input.style.width = "100%";
+      input.addEventListener("change", () => {
+        this._value = input.value;
+        this.dispatchEvent(
+          new CustomEvent("value-changed", {
+            detail: { value: input.value },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      });
+      const list = document.createElement("datalist");
+      list.id = id;
+      this._input = input;
+      this._list = list;
+      this._syncOptions();
+      this.append(input, list);
+    }
+  }
+  customElements.define("ha-combo-box", HaComboBoxStub);
 }
 
 // ---- register the real card + editor --------------------------------------

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -17,6 +17,7 @@ import type {
   TrackerSensor,
   Area,
   AreaPoint,
+  HaAreaInfo,
 } from "./types";
 import {
   DEFAULT_CUSTOM_PERCENT,
@@ -373,7 +374,7 @@ export class FloorplanCardEditor extends LitElement {
     void this._ensureHaComponents();
     // Upgrade the plain-input fallbacks in place whenever a component gets
     // defined later (by us or by another editor the user opened).
-    for (const tag of ["ha-form", "ha-entity-picker", "ha-icon-picker"]) {
+    for (const tag of ["ha-form", "ha-entity-picker", "ha-icon-picker", "ha-combo-box"]) {
       if (!customElements.get(tag)) {
         void customElements.whenDefined(tag).then(() => this.requestUpdate());
       }
@@ -1731,41 +1732,78 @@ export class FloorplanCardEditor extends LitElement {
    */
   private _renderAreaNameRow(a: Area): TemplateResult {
     const haAreas = haAreasOf(this.hass);
-    const listId = `ha-areas-${a.id}`;
     const linked = a.haArea ? haAreas.find((ha) => ha.area_id === a.haArea) : undefined;
     return html`
       <div class="row wide">
         <label>Name</label>
-        <input
-          type="text"
-          list=${haAreas.length ? listId : nothing}
-          placeholder="Room name (or a Home Assistant area)"
-          .value=${a.name ?? ""}
-          @change=${(e: Event) =>
-            this._commitAreaName(a.id, (e.target as HTMLInputElement).value)}
-        />
-        ${haAreas.length
-          ? html`<datalist id=${listId}>
-              ${haAreas.map((ha) => html`<option value=${ha.name}></option>`)}
-            </datalist>`
-          : nothing}
+        ${this._renderAreaNamePicker(a, haAreas)}
+      </div>
+      <div class="row wide area-name-status">
+        <label></label>
         ${a.haArea
-          ? html`<span class="ha-link-chip" title=${`Linked to the Home Assistant area "${linked?.name ?? a.haArea}"`}>
-                <ha-icon icon="mdi:link-variant"></ha-icon>Linked
-                <button
-                  class="unlink"
-                  title="Keep this name but unlink the Home Assistant area"
-                  @click=${() => this._unlinkHaArea(a.id)}
-                >
-                  <ha-icon icon="mdi:close"></ha-icon>
-                </button>
-              </span>`
+          ? html`<span
+              class="ha-link-chip"
+              title=${`Linked to the Home Assistant area "${linked?.name ?? a.haArea}"`}
+            >
+              <ha-icon icon="mdi:link-variant"></ha-icon>Linked
+              <button
+                class="unlink"
+                title="Keep this name but unlink the Home Assistant area"
+                @click=${() => this._unlinkHaArea(a.id)}
+              >
+                <ha-icon icon="mdi:close"></ha-icon>
+              </button>
+            </span>`
           : html`<span class="hint"
               >${haAreas.length
-                ? "Matching a Home Assistant area's name links it."
+                ? "Type or pick a Home Assistant area's name to link it."
                 : "No Home Assistant areas available."}</span
             >`}
       </div>
+    `;
+  }
+
+  /**
+   * The name control itself: HA's own `ha-combo-box` when it's defined, so this
+   * field looks and behaves like the entity/icon pickers elsewhere in the
+   * editor (filter-as-you-type dropdown, keyboard nav) rather than a bare text
+   * box. `allow-custom-value` is what makes the merged field work — a name that
+   * matches no HA area is still accepted as a plain label.
+   *
+   * Falls back to `<input list>` + `<datalist>`: native autocomplete, no HA
+   * components required (older HA, the dev harness).
+   */
+  private _renderAreaNamePicker(a: Area, haAreas: HaAreaInfo[]): TemplateResult {
+    const placeholder = "Room name (or a Home Assistant area)";
+    if (customElements.get("ha-combo-box")) {
+      return html`<ha-combo-box
+        .hass=${this.hass}
+        .items=${haAreas}
+        item-value-path="name"
+        item-label-path="name"
+        item-id-path="area_id"
+        allow-custom-value
+        .placeholder=${placeholder}
+        .value=${a.name ?? ""}
+        @value-changed=${(e: CustomEvent) =>
+          this._commitAreaName(a.id, ((e.detail as { value?: string }).value ?? "").toString())}
+      ></ha-combo-box>`;
+    }
+    const listId = `ha-areas-${a.id}`;
+    return html`
+      <input
+        type="text"
+        list=${haAreas.length ? listId : nothing}
+        placeholder=${placeholder}
+        .value=${a.name ?? ""}
+        @change=${(e: Event) =>
+          this._commitAreaName(a.id, (e.target as HTMLInputElement).value)}
+      />
+      ${haAreas.length
+        ? html`<datalist id=${listId}>
+            ${haAreas.map((ha) => html`<option value=${ha.name}></option>`)}
+          </datalist>`
+        : nothing}
     `;
   }
 
@@ -4460,7 +4498,8 @@ export class FloorplanCardEditor extends LitElement {
       color: var(--primary-text-color);
     }
     ha-entity-picker,
-    ha-icon-picker {
+    ha-icon-picker,
+    ha-combo-box {
       flex: 1;
       min-width: 0;
     }
@@ -4481,6 +4520,19 @@ export class FloorplanCardEditor extends LitElement {
       font-size: 13px;
       color: var(--secondary-text-color);
       line-height: 1.5;
+    }
+    /* The Area name's status line (Linked chip / hint). It sits on its own row
+       under the field rather than beside it: the docked inspector is only
+       340px wide in full screen, and a chip + hint sharing that row squeezed
+       the name box down to a sliver. The empty label keeps it aligned with the
+       field above, and -4px claws back the row's own bottom margin so the pair
+       still reads as one control. */
+    .area-name-status {
+      margin-top: -4px;
+    }
+    .area-name-status label {
+      /* Alignment spacer only — nothing to announce. */
+      flex: 0 0 90px;
     }
     /* "Linked" badge on the Area name row: the HA-area association is implied
        by the name matching, so it needs to be visible somewhere. */


### PR DESCRIPTION
Follow-up to #87 on two pieces of feedback: the name field didn't *feel* like the editor's other HA-backed fields, and in the expanded (full-screen) editor it was barely visible.

## 1. It now uses HA's own picker component

It was a bare `<input list>` + `<datalist>` — native autocomplete, but visually and behaviourally unlike the `ha-entity-picker` / `ha-icon-picker` sitting right next to it.

It now renders **`ha-combo-box`** when defined — the same component `ha-entity-picker` is built on, so you get the filter-as-you-type dropdown, keyboard navigation and HA styling. `allow-custom-value` is what keeps the merged field working: a name that matches no HA area is still accepted as a plain label.

The `<input list>` path stays as the fallback for older HA, and `ha-combo-box` was added to the late-definition watch list so the fallback upgrades itself once HA defines the component.

## 2. It's no longer squeezed in expanded view

The docked inspector is a fixed **340px** column in full screen, and the name row had the label, the field *and* the "Linked" chip on one line. Measured in the harness, that left the field **92px** wide — the "barely visible" report.

The chip/hint now sit on their own status row beneath the field, aligned under it.

| | name field width (342px panel) |
|---|---|
| before (main) | **92px** |
| after | **236px** |

Both measured the same way in the dev harness with the inspector docked.

## Verified

Behaviour is unchanged through the new component — driven via the combo box's `value-changed`:

| step | name | haArea | chip |
|---|---|---|---|
| type `Lounge` | Lounge | cleared | — |
| type `living room` | **Living Room** | `living_room` | ✅ |
| click unlink × | Living Room | cleared | — |
| type `Living Room` | Living Room | `living_room` | ✅ |

The dev harness gains an **`ha-combo-box` stub** (matching the existing `ha-entity-picker` one), so `npm run serve` exercises the branch that actually runs in HA rather than only the fallback — that's how the above was tested.

`npm test` 431 passed, `typecheck` and `build` clean.

> Note: the stub approximates the real `ha-combo-box` (native input + datalist). The wiring — items, `item-label-path`, `allow-custom-value`, `value-changed` — is exercised locally, but the real dropdown's look/feel can only be confirmed in a live HA install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)