### PR TITLE
Color elements by entity state (#68, #79, #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,12 @@ By default it shows an icon badge:
   of the state (a climate's `current_temperature` rather than "heat"), and
   **2nd attribute** for a second reading from the same device — so one climate
   entity renders `21.5 °C · 45%`. Formatted by HA's own attribute formatter.
-- **Threshold colors** — `stateColor` (YAML) colors the label by value:
+- **Active color** — every active device is the theme's yellow by default, which
+  makes a wall of lights, covers and switches hard to read. Set **Active color**
+  per device to tell them apart at a glance — lights yellow, covers purple,
+  thermostats orange. Ripples follow it unless you set a ripple color too.
+- **Color by state** — the **Color by state** rules color the label by what the
+  entity reads. Add rules in the editor, or in YAML:
 
   ```yaml
   stateColor:
@@ -203,7 +208,18 @@ By default it shows an icon badge:
   ```
 
   The highest matching `above` wins; non-numeric values use the default rule.
-  Colors go through the same injection allowlist as every other config color.
+  A rule can also match an exact state instead of a threshold, for entities
+  whose value is a word rather than a number:
+
+  ```yaml
+  stateColor:
+    - state: open
+      color: red
+    - color: green
+  ```
+
+  An exact `state` match beats a threshold. Colors go through the same
+  injection allowlist as every other config color.
 - **No entity? Still on the map** — a device with no entity bound renders as a plain
   badge (its icon override or kind default), so hardware that has no Home Assistant
   entity — a dumb smoke detector, a wired doorbell — can still be marked on the plan.
@@ -528,7 +544,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `secondaryEntity` | string                             | —            | Optional 2nd entity shown alongside (e.g. humidity).   |
 | `attribute`   | string                                 | —            | Show this attribute of `entity` instead of its state (e.g. `current_temperature`). |
 | `secondaryAttribute` | string                          | —            | Attribute for the 2nd reading — from `secondaryEntity`, or from `entity` when none. |
-| `stateColor`  | rule[]                                 | —            | Threshold colors for the label: `[{above: 26, color: red}, {color: white}]`. Highest matching `above` wins. |
+| `stateColor`  | rule[]                                 | —            | Colors for the label: `[{above: 26, color: red}, {color: white}]`. A rule matches `above: <n>` or `state: <value>`; an exact state beats a threshold, the highest matching `above` beats a lower one, and a rule with neither is the default. |
 | `x`, `y`      | number                                 | —            | Position.                                              |
 | `kind`        | light/switch/sensor/binary_sensor/climate/cover/generic | inferred | Used for the default icon.            |
 | `icon`        | string                                 | entity icon  | Override mdi icon.                                     |
@@ -537,7 +553,8 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
 | `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn.                               |
 | `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. |
-| `rippleColor` | string                                 | primary color| Ripple ring color (ripple modes).                     |
+| `activeColor` | string                                 | theme color  | Badge color while the device is on — lets domains be told apart at a glance. |
+| `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
@@ -554,10 +571,27 @@ domains open the more-info dialog.
 
 ### Furniture
 
-`{ id, type, x, y, w, h, angle?, color? }` where `type` is one of `table`, `roundTable`,
-`desk`, `chair`, `sofa`, `bed`, `wardrobe`, `rug`, `plant`, `fridge`, `stove`, `sink`,
-`toilet`, `stairs`, `tv`. `color` defaults to gray so furniture reads differently from
-walls.
+`{ id, type, x, y, w, h, angle?, color?, entity?, activeColor?, stateColor? }` where
+`type` is one of `table`, `roundTable`, `desk`, `chair`, `sofa`, `bed`, `wardrobe`,
+`rug`, `plant`, `fridge`, `stove`, `sink`, `toilet`, `stairs`, `tv`. `color` defaults
+to gray so furniture reads differently from walls.
+
+Furniture can bind an **entity** to make the drawing live: `stateColor` and
+`activeColor` then recolor the whole diagram the same way they do a device label.
+A plant with a soil sensor goes red when it needs watering; a fish tank turns on
+a water-temperature threshold; a cabinet with a contact sensor highlights while
+its door is open.
+
+```yaml
+{ id: plant1, type: plant, x: 300, y: 220, w: 40, h: 40,
+  entity: sensor.ficus_soil_moisture,
+  stateColor:
+    - above: 80
+      color: green
+    - above: 65
+      color: yellow
+    - color: red }
+```
 
 ### Tracker
 

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -255,6 +255,21 @@ const hass = {
       state: "on",
       attributes: { friendly_name: "Living Room" },
     },
+    // Per-device active colors (issue #79): this cover and the light above are
+    // both active on the demo floor, with different `activeColor`s — the whole
+    // point of the option is that they no longer look identical.
+    "cover.living_blinds": {
+      entity_id: "cover.living_blinds",
+      state: "open",
+      attributes: { friendly_name: "Living Blinds", device_class: "blind" },
+    },
+    // Entity-bound furniture (issue #82): the plant on the demo floor reads
+    // this, and the emulator below gives it a 0–100 slider.
+    "sensor.ficus_soil_moisture": {
+      entity_id: "sensor.ficus_soil_moisture",
+      state: "72",
+      attributes: { friendly_name: "Ficus Soil Moisture", unit_of_measurement: "%" },
+    },
     // "Show as" demo (issue #29): a binary_sensor with device_class lock should
     // render mdi:lock / mdi:lock-open instead of the generic kind icon.
     "binary_sensor.door_lock": {
@@ -395,9 +410,44 @@ const demoFloor = {
     // deviceRegistry/areaRegistry) scopes its entity picker — drag it outside
     // the polygon to watch the picker widen back up.
     { id: "i2", entity: "light.living_room", x: 220, y: 180, kind: "light" as const },
+    // Issue #79: two active devices side by side with different active colors.
+    // Both are "on"; before the option existed both badges were the same yellow.
+    {
+      id: "i3",
+      entity: "light.living_room",
+      x: 300,
+      y: 180,
+      kind: "light" as const,
+      activeColor: "#ffb300",
+    },
+    {
+      id: "i4",
+      entity: "cover.living_blinds",
+      x: 380,
+      y: 180,
+      kind: "cover" as const,
+      activeColor: "#8e24aa",
+    },
   ],
   texts: [],
-  furniture: [],
+  // Issue #82: a plant bound to a soil sensor, colored by threshold — the
+  // exact configuration the issue asks for.
+  furniture: [
+    {
+      id: "fu1",
+      type: "plant" as const,
+      x: 700,
+      y: 380,
+      w: 60,
+      h: 60,
+      entity: "sensor.ficus_soil_moisture",
+      stateColor: [
+        { above: 80, color: "#2e7d32" },
+        { above: 65, color: "#f9a825" },
+        { color: "#c62828" },
+      ],
+    },
+  ],
   trackers: [],
   // Area demo: the whole room, linked to the mock "living_room" HA area so
   // the entity-filtering behavior (light.living_room in, fan.ceiling_fan out)

--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { cssColor } from "./css-safe";
+import { furnitureColor } from "./render";
+import type { Furniture } from "./types";
 
 describe("cssColor — adversarial: exotic breakout attempts all rejected", () => {
   const ATTACKS = [
@@ -110,5 +112,63 @@ describe("cssColor — INVARIANT: nothing accepted can break out of a style decl
     }
     // sanity: the legit seeds really were accepted (so the invariant isn't vacuous)
     expect(accepted).toBeGreaterThanOrEqual(6);
+  });
+});
+
+/*
+ * The colors added for #68/#79/#82 reach a `stroke`/`fill` attribute or a CSS
+ * custom property, so each new path needs its own gate — resolveStateColor
+ * deliberately returns the config string unfiltered, and it is the caller's
+ * job to run cssColor on it. These assert the callers actually do.
+ */
+describe("entity-driven colors are gated (issues #68, #79, #82)", () => {
+  const HOSTILE = "red;position:fixed";
+
+  it("furnitureColor filters a hostile stateColor rule", () => {
+    const f = {
+      id: "f",
+      type: "plant",
+      x: 0,
+      y: 0,
+      w: 10,
+      h: 10,
+      entity: "sensor.soil",
+      stateColor: [{ color: HOSTILE }],
+    } as Furniture;
+    expect(furnitureColor(f, "1")).toBeUndefined();
+  });
+
+  it("furnitureColor filters a hostile activeColor", () => {
+    const f = {
+      id: "f",
+      type: "plant",
+      x: 0,
+      y: 0,
+      w: 10,
+      h: 10,
+      entity: "binary_sensor.x",
+      activeColor: HOSTILE,
+    } as Furniture;
+    expect(furnitureColor(f, "on")).toBeUndefined();
+  });
+
+  it("a legitimate color still survives both paths", () => {
+    const base = { id: "f", type: "plant", x: 0, y: 0, w: 10, h: 10, entity: "sensor.s" };
+    expect(furnitureColor({ ...base, stateColor: [{ color: "#ff0000" }] } as Furniture, "1")).toBe(
+      "#ff0000",
+    );
+    expect(
+      furnitureColor(
+        { ...base, entity: "binary_sensor.x", activeColor: "var(--primary-color)" } as Furniture,
+        "on",
+      ),
+    ).toBe("var(--primary-color)");
+  });
+
+  // The item badge's activeColor (#79) lands in a --fp-active custom property;
+  // the card runs it through the same gate before it reaches the style string.
+  it("a hostile item activeColor does not survive cssColor", () => {
+    expect(cssColor(HOSTILE)).toBeUndefined();
+    expect(cssColor("#fdd835")).toBe("#fdd835");
   });
 });

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -322,6 +322,44 @@ describe("textForm / furnitureForm / trackerForm", () => {
     const d = trackerForm({ id: "t", x: 1.6, y: 2.2, w: 20, h: 20 } as never).data;
     expect(d).toMatchObject({ x: 2, y: 2, w: 20, h: 20 });
   });
+
+  // Issue #82: furniture can bind an entity so the drawing goes live.
+  it("furniture offers an optional entity, empty when unbound", () => {
+    const form = furnitureForm({ id: "f", type: "plant", x: 0, y: 0, w: 10, h: 10 } as never);
+    const entity = form.fields.find((x) => x.name === "entity")!;
+    expect(entity.required).toBeUndefined();
+    expect(entity.selector).toEqual({ entity: {} });
+    expect(form.data.entity).toBe("");
+  });
+
+  it("furniture entity picker scopes to a linked HA area when given one", () => {
+    const form = furnitureForm({ id: "f", type: "plant", x: 0, y: 0, w: 10, h: 10 } as never, [
+      "sensor.soil",
+    ]);
+    expect(form.fields.find((x) => x.name === "entity")!.selector).toEqual({
+      entity: { include_entities: ["sensor.soil"] },
+    });
+  });
+
+  it("sectional keeps its chaise-side field alongside the entity", () => {
+    const form = furnitureForm({
+      id: "f",
+      type: "sectional",
+      x: 0,
+      y: 0,
+      w: 10,
+      h: 10,
+      entity: "binary_sensor.x",
+    } as never);
+    expect(form.fields.map((x) => x.name)).toContain("hand");
+    expect(form.data).toMatchObject({ hand: "right", entity: "binary_sensor.x" });
+  });
+
+  it("non-sectional furniture has no chaise-side field or data", () => {
+    const form = furnitureForm({ id: "f", type: "table", x: 0, y: 0, w: 10, h: 10 } as never);
+    expect(form.fields.map((x) => x.name)).not.toContain("hand");
+    expect("hand" in form.data).toBe(false);
+  });
 });
 
 describe("wallForm / projectForm / floorImageForm", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -432,7 +432,12 @@ export function textForm(t: FloorText): FormSpec {
   };
 }
 
-export function furnitureForm(f: Furniture): FormSpec {
+/**
+ * `areaEntities` scopes the entity picker to a linked HA area, exactly as in
+ * {@link itemForm} — a plant drawn inside the Living Room offers the Living
+ * Room's sensors first.
+ */
+export function furnitureForm(f: Furniture, areaEntities?: string[]): FormSpec {
   return {
     fields: [
       {
@@ -461,11 +466,24 @@ export function furnitureForm(f: Furniture): FormSpec {
       { name: "w", label: "Width", required: true, selector: { number: { min: 10, mode: "box" } } },
       { name: "h", label: "Height", required: true, selector: { number: { min: 10, mode: "box" } } },
       angleField(),
+      // Optional entity that makes the drawing live (issue #82) — a soil
+      // sensor on a plant, a contact sensor on a cabinet. Last, because most
+      // furniture is decoration and never binds anything.
+      {
+        name: "entity",
+        label: "Entity",
+        helper: "Optional — lets the drawing change color with a sensor",
+        selector: areaEntities ? { entity: { include_entities: areaEntities } } : { entity: {} },
+      },
     ],
-    data:
-      f.type === "sectional"
-        ? { type: f.type, hand: f.hand ?? "right", w: f.w, h: f.h, angle: f.angle ?? 0 }
-        : { type: f.type, w: f.w, h: f.h, angle: f.angle ?? 0 },
+    data: {
+      type: f.type,
+      ...(f.type === "sectional" ? { hand: f.hand ?? "right" } : {}),
+      w: f.w,
+      h: f.h,
+      angle: f.angle ?? 0,
+      entity: f.entity ?? "",
+    },
     toPatch: identity,
   };
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -18,6 +18,7 @@ import type {
   Area,
   AreaPoint,
   HaAreaInfo,
+  StateColorRule,
 } from "./types";
 import {
   DEFAULT_CUSTOM_PERCENT,
@@ -1736,6 +1737,165 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
+  /**
+   * The editor's colour control: a swatch that edits live as you drag, plus a
+   * text box for theme variables and named colours, committed on change.
+   * Emptying the text box clears the override.
+   *
+   * Every colour in this editor is one of these. It lived as eight copies of
+   * the same markup before the colour rules below needed a ninth.
+   */
+  private _renderColorRow(opts: {
+    label: string;
+    value: string | undefined;
+    /** Swatch colour shown when nothing is set — the effective default. */
+    swatch: string;
+    /** Text-box placeholder naming that default, e.g. "(primary)". */
+    placeholder: string;
+    onLive: (color: string) => void;
+    onCommit: (color: string | undefined) => void;
+    title?: string;
+  }): TemplateResult {
+    return html`
+      <div class="row">
+        <label title=${opts.title ?? nothing}>${opts.label}</label>
+        <input
+          type="color"
+          title=${opts.title ?? nothing}
+          .value=${opts.value ?? opts.swatch}
+          @input=${(e: Event) => opts.onLive((e.target as HTMLInputElement).value)}
+        />
+        <input
+          type="text"
+          placeholder=${opts.placeholder}
+          .value=${opts.value ?? ""}
+          @change=${(e: Event) => opts.onCommit((e.target as HTMLInputElement).value || undefined)}
+        />
+      </div>
+    `;
+  }
+
+  /**
+   * The "Color by state" block (issues #68, #79, #82): a list of rules, each
+   * one a condition and a colour, plus an "Add rule" button.
+   *
+   * A rule's condition is either a numeric threshold or an exact state, chosen
+   * per row — the two ways an entity's value comes back. A rule with neither is
+   * the fallback, and reads as "otherwise" in the UI.
+   *
+   * These are plain rows rather than `ha-form` fields: the list is repeatable
+   * and ha-form has no selector for that (its `object` selector is a raw YAML
+   * box). Colours are the one part of this editor that was always hand-rolled,
+   * so the block still matches its neighbours.
+   */
+  private _renderStateColorRules(
+    rules: StateColorRule[] | undefined,
+    onChange: (next: StateColorRule[] | undefined) => void
+  ): TemplateResult {
+    const list = rules ?? [];
+    const patch = (i: number, part: Partial<StateColorRule>): void => {
+      const next = list.map((r, j) => (j === i ? { ...r, ...part } : r));
+      onChange(next);
+    };
+    return html`
+      <div class="row wide state-colors">
+        <label title="Color the element by what its entity reads">Color by state</label>
+      </div>
+      ${list.map((rule, i) => {
+        const mode = typeof rule.state === "string" ? "state" : typeof rule.above === "number" ? "above" : "else";
+        return html`
+          <div class="row wide state-color-rule">
+            <select
+              .value=${mode}
+              title="When this rule applies"
+              @change=${(e: Event) => {
+                const m = (e.target as HTMLSelectElement).value;
+                // Switching condition drops the other kind, so a rule can
+                // never carry both an `above` and a `state`.
+                patch(i, {
+                  above: m === "above" ? (rule.above ?? 0) : undefined,
+                  state: m === "state" ? (rule.state ?? "") : undefined,
+                });
+              }}
+            >
+              <option value="above">above</option>
+              <option value="state">state is</option>
+              <option value="else">otherwise</option>
+            </select>
+            ${mode === "above"
+              ? html`<input
+                  type="number"
+                  class="cond"
+                  .value=${String(rule.above ?? 0)}
+                  @change=${(e: Event) =>
+                    patch(i, { above: Number((e.target as HTMLInputElement).value) || 0 })}
+                />`
+              : mode === "state"
+                ? html`<input
+                    type="text"
+                    class="cond"
+                    placeholder="on"
+                    .value=${rule.state ?? ""}
+                    @change=${(e: Event) => patch(i, { state: (e.target as HTMLInputElement).value })}
+                  />`
+                : html`<span class="cond hint">any other value</span>`}
+            <input
+              type="color"
+              .value=${rule.color || "#ff0000"}
+              @input=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
+            />
+            <input
+              type="text"
+              class="rule-color-text"
+              placeholder="red"
+              .value=${rule.color ?? ""}
+              @change=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
+            />
+            <button
+              class="rule-remove"
+              aria-label="Remove rule"
+              title="Remove this rule"
+              @click=${() => {
+                const next = list.filter((_, j) => j !== i);
+                onChange(next.length ? next : undefined);
+              }}
+            >
+              <ha-icon icon="mdi:close"></ha-icon>
+            </button>
+          </div>
+        `;
+      })}
+      <div class="row wide state-color-add">
+        <button
+          @click=${() =>
+            onChange([
+              ...list,
+              // A fresh rule defaults to a threshold: the numeric case is what
+              // both #68 and #82 ask for, and it's the one that needs no typing.
+              { above: 0, color: "#ff0000" },
+            ])}
+        >
+          <ha-icon icon="mdi:plus"></ha-icon>Add rule
+        </button>
+      </div>
+    `;
+  }
+
+  /**
+   * Entity ids to scope a picker to for something sitting at (x, y), or
+   * undefined for "offer everything".
+   *
+   * An element inside an Area linked to a Home Assistant area gets its pickers
+   * scoped to that area, unless the area's own "Filter entities" toggle turns
+   * that off. Recomputed on every render from the live coordinates, so it
+   * tracks the element as it's dragged in/out of the polygon, even before the
+   * form reopens.
+   */
+  private _areaEntitiesAt(x: number, y: number): string[] | undefined {
+    const area = areaContainingPoint(this._floor(), x, y);
+    return areaFiltersEntities(area) ? entityIdsInHaArea(this.hass, area!.haArea!) : undefined;
+  }
+
   /** Every entity in `area`'s linked HA area not already placed as an item on this floor. */
   private _pendingAreaEntities(area: Area): string[] {
     if (!area.haArea) return [];
@@ -3092,22 +3252,14 @@ export class FloorplanCardEditor extends LitElement {
           if (live) this._patchConfigLive(patch as Partial<FloorplanCardConfig>);
           else this._patchConfig(patch as Partial<FloorplanCardConfig>);
         })}
-        <div class="row">
-          <label>Background</label>
-          <input
-            type="color"
-            .value=${this._config.background ?? "#ffffff"}
-            @input=${(e: Event) =>
-              this._patchConfigLive({ background: (e.target as HTMLInputElement).value })}
-          />
-          <input
-            type="text"
-            placeholder="#ffffff or empty"
-            .value=${this._config.background ?? ""}
-            @change=${(e: Event) =>
-              this._patchConfig({ background: (e.target as HTMLInputElement).value || undefined })}
-          />
-        </div>
+        ${this._renderColorRow({
+          label: "Background",
+          value: this._config.background,
+          swatch: "#ffffff",
+          placeholder: "#ffffff or empty",
+          onLive: (background) => this._patchConfigLive({ background }),
+          onCommit: (background) => this._patchConfig({ background }),
+        })}
         ${this._renderForm(floorImageForm(this._floor()), (patch, live) => {
           if (live) this._patchFloorLive(patch as Partial<Floor>);
           else this._commitFloor(patch as Partial<Floor>);
@@ -3148,26 +3300,14 @@ export class FloorplanCardEditor extends LitElement {
           this._applyElementPatch("opening", o.id, patch, live);
         })}
         ${o.entity
-          ? html`<div class="row">
-              <label>Active color</label>
-              <input
-                type="color"
-                .value=${o.activeColor ?? "#03a9f4"}
-                @input=${(e: Event) =>
-                  this._updateOpeningLive(o.id, {
-                    activeColor: (e.target as HTMLInputElement).value,
-                  })}
-              />
-              <input
-                type="text"
-                placeholder="(primary)"
-                .value=${o.activeColor ?? ""}
-                @change=${(e: Event) =>
-                  this._updateOpening(o.id, {
-                    activeColor: (e.target as HTMLInputElement).value || undefined,
-                  })}
-              />
-            </div>`
+          ? this._renderColorRow({
+              label: "Active color",
+              value: o.activeColor,
+              swatch: "#03a9f4",
+              placeholder: "(primary)",
+              onLive: (activeColor) => this._updateOpeningLive(o.id, { activeColor }),
+              onCommit: (activeColor) => this._updateOpening(o.id, { activeColor }),
+            })
           : nothing}
       `;
     }
@@ -3175,15 +3315,7 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "item") {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
-      // A device placed inside an Area linked to a Home Assistant area gets
-      // its entity pickers scoped to that HA area, unless the area's own
-      // "Filter entities" toggle turns that off — recomputed on every render
-      // from the device's live x/y, so it tracks the device as it's dragged
-      // in/out of the polygon, even before the form reopens.
-      const containingArea = areaContainingPoint(this._floor(), it.x, it.y);
-      const areaEntities = areaFiltersEntities(containingArea)
-        ? entityIdsInHaArea(this.hass, containingArea!.haArea!)
-        : undefined;
+      const areaEntities = this._areaEntitiesAt(it.x, it.y);
       return html`
         ${this._renderForm(itemForm(it, areaEntities), (patch, live) => {
           // Any entity change re-derives the item kind (icon defaults etc.) —
@@ -3193,28 +3325,28 @@ export class FloorplanCardEditor extends LitElement {
           }
           this._applyElementPatch("item", it.id, patch, live);
         })}
+        ${this._renderColorRow({
+          label: "Active color",
+          title: "Badge color while this device is on (issue #79)",
+          value: it.activeColor,
+          swatch: "#fdd835",
+          placeholder: "(theme)",
+          onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
+          onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
+        })}
         ${(it.display ?? "badge") !== "badge"
-          ? html`<div class="row">
-              <label>Ripple color</label>
-              <input
-                type="color"
-                .value=${it.rippleColor ?? "#03a9f4"}
-                @input=${(e: Event) =>
-                  this._updateItemLive(it.id, {
-                    rippleColor: (e.target as HTMLInputElement).value,
-                  })}
-              />
-              <input
-                type="text"
-                placeholder="(primary)"
-                .value=${it.rippleColor ?? ""}
-                @change=${(e: Event) =>
-                  this._updateItem(it.id, {
-                    rippleColor: (e.target as HTMLInputElement).value || undefined,
-                  })}
-              />
-            </div>`
+          ? this._renderColorRow({
+              label: "Ripple color",
+              value: it.rippleColor,
+              swatch: it.activeColor ?? "#03a9f4",
+              placeholder: it.activeColor ? "(active color)" : "(primary)",
+              onLive: (rippleColor) => this._updateItemLive(it.id, { rippleColor }),
+              onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
+            })
           : nothing}
+        ${this._renderStateColorRules(it.stateColor, (stateColor) =>
+          this._updateItem(it.id, { stateColor })
+        )}
       `;
     }
 
