### PR TITLE
Editor fixes: overlapping selection, sticky preview floor, entity picker scoped to nothing — closes #81, #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ for the current selection) and **Project** (page-level settings like canvas size
 background):
 
 - **Select** — the default tool. Click an element to select it; Shift/Ctrl-click or drag
-  a box to select several at once. Arrow keys nudge the selection (Shift+arrow jumps a
+  a box to select several at once. Where elements **overlap**, the first click takes the
+  most specific one (a device beats the tracker zone it sits in), and clicking again
+  without moving steps to the next element underneath, wrapping around — so nothing is
+  ever unreachable. Move the pointer and the next click starts over. Arrow keys nudge the selection (Shift+arrow jumps a
   full grid cell); **Ctrl/Cmd+C/V/D** copy / paste / duplicate — pasting also works
   across floors (copy, switch floor, paste); **Ctrl/Cmd+Z** undoes
   (**Shift+Z** or **Ctrl+Y** redoes); **Escape** cancels an in-progress draw or clears
@@ -125,6 +128,10 @@ background):
   Prefer the ▲/▼ buttons over reordering floor blocks in YAML: hand-editing easily
   drops or duplicates floor `id`s (the card now repairs both, but edits made while
   ids collide can land on the wrong floor).
+
+The **Labels** toolbar toggle hides the element name labels on the canvas — useful on a
+dense plan where labels overlap the things you are trying to click. It only affects the
+editor view; the live card is unchanged.
 
 Undo/redo buttons sit at the right of the tools row. Zoom controls live on the canvas
 itself (bottom-right): **−** / **+** step, click the percentage to reset, the fit button
@@ -414,6 +421,9 @@ card's switcher button (`GF`, `1st`…) while the full name stays as its tooltip
 **Color** — an accent for that button while its floor is active (goes through the
 config-color allowlist); and **Default** — which floor the live card opens on
 (stored as the top-level `defaultFloor`).
+
+While editing, the preview keeps showing whichever floor you switched it to, instead of
+snapping back to the default one after every change.
 
 **`haFloor`** optionally stores the id of a linked Home Assistant floor (set from the
 editor's floor gear popover). Today the link auto-names the floor; it is kept in the

--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ background):
   drops or duplicates floor `id`s (the card now repairs both, but edits made while
   ids collide can land on the wrong floor).
 
+When a device sits inside an **Area** linked to a Home Assistant area, its entity pickers
+list only that area's entities — and the room is highlighted on the canvas (a breathing
+tint with a marching-ants border) with a matching note above the fields, so it's obvious
+*why* the list is short and where to widen it. An area with nothing assigned to it in HA
+filters nothing, the entity already bound always stays pickable, and an element outside
+every area is never filtered.
+
 The **Labels** toolbar toggle hides the element name labels on the canvas — useful on a
 dense plan where labels overlap the things you are trying to click. It only affects the
 editor view; the live card is unchanged.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -464,3 +464,19 @@ describe("openingForm — sash and shutter (issues #73 / #74)", () => {
     expect(openingForm({ ...win, sash: "single" } as Opening).data.sash).toBe("single");
   });
 });
+
+describe("area scoping never traps you (issue reported on #83)", () => {
+  const item = { id: "i", entity: "", kind: "light", x: 0, y: 0 } as FloorItem;
+
+  it("outside every area, and inside an empty one, nothing is filtered", () => {
+    // No scope at all — the element sits outside every area.
+    expect(itemForm(item).fields.find((x) => x.name === "entity")!.selector).toEqual({
+      entity: {},
+    });
+    // Inside an area whose HA area has no entities: same, unfiltered.
+    expect(
+      itemForm(item, { entities: [], name: "Spare" }).fields.find((x) => x.name === "entity")!
+        .selector
+    ).toEqual({ entity: {} });
+  });
+});

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -227,16 +227,49 @@ describe("itemForm", () => {
     expect(d.angle).toBe(0);
   });
 
-  it("scopes the entity/secondaryEntity pickers to areaEntities when given", () => {
+  it("scopes the entity/secondaryEntity pickers to the area's entities when given", () => {
     const unscoped = itemForm(item);
     expect(unscoped.fields.find((x) => x.name === "entity")!.selector).toEqual({ entity: {} });
-    const scoped = itemForm(item, ["light.kitchen", "switch.kitchen"]);
+    const scoped = itemForm({ ...item, entity: "light.kitchen" } as FloorItem, {
+      entities: ["light.kitchen", "switch.kitchen"],
+      name: "Kitchen",
+    });
     expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({
       entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
     });
     expect(scoped.fields.find((x) => x.name === "secondaryEntity")!.selector).toEqual({
       entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
     });
+  });
+
+  it("an empty area list does NOT filter — an empty picker would hide everything", () => {
+    // Regression: `[]` is truthy, so the old code emitted
+    // `include_entities: []` and the picker listed nothing at all — the
+    // common case when a linked HA area has no entities assigned.
+    const scoped = itemForm(item, { entities: [], name: "Kitchen" });
+    expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({ entity: {} });
+    expect(scoped.fields.find((x) => x.name === "entity")!.helper).toBeUndefined();
+  });
+
+  it("always keeps the bound entity pickable, even from another area", () => {
+    const scoped = itemForm({ ...item, entity: "light.hallway" } as FloorItem, {
+      entities: ["light.kitchen"],
+      name: "Kitchen",
+    });
+    expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({
+      entity: { include_entities: ["light.kitchen", "light.hallway"] },
+    });
+  });
+
+  it("says why the list is short, and how to widen it", () => {
+    const scoped = itemForm(item, { entities: ["light.kitchen"], name: "Kitchen" });
+    const helper = scoped.fields.find((x) => x.name === "entity")!.helper!;
+    expect(helper).toContain("Kitchen");
+    expect(helper).toContain("Filter entities");
+    // The secondary picker keeps its own explanation too.
+    expect(scoped.fields.find((x) => x.name === "secondaryEntity")!.helper).toContain(
+      "Shown next to the primary state"
+    );
   });
 });
 
