### PR TITLE
Areas: render the name field through ha-form so it looks like HA's own

### DIFF
--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -13,6 +13,7 @@ import {
   projectRotationForm,
   floorImageForm,
   areaForm,
+  areaNameForm,
 } from "./editor-forms";
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
@@ -239,6 +240,38 @@ describe("itemForm", () => {
   });
 });
 
+describe("areaNameForm", () => {
+  const area = (extra: Partial<Area> = {}): Area => ({
+    id: "a",
+    points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }],
+    ...extra,
+  });
+
+  it("offers the HA areas as a typeable dropdown (so HA renders it natively)", () => {
+    const name = areaNameForm(area(), ["Bedroom", "Living Room"]).fields[0];
+    expect(name.selector).toEqual({
+      select: {
+        options: [
+          { value: "Bedroom", label: "Bedroom" },
+          { value: "Living Room", label: "Living Room" },
+        ],
+        custom_value: true,
+        mode: "dropdown",
+        sort: false,
+      },
+    });
+  });
+
+  it("degrades to a plain text field when there are no HA areas to offer", () => {
+    expect(areaNameForm(area()).fields[0].selector).toEqual({ text: {} });
+  });
+
+  it("carries the current name as its data", () => {
+    expect(areaNameForm(area({ name: "Kitchen" })).data).toEqual({ name: "Kitchen" });
+    expect(areaNameForm(area()).data).toEqual({ name: "" });
+  });
+});
+
 describe("areaForm", () => {
   const area = (extra: Partial<Area> = {}): Area => ({
     id: "a",
@@ -256,10 +289,8 @@ describe("areaForm", () => {
     expect(d).toMatchObject({ showName: false, opacity: 0.5 });
   });
 
-  it("omits name — it's a bespoke row (autocompletes against HA areas to link one)", () => {
-    const f = areaForm(area({ name: "Kitchen" }));
-    expect(f.fields.some((x) => x.name === "name")).toBe(false);
-    expect(f.data).not.toHaveProperty("name");
+  it("keeps name out of the style form — it's its own form, above the link status", () => {
+    expect(areaForm(area({ name: "Kitchen" })).fields.some((x) => x.name === "name")).toBe(false);
   });
 
   it("opacity field is a 0..1 slider", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -497,11 +497,39 @@ export function trackerForm(tr: Tracker): FormSpec {
 }
 
 /**
- * Visibility/opacity fields for an Area (a room polygon). Color and the
- * name — which doubles as the HA-area link, so it needs a datalist of area
- * names and an unlink affordance — are bespoke rows in the editor's selection
- * editor, same as every other color field / registry link in this file (see
- * `textForm`'s caller / `_renderHaFloorRow` in editor.ts).
+ * Name/visibility/opacity fields for an Area (a room polygon). Only the color
+ * stays a bespoke row in the editor's selection editor, same as every other
+ * color field in this file (see `textForm`'s caller).
+ *
+ * The name doubles as the HA-area link, so with `haAreaNames` it's a `select`
+ * with `custom_value` — HA renders that as a combo box you can also type into,
+ * which is what makes the field look and behave like the rest of the form
+ * (a bespoke row outside `ha-form` can't match HA's own field rendering).
+ * Without any HA areas to offer there's nothing to pick from, so it degrades
+ * to a plain text field rather than an empty dropdown.
+ */
+export function areaNameForm(a: Area, haAreaNames: readonly string[] = []): FormSpec {
+  const nameSelector = haAreaNames.length
+    ? {
+        select: {
+          options: haAreaNames.map((n) => ({ value: n, label: n })),
+          custom_value: true,
+          mode: "dropdown",
+          sort: false,
+        },
+      }
+    : { text: {} };
+  return {
+    fields: [{ name: "name", label: "Name", selector: nameSelector }],
+    data: { name: a.name ?? "" },
+    toPatch: identity,
+  };
+}
+
+/**
+ * The Area's remaining style fields. Split from {@link areaNameForm} so the
+ * editor can slot the HA-link status line directly beneath the name it
+ * describes; both halves still render through `ha-form`.
  */
 export function areaForm(a: Area): FormSpec {
   return {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -36,7 +36,7 @@ import {
   makeFloor,
   haFloorsOf,
   haAreasOf,
-  matchHaAreaByName,
+  areaNamePatch,
   entityIdsInHaArea,
   areaFiltersEntities,
   moveFloor,
@@ -87,6 +87,7 @@ import {
   FURNITURE_LABELS,
   FURNITURE_TYPES,
   areaForm,
+  areaNameForm,
   diffFormValue,
   floorImageForm,
   furnitureForm,
@@ -1695,49 +1696,21 @@ export class FloorplanCardEditor extends LitElement {
     });
   }
 
-  /**
-   * Commit the Area's name, which doubles as the HA-area link: one field, so
-   * typing (or picking from the datalist) a name that matches a Home Assistant
-   * area links to it, and any other text is just a free label and clears the
-   * link. Picking from the datalist adopts the HA area's exact spelling, so a
-   * case-insensitive match doesn't leave the plan labelled "living room".
-   *
-   * The link is never silent — {@link _renderAreaNameRow} shows a "Linked"
-   * chip whenever `haArea` is set, with its own unlink button for the one case
-   * this can't express: keeping the name while dropping the link.
-   */
-  private _commitAreaName(id: string, typed: string): void {
-    const name = typed.trim();
-    const ha = matchHaAreaByName(haAreasOf(this.hass), name);
-    this._updateArea(id, {
-      name: ha ? ha.name : name || undefined,
-      haArea: ha?.area_id,
-    });
-  }
-
   /** Drop the HA-area link but keep the name the user sees on the plan. */
   private _unlinkHaArea(id: string): void {
     this._updateArea(id, { haArea: undefined });
   }
 
   /**
-   * The Area's single name field: a free-text input whose `<datalist>` offers
-   * every Home Assistant area, so naming a room after one links it (see
-   * {@link _commitAreaName}). A "Linked" chip — with an unlink button — makes
-   * the resulting association visible rather than implied by the text alone.
-   *
-   * Falls back to a plain input when `hass` exposes no area registry (older
-   * HA, the dev harness): the field still names the room, there's just nothing
-   * to autocomplete against.
+   * Status line under the Area's name field. The name doubles as the HA-area
+   * link (see {@link areaNamePatch}), so the resulting association would
+   * otherwise be invisible: this shows a "Linked" chip whenever `haArea` is
+   * set, with an unlink button for the one intent the merged field can't
+   * express — keeping the name while dropping the link.
    */
-  private _renderAreaNameRow(a: Area): TemplateResult {
-    const haAreas = haAreasOf(this.hass);
+  private _renderAreaLinkRow(a: Area, haAreas: HaAreaInfo[]): TemplateResult {
     const linked = a.haArea ? haAreas.find((ha) => ha.area_id === a.haArea) : undefined;
     return html`
-      <div class="row wide">
-        <label>Name</label>
-        ${this._renderAreaNamePicker(a, haAreas)}
-      </div>
       <div class="row wide area-name-status">
         <label></label>
         ${a.haArea
@@ -1756,54 +1729,10 @@ export class FloorplanCardEditor extends LitElement {
             </span>`
           : html`<span class="hint"
               >${haAreas.length
-                ? "Type or pick a Home Assistant area's name to link it."
+                ? "Name this room after a Home Assistant area to link it."
                 : "No Home Assistant areas available."}</span
             >`}
       </div>
-    `;
-  }
-
-  /**
-   * The name control itself: HA's own `ha-combo-box` when it's defined, so this
-   * field looks and behaves like the entity/icon pickers elsewhere in the
-   * editor (filter-as-you-type dropdown, keyboard nav) rather than a bare text
-   * box. `allow-custom-value` is what makes the merged field work — a name that
-   * matches no HA area is still accepted as a plain label.
-   *
-   * Falls back to `<input list>` + `<datalist>`: native autocomplete, no HA
-   * components required (older HA, the dev harness).
-   */
-  private _renderAreaNamePicker(a: Area, haAreas: HaAreaInfo[]): TemplateResult {
-    const placeholder = "Room name (or a Home Assistant area)";
-    if (customElements.get("ha-combo-box")) {
-      return html`<ha-combo-box
-        .hass=${this.hass}
-        .items=${haAreas}
-        item-value-path="name"
-        item-label-path="name"
-        item-id-path="area_id"
-        allow-custom-value
-        .placeholder=${placeholder}
-        .value=${a.name ?? ""}
-        @value-changed=${(e: CustomEvent) =>
-          this._commitAreaName(a.id, ((e.detail as { value?: string }).value ?? "").toString())}
-      ></ha-combo-box>`;
-    }
-    const listId = `ha-areas-${a.id}`;
-    return html`
-      <input
-        type="text"
-        list=${haAreas.length ? listId : nothing}
-        placeholder=${placeholder}
-        .value=${a.name ?? ""}
-        @change=${(e: Event) =>
-          this._commitAreaName(a.id, (e.target as HTMLInputElement).value)}
-      />
-      ${haAreas.length
-        ? html`<datalist id=${listId}>
-            ${haAreas.map((ha) => html`<option value=${ha.name}></option>`)}
-          </datalist>`
-        : nothing}
     `;
   }
 
@@ -2631,7 +2560,30 @@ export class FloorplanCardEditor extends LitElement {
     const value = spec.data[f.name];
     const sel = f.selector;
     if ("select" in sel) {
-      const options = (sel.select as { options: { value: string; label: string }[] }).options;
+      const select = sel.select as {
+        options: { value: string; label: string }[];
+        custom_value?: boolean;
+      };
+      const options = select.options;
+      // `custom_value` means "pick one of these, or type your own" — a <select>
+      // can't express that, so mirror HA's combo box with a datalist-backed
+      // input (the Area name field, which doubles as its HA-area link).
+      if (select.custom_value) {
+        const listId = `sel-${f.name}-${options.length}`;
+        return html`<div class="row wide">
+          <label>${f.label}</label>
+          <input
+            type="text"
+            list=${listId}
+            .value=${String(value ?? "")}
+            @change=${(e: Event) =>
+              this._applyFallback(spec, f, (e.target as HTMLInputElement).value, false, apply)}
+          />
+          <datalist id=${listId}>
+            ${options.map((o) => html`<option value=${o.value}></option>`)}
+          </datalist>
+        </div>`;
+      }
       return html`<div class="row">
         <label>${f.label}</label>
         <select
@@ -3323,9 +3275,17 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "area") {
       const a = (this._floor().areas ?? []).find((x) => x.id === sel.id);
       if (!a) return html`${nothing}`;
+      const haAreas = haAreasOf(this.hass);
       const pendingEntities = a.haArea ? this._pendingAreaEntities(a) : [];
       return html`
-        ${this._renderAreaNameRow(a)}
+        ${this._renderForm(
+          areaNameForm(a, haAreas.map((ha) => ha.name)),
+          (patch, live) =>
+            // The name field doubles as the HA-area link, so a name change also
+            // decides `haArea` (see areaNamePatch).
+            this._applyElementPatch("area", a.id, areaNamePatch(patch, haAreas), live)
+        )}
+        ${this._renderAreaLinkRow(a, haAreas)}
         ${this._renderForm(areaForm(a), (patch, live) =>
           this._applyElementPatch("area", a.id, patch, live)
         )}

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -11,6 +11,7 @@ import {
   haFloorsOf,
   haAreasOf,
   matchHaAreaByName,
+  areaNamePatch,
   entityHaAreaId,
   entityIdsInHaArea,
   areaFiltersEntities,
@@ -353,6 +354,44 @@ describe("matchHaAreaByName", () => {
       { area_id: "bath_down", name: "Bathroom" },
     ];
     expect(matchHaAreaByName(dupes, "Bathroom")?.area_id).toBe("bath_up");
+  });
+});
+
+describe("areaNamePatch", () => {
+  const areas = [
+    { area_id: "bedroom", name: "Bedroom" },
+    { area_id: "living_room", name: "Living Room" },
+  ];
+
+  it("links (and canonicalizes) when the new name matches an HA area", () => {
+    expect(areaNamePatch({ name: "living room" }, areas)).toEqual({
+      name: "Living Room",
+      haArea: "living_room",
+    });
+  });
+
+  it("clears the link for a free-text name", () => {
+    expect(areaNamePatch({ name: "Lounge" }, areas)).toEqual({
+      name: "Lounge",
+      haArea: undefined,
+    });
+  });
+
+  it("drops an emptied name entirely (and its link)", () => {
+    expect(areaNamePatch({ name: "  " }, areas)).toEqual({ name: undefined, haArea: undefined });
+  });
+
+  it("passes through patches that don't touch the name", () => {
+    const patch = { showName: false, opacity: 0.4 };
+    expect(areaNamePatch(patch, areas)).toBe(patch);
+  });
+
+  it("preserves other keys in a patch that does touch the name", () => {
+    expect(areaNamePatch({ name: "Bedroom", showName: false }, areas)).toEqual({
+      name: "Bedroom",
+      haArea: "bedroom",
+      showName: false,
+    });
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -660,6 +660,23 @@ export function haAreasOf(hass: unknown): HaAreaInfo[] {
  * wins. That ambiguity is inherent to naming an area by name; picking the
  * other one means renaming it in HA.
  */
+/**
+ * Resolve the HA-area link for an Area form patch that may carry a new `name`.
+ * The name field doubles as the link, so committing a name also decides
+ * `haArea`: a name matching an HA area links it (adopting that area's exact
+ * spelling), anything else clears the link and stands as a plain label.
+ * Patches that don't touch `name` pass through untouched.
+ */
+export function areaNamePatch(
+  patch: Record<string, unknown>,
+  areas: readonly HaAreaInfo[]
+): Record<string, unknown> {
+  if (!("name" in patch)) return patch;
+  const typed = (patch.name ?? "").toString().trim();
+  const ha = matchHaAreaByName(areas, typed);
+  return { ...patch, name: ha ? ha.name : typed || undefined, haArea: ha?.area_id };
+}
+
 export function matchHaAreaByName(
   areas: readonly HaAreaInfo[],
   name: string | undefined


### PR DESCRIPTION
Follow-up to #89 — the name field still didn't feel like the editor's other HA-backed inputs.

## Why it looked foreign (the actual cause)

It wasn't the component choice. Look at `_renderForm`:

```ts
if (customElements.get("ha-form")) {
  return html`<ha-form .hass=… .data=… .schema=…>`;   // HA renders EVERY field
}
return html`${spec.fields.map((f) => this._renderFallbackField(spec, f, apply))}`;
```

**Inside HA, the editor hands the whole `FormSpec` to `ha-form` and HA renders the fields itself** — that's where the native look comes from (HA's own text fields, floating labels, spacing). The `_renderFallbackField` path, and `_renderEntityPicker` with it, only ever runs *outside* HA.

#87 moved the name **out of the form** into a bespoke row so it could have a datalist. That put it outside HA's rendering entirely — so no component I dropped into that row (`<input list>`, then `ha-combo-box`) could match the fields above and below it. It was structurally foreign.

## The fix

Put the name **back inside the form**, as a `select` selector with `custom_value: true`:

```ts
{ name: "name", label: "Name", selector: {
    select: { options: haAreaNames.map(n => ({ value: n, label: n })),
              custom_value: true, mode: "dropdown", sort: false } } }
```

HA renders that as a combo box you can also type into — exactly the "pick an area, or write your own label" behaviour the merged field needs, and native by construction. With no HA areas to offer it degrades to a plain `text` selector rather than an empty dropdown.

Supporting changes:
- **`areaNamePatch`** — a pure helper applied to the form's patch, so committing a name still resolves (or clears) `haArea`. Replaces the old bespoke commit handler.
- **Form split in two** (`areaNameForm` → link status row → `areaForm`) so the "Linked" chip stays directly under the name it describes instead of drifting below Fill opacity. Both halves still render through `ha-form`.
- **Fallback honours `custom_value`** (datalist-backed input) so outside-HA use keeps free text + suggestions.

## Verified

Row order in the panel is `Name → [Linked chip] → Show name → Fill opacity → Color → Filter entities`, and the link behaviour is unchanged:

| step | name | haArea | chip |
|---|---|---|---|
| type `Lounge` | Lounge | cleared | — |
| type `living room` | **Living Room** | `living_room` | ✅ |
| click unlink × | Living Room | cleared | — |
| type `Living Room` | Living Room | `living_room` | ✅ |

`npm test` **439 passed** (+8: `areaNamePatch` ×5, `areaNameForm` ×3), `typecheck` and `build` clean.

> As before, the harness has no `ha-form`, so locally this exercises the fallback path. The HA path is the one thing I can't run here — but it's now the *same* mechanism every other field in this editor uses, which is what makes it match rather than a component I picked to imitate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)