### PR TITLE
Color by state: paint the badge, and own the colour when set

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,9 @@ By default it shows an icon badge:
   makes a wall of lights, covers and switches hard to read. Set **Active color**
   per device to tell them apart at a glance — lights yellow, covers purple,
   thermostats orange. Ripples follow it unless you set a ripple color too.
-- **Color by state** — the **Color by state** rules color the label by what the
-  entity reads. Add rules in the editor, or in YAML:
+- **Color by state** — the **Color by state** rules color the element by what the
+  entity reads: both the **icon badge** and the label, whether or not the entity is
+  "on" (a temperature sensor never is). Add rules in the editor, or in YAML:
 
   ```yaml
   stateColor:
@@ -234,6 +235,11 @@ By default it shows an icon badge:
 
   An exact `state` match beats a threshold. Colors go through the same
   injection allowlist as every other config color.
+
+  State rules **take precedence over `activeColor`** (and the ripple follows them, so
+  a device is never badged one color and ringed another), so the editor hides the
+  **Active color** field once rules exist rather than leaving a control that would
+  silently lose.
 - **No entity? Still on the map** — a device with no entity bound renders as a plain
   badge (its icon override or kind default), so hardware that has no Home Assistant
   entity — a dumb smoke detector, a wired doorbell — can still be marked on the plan.
@@ -561,7 +567,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `secondaryEntity` | string                             | —            | Optional 2nd entity shown alongside (e.g. humidity).   |
 | `attribute`   | string                                 | —            | Show this attribute of `entity` instead of its state (e.g. `current_temperature`). |
 | `secondaryAttribute` | string                          | —            | Attribute for the 2nd reading — from `secondaryEntity`, or from `entity` when none. |
-| `stateColor`  | rule[]                                 | —            | Colors for the label: `[{above: 26, color: red}, {color: white}]`. A rule matches `above: <n>` or `state: <value>`; an exact state beats a threshold, the highest matching `above` beats a lower one, and a rule with neither is the default. |
+| `stateColor`  | rule[]                                 | —            | Colors for the badge and label (regardless of on/off; beats `activeColor`): `[{above: 26, color: red}, {color: white}]`. A rule matches `above: <n>` or `state: <value>`; an exact state beats a threshold, the highest matching `above` beats a lower one, and a rule with neither is the default. |
 | `x`, `y`      | number                                 | —            | Position.                                              |
 | `kind`        | light/switch/sensor/binary_sensor/climate/cover/generic | inferred | Used for the default icon.            |
 | `icon`        | string                                 | entity icon  | Override mdi icon.                                     |
@@ -570,7 +576,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
 | `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn.                               |
 | `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. |
-| `activeColor` | string                                 | theme color  | Badge color while the device is on — lets domains be told apart at a glance. |
+| `activeColor` | string                                 | theme color  | Badge color while the device is on — lets domains be told apart at a glance. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -60,6 +60,7 @@ import {
   trackerSensorReading,
   kindFromEntity,
   resolveItemIcon,
+  resolveStateColor,
   resolveIconAnimation,
   itemIconSize,
   itemLabelSize,
@@ -67,7 +68,7 @@ import {
   collectWatchedEntities,
   hassRenderInputsChanged,
 } from "./render";
-import { cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber } from "./css-safe";
 import {
   ENDPOINT_SNAP,
   applyDelta,
@@ -3270,7 +3271,13 @@ export class FloorplanCardEditor extends LitElement {
     const size = cssNumber(it.size, DEFAULT_ITEM_SIZE);
     const showIcon = it.showIcon ?? true;
     const display = it.display ?? "badge";
-    const rippleColor = it.rippleColor ?? "var(--primary-color, #03a9f4)";
+    // Same resolution as the card, so the canvas shows the colour the plan
+    // will actually render (state rules first, then the active colour).
+    const rawValue = it.attribute
+      ? (st?.attributes as Record<string, unknown> | undefined)?.[it.attribute]
+      : st?.state;
+    const stateColor = cssColor(resolveStateColor(it.stateColor, rawValue));
+    const rippleColor = it.rippleColor ?? stateColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     // Live preview: the icon animates exactly when the card would animate it
@@ -3278,8 +3285,10 @@ export class FloorplanCardEditor extends LitElement {
     // effect without leaving the editor.
     const anim = resolveIconAnimation(it, st?.state);
     const badge = html`<div
-      class="badge ${showIcon ? "" : "ghost"}"
-      style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(it.angle, 0)}deg);"
+      class="badge ${showIcon ? "" : "ghost"} ${stateColor ? "state-colored" : ""}"
+      style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(it.angle, 0)}deg);${
+        stateColor ? `--fp-state:${stateColor};` : ""
+      }"
     >
       <ha-icon
         class=${anim ? `anim-${anim}` : ""}
@@ -3455,15 +3464,22 @@ export class FloorplanCardEditor extends LitElement {
           }
           this._applyElementPatch("item", it.id, patch, live);
         })}
