### PR TITLE
Shutters: hinged louvered panels, and contact sensors — closes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,15 @@ tracks state:
   otherwise. A door's leaf swings around its hinge; a window's two leaves swing outward
   from the middle — or set **Sashes** to *Single* for a one-sash window (hinged at
   either jamb via **Hinge**).
-- **Window + external shutter** — a window and its roller shutter share one wall gap:
-  bind the window's contact sensor as **Entity** and the shutter's `cover` as
-  **Shutter**. The sash and the slatted curtain render independently, so an open
-  window behind a closed shutter shows both truthfully. When closed the swing arc is hidden; as the opening moves, the arc
+- **External shutters** — an opening and its shutter share one wall gap: bind the
+  window's contact sensor as **Entity** and the shutter as **Shutter** (a `cover`, or
+  a `binary_sensor` contact). Two kinds are drawn, picked by **Shutter type**:
+  *Hinged* — louvered panels outside the wall that fold back against the façade
+  (persiane/scuri) — and *Roll-up* — a slatted curtain that disappears upward
+  (tapparella). It defaults from the entity: a contact sensor can only say
+  open/closed, so it draws hinged; a position-carrying `cover` draws roll-up. The
+  opening and its shutter render independently, so an open window behind a closed
+  shutter shows both truthfully. Doors can have shutters too. When closed the swing arc is hidden; as the opening moves, the arc
   **draws on**, tracing the path of the leaf edge — animated smoothly.
 - **Partial (position covers)** — if the bound `cover` reports a `current_position`
   (0–100), the opening is drawn **partly open** to match — a door swings partway, a
@@ -547,7 +552,8 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves. `swing` (default) hinged door / casement window; `slide` sliding panels; `roll` roll-up cover (garage / roller shutter) drawn as a slatted curtain that thins onto its track as it opens. |
 | `sash`        | `single` \| `double`        | Swing windows only: one full-width sash or the classic two leaves. Default `double`. |
-| `shutterEntity` | string                     | Windows only: a `cover` for an external roller shutter over the same gap — drawn as a slatted curtain layered on the sash, with its own open/closed state. |
+| `shutterEntity` | string                     | An external shutter over the same gap — a `cover` or a `binary_sensor` contact — layered on the sash with its own open/closed state. |
+| `shutterStyle` | `swing` \| `roll`           | How that shutter is drawn: hinged louvered panels, or a roll-up curtain. Defaults from the entity (`binary_sensor` → `swing`, `cover` → `roll`). |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -449,11 +449,30 @@ describe("openingForm — sash and shutter (issues #73 / #74)", () => {
     ).not.toContain("sash");
   });
 
