### PR TITLE
Walls: state the wall mask's own region so rotation stops clipping them (closes #102)

### DIFF
--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -11,6 +11,7 @@ import {
   windowSash,
   shutterAmount,
   shutterStyleOf,
+  renderWallMask,
   shutterActive,
   openingClickAction,
   resolveOpeningOpen,
@@ -1361,6 +1362,38 @@ describe("renderArea", () => {
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).not.toContain("position:fixed");
+  });
+});
+
+describe("renderWallMask region (issue #102)", () => {
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+
+  it("states its own region instead of inheriting the viewport default", () => {
+    const markup = flatten(renderWallMask([], 1000, 600, "m1"));
+    const mask = markup.slice(markup.indexOf("<mask"), markup.indexOf(">", markup.indexOf("<mask")));
+    // Without these, the region falls back to -10%..110% of the viewport, which
+    // the rotated card swaps — clipping walls past x=660 on a 1000x600 plan.
+    expect(mask).toContain('x=-8');
+    expect(mask).toContain('y=-8');
+    expect(mask).toContain("width=1016");
+    expect(mask).toContain("height=616");
+  });
+
+  it("covers the whole plan even where the viewport is narrower than it", () => {
+    // A 90°-rotated 1000x600 plan is drawn into a 600x1000 viewport, so the
+    // region must reach plan x=1000 regardless of that 600.
+    const markup = flatten(renderWallMask([], 1000, 600, "m2"));
+    const nums = [...markup.matchAll(/(?:x|y|width|height)=(-?\d+)/g)].map((m) => Number(m[1]));
+    const right = 1000 + 8;
+    expect(Math.max(...nums)).toBeGreaterThanOrEqual(right);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1111,6 +1111,13 @@ export function planRotationTransform(w: number, h: number, rot: PlanRotation): 
  * shows through — including any background image. Shared by the live card and the
  * editor so both cut walls identically. Wrap the wall strokes in
  * `<g mask="url(#id)">` (or set `mask="url(#id)"` on each wall line).
+ *
+ * The mask's own region is stated explicitly (issue #102). Left unset it defaults
+ * to -10%..110% *of the viewport*, and the rotated card (issue #33) swaps the
+ * viewport's width and height while the mask content stays in plan coordinates —
+ * so on a 1000x600 plan turned 90°, the region ended at 110% of 600 and every
+ * wall past x=660 was masked away. Only walls, because only walls wear the mask.
+ * A margin of one wall thickness keeps strokes that sit on the canvas edge whole.
  */
 export function renderWallMask(
   openings: Opening[],
@@ -1119,10 +1126,13 @@ export function renderWallMask(
   id: string
 ): SVGTemplateResult {
   const cutH = WALL_THICKNESS + 4;
+  const pad = WALL_THICKNESS;
   return svg`
     <defs>
-      <mask id=${id} maskUnits="userSpaceOnUse">
-        <rect x="0" y="0" width=${width} height=${height} fill="white" />
+      <mask id=${id} maskUnits="userSpaceOnUse"
+            x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}>
+        <rect x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}
+              fill="white" />
         ${openings.map((o) => {
           const half = o.length / 2;
           return svg`<rect x=${o.x - half} y=${o.y - cutH / 2}


### PR DESCRIPTION
Closes #102. Thanks @thewan056 — the screenshot made this one findable.

### Cause

The wall mask set `maskUnits="userSpaceOnUse"` but gave no `x`/`y`/`width`/`height`. Those default to **−10%..110% of the viewport**. The rotated card (#33) swaps the viewport's width and height, while the mask's content stays in *plan* coordinates — so on a 1000x600 plan turned 90°, the region ran to 110% of **600** = **660**, and every wall past x=660 was masked away.

That accounts for all three details of the report:

- **only walls** — nothing else wears the mask
- **only 90/270** — 180° keeps the viewport's proportions, so the default region still covers the plan
- **"beyond a certain point"** — precisely 110% of the short side

### Fix

State the region explicitly, padded by one wall thickness so strokes sitting on the canvas edge stay whole.

```diff
-      <mask id=${id} maskUnits="userSpaceOnUse">
-        <rect x="0" y="0" width=${width} height=${height} fill="white" />
+      <mask id=${id} maskUnits="userSpaceOnUse"
+            x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}>
+        <rect x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}
+              fill="white" />
```

### Verification

Rasterised the card's **own emitted markup** and counted painted pixels — a 1000-unit wall spanning a 1000x600 plan at rotation 90:

| | Wall drawn |
| --- | --- |
| before | **659** / 1000 |
| after | **999** / 1000 |

Reproduced by stripping just the four new attributes from the fixed card's markup, so the 659 is this code path, not a hand-built mock. All four rotations (0/90/180/270) now draw the wall in full. Two regression tests added, both of which fail against the old markup. Typecheck clean, **485/485 tests**, build clean.

Branched off `main`, independent of #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)