### PR TITLE
Background images: per-floor fit so mixed-resolution scans stop distorting (closes #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ and remain valid for backward compatibility.
 
 ### Floor
 
-`{ id, name, short?, color?, haFloor?, image?, imageOpacity?, walls, openings, items, texts, furniture, trackers, areas }`
+`{ id, name, short?, color?, haFloor?, image?, imageFit?, imageOpacity?, walls, openings, items, texts, furniture, trackers, areas }`
 — a named floor with its own elements. Use the **floor** controls in the editor toolbar
 to add, rename, switch and delete floors; the live card shows a floor switcher in the
 top-right when there is more than one.
@@ -542,9 +542,29 @@ config so other features (like the per-**Area** HA-area entity filtering above) 
 on the same idea one level down.
 
 Set **`image`** to a background image URL (e.g. `/local/floorplan.png` or an external
-URL) to draw it behind the elements — handy for tracing over a real floor plan. It fills
-the canvas, so match the canvas `width`/`height` to the image's aspect ratio to avoid
-distortion. **`imageOpacity`** (0–1, default 1) fades it.
+URL) to draw it behind the elements — handy for tracing over a real floor plan.
+**`imageOpacity`** (0–1, default 1) fades it.
+
+**`imageFit`** controls how that image maps onto the canvas. The canvas `width`/`height`
+are set once for the whole card, but `image` is per floor — so if your scans differ in
+resolution, no single canvas ratio suits them all and some floors would be squashed.
+`imageFit` is per floor so each scan can choose for itself:
+
+| `imageFit` | What it does |
+| --- | --- |
+| `stretch` *(default)* | Fills the canvas, distorting if the ratios disagree. |
+| `contain` | Scales to fit, keeping proportions — may leave the canvas showing on two sides. |
+| `cover` | Fills the canvas keeping proportions, cropping the overflow. |
+
+The default stays `stretch` on purpose: plans traced over a stretched image would shift
+away from their walls if the fit changed under them. Set it to `contain` on a floor whose
+image looks squashed.
+
+One caveat: `imageFit` settles the image-against-canvas ratio, but the whole card is still
+stretched into whatever box your dashboard gives it. If that box's proportions differ from
+`width`/`height`, everything — image and elements alike — stretches together, and a
+`contain` image will look distorted again. Keep the card's `width`/`height` close to the
+shape it occupies on screen.
 
 ### Wall
 

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -363,6 +363,29 @@ const bgImage =
      </svg>`
   );
 
+// A deliberately SQUARE source image, for testing `imageFit` (issue #86) — the
+// case of a scan whose aspect ratio disagrees with the canvas. The circle is
+// the tell: stretched onto the 1000x600 canvas it becomes a visible ellipse,
+// and `imageFit: "contain"` snaps it back to a circle. Swap it into
+// `demoFloor.image` (or set it from the console) to reproduce.
+//
+// The viewBox is load-bearing: an <image> honours preserveAspectRatio against a
+// referenced SVG's viewBox, and without one this fixture would stretch under
+// every fit and look like the feature was broken. Real PNG/JPG scans carry an
+// intrinsic size and need no such help.
+export const squareBgImage =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='600' height='600' viewBox='0 0 600 600'>
+       <rect width='600' height='600' fill='#ffd54f'/>
+       <circle cx='300' cy='300' r='250' fill='none' stroke='#e53935' stroke-width='8'/>
+       <g stroke='#000' stroke-opacity='0.18'>
+         ${Array.from({ length: 7 }, (_, i) => `<line x1='${i * 100}' y1='0' x2='${i * 100}' y2='600'/>`).join("")}
+         ${Array.from({ length: 7 }, (_, i) => `<line x1='0' y1='${i * 100}' x2='600' y2='${i * 100}'/>`).join("")}
+       </g>
+     </svg>`
+  );
+
 // Start with a blank floor so you can draw a perimeter from scratch. Flip
 // START_WITH_DEMO to true to instead load a sample room (walls + door + window
 // over the background image) — handy for testing rendering of existing plans.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -431,6 +431,24 @@ describe("wallForm / projectForm / floorImageForm", () => {
     );
     expect(floorImageForm({} as Floor).fields.map((x) => x.name)).not.toContain("imageOpacity");
   });