-  it("windows offer a Shutter cover picker; doors don't", () => {
-    const f = openingForm(win).fields.find((x) => x.name === "shutterEntity");
-    expect(f).toBeDefined();
-    expect(f!.selector).toEqual({ entity: { filter: [{ domain: "cover" }] } });
-    expect(openingForm(door).fields.map((x) => x.name)).not.toContain("shutterEntity");
+  it("every opening offers a Shutter picker taking covers or contact sensors", () => {
+    // Doors get shutters too (French/patio doors), and a hinged shutter
+    // usually reports through a binary_sensor rather than a cover (#74).
+    for (const o of [win, door]) {
+      const f = openingForm(o).fields.find((x) => x.name === "shutterEntity");
+      expect(f).toBeDefined();
+      expect(f!.selector).toEqual({
+        entity: { filter: [{ domain: ["cover", "binary_sensor"] }] },
+      });
+    }
+  });
+
+  it("the shutter type appears only once one is bound, and defaults per domain", () => {
+    expect(openingForm(win).fields.map((x) => x.name)).not.toContain("shutterStyle");
+    const contact = openingForm({ ...win, shutterEntity: "binary_sensor.shutter" } as Opening);
+    expect(contact.fields.map((x) => x.name)).toContain("shutterStyle");
+    expect(contact.data.shutterStyle).toBe("swing");
+    const roller = openingForm({ ...win, shutterEntity: "cover.tapparella" } as Opening);
+    expect(roller.data.shutterStyle).toBe("roll");
+    // An explicit choice overrides the domain default either way.
+    expect(
+      openingForm({ ...win, shutterEntity: "cover.x", shutterStyle: "swing" } as Opening).data
+        .shutterStyle
+    ).toBe("swing");
   });
 
   it("patches map back to config shape (double stays out of the YAML)", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -31,6 +31,7 @@ import {
   normalizePlanRotation,
   openingMotion,
   sliderStyleOf,
+  shutterStyleOf,
   windowSash,
 } from "./render";
 import { defaultItemAction } from "./actions";
@@ -247,12 +248,21 @@ export function openingForm(o: Opening): FormSpec {
     helper: "Type and motion follow the entity's device class",
     selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
   });
-  if (o.type === "window") {
+  // Offered on doors too: French doors and patio doors get shutters as well.
+  // A hinged shutter usually reports through a contact sensor, so binary
+  // sensors belong in the picker next to covers (issue #74).
+  fields.push({
+    name: "shutterEntity",
+    label: "Shutter",
+    helper: "External shutter over this opening — a cover, or a contact sensor",
+    selector: { entity: { filter: [{ domain: ["cover", "binary_sensor"] }] } },
+  });
+  if (o.shutterEntity) {
     fields.push({
-      name: "shutterEntity",
-      label: "Shutter",
-      helper: "External roller shutter over this window (a cover)",
-      selector: { entity: { filter: [{ domain: "cover" }] } },
+      name: "shutterStyle",
+      label: "Shutter type",
+      helper: "Hinged panels fold back against the wall; roll-up slats disappear upward",
+      selector: dropdown(opt("swing", "Hinged (louvered panels)"), opt("roll", "Roll-up (slats)")),
     });
   }
   if (o.entity) fields.push({ name: "invert", label: "Invert", selector: { boolean: {} } });
@@ -270,6 +280,7 @@ export function openingForm(o: Opening): FormSpec {
       sash: windowSash(o),
       entity: o.entity ?? "",
       shutterEntity: o.shutterEntity ?? "",
+      shutterStyle: shutterStyleOf(o),
       invert: o.invert ?? false,
       angle: o.angle,
     },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -52,6 +52,7 @@ import {
   renderWallMask,
   openingDefaultOpen,
   openingMotion,
+  shutterStyleOf,
   openingFromDeviceClass,
   renderRipple,
   renderFurniture,
@@ -3146,7 +3147,7 @@ export class FloorplanCardEditor extends LitElement {
           amount: openingMotion(o) !== "swing" ? 0.55 : undefined,
           // Shutter previewed half-rolled so the layer is visible while
           // configuring, whatever the live state.
-          shutter: o.shutterEntity ? { amount: 0.55 } : undefined,
+          shutter: o.shutterEntity ? { amount: 0.55, style: shutterStyleOf(o) } : undefined,
         })}
       </g>`;
   }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -20,6 +20,7 @@ import {
   openingIsActive,
   openingClickAction,
   shutterAmount,
+  shutterStyleOf,
   shutterActive,
   renderRipple,
   renderFurniture,
@@ -414,7 +415,11 @@ export class FloorplanCard extends LitElement {
                 // External roller shutter layer (issue #74). No entity bound
                 // yet → previewed shut, like a static plan.
                 shutter: o.shutterEntity
-                  ? { amount: shutterAmount(shutterState), active: shutterActive(shutterState) }
+                  ? {
+                      amount: shutterAmount(shutterState),
+                      active: shutterActive(shutterState),
+                      style: shutterStyleOf(o),
+                    }
                   : undefined,
               });
               if (!o.entity) return symbol;

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -169,3 +169,45 @@ describe("renderOpening — external shutter layer (issue #74)", () => {
     expect(s).toContain("#ff0000"); // curtain wears the accent while the sash doesn't
   });
 });
+
+describe("renderOpening — hinged external shutter (issue #74)", () => {
+  const win = { type: "window" } as Partial<Opening>;
+
+  it("closed: two louvered panels lying across the opening, outside the wall", () => {
+    const s = svgOf(win, { open: false, shutter: { amount: 0, style: "swing" } });
+    // One panel hinged at each jamb, neither rotated while shut.
+    expect(s).toContain("rotate(0deg)");
+    expect(s).toContain("fp-door-leaf");
+    expect(s).toContain("fp-leaf-r");
+    // Panels sit beyond the wall band (positive y), clear of the casement sashes.
+    expect(s).toMatch(/translate\(-45 [0-9.]+\)/);
+    // Louver ticks are drawn in the background colour.
+    expect(s).toContain("var(--card-background-color, #fff)");
+  });
+
+  it("open: both panels fold back to the wall, in opposite directions", () => {
+    const s = svgOf(win, { open: false, shutter: { amount: 1, style: "swing" } });
+    expect(s).toContain("rotate(90deg)");
+    expect(s).toContain("rotate(-90deg)");
+  });
+
+  it("partial: panels swing proportionally", () => {
+    const s = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing" } });
+    expect(s).toContain("rotate(45deg)");
+    expect(s).toContain("rotate(-45deg)");
+  });
+
+  it("swing draws no roll curtain, and roll draws no hinged panels", () => {
+    const swing = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing" } });
+    expect(swing).not.toContain("fp-roll-curtain");
+    const roll = svgOf(win, { open: false, shutter: { amount: 0.5, style: "roll" } });
+    expect(roll).toContain("fp-roll-curtain");
+  });
+
+  it("the window underneath still renders its own sashes", () => {
+    const s = svgOf(win, { open: true, shutter: { amount: 0, style: "swing" } });
+    // Casement leaves swung open behind a shut shutter — both are true at once.
+    expect(s).toContain("rotate(-90deg)");
+    expect(s).toContain("rotate(0deg)");
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -10,6 +10,7 @@ import {
   openingFromDeviceClass,
   windowSash,
   shutterAmount,
+  shutterStyleOf,
   shutterActive,
   openingClickAction,
   resolveOpeningOpen,
@@ -1359,5 +1360,21 @@ describe("renderArea", () => {
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).not.toContain("position:fixed");
+  });
+});
+
+describe("shutterStyleOf (issue #74)", () => {
+  it("infers from the bound entity: contacts hinge, covers roll", () => {
+    expect(shutterStyleOf({ shutterEntity: "binary_sensor.persiana" })).toBe("swing");
+    expect(shutterStyleOf({ shutterEntity: "cover.tapparella" })).toBe("roll");
+  });
+
+  it("an explicit style always wins", () => {
+    expect(shutterStyleOf({ shutterEntity: "cover.x", shutterStyle: "swing" })).toBe("swing");
+    expect(shutterStyleOf({ shutterEntity: "binary_sensor.x", shutterStyle: "roll" })).toBe("roll");
+  });
+
+  it("defaults to roll with nothing bound, so existing configs are untouched", () => {
+    expect(shutterStyleOf({})).toBe("roll");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -570,6 +570,18 @@ export function windowSash(o: Opening): "single" | "double" {
  * position when published, else open-ish states = 1. Fails closed on an
  * outage — a stale "open" shutter is worse than drawing it shut.
  */
+/**
+ * How an opening's external shutter is drawn (issue #74). An explicit
+ * `shutterStyle` wins; otherwise the bound entity decides: a `binary_sensor`
+ * only reports open/closed — what a hinged shutter (persiana) can say — so it
+ * defaults to `swing`, while a `cover` carries a position and defaults to the
+ * roller curtain (tapparella).
+ */
+export function shutterStyleOf(o: Pick<Opening, "shutterEntity" | "shutterStyle">): "roll" | "swing" {
+  if (o.shutterStyle === "roll" || o.shutterStyle === "swing") return o.shutterStyle;
+  return o.shutterEntity?.split(".")[0] === "binary_sensor" ? "swing" : "roll";
+}
+
 export function shutterAmount(
   state: { state: string; attributes?: Record<string, unknown> } | undefined,
 ): number {
@@ -747,6 +759,53 @@ function rollCurtain(length: number, tone: string, amt: number): SVGTemplateResu
     </g>`;
 }
 
+/**
+ * Hinged external shutters (issue #74) — the louvered panels you fold back
+ * against the façade, not a roller curtain. Two leaves hinged at the jambs,
+ * drawn just **outside** the wall band so they never collide with the
+ * window's own casement sashes (which swing to the near side), rotating
+ * outward as they open. Closed, they cover the opening.
+ */
+function swingShutter(
+  length: number,
+  cutH: number,
+  tone: string,
+  amt: number
+): SVGTemplateResult {
+  const half = length / 2;
+  const t = 3;
+  // Sit the panels beyond the wall band, on the far side from the sashes.
+  const y0 = cutH / 2 + t / 2;
+  /** Slat ticks across a panel whose rect starts at `x0` and runs `w` wide. */
+  const louvers = (x0: number, w: number): SVGTemplateResult[] => {
+    const out: SVGTemplateResult[] = [];
+    const n = Math.max(2, Math.round(w / 14));
+    for (let i = 1; i < n; i++) {
+      const x = x0 + (w * i) / n;
+      out.push(
+        svg`<line x1=${x} y1=${-t / 2} x2=${x} y2=${t / 2}
+              stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
+      );
+    }
+    return out;
+  };
+  // Reuses the door-leaf transition classes: same hinge semantics, so the
+  // panels animate with the rest of the plan for free.
+  return svg`
+      <g transform="translate(${-half} ${y0})">
+        <g class="fp-door-leaf" style="transform:rotate(${90 * amt}deg);">
+          <rect x="0" y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+          ${louvers(0, half)}
+        </g>
+      </g>
+      <g transform="translate(${half} ${y0})">
+        <g class="fp-leaf-r" style="transform:rotate(${-90 * amt}deg);">
+          <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+          ${louvers(-half, half)}
+        </g>
+      </g>`;
+}
+
 /** Style options for {@link renderOpening}. */
 export interface OpeningStyle {
   /** Base color of the jambs / leaf / swing arc. */
@@ -768,7 +827,7 @@ export interface OpeningStyle {
    * open (0..1, see {@link shutterAmount}) and whether it wears the accent.
    * Rendered as the roll curtain on top of the sash.
    */
-  shutter?: { amount: number; active?: boolean };
+  shutter?: { amount: number; active?: boolean; style?: "roll" | "swing" };
 }
 
 /**
@@ -946,8 +1005,16 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   // sash so a shut shutter visibly covers an open window. Its own
   // active/accent state is independent of the window's.
   if (style.shutter) {
-    const shutterTone = style.shutter.active ? accent : color;
-    body = svg`${body}${rollCurtain(o.length, cssColorOr(shutterTone, "var(--primary-color, #03a9f4)"), style.shutter.amount)}`;
+    const shutterTone = cssColorOr(
+      style.shutter.active ? accent : color,
+      "var(--primary-color, #03a9f4)"
+    );
+    const amt2 = Math.max(0, Math.min(1, style.shutter.amount));
+    body = svg`${body}${
+      style.shutter.style === "swing"
+        ? swingShutter(o.length, cutH, shutterTone, amt2)
+        : rollCurtain(o.length, shutterTone, amt2)
+    }`;
   }
   const { sx, sy } = openingMirror(o);
   return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,12 +98,24 @@ export interface Opening {
    */
   sash?: "single" | "double";
   /**
-   * Windows only: a `cover` entity for an external roller shutter sharing the
-   * same wall gap (issue #74). Drawn as a slatted roll curtain layered over
-   * the sash — `entity` keeps driving the window itself, so an open window
-   * behind a closed shutter renders both truthfully.
+   * An external shutter sharing this opening's wall gap (issue #74): a
+   * `cover` (roller shutter / tapparella) or a `binary_sensor` contact on a
+   * hinged shutter (persiana). `entity` keeps driving the opening itself, so
+   * an open window behind a closed shutter renders both truthfully.
    */
   shutterEntity?: string;
+  /**
+   * How that shutter is drawn (issue #74):
+   * - `roll` — a slatted curtain that rolls up out of the floor plane.
+   * - `swing` — louvered panels hinged at the jambs, **outside** the wall,
+   *   swinging outward (the shutters you fold back against the façade).
+   *
+   * Defaults from the bound entity: a `binary_sensor` can only say
+   * open/closed, which is what a hinged shutter reports, so it defaults to
+   * `swing`; a position-carrying `cover` defaults to `roll`. Set explicitly
+   * to override. See {@link shutterStyleOf}.
+   */
+  shutterStyle?: "roll" | "swing";
   /**
    * Sliding openings only (`motion: "slide"`): how the panels are arranged.
    * - `single` (default) — one panel slides aside into the wall.


### PR DESCRIPTION
Fixes what I got wrong in #75.

## What the reporter actually asked for
His photo shows **persiane/scuri** — louvered panels hinged *outside* the window that fold back against the façade — reported by a **door contact sensor**. What I shipped was a **tapparella**: a roller curtain, `cover` entities only. Same English word, two different objects; I mapped his photo onto the roll-up work already in flight rather than reading it as a new shape. His follow-up said so plainly, including that the picker wouldn't list his binary sensor.

## The fix
- **`shutterStyle: "swing"`** draws two louvered panels hinged at the jambs, **outside the wall band** so they never collide with the window's own casement sashes, swinging outward as they open. `"roll"` keeps the existing curtain.
- **The style defaults from the bound entity**: a `binary_sensor` can only report open/closed — exactly what a hinged shutter says — so it draws hinged; a position-carrying `cover` keeps the roller. An explicit choice always wins, so **existing cover-bound configs render exactly as before**.
- **The picker accepts `binary_sensor` as well as `cover`**, and is offered on **doors** too (French and patio doors get shutters).

## Verification
`tsc` clean, **480/480 tests** (+9: the glyph's shut/partial/open geometry, panels-outside-the-wall placement, mutual exclusion with the roll curtain, the window still rendering its own sashes underneath, and the `shutterStyleOf` inference/override matrix). Harness screenshot in the thread shows three windows side by side — shutter shut, *window open with shutter shut*, both open — plus a roller for comparison; the middle case is the one the issue is about.

## A note for @sononicola
Two things worth saying on the issue: the Shutter field only landed after the last release, so it isn't in a downloaded build yet — which is likely why the option was missing from your editor entirely. And with this change you'd bind your shutter's **binary sensor**, and the hinged drawing is chosen for you.

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)