@@ -333,9 +366,10 @@ describe("textForm / furnitureForm / trackerForm", () => {
   });
 
   it("furniture entity picker scopes to a linked HA area when given one", () => {
-    const form = furnitureForm({ id: "f", type: "plant", x: 0, y: 0, w: 10, h: 10 } as never, [
-      "sensor.soil",
-    ]);
+    const form = furnitureForm({ id: "f", type: "plant", x: 0, y: 0, w: 10, h: 10 } as never, {
+      entities: ["sensor.soil"],
+      name: "Living room",
+    });
     expect(form.fields.find((x) => x.name === "entity")!.selector).toEqual({
       entity: { include_entities: ["sensor.soil"] },
     });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -294,17 +294,62 @@ export function openingForm(o: Opening): FormSpec {
 
 /**
  * When `it` sits inside a Home Assistant area-linked {@link Area} on the
- * plan, `areaEntities` narrows the `entity`/`secondaryEntity` pickers to
- * that HA area's entities. `include_entities` on the entity selector is the
+ * plan, `areaScope` narrows the `entity`/`secondaryEntity` pickers to that HA
+ * area's entities — but never to an empty list, and never hiding the entity
+ * already bound (see {@link areaScopedEntity}). `include_entities` on the entity selector is the
  * assumed-but-unverified `<ha-form>` equivalent of `ha-entity-picker`'s own
  * `.includeEntities` property — see areas.md decision #5.
  */
-export function itemForm(it: FloorItem, areaEntities?: string[]): FormSpec {
+/**
+ * Scoping applied to an element's entity pickers because it sits inside an
+ * Area linked to a Home Assistant area (issue #83). `name` is shown to the
+ * user so the narrowed list is never a mystery.
+ */
+export interface AreaEntityScope {
+  entities: string[];
+  name?: string;
+}
+
+/**
+ * Entity selector for an element inside a linked Area.
+ *
+ * Two rules keep the scoping from becoming a trap:
+ * - an **empty** area list means "don't filter at all". `include_entities: []`
+ *   renders a picker with *nothing* in it — not even searchable — which is
+ *   what happens whenever the linked HA area has no entities assigned (very
+ *   common: many setups assign areas to devices only, or not at all).
+ * - the currently bound entity is **always** included, so opening an existing
+ *   element never shows an empty box just because that entity lives elsewhere.
+ */
+function areaScopedEntity(
+  scope: AreaEntityScope | undefined,
+  current?: string
+): Record<string, unknown> {
+  if (!scope?.entities.length) return { entity: {} };
+  const include = current && !scope.entities.includes(current)
+    ? [...scope.entities, current]
+    : scope.entities;
+  return { entity: { include_entities: include } };
+}
+
+/** Helper text telling the user their picker is area-scoped, and how to undo it. */
+function areaScopeHelper(scope: AreaEntityScope | undefined, base?: string): string | undefined {
+  if (!scope?.entities.length) return base;
+  const where = scope.name ? `the ${scope.name} area` : "this area";
+  const note = `Only entities in ${where} — turn off “Filter entities” on the area to see all`;
+  return base ? `${base}. ${note}` : note;
+}
+
+export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
   const display = it.display ?? "badge";
-  const entitySelector = (): Record<string, unknown> =>
-    areaEntities ? { entity: { include_entities: areaEntities } } : { entity: {} };
   const fields: FormField[] = [
-    { name: "entity", label: "Entity", required: true, selector: entitySelector() },
+    {
+      name: "entity",
+      label: "Entity",
+      required: true,
+      helper: areaScopeHelper(areaScope),
+      selector: areaScopedEntity(areaScope, it.entity),
+    },
     {
       name: "attribute",
       label: "Attribute",
@@ -314,8 +359,8 @@ export function itemForm(it: FloorItem, areaEntities?: string[]): FormSpec {
     {
       name: "secondaryEntity",
       label: "Second entity",
-      helper: "Shown next to the primary state",
-      selector: entitySelector(),
+      helper: areaScopeHelper(areaScope, "Shown next to the primary state"),
+      selector: areaScopedEntity(areaScope, it.secondaryEntity),
     },
     {
       name: "secondaryAttribute",
@@ -437,7 +482,7 @@ export function textForm(t: FloorText): FormSpec {
  * {@link itemForm} — a plant drawn inside the Living Room offers the Living
  * Room's sensors first.
  */
-export function furnitureForm(f: Furniture, areaEntities?: string[]): FormSpec {
+export function furnitureForm(f: Furniture, areaScope?: AreaEntityScope): FormSpec {
   return {
     fields: [
       {
@@ -472,8 +517,8 @@ export function furnitureForm(f: Furniture, areaEntities?: string[]): FormSpec {
       {
         name: "entity",
         label: "Entity",
-        helper: "Optional — lets the drawing change color with a sensor",
-        selector: areaEntities ? { entity: { include_entities: areaEntities } } : { entity: {} },
+        helper: areaScopeHelper(areaScope, "Optional — lets the drawing change color with a sensor"),
+        selector: areaScopedEntity(areaScope, f.entity),
       },
     ],
     data: {

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -5,6 +5,8 @@ import {
   elementsInRect,
   applyDelta,
   attachedCorners,
+  elementsAtPoint,
+  cyclePick,
 } from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
 import type { Floor, Wall } from "./types";
@@ -164,5 +166,69 @@ describe("attachedCorners (issue #30: stretch-drag shared room corners)", () => 
       { id: "b", end: 1, which: 1, x0: 0, y0: 0 },
       { id: "b", end: 2, which: 2, x0: 100, y0: 0 },
     ]);
+  });
+});
+
+describe("elementsAtPoint / cyclePick (issue #52)", () => {
+  const opts = { itemSize: 34, textSize: 16, wallThickness: 8 };
+  // A device sitting inside a tracker zone, over a wall — the reported case.
+  const floor = {
+    id: "f", name: "F",
+    walls: [{ id: "w", x1: 0, y1: 200, x2: 400, y2: 200 }],
+    openings: [{ id: "o", type: "door", x: 300, y: 200, length: 90, angle: 0 }],
+    items: [{ id: "i", entity: "light.a", kind: "light", x: 100, y: 200 }],
+    texts: [],
+    furniture: [{ id: "fu", type: "table", x: 100, y: 200, w: 120, h: 80 }],
+    trackers: [{ id: "tr", x: 0, y: 100, w: 400, h: 200 }],
+  } as unknown as Floor;
+
+  it("orders overlapping candidates most-specific-first", () => {
+    // (100, 200) is inside the item, the table, the wall and the zone.
+    const at = elementsAtPoint(floor, 100, 200, opts);
+    expect(at.map((s) => s.kind)).toEqual(["item", "furniture", "wall", "tracker"]);
+  });
+
+  it("a big tracker zone never steals the first click from a device", () => {
+    expect(elementsAtPoint(floor, 100, 200, opts)[0]).toEqual({ kind: "item", id: "i" });
+  });
+
+  it("misses report nothing; a lone zone still reports itself", () => {
+    expect(elementsAtPoint(floor, 390, 110, opts).map((s) => s.kind)).toEqual(["tracker"]);
+    expect(elementsAtPoint(floor, 1000, 1000, opts)).toEqual([]);
+  });
+
+  it("hit areas respect rotation", () => {
+    const rotated = {
+      ...floor,
+      trackers: [],
+      furniture: [{ id: "fu", type: "table", x: 100, y: 200, w: 200, h: 20, angle: 90 }],
+      items: [], walls: [], openings: [],
+    } as unknown as Floor;
+    // Long axis now runs vertically, so a point 80 above the centre hits…
+    expect(elementsAtPoint(rotated, 100, 120, opts).map((s) => s.id)).toEqual(["fu"]);
+    // …while the same distance horizontally misses.
+    expect(elementsAtPoint(rotated, 180, 200, opts)).toEqual([]);
+  });
+
+  it("cyclePick steps down the stack on repeat clicks and wraps", () => {
+    const c = elementsAtPoint(floor, 100, 200, opts);
+    // First click at a fresh spot: most specific.
+    expect(cyclePick(c, [], false)).toEqual({ kind: "item", id: "i" });
+    // Same spot again: the next one underneath, and so on, wrapping.
+    expect(cyclePick(c, [{ kind: "item", id: "i" }], true)).toEqual({ kind: "furniture", id: "fu" });
+    expect(cyclePick(c, [{ kind: "furniture", id: "fu" }], true)).toEqual({ kind: "wall", id: "w" });
+    expect(cyclePick(c, [{ kind: "tracker", id: "tr" }], true)).toEqual({ kind: "item", id: "i" });
+  });
+
+  it("moving away restarts at the most specific candidate", () => {
+    const c = elementsAtPoint(floor, 100, 200, opts);
+    expect(cyclePick(c, [{ kind: "item", id: "i" }], false)).toEqual({ kind: "item", id: "i" });
+  });
+
+  it("a multi-selection or an empty stack doesn't cycle", () => {
+    const c = elementsAtPoint(floor, 100, 200, opts);
+    const multi = [{ kind: "item" as const, id: "i" }, { kind: "wall" as const, id: "w" }];
+    expect(cyclePick(c, multi, true)).toEqual({ kind: "item", id: "i" });
+    expect(cyclePick([], [], true)).toBeNull();
   });
 });

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -180,3 +180,109 @@ export function applyDelta(f: Floor, dx: number, dy: number, orig: Map<string, O
     }),
   };
 }
+
+// ---- hit testing for click-cycling (issue #52) ------------------------------
+
+/**
+ * Pick priority when several elements sit under one click: most *specific*
+ * first, so a small device inside a big tracker zone wins the first click and
+ * the zone is still reachable by clicking again. Ties inside a kind are broken
+ * by draw order (last drawn = on top = picked first).
+ */
+const PICK_ORDER: SelKind[] = ["item", "text", "opening", "furniture", "wall", "tracker"];
+
+/** Hit tolerances in virtual units. Wall matches the editor's fat hit stroke. */
+export const HIT = {
+  wall: 11,
+  /** Padding around an item badge / text box so small glyphs stay grabbable. */
+  pad: 4,
+} as const;
+
+/** Rotate (x, y) by −deg around (cx, cy) — i.e. into the element's local frame. */
+function toLocal(x: number, y: number, cx: number, cy: number, deg: number) {
+  const rad = (-(deg || 0) * Math.PI) / 180;
+  const dx = x - cx;
+  const dy = y - cy;
+  return { x: dx * Math.cos(rad) - dy * Math.sin(rad), y: dx * Math.sin(rad) + dy * Math.cos(rad) };
+}
+
+/** Distance from a point to a segment (used for wall hit tests). */
+function distToSegment(x: number, y: number, w: WallSegment): number {
+  const vx = w.x2 - w.x1;
+  const vy = w.y2 - w.y1;
+  const len2 = vx * vx + vy * vy;
+  if (len2 === 0) return Math.hypot(x - w.x1, y - w.y1);
+  let t = ((x - w.x1) * vx + (y - w.y1) * vy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(x - (w.x1 + t * vx), y - (w.y1 + t * vy));
+}
+
+/**
+ * Every element whose hit area contains (x, y), ordered by {@link PICK_ORDER}
+ * — the candidate list the editor cycles through on repeated clicks at the
+ * same spot (issue #52). Geometry only: no DOM, no z-index, so it is
+ * unit-testable and agrees with what the user sees.
+ *
+ * `itemSize` / `textSize` supply the per-element defaults the caller renders
+ * with, since those live in the card's config layer.
+ */
+export function elementsAtPoint(
+  f: Floor,
+  x: number,
+  y: number,
+  opts: { itemSize: number; textSize: number; wallThickness: number }
+): Sel[] {
+  const hits: { sel: Sel; rank: number; order: number }[] = [];
+  const push = (kind: SelKind, id: string, order: number) =>
+    hits.push({ sel: { kind, id }, rank: PICK_ORDER.indexOf(kind), order });
+
+  f.items.forEach((it, i) => {
+    const r = (it.size ?? opts.itemSize) / 2 + HIT.pad;
+    if (Math.abs(x - it.x) <= r && Math.abs(y - it.y) <= r) push("item", it.id, i);
+  });
+  f.texts.forEach((t, i) => {
+    // Rough box: text is centered on (x, y); width scales with the string.
+    const size = t.size ?? opts.textSize;
+    const hw = (size * 0.6 * Math.max(1, t.text?.length ?? 1)) / 2 + HIT.pad;
+    const hh = size / 2 + HIT.pad;
+    const p = toLocal(x, y, t.x, t.y, t.angle ?? 0);
+    if (Math.abs(p.x) <= hw && Math.abs(p.y) <= hh) push("text", t.id, i);
+  });
+  f.openings.forEach((o, i) => {
+    const p = toLocal(x, y, o.x, o.y, o.angle ?? 0);
+    if (Math.abs(p.x) <= o.length / 2 && Math.abs(p.y) <= opts.wallThickness / 2 + HIT.pad) {
+      push("opening", o.id, i);
+    }
+  });
+  f.furniture.forEach((fu, i) => {
+    const p = toLocal(x, y, fu.x, fu.y, fu.angle ?? 0);
+    if (Math.abs(p.x) <= fu.w / 2 && Math.abs(p.y) <= fu.h / 2) push("furniture", fu.id, i);
+  });
+  f.walls.forEach((w, i) => {
+    if (distToSegment(x, y, w) <= HIT.wall) push("wall", w.id, i);
+  });
+  (f.trackers ?? []).forEach((tr, i) => {
+    const p = toLocal(x, y, tr.x + tr.w / 2, tr.y + tr.h / 2, tr.angle ?? 0);
+    if (Math.abs(p.x) <= tr.w / 2 && Math.abs(p.y) <= tr.h / 2) push("tracker", tr.id, i);
+  });
+
+  // Specific kinds first; within a kind, the last drawn sits on top.
+  return hits.sort((a, b) => a.rank - b.rank || b.order - a.order).map((h) => h.sel);
+}
+
+/**
+ * The element a click should select, given the candidates under the cursor and
+ * what is selected now (issue #52). Repeat clicks at the same spot step
+ * *down* the stack and wrap; a click elsewhere restarts at the most specific
+ * candidate. Returns null when there is nothing to pick.
+ */
+export function cyclePick(
+  candidates: readonly Sel[],
+  current: readonly Sel[],
+  sameSpot: boolean
+): Sel | null {
+  if (!candidates.length) return null;
+  if (!sameSpot || current.length !== 1) return candidates[0]!;
+  const i = candidates.findIndex((c) => c.kind === current[0]!.kind && c.id === current[0]!.id);
+  return i < 0 ? candidates[0]! : candidates[(i + 1) % candidates.length]!;
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1943,6 +1943,31 @@ export class FloorplanCardEditor extends LitElement {
    * tracks the element as it's dragged in/out of the polygon, even before the
    * form reopens.
    */
+  /**
+   * The Area actively scoping the selected element's entity picker, if any —
+   * i.e. the element is a device/furniture, it sits inside an Area, and that
+   * Area is linked to an HA area with filtering on. The canvas animates this
+   * one so it is obvious *which room you are working in* and why the picker
+   * is short; nothing else in the editor communicated that.
+   */
+  private _scopingAreaId(): string | undefined {
+    if (this._selection.length !== 1) return undefined;
+    const sel = this._selection[0]!;
+    const f = this._floor();
+    const el =
+      sel.kind === "item"
+        ? f.items.find((x) => x.id === sel.id)
+        : sel.kind === "furniture"
+          ? f.furniture.find((x) => x.id === sel.id)
+          : undefined;
+    if (!el) return undefined;
+    const area = areaContainingPoint(f, el.x, el.y);
+    // Only when it actually narrows the picker: an unlinked area, or one with
+    // nothing assigned in HA, filters nothing and must not claim otherwise.
+    if (!areaFiltersEntities(area)) return undefined;
+    return entityIdsInHaArea(this.hass, area!.haArea!).length ? area!.id : undefined;
+  }
+
   private _areaEntitiesAt(x: number, y: number): AreaEntityScope | undefined {
     const area = areaContainingPoint(this._floor(), x, y);
     if (!areaFiltersEntities(area)) return undefined;
@@ -2374,6 +2399,10 @@ export class FloorplanCardEditor extends LitElement {
     const c = this._config;
     const floor = this._floor();
     const floors = c.floors ?? [];
+    // Which room, if any, is currently narrowing the selected element's
+    // entity picker — animated on the canvas so the scoping is never a
+    // mystery (see _scopingAreaId).
+    const scopingAreaId = this._scopingAreaId();
     const floorEmpty =
       !floor.walls.length &&
       !floor.openings.length &&
@@ -2649,7 +2678,7 @@ export class FloorplanCardEditor extends LitElement {
               ${repeat(
                 floor.areas ?? [],
                 (a, i) => a.id || i,
-                (a) => this._renderAreaSel(a)
+                (a) => this._renderAreaSel(a, scopingAreaId)
               )}
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
@@ -3050,7 +3079,8 @@ export class FloorplanCardEditor extends LitElement {
           ? html`<p class="hint">
               Edit elements one at a time. Drag any selected element to move the whole group.
             </p>`
-          : html`<div class="rows">${this._renderSelectionEditor()}</div>`}
+          : html`${this._renderAreaScopeHint()}
+              <div class="rows">${this._renderSelectionEditor()}</div>`}
       </section>
     `;
   }
@@ -3158,11 +3188,30 @@ export class FloorplanCardEditor extends LitElement {
    * vertex (decision #1 in areas.md: vertices reshape independently, with
    * no cross-element corner-stretch).
    */
-  private _renderAreaSel(a: Area): TemplateResult {
+  /**
+   * States in words what the canvas animation shows: this element sits in a
+   * linked room, so its entity picker only lists that room's entities. Colour
+   * alone can't carry that, and the off-switch lives on the Area element.
+   */
+  private _renderAreaScopeHint(): TemplateResult | typeof nothing {
+    const id = this._scopingAreaId();
+    if (!id) return nothing;
+    const area = (this._floor().areas ?? []).find((a) => a.id === id);
+    const name = area?.name ? `the ${area.name} area` : "this area";
+    return html`<p class="hint area-scope-hint">
+      <ha-icon icon="mdi:vector-polygon"></ha-icon>
+      Inside ${name} — the entity pickers list only its entities. Select the area and turn
+      off <strong>Filter entities</strong> to see everything.
+    </p>`;
+  }
+
+  private _renderAreaSel(a: Area, scopingId?: string): TemplateResult {
     const selected = this._isSel("area", a.id);
+    const scoping = a.id === scopingId;
     const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
     return svg`
-      <g class="area-hit ${selected ? "selected" : ""}">
+      <g class="area-hit ${selected ? "selected" : ""} ${scoping ? "scoping" : ""}">
+        ${scoping ? svg`<polygon points=${pts} class="area-scoping" />` : nothing}
         ${renderArea(a)}
         <polygon points=${pts} class="area-hit-shape"
                  @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "area", id: a.id })} />
@@ -4374,11 +4423,54 @@ export class FloorplanCardEditor extends LitElement {
       stroke: none;
       pointer-events: all;
     }
+    .area-scope-hint {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 0 0 6px;
+      color: var(--primary-color, #03a9f4);
+    }
+    .area-scope-hint ha-icon {
+      --mdc-icon-size: 16px;
+      flex: 0 0 auto;
+    }
     .area-outline {
       fill: none;
       stroke: var(--primary-color, #03a9f4);
       stroke-width: 2;
       pointer-events: none;
+    }
+    /* The room currently scoping the selected element's entity picker: a
+       breathing tint plus marching-ants border, so "you are working inside
+       the Kitchen — that's why the picker is short" reads at a glance. */
+    .area-scoping {
+      fill: var(--primary-color, #03a9f4);
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 2.5;
+      stroke-dasharray: 10 6;
+      pointer-events: none;
+      animation: fp-area-breathe 2.2s ease-in-out infinite,
+        fp-area-ants 1.4s linear infinite;
+    }
+    @keyframes fp-area-breathe {
+      0%,
+      100% {
+        fill-opacity: 0.1;
+      }
+      50% {
+        fill-opacity: 0.28;
+      }
+    }
+    @keyframes fp-area-ants {
+      to {
+        stroke-dashoffset: -16;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .area-scoping {
+        animation: none;
+        fill-opacity: 0.2;
+      }
     }
     .area-draft-line {
       fill: none;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -63,6 +63,8 @@ import {
   ENDPOINT_SNAP,
   applyDelta,
   attachedCorners,
+  elementsAtPoint,
+  cyclePick,
   elementsInRect,
   nearestCorner,
   snapWallEnd,
@@ -153,6 +155,12 @@ interface Clipboard {
 
 /** Snap distance (virtual units) for openings onto walls. */
 const WALL_SNAP = 35;
+/**
+ * How far the pointer may move between clicks and still count as "the same
+ * spot" for click-cycling (issue #52). Generous enough for hand tremor on a
+ * touchpad, tight enough that aiming at a neighbour restarts the cycle.
+ */
+const PICK_EPS = 6;
 const HISTORY_MAX = 60;
 /** Angle (degrees) within which a drawn wall is snapped flat to horizontal/vertical. */
 const WALL_AXIS_SNAP_DEG = 10;
@@ -222,6 +230,18 @@ export class FloorplanCardEditor extends LitElement {
   @query(".canvas-wrap") private _canvasWrap?: HTMLElement;
 
   private _drag: Drag | null = null;
+  /**
+   * Where the last plain selection click landed, for click-cycling through
+   * overlapping elements (issue #52). Cleared whenever the pointer lands
+   * somewhere else, so cycling only happens on repeat clicks in one spot.
+   */
+  private _pickAnchor: { x: number; y: number } | null = null;
+  /**
+   * Hide the canvas name labels while editing (issue #52). Editor view state
+   * only — never written to the config, so it can't change what the live card
+   * shows. A dense plan is much easier to aim at without them.
+   */
+  @state() private _hideLabels = false;
   /** Live touch points on the canvas wrap, for pinch-zoom (issue #38). */
   private _pinchPts = new Map<number, { x: number; y: number }>();
   /** Pinch baseline: finger distance, zoom, and centroid (content coords) at pinch start. */
@@ -917,6 +937,8 @@ export class FloorplanCardEditor extends LitElement {
       return;
     }
     // Select tool, empty canvas: start a marquee (rubber-band) selection.
+    // Clicking empty space also ends any cycling run (issue #52).
+    this._pickAnchor = null;
     this._marqueeAdd = ev.shiftKey || ev.ctrlKey || ev.metaKey;
     this._marquee = { x0: raw.x, y0: raw.y, x1: raw.x, y1: raw.y };
     this._gesturePointer = ev.pointerId;
@@ -1043,21 +1065,48 @@ export class FloorplanCardEditor extends LitElement {
 
   // ---- dragging existing elements ----------------------------------------
 
+  /**
+   * Which element a plain click should actually select (issue #52). The
+   * element whose hit area received the event is only a starting point: a big
+   * tracker zone or a wall can sit over a device, so we hit-test the point
+   * geometrically and take the most *specific* candidate. Clicking again
+   * without moving steps to the next candidate underneath and wraps, which is
+   * what makes buried elements reachable at all.
+   *
+   * Modifier-clicks (multi-select) and explicit handles keep their old
+   * behavior — they address one element on purpose.
+   */
+  private _resolvePick(ev: PointerEvent, sel: Sel): Sel {
+    if (ev.shiftKey || ev.ctrlKey || ev.metaKey) return sel;
+    const p = this._toVirtual(ev, false);
+    const candidates = elementsAtPoint(this._floor(), p.x, p.y, {
+      itemSize: DEFAULT_ITEM_SIZE,
+      textSize: DEFAULT_TEXT_SIZE,
+      wallThickness: WALL_THICKNESS,
+    });
+    const sameSpot =
+      !!this._pickAnchor && Math.hypot(p.x - this._pickAnchor.x, p.y - this._pickAnchor.y) <= PICK_EPS;
+    this._pickAnchor = p;
+    return cyclePick(candidates, this._selection, sameSpot) ?? sel;
+  }
+
   private _startDrag(ev: PointerEvent, sel: Sel, endpoint?: 1 | 2): void {
     if (this._tool !== "select") return;
     ev.stopPropagation();
     if (this._gesturePointer !== null) return;
     this._canvasWrap?.focus();
-    // Endpoint handles always operate on that single wall.
-    if (endpoint) this._selectOne(sel);
-    else this._selectForPointer(ev, sel);
+    // Endpoint handles always operate on that single wall; everything else
+    // goes through the overlap-aware picker (issue #52).
+    const pick = endpoint ? sel : this._resolvePick(ev, sel);
+    if (endpoint) this._selectOne(pick);
+    else this._selectForPointer(ev, pick);
     this._drag = {
-      primary: sel,
+      primary: pick,
       start: this._toVirtual(ev, false),
       orig: this._snapshotSelection(),
       endpoint,
     };
-    if (sel.kind === "wall") this._drag.attached = this._attachedCorners(sel.id, endpoint);
+    if (pick.kind === "wall") this._drag.attached = this._attachedCorners(pick.id, endpoint);
     this._gesturePointer = ev.pointerId;
     this._capturePointer(ev);
   }
@@ -1203,9 +1252,10 @@ export class FloorplanCardEditor extends LitElement {
     ev.preventDefault();
     if (this._gesturePointer !== null) return;
     this._canvasWrap?.focus();
-    this._selectForPointer(ev, sel);
+    const pick = this._resolvePick(ev, sel);
+    this._selectForPointer(ev, pick);
     this._drag = {
-      primary: sel,
+      primary: pick,
       start: this._toVirtual(ev, false),
       orig: this._snapshotSelection(),
     };
@@ -1972,6 +2022,23 @@ export class FloorplanCardEditor extends LitElement {
             ${this._fullscreen ? "Exit" : "Expand"}
           </button>
 
+          <!-- Labels: declutter a dense plan while editing (issue #52). -->
+          <button
+            class="icon-btn"
+            aria-pressed=${this._hideLabels}
+            title=${this._hideLabels
+              ? "Show element labels on the canvas"
+              : "Hide element labels — easier to aim on a dense plan"}
+            @click=${() => {
+              this._hideLabels = !this._hideLabels;
+            }}
+          >
+            <ha-icon
+              icon=${this._hideLabels ? "mdi:label-off-outline" : "mdi:label-outline"}
+            ></ha-icon>
+            Labels
+          </button>
+
           <span class="divider"></span>
 
           <!-- Insert — one popover for everything droppable on the floor -->
@@ -2687,9 +2754,16 @@ export class FloorplanCardEditor extends LitElement {
         @pointercancel=${this._onPointerCancel}
       >
         ${visual}
-        <!-- The editor label always shows (identification while editing);
-             only its size previews the card's labelSize (issue #59). -->
-        <span class="ilabel" style="font-size:${it.labelSize != null ? itemLabelSize(it.labelSize) : 11}px;">${label}</span>
+        <!-- Identification while editing; the Labels toolbar toggle hides it
+             on dense plans (issue #52), and its size previews the card's
+             labelSize (issue #59). -->
+        ${this._hideLabels
+          ? nothing
+          : html`<span
+              class="ilabel"
+              style="font-size:${it.labelSize != null ? itemLabelSize(it.labelSize) : 11}px;"
+              >${label}</span
+            >`}
       </div>
     `;
   }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -86,6 +86,7 @@ import {
   type Sel,
   type SelKind,
 } from "./editor-geometry";
+import type { AreaEntityScope } from "./editor-forms";
 import {
   FURNITURE_LABELS,
   FURNITURE_TYPES,
@@ -1942,9 +1943,14 @@ export class FloorplanCardEditor extends LitElement {
    * tracks the element as it's dragged in/out of the polygon, even before the
    * form reopens.
    */
-  private _areaEntitiesAt(x: number, y: number): string[] | undefined {
+  private _areaEntitiesAt(x: number, y: number): AreaEntityScope | undefined {
     const area = areaContainingPoint(this._floor(), x, y);
-    return areaFiltersEntities(area) ? entityIdsInHaArea(this.hass, area!.haArea!) : undefined;
+    if (!areaFiltersEntities(area)) return undefined;
+    const entities = entityIdsInHaArea(this.hass, area!.haArea!);
+    // An area with nothing assigned to it in HA must not produce an empty
+    // picker — the form treats an empty list as "no scoping" (see
+    // areaScopedEntity), and the name lets it say so when it does scope.
+    return { entities, name: area!.name };
   }
 
   /** Every entity in `area`'s linked HA area not already placed as an item on this floor. */

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -44,6 +44,23 @@ import type { Opening } from "./types";
 import { actionForGesture, executeAction, hasAction } from "./actions";
 import { actionHandler } from "./action-handler";
 
+/**
+ * Which floor each plan was last viewed on, keyed by its floor-id set (issue
+ * #81). Home Assistant's card editor **recreates** the preview element on
+ * every config change, so per-instance view state alone is lost on each
+ * keystroke and the preview snaps back to the default floor — making an
+ * upstairs plan almost uneditable. Module-level so it survives that
+ * re-creation, keyed by content so unrelated cards never share a floor.
+ *
+ * Deliberately not persisted: it is view state, never written to the config.
+ */
+const lastViewedFloor = new Map<string, string>();
+
+/** Content key for {@link lastViewedFloor} — the plan's floor ids, in order. */
+function floorMemoryKey(floors: readonly Floor[]): string {
+  return floors.map((f) => f.id).join("|");
+}
+
 @customElement("easy-floorplan-card")
 export class FloorplanCard extends LitElement {
   private static _nextWallMaskId = 0;
@@ -82,6 +99,16 @@ export class FloorplanCard extends LitElement {
       furniture: config.furniture ?? [],
     };
     this._watchedEntities = collectWatchedEntities(this._config);
+    // Restore the floor this plan was last viewed on (issue #81). Only when
+    // this instance has no floor of its own yet — a live floor switch always
+    // wins — and only if that floor still exists.
+    if (!this._activeFloorId) {
+      const floors = getFloors(this._config);
+      const remembered = lastViewedFloor.get(floorMemoryKey(floors));
+      if (remembered && floors.some((f) => f.id === remembered)) {
+        this._activeFloorId = remembered;
+      }
+    }
   }
 
   /**
@@ -413,6 +440,8 @@ export class FloorplanCard extends LitElement {
               style=${accent ? `background:${accent};border-color:${accent};` : nothing}
               @click=${() => {
                 this._activeFloorId = f.id;
+                // Remember it for the next element the editor preview builds.
+                lastViewedFloor.set(floorMemoryKey(floors), f.id);
               }}
             >
               ${f.short || f.name}


### PR DESCRIPTION
Three defects (no enhancements), all under one theme: the editor fighting you while you edit.

## #81 — preview snapped back to the default floor after every change
Editing anything above the ground floor meant re-selecting the floor after every keystroke.

**Diagnosis first**: our `_activeFloorId` *does* survive `setConfig` (verified in the harness), so nothing on our side was resetting it — Home Assistant **recreates the preview element** on each config change, and per-instance view state dies with it.

**Fix**: remember the viewed floor module-side, keyed by the plan's floor-id set, and restore it in `setConfig` only when the instance has no floor of its own (a live switch always wins) and the floor still exists. Consequences that fall out of keying by content: an unrelated plan never inherits a floor, and deleting the remembered floor falls back to the default. It stays view state — never written to config.

## #52 — improve how elements are selected
Two halves, matching the thread:

**(a) You couldn't reach what was underneath.** A tracker zone is a large invisible rectangle, so devices inside it were hard to grab. Now a plain click hit-tests **geometrically** (`elementsAtPoint`) and orders candidates **most-specific-first**: device → text → opening → furniture → wall → tracker zone. Clicking again *without moving* steps to the next candidate and wraps (`cyclePick`).

> A light badge inside a tracker zone, both under the cursor:
> click 1 → **Light**, click 2 → **Tracker**, click 3 → **Light** again.
> Move a few units and the next click restarts at the most specific.

Deliberately unchanged: wall **endpoint handles** (explicit) and **Shift/Ctrl-click** (multi-select) — verified a shift-click still adds to the selection instead of cycling.

**(b) The canvas was too noisy to aim at** — @gorischek's original ask was hiding entity names. New **Labels** toolbar toggle hides the canvas name labels while editing. Editor view state only; the live card is untouched and the config never sees it.

## Entity picker lists almost nothing (found during review of this PR)

After the areas feature landed, the device **Entity** picker stopped listing most of the house — not in the dropdown, not via search.

**Cause**: a device inside an Area linked to an HA area has its picker scoped to that area's entities (#83, on by default). `entityIdsInHaArea` returns `[]` whenever the linked HA area has no entities assigned — very common, since plenty of setups assign areas to *devices* only, or not at all — and **`[]` is truthy in JS**, so the form still emitted `include_entities: []`. That renders a picker containing *nothing*, and searching can't help. A quieter second contributor: the scope is built from `hass.entities`, the entity **registry**, so YAML template sensors / helpers without a `unique_id` can never appear while scoping is active.

**Fixes**, all in the form layer:
- an empty area list now means **"don't scope at all"** rather than "show nothing";
- the **currently bound entity is always included**, so opening an element whose entity lives in another area no longer shows an empty box;
- when scoping *does* apply, the field **says so**: *"Only entities in the Kitchen area — turn off 'Filter entities' on the area to see all"* — needed because that off switch lives on the **Area** element, not on the device you're editing.

Scoping still behaves as designed when the area genuinely has entities; it just can't strand you any more.

## Verification
`tsc` clean, **463/463 tests** (+8 selection/hit-test: candidate ordering, zone-doesn't-steal-first-click, rotation-aware hit areas, misses, cycle/wrap, restart-on-move, multi-select and empty-stack guards). Harness, driving the real component: four clicks at one spot on a device/table/wall/zone stack yield `item → furniture → wall → tracker`; clicking elsewhere restarts; shift-click yields `item,tracker`. Labels toggle removes/restores the labels with `aria-pressed` tracking and no config mutation. #81: a card switched to Upstairs, destroyed, and rebuilt with an edited config reopens on **Upstairs**, while an unrelated plan opens on its own first floor.

Area scoping adds four more: an empty list falls back to unscoped, the bound entity survives an out-of-area scope, the helper names both the area and the escape hatch, and a genuine scope still filters.

*(Harness note: the preview window was unfocused, so canvas rects were zero and coordinate-based synthetic clicks couldn't land — the interaction was driven through the component API with 1:1 coordinate mapping instead.)*

## Backwards compatibility
No schema changes. Selection behavior only differs where hit areas actually overlap; single-element clicking is unchanged.

Closes #81. Closes #52. Also fixes the area-scoped entity-picker regression introduced with #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