+
+  it("offers the fit only alongside an image, defaulting to stretch (issue #86)", () => {
+    const withImage = floorImageForm({ image: "x.png" } as Floor);
+    expect(withImage.fields.map((x) => x.name)).toContain("imageFit");
+    expect(withImage.data.imageFit).toBe("stretch");
+    expect(floorImageForm({} as Floor).fields.map((x) => x.name)).not.toContain("imageFit");
+    expect(floorImageForm({ image: "x.png", imageFit: "contain" } as Floor).data.imageFit).toBe(
+      "contain"
+    );
+  });
+
+  it("drops the default fit from the config instead of writing it out", () => {
+    const { toPatch } = floorImageForm({ image: "x.png" } as Floor);
+    expect(toPatch({ imageFit: "stretch" }).imageFit).toBeUndefined();
+    expect(toPatch({ imageFit: "cover" }).imageFit).toBe("cover");
+    // Untouched keys must survive the patch — it rewrites one field, not the form.
+    expect(toPatch({ imageFit: "stretch", imageOpacity: 0.5 }).imageOpacity).toBe(0.5);
+  });
 });
 
 describe("openingForm — sash and shutter (issues #73 / #74)", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -693,10 +693,29 @@ export function floorImageForm(f: Floor): FormSpec {
   ];
   if (f.image) {
     fields.push({
+      name: "imageFit",
+      label: "Image fit",
+      helper: "Per floor, so scans of different resolutions can each fit properly",
+      selector: dropdown(
+        opt("stretch", "Stretch to canvas (may distort)"),
+        opt("contain", "Fit inside (keep proportions)"),
+        opt("cover", "Fill canvas (keep proportions, crop)")
+      ),
+    });
+    fields.push({
       name: "imageOpacity",
       label: "Image opacity",
       selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
     });
   }
-  return { fields, data: { image: f.image ?? "", imageOpacity: f.imageOpacity ?? 1 }, toPatch: identity };
+  return {
+    fields,
+    data: {
+      image: f.image ?? "",
+      imageFit: f.imageFit ?? "stretch",
+      imageOpacity: f.imageOpacity ?? 1,
+    },
+    // "stretch" is the default, so keep it out of the YAML.
+    toPatch: (p) => ("imageFit" in p && p.imageFit === "stretch" ? { ...p, imageFit: undefined } : p),
+  };
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -50,6 +50,7 @@ import {
   WALL_THICKNESS,
   renderOpening,
   renderWallMask,
+  imageFitRatio,
   openingDefaultOpen,
   openingMotion,
   shutterStyleOf,
@@ -2696,7 +2697,8 @@ export class FloorplanCardEditor extends LitElement {
               />
               ${floor.image
                 ? svg`<image href=${floor.image} x="0" y="0" width=${c.width} height=${c.height}
-                            preserveAspectRatio="none" opacity=${floor.imageOpacity ?? 1} />`
+                            preserveAspectRatio=${imageFitRatio(floor.imageFit)}
+                            opacity=${floor.imageOpacity ?? 1} />`
                 : nothing}
               ${this._renderGrid()}
               ${repeat(

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -16,6 +16,7 @@ import {
   WALL_THICKNESS,
   renderOpening,
   renderWallMask,
+  imageFitRatio,
   resolveOpeningAmount,
   openingIsActive,
   openingClickAction,
@@ -381,7 +382,8 @@ export class FloorplanCard extends LitElement {
             <g transform=${rotTransform || nothing}>
             ${active.image
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
-                          preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
+                          preserveAspectRatio=${imageFitRatio(active.imageFit)}
+                          opacity=${active.imageOpacity ?? 1} />`
               : nothing}
             ${active.areas?.map((a) => renderArea(a))}
             ${active.furniture.map((f) =>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -11,6 +11,7 @@ import {
   windowSash,
   shutterAmount,
   shutterStyleOf,
+  imageFitRatio,
   shutterActive,
   openingClickAction,
   resolveOpeningOpen,
@@ -1361,6 +1362,21 @@ describe("renderArea", () => {
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).not.toContain("position:fixed");
+  });
+});
+
+describe("imageFitRatio (issue #86)", () => {
+  it("maps each fit onto SVG's own aspect-ratio handling", () => {
+    expect(imageFitRatio("contain")).toBe("xMidYMid meet");
+    expect(imageFitRatio("cover")).toBe("xMidYMid slice");
+    expect(imageFitRatio("stretch")).toBe("none");
+  });
+
+  it("keeps stretching when unset, so existing traced plans do not shift", () => {
+    expect(imageFitRatio(undefined)).toBe("none");
+    // A value from a hand-written config we don't recognise must not silently
+    // become "contain" and move every wall off the image it was traced over.
+    expect(imageFitRatio("fill" as never)).toBe("none");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,7 @@
 import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
 import type {
   FloorplanCardConfig,
+  Floor,
   SectionalHand,
   Opening,
   ItemKind,
@@ -1102,6 +1103,29 @@ export function planRotationTransform(w: number, h: number, rot: PlanRotation): 
       return `translate(0 ${w}) rotate(-90)`;
     default:
       return "";
+  }
+}
+
+/**
+ * `preserveAspectRatio` for a floor's background image (issue #86).
+ *
+ * SVG already knows how to do this, so the fit option is a straight mapping
+ * rather than any arithmetic of ours: `none` stretches, `meet` fits inside
+ * (letterbox), `slice` fills and crops. Centred in both directions.
+ *
+ * This governs only how the bitmap maps into its own rect — the rect still
+ * spans the canvas, so element coordinates are untouched and a plan traced
+ * over the image keeps its alignment with everything else.
+ */
+export function imageFitRatio(fit: Floor["imageFit"]): string {
+  switch (fit) {
+    case "contain":
+      return "xMidYMid meet";
+    case "cover":
+      return "xMidYMid slice";
+    default:
+      // Unset and any stray value fall back to the historical behaviour.
+      return "none";
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -564,10 +564,25 @@ export interface Floor {
   /**
    * Optional background image URL (e.g. `/local/floorplan.png` or an external
    * URL) drawn behind the elements — handy for tracing over a real floor plan.
-   * It fills the virtual canvas, so match the canvas width/height to the image
-   * aspect ratio to avoid distortion.
    */
   image?: string;
+  /**
+   * How the background image maps onto the virtual canvas (issue #86).
+   *
+   * The canvas width/height are config-level but `image` is per-floor, so a
+   * multi-floor plan whose scans differ in resolution cannot pick one canvas
+   * ratio that suits them all — at least one floor gets squashed. This is
+   * per-floor precisely so each scan can choose for itself.
+   *
+   * - **`stretch`** (default) — fill the canvas, distorting if the ratios
+   *   disagree. Kept as the default because existing plans were traced over a
+   *   stretched image; changing it under them would shift every wall.
+   * - **`contain`** — scale to fit, preserving the image's own aspect ratio.
+   *   Letterboxes: the canvas may show through on two sides.
+   * - **`cover`** — fill the canvas preserving aspect ratio, cropping the
+   *   overflow.
+   */
+  imageFit?: "stretch" | "contain" | "cover";
   /** Background image opacity, 0–1. Default 1. */
   imageOpacity?: number;
   walls: Wall[];


### PR DESCRIPTION
Closes #86.

### The problem

`width`/`height` (the virtual canvas) are **config-level**, but `image` is **per floor**. Rolf has four floors whose PNGs differ in resolution — there is no single canvas ratio that suits them all, so at least one floor is always squashed. The image was drawn with `preserveAspectRatio="none"`, which made that unavoidable rather than merely awkward.

### The fix

A per-floor **`imageFit`**, mapping onto SVG's own aspect-ratio handling rather than any arithmetic of ours:

| `imageFit` | `preserveAspectRatio` | Behaviour |
| --- | --- | --- |
| `stretch` *(default)* | `none` | Fills the canvas, distorting if ratios disagree. |
| `contain` | `xMidYMid meet` | Scales to fit, keeping proportions. Letterboxes. |
| `cover` | `xMidYMid slice` | Fills the canvas keeping proportions, crops. |

It governs only how the bitmap maps into its own rect — the rect still spans the canvas, so element coordinates are untouched and a plan traced over the image keeps its alignment.

**The default stays `stretch` deliberately.** Existing plans were traced over a stretched image; changing the fit under them would shift every wall off the thing it was traced onto.

### Verification

Measured in the dev harness against a real 600x600 PNG on a 1000x600 canvas, sampling the drawn circle's painted extents (width:height, 1.000 = undistorted):

| Fit | Ratio | |
| --- | --- | --- |
| `stretch` | **1.668** | the reported bug |
| `contain` | **1.000** | fixed |
| `cover` | undistorted, cropped to the canvas height | as intended |

All three values confirmed reaching the live DOM in the card. Typecheck clean, **487/487 tests**, build clean.

### One thing this does *not* fix

`imageFit` settles image-vs-canvas. It does **not** touch the outer stage stretch: if the card's on-screen box disagrees with `width`/`height`, both layers still stretch together — I measured 2.012 for a `contain` image in a 1000x300 box. That is the long-standing deliberate behaviour documented on the stage's own `preserveAspectRatio` (the "do not fix this line" comment), since letterboxing the stage alone would drift every icon off its wall. The README now states the caveat instead of leaving people to discover it.

### Note on the harness fixture

The square test image needs an explicit `viewBox`. An `<image>` honours `preserveAspectRatio` against a referenced SVG's viewBox, and without one the fixture stretches under every fit — which looks exactly like the feature being broken. It cost me a wrong reading before I switched to a raster PNG, so the fixture carries a comment. Real PNG/JPG scans carry an intrinsic size and need no such help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)