-        ${this._renderColorRow({
-          label: "Active color",
-          title: "Badge color while this device is on (issue #79)",
-          value: it.activeColor,
-          swatch: "#fdd835",
-          placeholder: "(theme)",
-          onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
-          onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
-        })}
+        ${it.stateColor?.length
+          ? // Colour by state supersedes the fixed active colour, so showing
+            // both invites setting one and seeing the other. Say which one is
+            // in charge instead of leaving a dead control on screen.
+            html`<p class="hint rule-note">
+              Colored by the state rules below — they replace the active color.
+            </p>`
+          : this._renderColorRow({
+              label: "Active color",
+              title: "Badge color while this device is on (issue #79)",
+              value: it.activeColor,
+              swatch: "#fdd835",
+              placeholder: "(theme)",
+              onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
+              onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
+            })}
         ${(it.display ?? "badge") !== "badge"
           ? this._renderColorRow({
               label: "Ripple color",
@@ -4791,6 +4807,24 @@ export class FloorplanCardEditor extends LitElement {
       padding-left: 8px;
       border-left: 2px solid var(--divider-color, #ccc);
       margin-bottom: 6px;
+    }
+    /* The docked inspector is only 340px wide, so a rule's condition and its
+       colour cannot share a line without crushing both. Wrap onto two lines
+       instead of squeezing — the fullscreen visibility complaint. */
+    .row.state-color-rule {
+      flex-wrap: wrap;
+      row-gap: 4px;
+    }
+    .rule-note {
+      margin: 0 0 6px;
+      font-style: italic;
+    }
+    /* The canvas preview mirrors the card: a resolved state colour paints the
+       badge whether or not the entity reads "on". */
+    .edit-item .badge.state-colored {
+      background: var(--fp-state);
+      border-color: var(--fp-state);
+      color: var(--text-primary-color, #212121);
     }
     .state-color-rule select {
       flex: 0 0 96px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -244,13 +244,21 @@ export class FloorplanCard extends LitElement {
     const rawValue = item.attribute
       ? (st?.attributes as Record<string, unknown> | undefined)?.[item.attribute]
       : st?.state;
-    const labelColor = cssColor(resolveStateColor(item.stateColor, rawValue));
+    // One resolved colour drives the whole element (issue #79 follow-up): the
+    // label *and* the badge. A sensor is never "on", so tying the badge to the
+    // active state alone left threshold colours invisible on exactly the
+    // devices they were written for.
+    const stateColor = cssColor(resolveStateColor(item.stateColor, rawValue));
+    const labelColor = stateColor;
     const showIcon = item.showIcon ?? true;
     const display = item.display ?? "badge";
     // Per-device active color (issue #79). Ripples follow it too, so a device
     // given one color does not come out yellow-badged with a blue ring.
+    // State rules win over the fixed active colour — they are the more
+    // specific statement about what this element should look like right now.
     const activeColor = cssColor(item.activeColor);
-    const rippleColor = item.rippleColor ?? item.activeColor ?? "var(--primary-color, #03a9f4)";
+    const rippleColor =
+      item.rippleColor ?? stateColor ?? item.activeColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = item.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     let visual: TemplateResult | typeof nothing = nothing;
@@ -271,8 +279,10 @@ export class FloorplanCard extends LitElement {
     const d = rotatedCanvasSize(c.width, c.height, rot);
     return html`
       <div
-        class="item ${on ? "on" : "off"}"
-        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;${activeColor
+        class="item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""}"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;${stateColor
+          ? `--fp-state:${stateColor};`
+          : ""}${activeColor
           ? `--fp-active:${activeColor};`
           : ""}"
         title=${this._label(item)}
@@ -626,6 +636,14 @@ export class FloorplanCard extends LitElement {
     .item.on .badge {
       background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
       border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
+      color: var(--text-primary-color, #212121);
+    }
+    /* A resolved state colour paints the badge whatever the on/off state —
+       thresholds exist for sensors, which are never "on". Declared *after* the
+       .on rule (equal specificity) so state rules win over the active colour. */
+    .item.state-colored .badge {
+      background: var(--fp-state);
+      border-color: var(--fp-state);
       color: var(--text-primary-color, #212121);
     }
     ha-icon {


### PR DESCRIPTION
Three related requests about colour-by-state.

## Colour by state now paints the icon badge
Rules only tinted the **label**, which hid the feature on its main use case: a temperature sensor is never `on`, so `.item.on .badge` never fired and the badge stayed white however hot the room got. The resolved colour now paints the **badge** as well, **regardless of on/off** — that's the whole point for sensors.

Verified: a sensor with `above: 26 → red` badges white at 20 °C and **red** at 27 °C, in both the card and the editor's canvas preview.

## Precedence, and no dead controls
- **State rules beat the fixed active colour** — they're the more specific statement about how this element should look right now. (Verified: an item with both renders purple when on and slate when off, ignoring its blue active colour; an item *without* rules is completely unchanged — active colour on, white off.)
- The **ripple follows the same colour**, so a device can't come out purple-badged with a blue ring — same reasoning #79 used for the active colour.
- The editor **hides the Active color row once rules exist**, replacing it with *"Colored by the state rules below — they replace the active color."* Answering your question directly: yes — if you choose colour by state, there is no active-colour option, because it would silently lose.

## Rules are usable in the expanded view
The docked inspector is 340 px, and a rule packed condition-dropdown + threshold + swatch + hex + delete onto one line, crushing all of them. Rule rows now **wrap onto two lines** instead of squeezing (screenshot in the thread shows the result).

## Verification
`tsc` clean, **471/471 tests**, build clean. Harness covers the matrix above plus the editor: Active color present without rules, absent with them, note shown, preview badge `rgb(255, 0, 0)` at 27 °C, rule rows computing `flex-wrap: wrap` in fullscreen.

## Backwards compatibility
Items without `stateColor` render exactly as before. Items *with* rules change appearance by design — that's the fix — and `activeColor` stays in the config (it simply stops applying while rules exist, so removing the rules restores it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)