### PR TITLE
Editor: reachable areas when cycling, steady zoom buttons, inline filter escape — closes #95, #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ background):
 
 When a device sits inside an **Area** linked to a Home Assistant area, its entity pickers
 list only that area's entities — and the room is highlighted on the canvas (a breathing
-tint with a marching-ants border) with a matching note above the fields, so it's obvious
-*why* the list is short and where to widen it. An area with nothing assigned to it in HA
+tint with a marching-ants border) with a matching note above the fields carrying a **Show all**
+link, so it's obvious *why* the list is short and it takes one click to widen it. An area with nothing assigned to it in HA
 filters nothing, the entity already bound always stays pickable, and an element outside
 every area is never filtered.
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -177,10 +177,16 @@ interface Clipboard {
 const WALL_SNAP = 35;
 /**
  * How far the pointer may move between clicks and still count as "the same
- * spot" for click-cycling (issue #52). Generous enough for hand tremor on a
- * touchpad, tight enough that aiming at a neighbour restarts the cycle.
+ * spot" for click-cycling (issue #52), in **screen pixels**.
+ *
+ * This used to be measured in canvas units, which made the tolerance depend
+ * on zoom: on a plan shown at a quarter scale, one canvas unit is a quarter
+ * of a pixel, so a couple of pixels of ordinary hand tremor blew past it and
+ * silently restarted the cycle — the last candidate in the stack (an Area)
+ * was then unreachable in practice (issue #95). Screen space is where the
+ * hand actually moves, so the tolerance belongs there.
  */
-const PICK_EPS = 6;
+const PICK_EPS_PX = 8;
 const HISTORY_MAX = 60;
 /** Angle (degrees) within which a drawn wall is snapped flat to horizontal/vertical. */
 const WALL_AXIS_SNAP_DEG = 10;
@@ -262,7 +268,7 @@ export class FloorplanCardEditor extends LitElement {
    * overlapping elements (issue #52). Cleared whenever the pointer lands
    * somewhere else, so cycling only happens on repeat clicks in one spot.
    */
-  private _pickAnchor: { x: number; y: number } | null = null;
+  private _pickAnchor: { clientX: number; clientY: number } | null = null;
   /**
    * Hide the canvas name labels while editing (issue #52). Editor view state
    * only — never written to the config, so it can't change what the live card
@@ -1176,8 +1182,10 @@ export class FloorplanCardEditor extends LitElement {
       wallThickness: WALL_THICKNESS,
     });
     const sameSpot =
-      !!this._pickAnchor && Math.hypot(p.x - this._pickAnchor.x, p.y - this._pickAnchor.y) <= PICK_EPS;
-    this._pickAnchor = p;
+      !!this._pickAnchor &&
+      Math.hypot(ev.clientX - this._pickAnchor.clientX, ev.clientY - this._pickAnchor.clientY) <=
+        PICK_EPS_PX;
+    this._pickAnchor = { clientX: ev.clientX, clientY: ev.clientY };
     return cyclePick(candidates, this._selection, sameSpot) ?? sel;
   }
 
@@ -2651,7 +2659,20 @@ export class FloorplanCardEditor extends LitElement {
 
         <div class="workspace">
         <div class="canvas-outer">
-        <div class="canvas-wrap" tabindex="0" @wheel=${this._onCanvasWheel}>
+        <!-- The viewport keeps the canvas's aspect ratio so its height does not
+             grow with the zoom level. Otherwise zooming in made this box taller,
+             which pushed the zoom buttons (anchored to its bottom-right) down the
+             page — you had to chase the + button between clicks. Fullscreen sizes
+             the viewport from the available space instead, which is why it never
+             had the problem. -->
+        <div
+          class="canvas-wrap"
+          tabindex="0"
+          style=${this._fullscreen
+            ? nothing
+            : `aspect-ratio:${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(c.height, DEFAULT_HEIGHT)};`}
+          @wheel=${this._onCanvasWheel}
+        >
           <div class="stage" style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
             c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;">
             <svg
@@ -3197,11 +3218,20 @@ export class FloorplanCardEditor extends LitElement {
     const id = this._scopingAreaId();
     if (!id) return nothing;
     const area = (this._floor().areas ?? []).find((a) => a.id === id);
-    const name = area?.name ? `the ${area.name} area` : "this area";
+    const name = area?.name ? area.name : "this area";
+    // The switch lives on the Area element, which is a deselect-navigate-
+    // reselect round trip from here — issue #94 was exactly someone reading
+    // the old wording and finding no such control. Offer it inline instead.
     return html`<p class="hint area-scope-hint">
       <ha-icon icon="mdi:vector-polygon"></ha-icon>
-      Inside ${name} — the entity pickers list only its entities. Select the area and turn
-      off <strong>Filter entities</strong> to see everything.
+      <span>Only entities in <strong>${name}</strong> are listed.</span>
+      <button
+        class="link-btn"
+        title="Turn off Filter entities for this area — every entity becomes selectable"
+        @click=${() => this._updateArea(id, { filterEntities: false })}
+      >
+        Show all
+      </button>
     </p>`;
   }
 
@@ -4429,6 +4459,16 @@ export class FloorplanCardEditor extends LitElement {
       gap: 6px;
       margin: 0 0 6px;
       color: var(--primary-color, #03a9f4);
+    }
+    .area-scope-hint .link-btn {
+      border: none;
+      background: none;
+      padding: 0 2px;
+      font: inherit;
+      color: var(--primary-color, #03a9f4);
+      text-decoration: underline;
+      cursor: pointer;
+      flex: 0 0 auto;
     }
     .area-scope-hint ha-icon {
       --mdc-icon-size: 16px;


### PR DESCRIPTION
Three editor annoyances, two of them regressions from my own recent PRs.

## #95 — cycling never reached areas
**Cause**: `PICK_EPS` measured "did the pointer stay put" in **canvas units**, so the tolerance silently scaled with zoom. On a 1000-unit plan drawn ~400px wide, 1px ≈ 2.5 units — so ~3px of ordinary hand tremor blew past the 6-unit threshold, the cycle restarted, and you got device → tracker → **device** forever. The Area, being last in the pick order, was unreachable in practice even though the logic was right (it cycles correctly with synthetic pixel-perfect clicks, which is why it passed review).

**Fix**: measure in **screen pixels** (8px), where the hand actually moves. Verified with simulated ±3px tremor at 2.5 units/px — exactly the case that used to break — now yielding `item → tracker → area → item`.

## Zoom buttons moved between clicks
The canvas viewport had no height of its own, so it grew as the stage grew with zoom — pushing the bottom-anchored zoom controls further down the page each time you pressed **+**, so the button slid out from under the cursor. The viewport now carries the canvas's aspect ratio, so its height is fixed by its width and zoom scrolls *inside* it. Fullscreen sizes the viewport from available space (which is why it never had the bug) and is left alone — verified it gets no inline ratio.

## #94 — a hint pointing at a control you can't see
The area-scope hint said "Select the area and turn off **Filter entities**" — a deselect → find area → toggle → reselect round trip, which reads as "there is no such option". The hint is now one line with an inline **Show all** link that clears the filter on the containing area in place. Verified: clicking it sets `filterEntities: false`, and the hint plus the area animation disappear because nothing is being scoped any more.

## Verification
`tsc` clean, **471/471 tests**, build clean. Harness: the tremor cycle above; the viewport's aspect ratio stays `1000 / 600` through 150% and 200% zoom while the stage grows to `200%`; the Show all link round-trips.

Closes #95. Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)