### PR TITLE
Devices: "Only when active" hides idle elements on the card (issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ By default it shows an icon badge:
   a device is never badged one color and ringed another), so the editor hides the
   **Active color** field once rules exist rather than leaving a control that would
   silently lose.
+- **Only when active** — tick it and the device disappears from the card while its
+  entity is off/idle, so a busy room only shows what's actually doing something.
+  "Active" is the same domain-aware test the badge highlight uses (a lock counts as
+  active when *unlocked*, a vacuum while cleaning), and an unavailable entity counts as
+  inactive. The editor always draws these devices — faded, with a dashed badge — so you
+  can still find and edit them.
 - **No entity? Still on the map** — a device with no entity bound renders as a plain
   badge (its icon override or kind default), so hardware that has no Home Assistant
   entity — a dumb smoke detector, a wired doorbell — can still be marked on the plan.
@@ -580,6 +586,7 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |
+| `hideWhenInactive` | boolean                           | `false`      | Hide the device on the card while its entity is inactive (issue #55). Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
 | `labelSize`   | number                                 | `12`         | Label line font size (px).                             |

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -406,6 +406,12 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
   }
   fields.push(
     { name: "showIcon", label: "Show icon", selector: { boolean: {} } },
+    {
+      name: "hideWhenInactive",
+      label: "Only when active",
+      helper: "Hide on the card while the entity is off/idle (still editable here)",
+      selector: { boolean: {} },
+    },
     { name: "showState", label: "Show state", selector: { boolean: {} } },
     {
       name: "showName",
@@ -450,6 +456,7 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       iconAnimation: it.iconAnimation ?? "auto",
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       showIcon: it.showIcon ?? true,
+      hideWhenInactive: it.hideWhenInactive ?? false,
       showState: it.showState ?? false,
       showName: it.showName ?? false,
       labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -61,6 +61,7 @@ import {
   kindFromEntity,
   resolveItemIcon,
   resolveStateColor,
+  itemHiddenWhenInactive,
   resolveIconAnimation,
   itemIconSize,
   itemLabelSize,
@@ -3340,9 +3341,13 @@ export class FloorplanCardEditor extends LitElement {
       visual = badge;
     }
 
+    // "Only when active" devices are invisible on the card while idle (issue
+    // #55). The editor must still show them — dimmed — or they could never be
+    // found and edited again.
+    const hiddenOnCard = itemHiddenWhenInactive(it, st?.state);
     return html`
       <div
-        class="edit-item ${selected ? "selected" : ""}"
+        class="edit-item ${selected ? "selected" : ""} ${hiddenOnCard ? "card-hidden" : ""}"
         style="left:${(it.x / c.width) * 100}%; top:${(it.y / c.height) * 100}%;"
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "item", id: it.id })}
         @pointermove=${this._onOverlayMove}
@@ -4361,6 +4366,14 @@ export class FloorplanCardEditor extends LitElement {
       justify-content: center;
       color: var(--primary-text-color);
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    }
+    /* Hidden on the live card right now (issue #55): faded and dashed here so
+       it reads as deliberately absent from the card, while staying selectable. */
+    .edit-item.card-hidden {
+      opacity: 0.4;
+    }
+    .edit-item.card-hidden .badge {
+      border-style: dashed;
     }
     .edit-item.selected .badge {
       border-color: var(--primary-color, #03a9f4);

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -31,6 +31,7 @@ import {
   entityIsActive,
   itemBadgeLabel,
   resolveStateColor,
+  itemHiddenWhenInactive,
   itemLabelSize,
   hassRenderInputsChanged,
   collectWatchedEntities,
@@ -451,7 +452,15 @@ export class FloorplanCard extends LitElement {
               // No entity filter: devices that exist physically but have no HA
               // entity still deserve their badge (issue #39). Keyed by id so a
               // floor switch builds fresh DOM (see the openings comment).
-              active.items,
+              // "Only when active" devices drop out here (issue #55) — the
+              // editor still draws them, dimmed, so they stay editable.
+              active.items.filter(
+                (it) =>
+                  !itemHiddenWhenInactive(
+                    it,
+                    it.entity ? this.hass?.states[it.entity]?.state : undefined
+                  )
+              ),
               (it, i) => it.id || i,
               (it) => this._renderItem(it, c, rot)
             )}

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -28,6 +28,7 @@ import {
   entityStateText,
   itemStateText,
   itemBadgeLabel,
+  itemHiddenWhenInactive,
   resolveStateColor,
   itemLabelSize,
   hassRenderInputsChanged,
@@ -1359,5 +1360,33 @@ describe("renderArea", () => {
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).not.toContain("position:fixed");
+  });
+});
+
+describe("itemHiddenWhenInactive (issue #55)", () => {
+  it("hides only when asked to, and only while inactive", () => {
+    expect(itemHiddenWhenInactive({ entity: "light.a", hideWhenInactive: true }, "off")).toBe(true);
+    expect(itemHiddenWhenInactive({ entity: "light.a", hideWhenInactive: true }, "on")).toBe(false);
+    // Off by default: an ordinary device always renders.
+    expect(itemHiddenWhenInactive({ entity: "light.a" }, "off")).toBe(false);
+  });
+
+  it("uses the domain-aware active test, not a bare on/off", () => {
+    // A lock is "active" when unlocked, a vacuum when cleaning — the same rule
+    // the badge highlight uses, so hiding matches what the user sees elsewhere.
+    expect(itemHiddenWhenInactive({ entity: "lock.front", hideWhenInactive: true }, "unlocked"))
+      .toBe(false);
+    expect(itemHiddenWhenInactive({ entity: "lock.front", hideWhenInactive: true }, "locked"))
+      .toBe(true);
+    expect(itemHiddenWhenInactive({ entity: "vacuum.r", hideWhenInactive: true }, "cleaning"))
+      .toBe(false);
+  });
+
+  it("an outage or a missing entity counts as inactive (fails hidden)", () => {
+    expect(itemHiddenWhenInactive({ entity: "light.a", hideWhenInactive: true }, "unavailable"))
+      .toBe(true);
+    expect(itemHiddenWhenInactive({ entity: "light.a", hideWhenInactive: true }, undefined))
+      .toBe(true);
+    expect(itemHiddenWhenInactive({ hideWhenInactive: true }, "on")).toBe(true);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -200,6 +200,24 @@ export function furnitureColor(f: Furniture, state: string | undefined): string 
   return undefined;
 }
 
+/**
+ * Whether a device should be omitted from the **live card** right now
+ * (issue #55): it asked to appear only while active, and it isn't. An item
+ * with no entity can never be active, so a hide-when-inactive item without
+ * one stays hidden rather than becoming permanently invisible furniture the
+ * user forgot about — the editor still shows it, dimmed.
+ */
+export function itemHiddenWhenInactive(
+  item: { entity?: string; hideWhenInactive?: boolean },
+  state: string | undefined,
+): boolean {
+  if (!item.hideWhenInactive) return false;
+  // No entity, nothing that can be active — hide, and don't let a stray state
+  // string argue otherwise (entityIsActive would read a bare "on" as active).
+  if (!item.entity) return true;
+  return !entityIsActive(item.entity, state);
+}
+
 /** Default label font size (px) for an item's name/state line. */
 export const DEFAULT_LABEL_SIZE = 12;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,14 @@ export interface FloorItem {
   labelSize?: number;
   /** Show the icon badge. When false only the state/label shows. Default true. */
   showIcon?: boolean;
+  /**
+   * Hide this device on the live card while its entity is inactive (issue
+   * #55), so a busy room only shows what is actually doing something. The
+   * editor always draws it — dimmed — or it could never be selected again.
+   * "Active" is the same domain-aware test the badge highlight uses
+   * ({@link entityIsActive}), so a lock reads unlocked, a vacuum cleaning.
+   */
+  hideWhenInactive?: boolean;
   /** Badge diameter in pixels. Default 34. */
   size?: number;
   /** Icon rotation in degrees. Default 0. */


### PR DESCRIPTION
Your suggested framing — a checkbox — for the first half of #55.

## What it does
**Only when active** on a device: while its entity is inactive, the live card simply doesn't render it. A room packed with devices then shows only what's actually doing something.

- "Active" is the **same domain-aware test the badge highlight uses** (`entityIsActive`), so a lock counts as active when *unlocked* and a vacuum while *cleaning* — hiding agrees with the rest of the card rather than inventing a second notion of "on".
- **Fails hidden**: `unavailable` / `unknown` / a missing entity count as inactive. A device that asked to appear only when active shouldn't reappear because its integration dropped out.
- **The editor always draws it**, at 40% opacity with a dashed badge. An element invisible in *both* views would be unselectable and unfixable — the config would be the only way back.

## Scope
This is the "hide if not truthy" half. The issue's other half — *"a bank of elements that will stack vertically or horizontally"* — is a layout feature (reflowing active elements into a list), not a visibility flag, so **#55 stays open** for it. Worth noting the reporter never sent the screenshot you asked for, so I deliberately built only the part that's unambiguous.

## Verification
`tsc` clean, **474/474 tests** (+3: the on/off pair, the domain-aware cases, and the fail-hidden cases). Harness: with the light on the card renders both devices; with it off, only the ordinary one — while the editor still shows the hidden one dimmed (`opacity: 0.4`, dashed border) and selectable.

One thing the tests caught worth mentioning: my first cut let a device with **no entity** count as active if a stray state string reached the helper. It now returns "hidden" for an unbound device, matching the documented rule.

## Backwards compatibility
Absent field = today's behavior; no rendering changes for existing configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)