@@ -3225,22 +3357,14 @@ export class FloorplanCardEditor extends LitElement {
         ${this._renderForm(textForm(t), (patch, live) =>
           this._applyElementPatch("text", t.id, patch, live)
         )}
-        <div class="row">
-          <label>Color</label>
-          <input
-            type="color"
-            .value=${t.color ?? "#000000"}
-            @input=${(e: Event) =>
-              this._updateTextLive(t.id, { color: (e.target as HTMLInputElement).value })}
-          />
-          <input
-            type="text"
-            placeholder="(theme default)"
-            .value=${t.color ?? ""}
-            @change=${(e: Event) =>
-              this._updateText(t.id, { color: (e.target as HTMLInputElement).value || undefined })}
-          />
-        </div>
+        ${this._renderColorRow({
+          label: "Color",
+          value: t.color,
+          swatch: "#000000",
+          placeholder: "(theme default)",
+          onLive: (color) => this._updateTextLive(t.id, { color }),
+          onCommit: (color) => this._updateText(t.id, { color }),
+        })}
       `;
     }
 
@@ -3248,27 +3372,33 @@ export class FloorplanCardEditor extends LitElement {
       const f = this._floor().furniture.find((x) => x.id === sel.id);
       if (!f) return html`${nothing}`;
       return html`
-        ${this._renderForm(furnitureForm(f), (patch, live) =>
+        ${this._renderForm(furnitureForm(f, this._areaEntitiesAt(f.x, f.y)), (patch, live) =>
           this._applyElementPatch("furniture", f.id, patch, live)
         )}
-        <div class="row">
-          <label>Color</label>
-          <input
-            type="color"
-            .value=${f.color ?? "#9e9e9e"}
-            @input=${(e: Event) =>
-              this._updateFurnitureLive(f.id, { color: (e.target as HTMLInputElement).value })}
-          />
-          <input
-            type="text"
-            placeholder="(gray)"
-            .value=${f.color ?? ""}
-            @change=${(e: Event) =>
-              this._updateFurniture(f.id, {
-                color: (e.target as HTMLInputElement).value || undefined,
+        ${this._renderColorRow({
+          label: "Color",
+          value: f.color,
+          swatch: "#9e9e9e",
+          placeholder: "(gray)",
+          onLive: (color) => this._updateFurnitureLive(f.id, { color }),
+          onCommit: (color) => this._updateFurniture(f.id, { color }),
+        })}
+        ${f.entity
+          ? html`
+              ${this._renderColorRow({
+                label: "Active color",
+                title: "Color while the entity is on",
+                value: f.activeColor,
+                swatch: "#03a9f4",
+                placeholder: "(no change)",
+                onLive: (activeColor) => this._updateFurnitureLive(f.id, { activeColor }),
+                onCommit: (activeColor) => this._updateFurniture(f.id, { activeColor }),
               })}
-          />
-        </div>
+              ${this._renderStateColorRules(f.stateColor, (stateColor) =>
+                this._updateFurniture(f.id, { stateColor })
+              )}
+            `
+          : nothing}
       `;
     }
 
@@ -3289,22 +3419,14 @@ export class FloorplanCardEditor extends LitElement {
         ${this._renderForm(areaForm(a), (patch, live) =>
           this._applyElementPatch("area", a.id, patch, live)
         )}
-        <div class="row">
-          <label>Color</label>
-          <input
-            type="color"
-            .value=${a.color ?? "#03a9f4"}
-            @input=${(e: Event) =>
-              this._updateAreaLive(a.id, { color: (e.target as HTMLInputElement).value })}
-          />
-          <input
-            type="text"
-            placeholder="(primary)"
-            .value=${a.color ?? ""}
-            @change=${(e: Event) =>
-              this._updateArea(a.id, { color: (e.target as HTMLInputElement).value || undefined })}
-          />
-        </div>
+        ${this._renderColorRow({
+          label: "Color",
+          value: a.color,
+          swatch: "#03a9f4",
+          placeholder: "(primary)",
+          onLive: (color) => this._updateAreaLive(a.id, { color }),
+          onCommit: (color) => this._updateArea(a.id, { color }),
+        })}
         ${a.haArea
           ? html`<div class="row wide">
               <label>Filter entities</label>
@@ -3353,24 +3475,14 @@ export class FloorplanCardEditor extends LitElement {
         ${this._renderForm(trackerForm(tr), (patch, live) =>
           this._applyElementPatch("tracker", tr.id, patch, live)
         )}
-        <div class="row">
-          <label>Color</label>
-          <input
-            type="color"
-            .value=${tr.color ?? "#03a9f4"}
-            @input=${(e: Event) =>
-              this._updateTrackerLive(tr.id, { color: (e.target as HTMLInputElement).value })}
-          />
-          <input
-            type="text"
-            placeholder="(primary)"
-            .value=${tr.color ?? ""}
-            @change=${(e: Event) =>
-              this._updateTracker(tr.id, {
-                color: (e.target as HTMLInputElement).value || undefined,
-              })}
-          />
-        </div>
+        ${this._renderColorRow({
+          label: "Color",
+          value: tr.color,
+          swatch: "#03a9f4",
+          placeholder: "(primary)",
+          onLive: (color) => this._updateTrackerLive(tr.id, { color }),
+          onCommit: (color) => this._updateTracker(tr.id, { color }),
+        })}
       `;
     }
 
@@ -4489,6 +4601,61 @@ export class FloorplanCardEditor extends LitElement {
        still reads as one control. */
     .area-name-status {
       margin-top: -4px;
+    }
+    /* "Color by state" rules (issues #68, #79, #82). The rules are a list, so
+       they read as one group indented under the heading row rather than as
+       more loose fields; the rail is what says "these belong together" in a
+       340px panel where indentation alone is too expensive. */
+    .state-colors {
+      margin-bottom: 4px;
+    }
+    .state-colors label {
+      flex: 1 1 auto;
+      font-weight: 500;
+    }
+    .state-color-rule,
+    .state-color-add {
+      padding-left: 8px;
+      border-left: 2px solid var(--divider-color, #ccc);
+      margin-bottom: 6px;
+    }
+    .state-color-rule select {
+      flex: 0 0 96px;
+    }
+    /* Higher specificity than the generic .row input rule above, which would
+       otherwise stretch a two-digit threshold across half the panel. */
+    .row.state-color-rule input.cond {
+      flex: 0 0 90px;
+    }
+    .row.state-color-rule span.cond {
+      flex: 0 0 auto;
+      font-size: 12px;
+      white-space: nowrap;
+    }
+    /* The color text box gives up width first — the condition and the swatch
+       are what you read, and the swatch already shows the colour. */
+    .row.state-color-rule input.rule-color-text {
+      flex: 1 1 60px;
+      min-width: 60px;
+    }
+    .state-color-rule .rule-remove,
+    .state-color-add button {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      border: 1px solid var(--divider-color, #ccc);
+      border-radius: 4px;
+      background: var(--card-background-color, #fff);
+      color: var(--secondary-text-color);
+      cursor: pointer;
+      padding: 3px 6px;
+    }
+    .state-color-rule .rule-remove {
+      flex: 0 0 auto;
+    }
+    .state-color-rule .rule-remove ha-icon,
+    .state-color-add button ha-icon {
+      --mdc-icon-size: 16px;
     }
     .area-name-status label {
       /* Alignment spacer only — nothing to announce. */

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -23,6 +23,7 @@ import {
   shutterActive,
   renderRipple,
   renderFurniture,
+  furnitureColor,
   renderTracker,
   renderArea,
   polygonCentroid,
@@ -219,7 +220,10 @@ export class FloorplanCard extends LitElement {
     const labelColor = cssColor(resolveStateColor(item.stateColor, rawValue));
     const showIcon = item.showIcon ?? true;
     const display = item.display ?? "badge";
-    const rippleColor = item.rippleColor ?? "var(--primary-color, #03a9f4)";
+    // Per-device active color (issue #79). Ripples follow it too, so a device
+    // given one color does not come out yellow-badged with a blue ring.
+    const activeColor = cssColor(item.activeColor);
+    const rippleColor = item.rippleColor ?? item.activeColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = item.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     let visual: TemplateResult | typeof nothing = nothing;
@@ -241,7 +245,9 @@ export class FloorplanCard extends LitElement {
     return html`
       <div
         class="item ${on ? "on" : "off"}"
-        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;${activeColor
+          ? `--fp-active:${activeColor};`
+          : ""}"
         title=${this._label(item)}
         role="button"
         tabindex="0"
@@ -339,7 +345,9 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
             ${active.areas?.map((a) => renderArea(a))}
-            ${active.furniture.map((f) => renderFurniture(f))}
+            ${active.furniture.map((f) =>
+              renderFurniture(f, furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined))
+            )}
             ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
             <g mask=${`url(#${this._wallMaskId})`}>
               ${active.walls.map(
@@ -581,9 +589,14 @@ export class FloorplanCard extends LitElement {
       color: var(--primary-text-color);
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     }
+    /*
+     * --fp-active is the item's own activeColor (issue #79) when it sets one;
+     * otherwise this falls through to the theme's active color, which is
+     * exactly what every badge used before the option existed.
+     */
     .item.on .badge {
-      background: var(--state-light-active-color, var(--state-active-color, #fdd835));
-      border-color: var(--state-light-active-color, var(--state-active-color, #fdd835));
+      background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
+      border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
       color: var(--text-primary-color, #212121);
     }
     ha-icon {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { FurnitureType, ItemKind } from "./types";
+import type { Furniture, FurnitureType, ItemKind } from "./types";
 import { FURNITURE_DEFAULT_SIZE } from "./types";
 import {
   snapToWall,
@@ -17,6 +17,7 @@ import {
   kindFromEntity,
   defaultIcon,
   renderFurniture,
+  furnitureColor,
   sectionalPoints,
   SECTIONAL_CHAISE_FRACTION,
   SECTIONAL_SEAT_FRACTION,
@@ -716,6 +717,66 @@ describe("collectWatchedEntities", () => {
     expect(got.has("light.legacy")).toBe(true);
     expect(got.size).toBe(1);
   });
+
+  // Issue #82: miss this and an entity-bound plant never repaints, because
+  // nothing tells the card its sensor is worth re-rendering for.
+  it("collects entity-bound furniture (issue #82)", () => {
+    const got = collectWatchedEntities({
+      furniture: [
+        { id: "p", type: "plant", x: 0, y: 0, w: 40, h: 40, entity: "sensor.soil" },
+        { id: "t", type: "table", x: 0, y: 0, w: 40, h: 40 },
+      ],
+    } as unknown as FloorplanCardConfig);
+    expect(got.has("sensor.soil")).toBe(true);
+    expect(got.size).toBe(1);
+  });
+});
+
+describe("furnitureColor (issue #82)", () => {
+  const plant = (extra: Record<string, unknown>) =>
+    ({ id: "p", type: "plant", x: 0, y: 0, w: 40, h: 40, ...extra }) as Furniture;
+
+  it("is undefined without an entity, so unbound furniture stays static", () => {
+    expect(furnitureColor(plant({ stateColor: [{ color: "red" }] }), "42")).toBeUndefined();
+    expect(furnitureColor(plant({ activeColor: "red" }), "on")).toBeUndefined();
+  });
+
+  it("resolves the matching threshold rule", () => {
+    const f = plant({
+      entity: "sensor.soil",
+      stateColor: [
+        { above: 80, color: "green" },
+        { above: 65, color: "yellow" },
+        { color: "red" },
+      ],
+    });
+    expect(furnitureColor(f, "90")).toBe("green");
+    expect(furnitureColor(f, "70")).toBe("yellow");
+    expect(furnitureColor(f, "40")).toBe("red");
+  });
+
+  it("falls back to activeColor only while the entity is active", () => {
+    const f = plant({ entity: "binary_sensor.cabinet", activeColor: "orange" });
+    expect(furnitureColor(f, "on")).toBe("orange");
+    expect(furnitureColor(f, "off")).toBeUndefined();
+    expect(furnitureColor(f, "unavailable")).toBeUndefined();
+  });
+
+  it("prefers a matching rule over activeColor", () => {
+    const f = plant({
+      entity: "binary_sensor.cabinet",
+      activeColor: "orange",
+      stateColor: [{ state: "on", color: "purple" }],
+    });
+    expect(furnitureColor(f, "on")).toBe("purple");
+  });
+
+  // The color reaches a `stroke` attribute, so the allowlist (#64) has to run
+  // on this path too — not only on the item label's.
+  it("gates hostile colors through cssColor", () => {
+    const f = plant({ entity: "sensor.soil", stateColor: [{ color: "red;fill:url(#x)" }] });
+    expect(furnitureColor(f, "1")).toBeUndefined();
+  });
 });
 
 describe("sectionalPoints", () => {
@@ -1037,6 +1098,30 @@ describe("fishTank glyph scales with its size (issue #72 review)", () => {
     expect(small).toBeGreaterThan(0);
     expect(large).toBeGreaterThan(small);
   });
+
+  // Issue #82: the entity-driven color replaces the configured one across the
+  // whole drawing — base shape and detail strokes alike, not just the outline.
+  describe("renderFurniture color override", () => {
+    const markupOf = (override?: string) =>
+      flatten(
+        renderFurniture(
+          { id: "f", type: "plant", x: 0, y: 0, w: 40, h: 40, color: "#111111" },
+          override,
+        ),
+      );
+
+    it("uses the configured color when no override is passed", () => {
+      const markup = markupOf();
+      expect(markup).toContain("#111111");
+      expect(markup).not.toContain("#ff0000");
+    });
+
+    it("the override replaces every occurrence of the configured color", () => {
+      const markup = markupOf("#ff0000");
+      expect(markup).toContain("#ff0000");
+      expect(markup).not.toContain("#111111");
+    });
+  });
 });
 
 describe("itemStateText with attributes (issue #70)", () => {
@@ -1122,6 +1207,58 @@ describe("resolveStateColor (issue #68)", () => {
   it("no rules, no color", () => {
     expect(resolveStateColor(undefined, 30)).toBeUndefined();
     expect(resolveStateColor([], 30)).toBeUndefined();
+  });
+
+  // Exact-state rules (issue #79): the same mechanism for entities whose
+  // value is a word rather than a number.
+  describe("state rules (issue #79)", () => {
+    const cover = [
+      { state: "open", color: "red" },
+      { state: "closed", color: "green" },
+      { color: "gray" },
+    ];
+
+    it("matches an exact state, case- and space-insensitively", () => {
+      expect(resolveStateColor(cover, "open")).toBe("red");
+      expect(resolveStateColor(cover, "OPEN")).toBe("red");
+      expect(resolveStateColor(cover, " closed ")).toBe("green");
+    });
+
+    it("an unmatched state falls to the default rule", () => {
+      expect(resolveStateColor(cover, "opening")).toBe("gray");
+      expect(resolveStateColor(cover, undefined)).toBe("gray");
+      expect(resolveStateColor([{ state: "open", color: "red" }], "closed")).toBeUndefined();
+    });
+
+    it("an exact state beats a matching threshold", () => {
+      const mixed = [
+        { above: 10, color: "orange" },
+        { state: "50", color: "blue" },
+      ];
+      expect(resolveStateColor(mixed, "50")).toBe("blue");
+      expect(resolveStateColor(mixed, "60")).toBe("orange");
+    });
+
+    it("the first listed state rule wins a duplicate", () => {
+      expect(
+        resolveStateColor(
+          [
+            { state: "on", color: "first" },
+            { state: "on", color: "second" },
+          ],
+          "on",
+        ),
+      ).toBe("first");
+    });
+
+    // A half-filled row in the editor ("state is", nothing typed yet) has no
+    // condition, so it behaves as the default rule rather than matching every
+    // reading or none of them.
+    it("a blank state is no condition at all", () => {
+      const rules = [{ state: "", color: "red" }];
+      expect(resolveStateColor(rules, "anything")).toBe("red");
+      expect(resolveStateColor(rules, "")).toBe("red");
+    });
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -20,7 +20,7 @@ import {
   getFloors,
   trackerAxisFraction,
 } from "./types";
-import { cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber } from "./css-safe";
 
 export const WALL_THICKNESS = 8;
 
@@ -76,6 +76,12 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);
       if (it.secondaryEntity) ids.add(it.secondaryEntity);
+    }
+    // Entity-bound furniture (issue #82) — without this the card never
+    // re-renders when the soil sensor moves, and the plant stays its
+    // first-painted color forever.
+    for (const fu of f.furniture) {
+      if (fu.entity) ids.add(fu.entity);
     }
     for (const tr of f.trackers) {
       for (const s of [tr.xSensor, tr.ySensor]) {
@@ -134,11 +140,18 @@ export function itemStateText(
 }
 
 /**
- * The threshold color for a value (issue #68), or undefined for "use the
- * theme default". Highest matching `above` wins; a rule without `above` is
- * the default. Non-numeric values (a climate saying "heat") only ever match
- * the default rule. The returned color is config-supplied — callers MUST
- * pass it through cssColor/cssColorOr before it reaches a style attribute.
+ * The colour for a value (issues #68, #79, #82), or undefined for "use the
+ * theme default". Precedence:
+ *
+ * 1. an exact `state` match (case-insensitive) — a cover "open", a light "on";
+ * 2. otherwise the highest matching `above` threshold;
+ * 3. otherwise the default rule (neither `above` nor `state`).
+ *
+ * A `state` rule is checked against the raw value stringified, so `state: "on"`
+ * works for a boolean-ish reading too. Non-numeric values (a climate saying
+ * "heat") never match an `above` rule. The returned color is config-supplied —
+ * callers MUST pass it through cssColor/cssColorOr before it reaches a style
+ * attribute.
  */
 export function resolveStateColor(
   rules: readonly StateColorRule[] | undefined,
@@ -147,11 +160,19 @@ export function resolveStateColor(
   if (!rules?.length) return undefined;
   const n = typeof raw === "number" ? raw : Number(raw);
   const numeric = typeof raw !== "boolean" && raw !== "" && raw != null && Number.isFinite(n);
+  const text = raw == null ? "" : String(raw).trim().toLowerCase();
+  let exact: string | undefined;
   let best: StateColorRule | undefined;
   let fallback: string | undefined;
   for (const rule of rules) {
     if (!rule || typeof rule !== "object" || typeof rule.color !== "string") continue;
-    if (typeof rule.above === "number") {
+    if (typeof rule.state === "string" && rule.state !== "") {
+      // First matching state rule wins, so an earlier rule shadows a later
+      // duplicate — the same "first one listed" reading as the default rule.
+      if (exact === undefined && text !== "" && rule.state.trim().toLowerCase() === text) {
+        exact = rule.color;
+      }
+    } else if (typeof rule.above === "number") {
       if (numeric && n > rule.above && (!best || rule.above > (best.above ?? -Infinity))) {
         best = rule;
       }
@@ -159,7 +180,24 @@ export function resolveStateColor(
       fallback = rule.color;
     }
   }
-  return best?.color ?? fallback;
+  return exact ?? best?.color ?? fallback;
+}
+
+/**
+ * The color a piece of furniture should draw in (issue #82), or undefined to
+ * keep its configured/static color. Rules first, then the active color while
+ * the entity is on — so a plant can go red below 50% moisture, and a cabinet
+ * with a contact sensor can go amber while its door is open.
+ *
+ * Returns a value already through the style-injection allowlist (#64), because
+ * it flows straight into `stroke`/`fill` attributes.
+ */
+export function furnitureColor(f: Furniture, state: string | undefined): string | undefined {
+  if (!f.entity) return undefined;
+  const rule = resolveStateColor(f.stateColor, state);
+  if (rule) return cssColor(rule);
+  if (f.activeColor && entityIsActive(f.entity, state)) return cssColor(f.activeColor);
+  return undefined;
 }
 
 /** Default label font size (px) for an item's name/state line. */
@@ -1079,8 +1117,13 @@ export function sectionalPoints(
   return hand === "left" ? pts.map(([x, y]) => [-x, y] as [number, number]) : pts;
 }
 
-export function renderFurniture(f: Furniture): SVGTemplateResult {
-  const color = f.color ?? FURNITURE_COLOR;
+/**
+ * A furniture diagram. `override` is the entity-driven color resolved by the
+ * caller (issue #82) — see {@link furnitureColor}; the editor passes nothing
+ * and keeps the static look while you are drawing.
+ */
+export function renderFurniture(f: Furniture, override?: string): SVGTemplateResult {
+  const color = override ?? f.color ?? FURNITURE_COLOR;
   const w = f.w;
   const h = f.h;
   const hw = w / 2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,16 @@ export interface FloorItem {
    *   - color: white
    * ```
    *
+   * Rules may also match an exact state instead of a threshold, for entities
+   * whose value is not a number:
+   *
+   * ```yaml
+   * stateColor:
+   *   - state: open
+   *     color: red
+   *   - color: green
+   * ```
+   *
    * Colors pass through the style-injection allowlist (#64) at render time.
    */
   stateColor?: StateColorRule[];
@@ -204,7 +214,14 @@ export interface FloorItem {
    * disables it.
    */
   iconAnimation?: IconAnimation;
-  /** Ripple ring color (CSS/hex). Falls back to the primary color. */
+  /**
+   * Badge color while the entity is active (issue #79). Falls back to the
+   * theme's active color — the yellow every device shares by default, which
+   * makes lights, covers and switches hard to tell apart at a glance.
+   * Same meaning as {@link Opening.activeColor}.
+   */
+  activeColor?: string;
+  /** Ripple ring color (CSS/hex). Falls back to `activeColor`, then the primary color. */
   rippleColor?: string;
   /** Max ripple ring diameter in pixels. Default 80. */
   rippleSize?: number;
@@ -216,10 +233,19 @@ export interface FloorItem {
 
 export type ItemDisplay = "badge" | "ripple" | "iconRipple";
 
-/** One threshold rule for {@link FloorItem.stateColor}. */
+/**
+ * One colour rule for {@link FloorItem.stateColor} / {@link Furniture.stateColor}.
+ *
+ * A rule matches either a numeric threshold (`above`) or an exact state
+ * (`state`); a rule with neither is the default. `state` covers non-numeric
+ * entities — a cover reading "open", a media player "playing" (issue #79) —
+ * while `above` covers readings like temperature or soil moisture (#68, #82).
+ */
 export interface StateColorRule {
-  /** Applies when the numeric value is strictly greater. Omit for the default rule. */
+  /** Applies when the numeric value is strictly greater. */
   above?: number;
+  /** Applies when the value equals this exactly (case-insensitive). */
+  state?: string;
   color: string;
 }
 
@@ -307,6 +333,21 @@ export interface Furniture {
   angle?: number;
   /** Stroke/fill color. Defaults to gray so it reads differently from walls. */
   color?: string;
+  /**
+   * Optional entity that makes the drawing live (issue #82) — a soil sensor on
+   * a plant, a water temperature sensor on a fish tank, a contact sensor on a
+   * cabinet. Drives {@link stateColor} and {@link activeColor}; furniture has
+   * no click action, so an unbound piece is still just a gray diagram.
+   */
+  entity?: string;
+  /**
+   * Threshold/state colors for the drawing, in the same shape as
+   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state; takes
+   * precedence over {@link activeColor} and {@link color}.
+   */
+  stateColor?: StateColorRule[];
+  /** Color while `entity` is active. Used when no {@link stateColor} rule matches. */
+  activeColor?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #68, closes #79, closes #82.

These three issues are the same feature seen from three angles — *an element's color should follow its entity* — so they share one mechanism instead of getting three.

## What each issue needed

**#68 (threshold colors) was already half-built.** `StateColorRule`, `resolveStateColor` and `FloorItem.stateColor` all existed and were wired into the card; what was missing was the editor UI, exactly as the issue thread says. So #68 cost a UI, not an engine — and that UI is what the other two reuse.

**#79 (per-device active colors)** was the smallest. `Opening.activeColor` already existed; `FloorItem` just never got the same field. The hard-coded yellow becomes a `--fp-active` custom property with today's value as the fallback, so a device that sets nothing renders byte-for-byte as before.

**#82 (plants)** needed `entity` on `Furniture` — the one placeable element that couldn't bind one. `renderFurniture` funnels every shape through a single `color` local, so binding it was one line rather than one edit per furniture type. Plants and fish tanks are furniture, per the issue discussion.

## The shared piece

`StateColorRule` gains an optional `state`, so one rule type covers numeric thresholds (#68, #82) and word-valued entities (#79):

```yaml
stateColor:
  - state: open      # exact match wins
    color: red
  - above: 26        # then highest matching threshold
    color: orange
  - color: white     # then the default rule
```

Purely additive — existing `above`-only configs keep their behaviour, and the pre-existing tests prove it unchanged.

The editor gets one **Color by state** block, used by both devices and furniture. It renders as plain rows rather than `ha-form` fields: the list is repeatable and `ha-form` has no selector for that (`object` is a raw YAML box). Given #91, worth being explicit — colors are the one part of this editor that was *always* hand-rolled, so the block matches its neighbours by construction. The eight copy-pasted color rows collapse into a single `_renderColorRow`, which is what pays for the ninth.

## Security

Every new color path runs through the `cssColor` allowlist (#64) before reaching a style attribute or an SVG `stroke` — `resolveStateColor` deliberately returns config strings unfiltered, so each caller is gated and the adversarial suite now covers both new ones.

## Verified

460 tests pass (+21), typecheck and build clean. In the dev harness, with a soil-sensor stub and an entity-bound plant added:

- the plant recolours live as the sensor moves — 90 green, 70 amber, 40 red — and the threshold is strict (81 green, 80 amber). This also proves the `collectWatchedEntities` wiring; without it the card would never re-render for the sensor at all, which was the easiest thing in this PR to miss.
- two active devices with different `activeColor`s render `#ffb300` and `#8e24aa` while an untouched active light stays the original `#fdd835` — no regression for existing configs.
- editing a rule updates the live card immediately; a hostile color (`red;position:fixed`) is rejected and the drawing falls back to gray rather than injecting.
- no row overflows at a 366px panel, the realistic docked-inspector width.

The harness has no `ha-form`, so as always the in-HA rendering of the *form* fields can't be exercised locally — but the rules block adds no new `ha-form` fields, so that gap is narrow here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)