### PR TITLE
Areas: conditional fill and outline coloring from a bound entity (issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ automatically to the card and screen size.
 - **Areas** — trace a room's outline point-by-point (points snap to wall corners and to
   neighboring areas' corners) to get a colored, named room polygon. Bind an entity to a
   room and its fill goes live — green while a presence sensor is occupied, red when a CO2
-  sensor crosses a threshold. Naming a room after
+  sensor crosses a threshold. Or bind a **light** and the room glows with that light's own
+  color and brightness, for a bird's-eye view of the tones set across the house. Naming a room after
   one of your Home Assistant areas (the name field autocompletes against them) links the
   two, which scopes the entity picker — for any device dropped inside it — to that HA
   area's entities, and can bulk-add every device in the area.
@@ -681,7 +682,7 @@ trackers:
 
 ### Area
 
-`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
+`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, lightEntity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
 
 - `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
   is implicitly closed from the last point back to the first.
@@ -696,9 +697,12 @@ trackers:
   a linked `haArea`.
 - `entity` — optional entity that makes the room itself live, in the same shape furniture
   uses. Drives `stateColor` and `activeColor`; an unbound area stays a static polygon.
+- `lightEntity` — a light in this room, whose own color and brightness paint it. See
+  **A room lit by its light** below.
 - `stateColor` — threshold/state rules for the fill (same shape as a device's
-  `stateColor`). Evaluated against `entity`'s state; takes precedence over `activeColor`
-  and `color`.
+  `stateColor`). Evaluated against `entity`'s state. A rule naming an `above` threshold
+  or an exact `state` outranks `lightEntity`; a catch-all rule (neither) ranks *below*
+  it — see the precedence list below.
 - `activeColor` — fill color while `entity` is active, used when no `stateColor` rule
   matches.
 - `activeOpacity` — fill opacity while `entity` resolves a color. Lets a room lift out of
@@ -708,6 +712,41 @@ trackers:
 - `highlight` — where a live color paints: `fill` (default), `border`, or `both`. Use
   `border` for a room that outlines itself while occupied without tinting everything
   inside it, which reads better on a busy plan.
+
+#### A room lit by its light
+
+Set `lightEntity` and the room takes the light's **own** color and brightness — a
+bird's-eye view where you can compare the tones set across the house at a glance. No
+rules to write: for a light you want the light's color, not a threshold.
+
+Lights differ in what they can report, so this degrades in rungs and every light does
+something sensible:
+
+| The light | What the room does |
+| --- | --- |
+| Reports a color (`rgb`, `xy`, or even `color_temp`) | Fills with that color, opacity from `brightness` |
+| Brightness only | Keeps its own `color`, opacity from `brightness` |
+| On/off only | Keeps its own `color`, at full brightness opacity |
+| Off, `unavailable` or `unknown` | Back to its resting `color`/`opacity` |
+
+Home Assistant derives an `rgb_color` even for `color_temp`-only bulbs, so a warm-white
+bulb still reads as amber. Brightness maps into a **0.15–0.5** opacity band rather than
+0–1: a room dimmed to 10% would otherwise be invisible, and "I can't see the room" reads
+worse than "the room is dim".
+
+#### Which color wins
+
+A room can bind both a light and a sensor. Highest priority first:
+
+1. a `stateColor` rule that **tested** the value (`above` or `state`) — so a smoke alarm
+   shows through a lit room;
+2. `lightEntity`, while the light is on;
+3. `activeColor`, while `entity` is active;
+4. a **catch-all** `stateColor` rule (neither `above` nor `state`) — it means "resting
+   color", so it ranks below anything that knows about right now. This matters: rule
+   lists conventionally end with a catch-all, and ranking it first would silently mask
+   the light on every config that has one;
+5. the static `color`.
 
 ```yaml
 areas:
@@ -751,6 +790,23 @@ areas:
       - { x: 900, y: 100 }
       - { x: 900, y: 500 }
       - { x: 500, y: 500 }
+
+  # The room glows with its light's own color and brightness — but a smoke
+  # alarm still shows through it, because a rule that tests the value
+  # outranks the light.
+  - id: bedroom
+    name: Bedroom
+    lightEntity: light.bedroom
+    entity: binary_sensor.bedroom_smoke
+    stateColor:
+      - { state: "on", color: "#e1243b" }
+    color: "#3366cc"
+    opacity: 0.12
+    points:
+      - { x: 500, y: 500 }
+      - { x: 900, y: 500 }
+      - { x: 900, y: 900 }
+      - { x: 500, y: 900 }
 
   # Or bind a numeric sensor and threshold it, so the whole room reddens
   # when air quality goes bad.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ automatically to the card and screen size.
   entity), custom icon (with autocomplete + preview), size and rotation.
 - **Presence ripples** — render presence/movement sensors as animated concentric rings
   that pulse while active and fade to a faint dot when idle.
+- **Cast light** — a light can pool its own color and brightness onto the plan from where
+  it sits. Several lights in one room each cast their own pool, and overlapping pools
+  *mix* — so a warm lamp and a cool lamp blend between them, and you can read the tones
+  set across the house at a glance.
 - **Animated doors & windows** — link a contact `binary_sensor` or `cover` so doors swing
   and windows open on the plan as their real state changes, with an optional accent color
   while open.
@@ -31,8 +35,7 @@ automatically to the card and screen size.
 - **Areas** — trace a room's outline point-by-point (points snap to wall corners and to
   neighboring areas' corners) to get a colored, named room polygon. Bind an entity to a
   room and its fill goes live — green while a presence sensor is occupied, red when a CO2
-  sensor crosses a threshold. Or bind a **light** and the room glows with that light's own
-  color and brightness, for a bird's-eye view of the tones set across the house. Naming a room after
+  sensor crosses a threshold. Naming a room after
   one of your Home Assistant areas (the name field autocompletes against them) links the
   two, which scopes the entity picker — for any device dropped inside it — to that HA
   area's entities, and can bulk-add every device in the area.
@@ -594,6 +597,9 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 | `activeColor` | string                                 | theme color  | Badge color while the device is on — lets domains be told apart at a glance. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
+| `glow`        | boolean                                | `false`      | Cast a pool of light onto the plan from this device (lights only). See **Cast light**. |
+| `glowRadius`  | number                                 | `140`        | Radius of the cast pool, in canvas units.              |
+| `glowColor`   | string                                 | `#ffd9a0`    | Color for a bulb that can't report one. A color-capable light always uses its own. |
 | `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |
 | `hideWhenInactive` | boolean                           | `false`      | Hide the device on the card while its entity is inactive (issue #55). Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
@@ -602,6 +608,45 @@ distortion. **`imageOpacity`** (0–1, default 1) fades it.
 
 Clicking a `light`, `switch`, `cover`, `fan` or `input_boolean` toggles it; other
 domains open the more-info dialog.
+
+#### Cast light
+
+Set `glow: true` on a light and it pools its own color and brightness onto the plan,
+centered where the device sits. The light falls **where the lamp is**, not across the
+whole room — so several lights in one room each cast their own pool, and where the pools
+overlap they **mix additively**: a warm lamp and a cool one blend to a neutral tone
+between them, exactly as they would in the room. That's something a single room-wide fill
+can't express, and it's what makes an open-plan space read correctly.
+
+```yaml
+items:
+  - id: lamp_warm
+    entity: light.living_standing_lamp
+    kind: light
+    x: 400
+    y: 300
+    glow: true
+    glowRadius: 200
+```
+
+Lights differ in what they can report, so this degrades in rungs and every light does
+something sensible:
+
+| The light | The pool |
+| --- | --- |
+| Reports a color (`rgb`, `xy`, or even `color_temp`) | Its own color, strength from `brightness` |
+| Brightness only | `glowColor` (warm white), strength from `brightness` |
+| On/off only | `glowColor`, at full strength |
+| Off, `unavailable` or `unknown` | Casts nothing |
+
+Home Assistant derives an `rgb_color` even for `color_temp`-only bulbs, so a warm-white
+bulb still reads as amber. Brightness maps into a **0.18–0.6** opacity band rather than
+0–1: a lamp dimmed to 10% would otherwise be invisible.
+
+The pools are drawn above the room fills but below furniture and walls, so light reads as
+cast onto the floor rather than painted over the plan. `glow` is independent of the icon —
+combine it with `showIcon: false` for light with no badge, or with `hideWhenInactive` to
+drop both when the light is off.
 
 ### Text
 
@@ -682,7 +727,7 @@ trackers:
 
 ### Area
 
-`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, lightEntity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
+`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
 
 - `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
   is implicitly closed from the last point back to the first.
@@ -697,12 +742,9 @@ trackers:
   a linked `haArea`.
 - `entity` — optional entity that makes the room itself live, in the same shape furniture
   uses. Drives `stateColor` and `activeColor`; an unbound area stays a static polygon.
-- `lightEntity` — a light in this room, whose own color and brightness paint it. See
-  **A room lit by its light** below.
 - `stateColor` — threshold/state rules for the fill (same shape as a device's
-  `stateColor`). Evaluated against `entity`'s state. A rule naming an `above` threshold
-  or an exact `state` outranks `lightEntity`; a catch-all rule (neither) ranks *below*
-  it — see the precedence list below.
+  `stateColor`). Evaluated against `entity`'s state; takes precedence over `activeColor`
+  and `color`.
 - `activeColor` — fill color while `entity` is active, used when no `stateColor` rule
   matches.
 - `activeOpacity` — fill opacity while `entity` resolves a color. Lets a room lift out of
@@ -712,41 +754,6 @@ trackers:
 - `highlight` — where a live color paints: `fill` (default), `border`, or `both`. Use
   `border` for a room that outlines itself while occupied without tinting everything
   inside it, which reads better on a busy plan.
-
-#### A room lit by its light
-
-Set `lightEntity` and the room takes the light's **own** color and brightness — a
-bird's-eye view where you can compare the tones set across the house at a glance. No
-rules to write: for a light you want the light's color, not a threshold.
-
-Lights differ in what they can report, so this degrades in rungs and every light does
-something sensible:
-
-| The light | What the room does |
-| --- | --- |
-| Reports a color (`rgb`, `xy`, or even `color_temp`) | Fills with that color, opacity from `brightness` |
-| Brightness only | Keeps its own `color`, opacity from `brightness` |
-| On/off only | Keeps its own `color`, at full brightness opacity |
-| Off, `unavailable` or `unknown` | Back to its resting `color`/`opacity` |
-
-Home Assistant derives an `rgb_color` even for `color_temp`-only bulbs, so a warm-white
-bulb still reads as amber. Brightness maps into a **0.15–0.5** opacity band rather than
-0–1: a room dimmed to 10% would otherwise be invisible, and "I can't see the room" reads
-worse than "the room is dim".
-
-#### Which color wins
-
-A room can bind both a light and a sensor. Highest priority first:
-
-1. a `stateColor` rule that **tested** the value (`above` or `state`) — so a smoke alarm
-   shows through a lit room;
-2. `lightEntity`, while the light is on;
-3. `activeColor`, while `entity` is active;
-4. a **catch-all** `stateColor` rule (neither `above` nor `state`) — it means "resting
-   color", so it ranks below anything that knows about right now. This matters: rule
-   lists conventionally end with a catch-all, and ranking it first would silently mask
-   the light on every config that has one;
-5. the static `color`.
 
 ```yaml
 areas:
@@ -790,23 +797,6 @@ areas:
       - { x: 900, y: 100 }
       - { x: 900, y: 500 }
       - { x: 500, y: 500 }
-
-  # The room glows with its light's own color and brightness — but a smoke
-  # alarm still shows through it, because a rule that tests the value
-  # outranks the light.
-  - id: bedroom
-    name: Bedroom
-    lightEntity: light.bedroom
-    entity: binary_sensor.bedroom_smoke
-    stateColor:
-      - { state: "on", color: "#e1243b" }
-    color: "#3366cc"
-    opacity: 0.12
-    points:
-      - { x: 500, y: 500 }
-      - { x: 900, y: 500 }
-      - { x: 900, y: 900 }
-      - { x: 500, y: 900 }
 
   # Or bind a numeric sensor and threshold it, so the whole room reddens
   # when air quality goes bad.

--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ trackers:
 
 ### Area
 
-`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity? }`
+`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
 
 - `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
   is implicitly closed from the last point back to the first.
@@ -703,6 +703,11 @@ trackers:
   matches.
 - `activeOpacity` — fill opacity while `entity` resolves a color. Lets a room lift out of
   the plan while it is live without permanently darkening it. Falls back to `opacity`.
+- `borderColor` / `borderWidth` — a static outline for the room. No outline is drawn by
+  default; `borderWidth` defaults to `3` canvas units once a color is set.
+- `highlight` — where a live color paints: `fill` (default), `border`, or `both`. Use
+  `border` for a room that outlines itself while occupied without tinting everything
+  inside it, which reads better on a busy plan.
 
 ```yaml
 areas:
@@ -731,6 +736,21 @@ areas:
       - { x: 500, y: 500 }
       - { x: 500, y: 900 }
       - { x: 100, y: 900 }
+
+  # Outline-only highlight: the room draws a green border while occupied and
+  # its fill never changes. activeOpacity is a fill concern, so it does not
+  # apply here.
+  - id: hall
+    name: Hall
+    entity: binary_sensor.hall_occupancy
+    activeColor: "#4caf50"
+    highlight: border
+    borderWidth: 4
+    points:
+      - { x: 500, y: 100 }
+      - { x: 900, y: 100 }
+      - { x: 900, y: 500 }
+      - { x: 500, y: 500 }
 
   # Or bind a numeric sensor and threshold it, so the whole room reddens
   # when air quality goes bad.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ automatically to the card and screen size.
   dishwasher, water heater, air handler, bathtub, vanity, sectional, fish tank,
   piano, hot tub.
 - **Areas** — trace a room's outline point-by-point (points snap to wall corners and to
-  neighboring areas' corners) to get a colored, named room polygon. Naming a room after
+  neighboring areas' corners) to get a colored, named room polygon. Bind an entity to a
+  room and its fill goes live — green while a presence sensor is occupied, red when a CO2
+  sensor crosses a threshold. Naming a room after
   one of your Home Assistant areas (the name field autocompletes against them) links the
   two, which scopes the entity picker — for any device dropped inside it — to that HA
   area's entities, and can bulk-add every device in the area.
@@ -679,7 +681,7 @@ trackers:
 
 ### Area
 
-`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities? }`
+`{ id, points, name?, showName?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity? }`
 
 - `points` — an array of `{ x, y }` vertices (canvas units), in drawing order; the shape
   is implicitly closed from the last point back to the first.
@@ -692,6 +694,15 @@ trackers:
 - `filterEntities` — with `haArea` set, scopes the entity picker (for any device placed
   inside this polygon) to that HA area's entities. Default `true`; has no effect without
   a linked `haArea`.
+- `entity` — optional entity that makes the room itself live, in the same shape furniture
+  uses. Drives `stateColor` and `activeColor`; an unbound area stays a static polygon.
+- `stateColor` — threshold/state rules for the fill (same shape as a device's
+  `stateColor`). Evaluated against `entity`'s state; takes precedence over `activeColor`
+  and `color`.
+- `activeColor` — fill color while `entity` is active, used when no `stateColor` rule
+  matches.
+- `activeOpacity` — fill opacity while `entity` resolves a color. Lets a room lift out of
+  the plan while it is live without permanently darkening it. Falls back to `opacity`.
 
 ```yaml
 areas:
@@ -705,6 +716,36 @@ areas:
       - { x: 900, y: 100 }
       - { x: 900, y: 500 }
       - { x: 100, y: 500 }
+
+  # The room lights up green while it is occupied, and lifts to a stronger
+  # fill so it reads at a glance.
+  - id: kitchen
+    name: Kitchen
+    haArea: kitchen
+    entity: binary_sensor.kitchen_occupancy
+    activeColor: "#4caf50"
+    opacity: 0.12
+    activeOpacity: 0.35
+    points:
+      - { x: 100, y: 500 }
+      - { x: 500, y: 500 }
+      - { x: 500, y: 900 }
+      - { x: 100, y: 900 }
+
+  # Or bind a numeric sensor and threshold it, so the whole room reddens
+  # when air quality goes bad.
+  - id: study
+    name: Study
+    entity: sensor.study_co2
+    stateColor:
+      - { above: 1200, color: "#e1243b" }
+      - { above: 800, color: "#ff9300" }
+      - { color: "#58d32f" }
+    points:
+      - { x: 500, y: 500 }
+      - { x: 900, y: 500 }
+      - { x: 900, y: 900 }
+      - { x: 500, y: 900 }
 ```
 
 ### Example

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -253,7 +253,55 @@ const hass = {
     "light.living_room": {
       entity_id: "light.living_room",
       state: "on",
-      attributes: { friendly_name: "Living Room" },
+      // Colour-capable, so a `glow` device here casts this amber (issue #6).
+      attributes: {
+        friendly_name: "Living Room",
+        supported_color_modes: ["color_temp", "xy"],
+        color_mode: "xy",
+        rgb_color: [255, 170, 80],
+        brightness: 255,
+      },
+    },
+    // Cast light (issue #6), the two rungs below a colour-capable bulb. Most
+    // lights on a real install are one of these, so the demo covers them:
+    // `light.warm_lamp` can report a colour, `light.dim_lamp` only a
+    // brightness, `light.plain_switch` only on/off.
+    "light.warm_lamp": {
+      entity_id: "light.warm_lamp",
+      state: "on",
+      attributes: {
+        friendly_name: "Warm lamp",
+        supported_color_modes: ["xy"],
+        color_mode: "xy",
+        rgb_color: [255, 120, 0],
+        brightness: 255,
+      },
+    },
+    "light.cool_lamp": {
+      entity_id: "light.cool_lamp",
+      state: "on",
+      attributes: {
+        friendly_name: "Cool lamp",
+        supported_color_modes: ["xy"],
+        color_mode: "xy",
+        rgb_color: [0, 120, 255],
+        brightness: 255,
+      },
+    },
+    "light.dim_lamp": {
+      entity_id: "light.dim_lamp",
+      state: "on",
+      attributes: {
+        friendly_name: "Dimmable lamp",
+        supported_color_modes: ["brightness"],
+        color_mode: "brightness",
+        brightness: 90,
+      },
+    },
+    "light.plain_switch": {
+      entity_id: "light.plain_switch",
+      state: "on",
+      attributes: { friendly_name: "Plain switch", supported_color_modes: ["onoff"], color_mode: "onoff" },
     },
     // Per-device active colors (issue #79): this cover and the light above are
     // both active on the demo floor, with different `activeColor`s — the whole
@@ -410,6 +458,51 @@ const demoFloor = {
     // deviceRegistry/areaRegistry) scopes its entity picker — drag it outside
     // the polygon to watch the picker widen back up.
     { id: "i2", entity: "light.living_room", x: 220, y: 180, kind: "light" as const },
+    // Cast light (issue #6). The warm and cool lamps sit 200 apart with 200
+    // radii, so their pools OVERLAP in the middle — that band is the whole
+    // point of the feature: the two colours mix there rather than one winning.
+    // The other two show the fallback rungs for bulbs that can't report a colour.
+    {
+      id: "glow_warm",
+      entity: "light.warm_lamp",
+      x: 400,
+      y: 380,
+      kind: "light" as const,
+      glow: true,
+      glowRadius: 200,
+    },
+    {
+      id: "glow_cool",
+      entity: "light.cool_lamp",
+      x: 600,
+      y: 380,
+      kind: "light" as const,
+      glow: true,
+      glowRadius: 200,
+    },
+    // Brightness-only: no colour of its own, so it casts the warm-white default,
+    // dimmed to match its brightness.
+    {
+      id: "glow_dim",
+      entity: "light.dim_lamp",
+      x: 780,
+      y: 200,
+      kind: "light" as const,
+      glow: true,
+      glowRadius: 120,
+    },
+    // On/off-only: no colour and no brightness, so full strength, and here with
+    // a custom glowColor to show that override.
+    {
+      id: "glow_plain",
+      entity: "light.plain_switch",
+      x: 780,
+      y: 430,
+      kind: "light" as const,
+      glow: true,
+      glowRadius: 110,
+      glowColor: "#b0ffd0",
+    },
     // Issue #79: two active devices side by side with different active colors.
     // Both are "on"; before the option existed both badges were the same yellow.
     {

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./editor-forms";
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
+import { DEFAULT_GLOW_RADIUS } from "./types";
 
 const fields: FormField[] = [
   { name: "name", label: "Name", selector: { text: {} } },
@@ -167,6 +168,19 @@ describe("openingForm", () => {
 
 describe("itemForm", () => {
   const item = { id: "i", entity: "light.a", kind: "light", x: 0, y: 0 } as FloorItem;
+
+  it("offers Cast light on lights only, with its controls behind the toggle (#6)", () => {
+    const names = (it: FloorItem) => itemForm(it).fields.map((x) => x.name);
+    expect(names(item)).toContain("glow");
+    // Radius/colour would be noise on a device that isn't casting yet.
+    expect(names(item)).not.toContain("glowRadius");
+    const lit = { ...item, glow: true } as FloorItem;
+    expect(names(lit)).toContain("glowRadius");
+    expect(names(lit)).toContain("glowColor");
+    expect(itemForm(lit).data.glowRadius).toBe(DEFAULT_GLOW_RADIUS);
+    // A sensor has no colour to cast, so it is never offered.
+    expect(names({ ...item, kind: "sensor", entity: "sensor.temp" } as FloorItem)).not.toContain("glow");
+  });
 
   it("hides ripple size for badge display, shows it otherwise", () => {
     expect(itemForm(item).fields.map((x) => x.name)).not.toContain("rippleSize");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -621,10 +621,20 @@ export function areaForm(a: Area): FormSpec {
         label: "Fill opacity",
         selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
       },
+      // Optional entity that makes the room itself live (issue #6) — a presence
+      // sensor that lights the room while it is occupied. Last, because most
+      // areas are just outlines and never bind anything.
+      {
+        name: "entity",
+        label: "Entity",
+        helper: "Optional — lets the room fill change color with a sensor",
+        selector: { entity: {} },
+      },
     ],
     data: {
       showName: a.showName ?? true,
       opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
+      entity: a.entity ?? "",
     },
     toPatch: identity,
   };

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -630,11 +630,21 @@ export function areaForm(a: Area): FormSpec {
         helper: "Optional — lets the room fill change color with a sensor",
         selector: { entity: {} },
       },
+      // A light in this room paints it with its own color and brightness
+      // (issue #6). Separate from `entity` so a room can glow with the light
+      // while a smoke detector still overrides it.
+      {
+        name: "lightEntity",
+        label: "Light",
+        helper: "Optional — the room takes this light's color and brightness",
+        selector: { entity: { filter: [{ domain: "light" }] } },
+      },
     ],
     data: {
       showName: a.showName ?? true,
       opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
       entity: a.entity ?? "",
+      lightEntity: a.lightEntity ?? "",
     },
     toPatch: identity,
   };

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
   DEFAULT_RIPPLE_SIZE,
+  DEFAULT_GLOW_RADIUS,
   DEFAULT_TEXT_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
 } from "./types";
@@ -415,6 +416,31 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       selector: { number: { min: 40, max: 400, step: 4, mode: "slider", unit_of_measurement: "px" } },
     });
   }
+  // A light can cast a pool of light onto the plan from where it sits (issue
+  // #6). Offered only for lights, since nothing else has a color to cast.
+  if (it.kind === "light" || it.entity?.startsWith("light.")) {
+    fields.push({
+      name: "glow",
+      label: "Cast light",
+      helper: "Pools the light's own color onto the plan; overlapping lights mix",
+      selector: { boolean: {} },
+    });
+    if (it.glow) {
+      fields.push(
+        {
+          name: "glowRadius",
+          label: "Light radius",
+          selector: { number: { min: 20, max: 600, step: 10, mode: "slider" } },
+        },
+        {
+          name: "glowColor",
+          label: "Light color",
+          helper: "Only for bulbs that can't report a color; others use their own",
+          selector: { text: {} },
+        }
+      );
+    }
+  }
   fields.push(
     { name: "showIcon", label: "Show icon", selector: { boolean: {} } },
     {
@@ -466,6 +492,9 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       display,
       iconAnimation: it.iconAnimation ?? "auto",
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
+      glow: it.glow ?? false,
+      glowRadius: it.glowRadius ?? DEFAULT_GLOW_RADIUS,
+      glowColor: it.glowColor ?? "",
       showIcon: it.showIcon ?? true,
       hideWhenInactive: it.hideWhenInactive ?? false,
       showState: it.showState ?? false,
@@ -630,21 +659,11 @@ export function areaForm(a: Area): FormSpec {
         helper: "Optional — lets the room fill change color with a sensor",
         selector: { entity: {} },
       },
-      // A light in this room paints it with its own color and brightness
-      // (issue #6). Separate from `entity` so a room can glow with the light
-      // while a smoke detector still overrides it.
-      {
-        name: "lightEntity",
-        label: "Light",
-        helper: "Optional — the room takes this light's color and brightness",
-        selector: { entity: { filter: [{ domain: "light" }] } },
-      },
     ],
     data: {
       showName: a.showName ?? true,
       opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
       entity: a.entity ?? "",
-      lightEntity: a.lightEntity ?? "",
     },
     toPatch: identity,
   };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -45,11 +45,15 @@ import {
   snapToGridPercent,
   trackerPresenceDetected,
   uid,
+  DEFAULT_GLOW_COLOR,
+  GLOW_MAX_OPACITY,
 } from "./types";
 import {
   WALL_THICKNESS,
   renderOpening,
   renderWallMask,
+  glowPaint,
+  renderGlow,
   openingDefaultOpen,
   openingMotion,
   shutterStyleOf,
@@ -2704,6 +2708,20 @@ export class FloorplanCardEditor extends LitElement {
                 (a, i) => a.id || i,
                 (a) => this._renderAreaSel(a, scopingAreaId)
               )}
+              <!-- Light pools (issue #6), same layer position as the card so
+                   what you place is what you get. Previewed at full strength
+                   with no hass in the editor, so the radius is adjustable
+                   without having to turn the real light on. -->
+              <g class="fp-glows">
+                ${floor.items.map((it, i) => {
+                  if (!it.glow) return nothing;
+                  const paint = glowPaint(it, this.hass?.states[it.entity]) ?? {
+                    color: cssColorOr(it.glowColor, DEFAULT_GLOW_COLOR),
+                    opacity: GLOW_MAX_OPACITY,
+                  };
+                  return renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`);
+                })}
+              </g>
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -27,7 +27,9 @@ import {
   furnitureColor,
   renderTracker,
   renderArea,
-  resolveAreaPaint,
+  areaColor,
+  glowPaint,
+  renderGlow,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -70,12 +72,15 @@ function floorMemoryKey(floors: readonly Floor[]): string {
 @customElement("easy-floorplan-card")
 export class FloorplanCard extends LitElement {
   private static _nextWallMaskId = 0;
+  private static _nextGlowId = 0;
 
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: FloorplanCardConfig;
   /** View-state: which floor is shown. Never persisted to config. */
   @state() private _activeFloorId?: string;
   private readonly _wallMaskId = `fp-wall-mask-${FloorplanCard._nextWallMaskId++}`;
+  /** Prefix for this card's glow gradient ids, unique per instance (issue #6). */
+  private readonly _glowIdBase = `fp-glow-${FloorplanCard._nextGlowId++}`;
   /** Entity ids this plan actually displays; used to skip irrelevant hass updates. */
   private _watchedEntities: Set<string> = new Set();
 
@@ -385,15 +390,21 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
             ${active.areas?.map((a) =>
-              renderArea(
-                a,
-                resolveAreaPaint(
-                  a,
-                  a.entity ? this.hass?.states[a.entity]?.state : undefined,
-                  a.lightEntity ? this.hass?.states[a.lightEntity] : undefined
-                )
-              )
+              renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))
             )}
+            <!-- Light pools (issue #6). Above the room fills but below the
+                 furniture and walls, so light reads as cast onto the floor
+                 rather than painted over the plan. Isolated as one layer: the
+                 pools screen-blend with each other (two lamps brighten where
+                 they meet) without screening against the plan beneath, which
+                 would wash out on a light theme. -->
+            <g class="fp-glows">
+              ${active.items.map((it, i) => {
+                if (!it.glow) return nothing;
+                const paint = glowPaint(it, this.hass?.states[it.entity]);
+                return paint ? renderGlow(it, paint, `${this._glowIdBase}-${i}`) : nothing;
+              })}
+            </g>
             ${active.furniture.map((f) =>
               renderFurniture(f, furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined))
             )}
@@ -563,6 +574,24 @@ export class FloorplanCard extends LitElement {
     }
     .wall {
       stroke: var(--primary-text-color);
+    }
+    /* Light pools (issue #6). "isolation" gives the layer its own compositing
+       group, so the pools blend with each other but not with the plan beneath
+       — screening against a light theme's white background would wash them
+       out entirely. Inside that group "screen" makes overlapping lights add,
+       so two lamps brighten where they meet instead of the topmost winning. */
+    .fp-glows {
+      isolation: isolate;
+    }
+    .fp-glow {
+      mix-blend-mode: screen;
+      /* Follow the light rather than snapping: a dimmer ramp reads as a ramp. */
+      transition: opacity 0.4s ease;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .fp-glow {
+        transition: none;
+      }
     }
     .fp-door-leaf,
     .fp-leaf-r {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -27,6 +27,7 @@ import {
   furnitureColor,
   renderTracker,
   renderArea,
+  areaColor,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -383,7 +384,9 @@ export class FloorplanCard extends LitElement {
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
-            ${active.areas?.map((a) => renderArea(a))}
+            ${active.areas?.map((a) =>
+              renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))
+            )}
             ${active.furniture.map((f) =>
               renderFurniture(f, furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined))
             )}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -27,7 +27,7 @@ import {
   furnitureColor,
   renderTracker,
   renderArea,
-  areaColor,
+  resolveAreaPaint,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -385,7 +385,14 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio="none" opacity=${active.imageOpacity ?? 1} />`
               : nothing}
             ${active.areas?.map((a) =>
-              renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))
+              renderArea(
+                a,
+                resolveAreaPaint(
+                  a,
+                  a.entity ? this.hass?.states[a.entity]?.state : undefined,
+                  a.lightEntity ? this.hass?.states[a.lightEntity] : undefined
+                )
+              )
             )}
             ${active.furniture.map((f) =>
               renderFurniture(f, furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined))

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Furniture, FurnitureType, ItemKind } from "./types";
-import { FURNITURE_DEFAULT_SIZE } from "./types";
+import { FURNITURE_DEFAULT_SIZE, LIGHT_MIN_OPACITY, LIGHT_MAX_OPACITY } from "./types";
 import {
   snapToWall,
   openingDefaultOpen,
@@ -45,7 +45,9 @@ import {
   planRotationTransform,
   polygonCentroid,
   renderArea,
-  areaColor,
+  resolveAreaPaint,
+  areaLightPaint,
+  matchStateColor,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -1365,19 +1367,19 @@ describe("renderArea", () => {
   });
 
   it("uses the live fill color over the resting one (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, "#4caf50"));
+    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, { color: "#4caf50" }));
     expect(markup).toContain("fill=#4caf50");
     expect(markup).not.toContain("fill=#ff0000");
   });
 
   it("applies activeOpacity only while live (#6)", () => {
     const a = { id: "a", points: square, opacity: 0.2, activeOpacity: 0.7 };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.7");
+    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("fill-opacity=0.7");
     expect(flatten(renderArea(a))).toContain("fill-opacity=0.2");
   });
 
   it("keeps the resting opacity when activeOpacity is unset (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
+    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, { color: "#4caf50" }));
     expect(markup).toContain("fill-opacity=0.2");
   });
 
@@ -1409,7 +1411,7 @@ describe("renderArea", () => {
 
   it("highlight=border paints the outline and leaves the fill at rest (#6)", () => {
     const a = { id: "a", points: square, color: "#ff0000", highlight: "border" as const };
-    const markup = flatten(renderArea(a, "#4caf50"));
+    const markup = flatten(renderArea(a, { color: "#4caf50" }));
     expect(markup).toContain("stroke=#4caf50");
     expect(markup).toContain("fill=#ff0000");
   });
@@ -1422,27 +1424,27 @@ describe("renderArea", () => {
       activeOpacity: 0.7,
       highlight: "border" as const,
     };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
+    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("fill-opacity=0.2");
   });
 
   it("highlight=both paints fill and outline (#6)", () => {
     const a = { id: "a", points: square, highlight: "both" as const };
-    const markup = flatten(renderArea(a, "#4caf50"));
+    const markup = flatten(renderArea(a, { color: "#4caf50" }));
     expect(markup).toContain("fill=#4caf50");
     expect(markup).toContain("stroke=#4caf50");
   });
 
   it("a live color overrides a static borderColor when it targets the border (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("stroke=#4caf50");
+    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("stroke=#4caf50");
   });
 });
 
-describe("areaColor", () => {
+describe("resolveAreaPaint", () => {
   const base = { id: "a", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] };
 
   it("returns undefined for an unbound area", () => {
-    expect(areaColor({ ...base, activeColor: "#4caf50" }, "on")).toBeUndefined();
+    expect(resolveAreaPaint({ ...base, activeColor: "#4caf50" }, "on").color).toBeUndefined();
   });
 
   it("prefers a matching stateColor rule over activeColor", () => {
@@ -1452,23 +1454,203 @@ describe("areaColor", () => {
       activeColor: "#4caf50",
       stateColor: [{ above: 1000, color: "#ff0000" }, { color: "#00ff00" }],
     };
-    expect(areaColor(a, "1200")).toBe("#ff0000");
-    expect(areaColor(a, "400")).toBe("#00ff00");
+    expect(resolveAreaPaint(a, "1200").color).toBe("#ff0000");
+    expect(resolveAreaPaint(a, "400").color).toBe("#00ff00");
   });
 
   it("uses activeColor when active and no rule matches", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
-    expect(areaColor(a, "on")).toBe("#4caf50");
+    expect(resolveAreaPaint(a, "on").color).toBe("#4caf50");
   });
 
   it("returns undefined when the bound entity is inactive", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
-    expect(areaColor(a, "off")).toBeUndefined();
+    expect(resolveAreaPaint(a, "off").color).toBeUndefined();
   });
 
   it("gates an unsafe activeColor through css-safe (#64)", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "red;position:fixed;inset:0" };
-    expect(areaColor(a, "on")).toBeUndefined();
+    expect(resolveAreaPaint(a, "on").color).toBeUndefined();
+  });
+});
+
+describe("areaLightPaint (issue #6)", () => {
+  const light = (state: string, attributes: Record<string, unknown> = {}) =>
+    ({ entity_id: "light.x", state, attributes }) as never;
+
+  it("paints a color-capable light's own rgb", () => {
+    const paint = areaLightPaint(light("on", { rgb_color: [255, 170, 80], brightness: 255 }));
+    expect(paint?.color).toBe("rgb(255, 170, 80)");
+    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
+  });
+
+  it("scales opacity with brightness, inside the legible band", () => {
+    const dim = areaLightPaint(light("on", { rgb_color: [255, 255, 255], brightness: 0 }));
+    const half = areaLightPaint(light("on", { rgb_color: [255, 255, 255], brightness: 128 }));
+    expect(dim?.opacity).toBeCloseTo(LIGHT_MIN_OPACITY, 5);
+    expect(half?.opacity).toBeGreaterThan(LIGHT_MIN_OPACITY);
+    expect(half?.opacity).toBeLessThan(LIGHT_MAX_OPACITY);
+    // The floor is the point: a dimmed room must stay visible, not vanish.
+    expect(dim?.opacity).toBeGreaterThan(0);
+  });
+
+  it("a brightness-only light offers opacity but no color of its own", () => {
+    // light.kitchen_lights on a real install: supported_color_modes ["brightness"].
+    const paint = areaLightPaint(light("on", { brightness: 255 }));
+    expect(paint).toBeDefined();
+    expect(paint?.color).toBeUndefined();
+    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
+  });
+
+  it("an on/off-only light goes fully lit, with no brightness to read", () => {
+    // light.main_living_room_switch_l1: supported_color_modes ["onoff"].
+    const paint = areaLightPaint(light("on"));
+    expect(paint?.color).toBeUndefined();
+    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
+  });
+
+  it("paints nothing when off, unavailable, unknown or missing (fails closed)", () => {
+    expect(areaLightPaint(light("off", { rgb_color: [255, 0, 0] }))).toBeUndefined();
+    expect(areaLightPaint(light("unavailable"))).toBeUndefined();
+    expect(areaLightPaint(light("unknown"))).toBeUndefined();
+    expect(areaLightPaint(undefined)).toBeUndefined();
+  });
+
+  it("ignores a malformed rgb_color rather than emitting a broken color", () => {
+    expect(areaLightPaint(light("on", { rgb_color: [255, 0] }))?.color).toBeUndefined();
+    expect(areaLightPaint(light("on", { rgb_color: "red;position:fixed" }))?.color).toBeUndefined();
+    expect(areaLightPaint(light("on", { rgb_color: [null, 1, 2] }))?.color).toBeUndefined();
+  });
+
+  it("clamps out-of-range channels instead of trusting the integration", () => {
+    expect(areaLightPaint(light("on", { rgb_color: [300, -20, 12.6] }))?.color)
+      .toBe("rgb(255, 0, 13)");
+  });
+});
+
+describe("resolveAreaPaint precedence (issue #6)", () => {
+  const base = { id: "a", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] };
+  const lit = { entity_id: "light.x", state: "on", attributes: { rgb_color: [10, 20, 30], brightness: 255 } } as never;
+
+  it("a conditional rule that tested the value beats the light", () => {
+    const a = {
+      ...base,
+      entity: "binary_sensor.smoke",
+      lightEntity: "light.x",
+      stateColor: [{ state: "on", color: "#ff0000" }],
+    };
+    expect(resolveAreaPaint(a, "on", lit).color).toBe("#ff0000");
+  });
+
+  it("but a catch-all rule does NOT — it would mask the light on every config", () => {
+    const a = {
+      ...base,
+      entity: "sensor.co2",
+      lightEntity: "light.x",
+      stateColor: [{ above: 1000, color: "#ff0000" }, { color: "#00ff00" }],
+    };
+    // Below the threshold only the catch-all matches, so the light shows.
+    expect(resolveAreaPaint(a, "400", lit).color).toBe("rgb(10, 20, 30)");
+    // Above it, the room is in alarm and the rule takes over.
+    expect(resolveAreaPaint(a, "1200", lit).color).toBe("#ff0000");
+  });
+
+  it("falls back to the catch-all when the light is off", () => {
+    const a = {
+      ...base,
+      entity: "sensor.co2",
+      lightEntity: "light.x",
+      stateColor: [{ color: "#00ff00" }],
+    };
+    const off = { entity_id: "light.x", state: "off", attributes: {} } as never;
+    expect(resolveAreaPaint(a, "400", off).color).toBe("#00ff00");
+  });
+
+  it("the light beats activeColor", () => {
+    const a = {
+      ...base,
+      entity: "binary_sensor.occupancy",
+      lightEntity: "light.x",
+      activeColor: "#4caf50",
+    };
+    expect(resolveAreaPaint(a, "on", lit).color).toBe("rgb(10, 20, 30)");
+  });
+
+  it("ignores the light entirely when the area does not bind one", () => {
+    const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
+    expect(resolveAreaPaint(a, "on", lit).color).toBe("#4caf50");
+  });
+
+  it("a light alone lights the room, with no conditional config at all", () => {
+    expect(resolveAreaPaint({ ...base, lightEntity: "light.x" }, undefined, lit)).toEqual({
+      color: "rgb(10, 20, 30)",
+      opacity: LIGHT_MAX_OPACITY,
+    });
+  });
+
+  it("an unsafe rule color falls through to the light rather than swallowing it", () => {
+    const a = {
+      ...base,
+      entity: "binary_sensor.smoke",
+      lightEntity: "light.x",
+      stateColor: [{ state: "on", color: "red;position:fixed;inset:0" }],
+    };
+    expect(resolveAreaPaint(a, "on", lit).color).toBe("rgb(10, 20, 30)");
+  });
+});
+
+describe("renderArea with a brightness-only light (issue #6)", () => {
+  const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+
+  it("keeps the room's own color and varies only the opacity", () => {
+    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, { opacity: 0.4 }));
+    expect(markup).toContain("fill=#ff0000");
+    expect(markup).toContain("fill-opacity=0.4");
+  });
+
+  it("the light's opacity outranks activeOpacity", () => {
+    const a = { id: "a", points: square, opacity: 0.1, activeOpacity: 0.7 };
+    expect(flatten(renderArea(a, { color: "#4caf50", opacity: 0.33 }))).toContain("fill-opacity=0.33");
+  });
+
+  it("an opacity-only paint never draws an outline, having no color for one", () => {
+    const a = { id: "a", points: square, highlight: "border" as const };
+    const markup = flatten(renderArea(a, { opacity: 0.4 }));
+    expect(markup).toContain("stroke=none");
+    expect(markup).toContain("stroke-width=0");
+  });
+});
+
+describe("matchStateColor (issue #6)", () => {
+  it("reports whether the matched rule actually tested the value", () => {
+    const rules = [{ above: 10, color: "#f00" }, { state: "open", color: "#0f0" }, { color: "#00f" }];
+    expect(matchStateColor(rules, 20)).toEqual({ color: "#f00", specific: true });
+    expect(matchStateColor(rules, "open")).toEqual({ color: "#0f0", specific: true });
+    expect(matchStateColor(rules, 5)).toEqual({ color: "#00f", specific: false });
+    expect(matchStateColor([], 5)).toBeUndefined();
+  });
+});
+
+describe("collectWatchedEntities covers areas (issue #6)", () => {
+  it("watches an area's entity and light, or the card freezes their color", () => {
+    const cfg = {
+      type: "custom:easy-floorplan-card",
+      width: 100,
+      height: 100,
+      areas: [{ id: "a", points: [], entity: "binary_sensor.occupancy", lightEntity: "light.kitchen" }],
+    } as never;
+    const watched = collectWatchedEntities(cfg);
+    expect(watched.has("binary_sensor.occupancy")).toBe(true);
+    expect(watched.has("light.kitchen")).toBe(true);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1380,6 +1380,62 @@ describe("renderArea", () => {
     const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
     expect(markup).toContain("fill-opacity=0.2");
   });
+
+  it("draws no outline by default (#6)", () => {
+    const markup = flatten(renderArea({ id: "a", points: square }));
+    expect(markup).toContain("stroke=none");
+    expect(markup).toContain("stroke-width=0");
+  });
+
+  it("honors a static borderColor and borderWidth (#6)", () => {
+    const markup = flatten(
+      renderArea({ id: "a", points: square, borderColor: "#123456", borderWidth: 5 })
+    );
+    expect(markup).toContain("stroke=#123456");
+    expect(markup).toContain("stroke-width=5");
+  });
+
+  it("falls back to the default border width (#6)", () => {
+    const markup = flatten(renderArea({ id: "a", points: square, borderColor: "#123456" }));
+    expect(markup).toContain("stroke-width=3");
+  });
+
+  it("gates an unsafe borderColor through css-safe (#64)", () => {
+    const markup = flatten(
+      renderArea({ id: "a", points: square, borderColor: "red;position:fixed;inset:0" })
+    );
+    expect(markup).not.toContain("position:fixed");
+  });
+
+  it("highlight=border paints the outline and leaves the fill at rest (#6)", () => {
+    const a = { id: "a", points: square, color: "#ff0000", highlight: "border" as const };
+    const markup = flatten(renderArea(a, "#4caf50"));
+    expect(markup).toContain("stroke=#4caf50");
+    expect(markup).toContain("fill=#ff0000");
+  });
+
+  it("highlight=border ignores activeOpacity, which is a fill concern (#6)", () => {
+    const a = {
+      id: "a",
+      points: square,
+      opacity: 0.2,
+      activeOpacity: 0.7,
+      highlight: "border" as const,
+    };
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
+  });
+
+  it("highlight=both paints fill and outline (#6)", () => {
+    const a = { id: "a", points: square, highlight: "both" as const };
+    const markup = flatten(renderArea(a, "#4caf50"));
+    expect(markup).toContain("fill=#4caf50");
+    expect(markup).toContain("stroke=#4caf50");
+  });
+
+  it("a live color overrides a static borderColor when it targets the border (#6)", () => {
+    const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("stroke=#4caf50");
+  });
 });
 
 describe("areaColor", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { Furniture, FurnitureType, ItemKind } from "./types";
-import { FURNITURE_DEFAULT_SIZE, LIGHT_MIN_OPACITY, LIGHT_MAX_OPACITY } from "./types";
+import {
+  FURNITURE_DEFAULT_SIZE,
+  DEFAULT_GLOW_RADIUS,
+  DEFAULT_GLOW_COLOR,
+  GLOW_MIN_OPACITY,
+  GLOW_MAX_OPACITY,
+} from "./types";
 import {
   snapToWall,
   openingDefaultOpen,
@@ -45,9 +51,9 @@ import {
   planRotationTransform,
   polygonCentroid,
   renderArea,
-  resolveAreaPaint,
-  areaLightPaint,
-  matchStateColor,
+  areaColor,
+  glowPaint,
+  renderGlow,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -1367,19 +1373,19 @@ describe("renderArea", () => {
   });
 
   it("uses the live fill color over the resting one (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, { color: "#4caf50" }));
+    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, "#4caf50"));
     expect(markup).toContain("fill=#4caf50");
     expect(markup).not.toContain("fill=#ff0000");
   });
 
   it("applies activeOpacity only while live (#6)", () => {
     const a = { id: "a", points: square, opacity: 0.2, activeOpacity: 0.7 };
-    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("fill-opacity=0.7");
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.7");
     expect(flatten(renderArea(a))).toContain("fill-opacity=0.2");
   });
 
   it("keeps the resting opacity when activeOpacity is unset (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, { color: "#4caf50" }));
+    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
     expect(markup).toContain("fill-opacity=0.2");
   });
 
@@ -1411,7 +1417,7 @@ describe("renderArea", () => {
 
   it("highlight=border paints the outline and leaves the fill at rest (#6)", () => {
     const a = { id: "a", points: square, color: "#ff0000", highlight: "border" as const };
-    const markup = flatten(renderArea(a, { color: "#4caf50" }));
+    const markup = flatten(renderArea(a, "#4caf50"));
     expect(markup).toContain("stroke=#4caf50");
     expect(markup).toContain("fill=#ff0000");
   });
@@ -1424,27 +1430,27 @@ describe("renderArea", () => {
       activeOpacity: 0.7,
       highlight: "border" as const,
     };
-    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("fill-opacity=0.2");
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
   });
 
   it("highlight=both paints fill and outline (#6)", () => {
     const a = { id: "a", points: square, highlight: "both" as const };
-    const markup = flatten(renderArea(a, { color: "#4caf50" }));
+    const markup = flatten(renderArea(a, "#4caf50"));
     expect(markup).toContain("fill=#4caf50");
     expect(markup).toContain("stroke=#4caf50");
   });
 
   it("a live color overrides a static borderColor when it targets the border (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
-    expect(flatten(renderArea(a, { color: "#4caf50" }))).toContain("stroke=#4caf50");
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("stroke=#4caf50");
   });
 });
 
-describe("resolveAreaPaint", () => {
+describe("areaColor", () => {
   const base = { id: "a", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] };
 
   it("returns undefined for an unbound area", () => {
-    expect(resolveAreaPaint({ ...base, activeColor: "#4caf50" }, "on").color).toBeUndefined();
+    expect(areaColor({ ...base, activeColor: "#4caf50" }, "on")).toBeUndefined();
   });
 
   it("prefers a matching stateColor rule over activeColor", () => {
@@ -1454,203 +1460,23 @@ describe("resolveAreaPaint", () => {
       activeColor: "#4caf50",
       stateColor: [{ above: 1000, color: "#ff0000" }, { color: "#00ff00" }],
     };
-    expect(resolveAreaPaint(a, "1200").color).toBe("#ff0000");
-    expect(resolveAreaPaint(a, "400").color).toBe("#00ff00");
+    expect(areaColor(a, "1200")).toBe("#ff0000");
+    expect(areaColor(a, "400")).toBe("#00ff00");
   });
 
   it("uses activeColor when active and no rule matches", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
-    expect(resolveAreaPaint(a, "on").color).toBe("#4caf50");
+    expect(areaColor(a, "on")).toBe("#4caf50");
   });
 
   it("returns undefined when the bound entity is inactive", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
-    expect(resolveAreaPaint(a, "off").color).toBeUndefined();
+    expect(areaColor(a, "off")).toBeUndefined();
   });
 
   it("gates an unsafe activeColor through css-safe (#64)", () => {
     const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "red;position:fixed;inset:0" };
-    expect(resolveAreaPaint(a, "on").color).toBeUndefined();
-  });
-});
-
-describe("areaLightPaint (issue #6)", () => {
-  const light = (state: string, attributes: Record<string, unknown> = {}) =>
-    ({ entity_id: "light.x", state, attributes }) as never;
-
-  it("paints a color-capable light's own rgb", () => {
-    const paint = areaLightPaint(light("on", { rgb_color: [255, 170, 80], brightness: 255 }));
-    expect(paint?.color).toBe("rgb(255, 170, 80)");
-    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
-  });
-
-  it("scales opacity with brightness, inside the legible band", () => {
-    const dim = areaLightPaint(light("on", { rgb_color: [255, 255, 255], brightness: 0 }));
-    const half = areaLightPaint(light("on", { rgb_color: [255, 255, 255], brightness: 128 }));
-    expect(dim?.opacity).toBeCloseTo(LIGHT_MIN_OPACITY, 5);
-    expect(half?.opacity).toBeGreaterThan(LIGHT_MIN_OPACITY);
-    expect(half?.opacity).toBeLessThan(LIGHT_MAX_OPACITY);
-    // The floor is the point: a dimmed room must stay visible, not vanish.
-    expect(dim?.opacity).toBeGreaterThan(0);
-  });
-
-  it("a brightness-only light offers opacity but no color of its own", () => {
-    // light.kitchen_lights on a real install: supported_color_modes ["brightness"].
-    const paint = areaLightPaint(light("on", { brightness: 255 }));
-    expect(paint).toBeDefined();
-    expect(paint?.color).toBeUndefined();
-    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
-  });
-
-  it("an on/off-only light goes fully lit, with no brightness to read", () => {
-    // light.main_living_room_switch_l1: supported_color_modes ["onoff"].
-    const paint = areaLightPaint(light("on"));
-    expect(paint?.color).toBeUndefined();
-    expect(paint?.opacity).toBeCloseTo(LIGHT_MAX_OPACITY, 5);
-  });
-
-  it("paints nothing when off, unavailable, unknown or missing (fails closed)", () => {
-    expect(areaLightPaint(light("off", { rgb_color: [255, 0, 0] }))).toBeUndefined();
-    expect(areaLightPaint(light("unavailable"))).toBeUndefined();
-    expect(areaLightPaint(light("unknown"))).toBeUndefined();
-    expect(areaLightPaint(undefined)).toBeUndefined();
-  });
-
-  it("ignores a malformed rgb_color rather than emitting a broken color", () => {
-    expect(areaLightPaint(light("on", { rgb_color: [255, 0] }))?.color).toBeUndefined();
-    expect(areaLightPaint(light("on", { rgb_color: "red;position:fixed" }))?.color).toBeUndefined();
-    expect(areaLightPaint(light("on", { rgb_color: [null, 1, 2] }))?.color).toBeUndefined();
-  });
-
-  it("clamps out-of-range channels instead of trusting the integration", () => {
-    expect(areaLightPaint(light("on", { rgb_color: [300, -20, 12.6] }))?.color)
-      .toBe("rgb(255, 0, 13)");
-  });
-});
-
-describe("resolveAreaPaint precedence (issue #6)", () => {
-  const base = { id: "a", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] };
-  const lit = { entity_id: "light.x", state: "on", attributes: { rgb_color: [10, 20, 30], brightness: 255 } } as never;
-
-  it("a conditional rule that tested the value beats the light", () => {
-    const a = {
-      ...base,
-      entity: "binary_sensor.smoke",
-      lightEntity: "light.x",
-      stateColor: [{ state: "on", color: "#ff0000" }],
-    };
-    expect(resolveAreaPaint(a, "on", lit).color).toBe("#ff0000");
-  });
-
-  it("but a catch-all rule does NOT — it would mask the light on every config", () => {
-    const a = {
-      ...base,
-      entity: "sensor.co2",
-      lightEntity: "light.x",
-      stateColor: [{ above: 1000, color: "#ff0000" }, { color: "#00ff00" }],
-    };
-    // Below the threshold only the catch-all matches, so the light shows.
-    expect(resolveAreaPaint(a, "400", lit).color).toBe("rgb(10, 20, 30)");
-    // Above it, the room is in alarm and the rule takes over.
-    expect(resolveAreaPaint(a, "1200", lit).color).toBe("#ff0000");
-  });
-
-  it("falls back to the catch-all when the light is off", () => {
-    const a = {
-      ...base,
-      entity: "sensor.co2",
-      lightEntity: "light.x",
-      stateColor: [{ color: "#00ff00" }],
-    };
-    const off = { entity_id: "light.x", state: "off", attributes: {} } as never;
-    expect(resolveAreaPaint(a, "400", off).color).toBe("#00ff00");
-  });
-
-  it("the light beats activeColor", () => {
-    const a = {
-      ...base,
-      entity: "binary_sensor.occupancy",
-      lightEntity: "light.x",
-      activeColor: "#4caf50",
-    };
-    expect(resolveAreaPaint(a, "on", lit).color).toBe("rgb(10, 20, 30)");
-  });
-
-  it("ignores the light entirely when the area does not bind one", () => {
-    const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
-    expect(resolveAreaPaint(a, "on", lit).color).toBe("#4caf50");
-  });
-
-  it("a light alone lights the room, with no conditional config at all", () => {
-    expect(resolveAreaPaint({ ...base, lightEntity: "light.x" }, undefined, lit)).toEqual({
-      color: "rgb(10, 20, 30)",
-      opacity: LIGHT_MAX_OPACITY,
-    });
-  });
-
-  it("an unsafe rule color falls through to the light rather than swallowing it", () => {
-    const a = {
-      ...base,
-      entity: "binary_sensor.smoke",
-      lightEntity: "light.x",
-      stateColor: [{ state: "on", color: "red;position:fixed;inset:0" }],
-    };
-    expect(resolveAreaPaint(a, "on", lit).color).toBe("rgb(10, 20, 30)");
-  });
-});
-
-describe("renderArea with a brightness-only light (issue #6)", () => {
-  const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
-
-  it("keeps the room's own color and varies only the opacity", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, { opacity: 0.4 }));
-    expect(markup).toContain("fill=#ff0000");
-    expect(markup).toContain("fill-opacity=0.4");
-  });
-
-  it("the light's opacity outranks activeOpacity", () => {
-    const a = { id: "a", points: square, opacity: 0.1, activeOpacity: 0.7 };
-    expect(flatten(renderArea(a, { color: "#4caf50", opacity: 0.33 }))).toContain("fill-opacity=0.33");
-  });
-
-  it("an opacity-only paint never draws an outline, having no color for one", () => {
-    const a = { id: "a", points: square, highlight: "border" as const };
-    const markup = flatten(renderArea(a, { opacity: 0.4 }));
-    expect(markup).toContain("stroke=none");
-    expect(markup).toContain("stroke-width=0");
-  });
-});
-
-describe("matchStateColor (issue #6)", () => {
-  it("reports whether the matched rule actually tested the value", () => {
-    const rules = [{ above: 10, color: "#f00" }, { state: "open", color: "#0f0" }, { color: "#00f" }];
-    expect(matchStateColor(rules, 20)).toEqual({ color: "#f00", specific: true });
-    expect(matchStateColor(rules, "open")).toEqual({ color: "#0f0", specific: true });
-    expect(matchStateColor(rules, 5)).toEqual({ color: "#00f", specific: false });
-    expect(matchStateColor([], 5)).toBeUndefined();
-  });
-});
-
-describe("collectWatchedEntities covers areas (issue #6)", () => {
-  it("watches an area's entity and light, or the card freezes their color", () => {
-    const cfg = {
-      type: "custom:easy-floorplan-card",
-      width: 100,
-      height: 100,
-      areas: [{ id: "a", points: [], entity: "binary_sensor.occupancy", lightEntity: "light.kitchen" }],
-    } as never;
-    const watched = collectWatchedEntities(cfg);
-    expect(watched.has("binary_sensor.occupancy")).toBe(true);
-    expect(watched.has("light.kitchen")).toBe(true);
+    expect(areaColor(a, "on")).toBeUndefined();
   });
 });
 
@@ -1667,6 +1493,105 @@ describe("shutterStyleOf (issue #74)", () => {
 
   it("defaults to roll with nothing bound, so existing configs are untouched", () => {
     expect(shutterStyleOf({})).toBe("roll");
+  });
+});
+
+describe("glowPaint (issue #6)", () => {
+  const light = (state: string, attributes: Record<string, unknown> = {}) =>
+    ({ entity_id: "light.x", state, attributes }) as never;
+
+  it("paints a color-capable light's own rgb", () => {
+    const paint = glowPaint({}, light("on", { rgb_color: [255, 170, 80], brightness: 255 }));
+    expect(paint?.color).toBe("rgb(255, 170, 80)");
+    expect(paint?.opacity).toBeCloseTo(GLOW_MAX_OPACITY, 5);
+  });
+
+  it("scales strength with brightness, inside the legible band", () => {
+    const dim = glowPaint({}, light("on", { rgb_color: [255, 255, 255], brightness: 0 }));
+    const half = glowPaint({}, light("on", { rgb_color: [255, 255, 255], brightness: 128 }));
+    expect(dim?.opacity).toBeCloseTo(GLOW_MIN_OPACITY, 5);
+    expect(half?.opacity).toBeGreaterThan(GLOW_MIN_OPACITY);
+    expect(half?.opacity).toBeLessThan(GLOW_MAX_OPACITY);
+    // The floor is the point: a dimmed lamp stays visible rather than vanishing.
+    expect(dim?.opacity).toBeGreaterThan(0);
+  });
+
+  it("a brightness-only light falls back to a warm white", () => {
+    // light.kitchen_lights on a real install: supported_color_modes ["brightness"].
+    const paint = glowPaint({}, light("on", { brightness: 255 }));
+    expect(paint?.color).toBe(DEFAULT_GLOW_COLOR);
+  });
+
+  it("an on/off-only light casts at full strength", () => {
+    // light.main_living_room_switch_l1: supported_color_modes ["onoff"].
+    const paint = glowPaint({}, light("on"));
+    expect(paint?.color).toBe(DEFAULT_GLOW_COLOR);
+    expect(paint?.opacity).toBeCloseTo(GLOW_MAX_OPACITY, 5);
+  });
+
+  it("honors a configured glowColor for a light that has none of its own", () => {
+    expect(glowPaint({ glowColor: "#00ff00" }, light("on", { brightness: 128 }))?.color)
+      .toBe("#00ff00");
+    // ...but never over a light that CAN report one.
+    expect(glowPaint({ glowColor: "#00ff00" }, light("on", { rgb_color: [1, 2, 3] }))?.color)
+      .toBe("rgb(1, 2, 3)");
+  });
+
+  it("gates an unsafe glowColor through css-safe (#64)", () => {
+    expect(glowPaint({ glowColor: "red;position:fixed;inset:0" }, light("on"))?.color)
+      .toBe(DEFAULT_GLOW_COLOR);
+  });
+
+  it("casts nothing when off, unavailable, unknown or missing (fails closed)", () => {
+    expect(glowPaint({}, light("off", { rgb_color: [255, 0, 0] }))).toBeUndefined();
+    expect(glowPaint({}, light("unavailable"))).toBeUndefined();
+    expect(glowPaint({}, light("unknown"))).toBeUndefined();
+    expect(glowPaint({}, undefined)).toBeUndefined();
+  });
+
+  it("ignores a malformed rgb_color rather than emitting a broken color", () => {
+    expect(glowPaint({}, light("on", { rgb_color: [255, 0] }))?.color).toBe(DEFAULT_GLOW_COLOR);
+    expect(glowPaint({}, light("on", { rgb_color: "red;position:fixed" }))?.color).toBe(DEFAULT_GLOW_COLOR);
+    expect(glowPaint({}, light("on", { rgb_color: [null, 1, 2] }))?.color).toBe(DEFAULT_GLOW_COLOR);
+  });
+
+  it("clamps out-of-range channels instead of trusting the integration", () => {
+    expect(glowPaint({}, light("on", { rgb_color: [300, -20, 12.6] }))?.color).toBe("rgb(255, 0, 13)");
+  });
+});
+
+describe("renderGlow (issue #6)", () => {
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+  const item = (extra: Record<string, unknown> = {}) =>
+    ({ id: "i", entity: "light.x", kind: "light", x: 300, y: 200, ...extra }) as never;
+
+  it("centers the pool on the device and fades to nothing at the rim", () => {
+    const markup = flatten(renderGlow(item(), { color: "rgb(1, 2, 3)", opacity: 0.5 }, "g1"));
+    expect(markup).toContain("cx=300");
+    expect(markup).toContain("cy=200");
+    expect(markup).toContain(`r=${DEFAULT_GLOW_RADIUS}`);
+    // Opaque at the centre, transparent at the edge — that's the falloff.
+    expect(markup).toContain('stop-opacity=0.5');
+    expect(markup).toContain('stop-opacity="0"');
+    expect(markup).toContain('fill=url(#g1)');
+  });
+
+  it("honors glowRadius, and gates a garbage one through css-safe", () => {
+    expect(flatten(renderGlow(item({ glowRadius: 250 }), { color: "#fff", opacity: 0.4 }, "g"))).toContain("r=250");
+    expect(flatten(renderGlow(item({ glowRadius: "6; evil" }), { color: "#fff", opacity: 0.4 }, "g")))
+      .toContain(`r=${DEFAULT_GLOW_RADIUS}`);
+  });
+
+  it("carries the class the blend mode hangs off, or lights would not mix", () => {
+    expect(flatten(renderGlow(item(), { color: "#fff", opacity: 0.4 }, "g"))).toContain('class="fp-glow"');
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -45,6 +45,7 @@ import {
   planRotationTransform,
   polygonCentroid,
   renderArea,
+  areaColor,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 
@@ -1361,6 +1362,57 @@ describe("renderArea", () => {
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).not.toContain("position:fixed");
+  });
+
+  it("uses the live fill color over the resting one (#6)", () => {
+    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, "#4caf50"));
+    expect(markup).toContain("fill=#4caf50");
+    expect(markup).not.toContain("fill=#ff0000");
+  });
+
+  it("applies activeOpacity only while live (#6)", () => {
+    const a = { id: "a", points: square, opacity: 0.2, activeOpacity: 0.7 };
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.7");
+    expect(flatten(renderArea(a))).toContain("fill-opacity=0.2");
+  });
+
+  it("keeps the resting opacity when activeOpacity is unset (#6)", () => {
+    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
+    expect(markup).toContain("fill-opacity=0.2");
+  });
+});
+
+describe("areaColor", () => {
+  const base = { id: "a", points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }] };
+
+  it("returns undefined for an unbound area", () => {
+    expect(areaColor({ ...base, activeColor: "#4caf50" }, "on")).toBeUndefined();
+  });
+
+  it("prefers a matching stateColor rule over activeColor", () => {
+    const a = {
+      ...base,
+      entity: "sensor.co2",
+      activeColor: "#4caf50",
+      stateColor: [{ above: 1000, color: "#ff0000" }, { color: "#00ff00" }],
+    };
+    expect(areaColor(a, "1200")).toBe("#ff0000");
+    expect(areaColor(a, "400")).toBe("#00ff00");
+  });
+
+  it("uses activeColor when active and no rule matches", () => {
+    const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
+    expect(areaColor(a, "on")).toBe("#4caf50");
+  });
+
+  it("returns undefined when the bound entity is inactive", () => {
+    const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "#4caf50" };
+    expect(areaColor(a, "off")).toBeUndefined();
+  });
+
+  it("gates an unsafe activeColor through css-safe (#64)", () => {
+    const a = { ...base, entity: "binary_sensor.occupancy", activeColor: "red;position:fixed;inset:0" };
+    expect(areaColor(a, "on")).toBeUndefined();
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -201,6 +201,22 @@ export function furnitureColor(f: Furniture, state: string | undefined): string 
 }
 
 /**
+ * Resolve the live fill color for an {@link Area} bound to an entity (issue #6),
+ * mirroring {@link furnitureColor}: `stateColor` rules win, then `activeColor`
+ * while the entity is active, else undefined so the static `color` applies.
+ *
+ * Returns a value already through the style-injection allowlist (#64), because
+ * it flows straight into a `fill` attribute.
+ */
+export function areaColor(a: Area, state: string | undefined): string | undefined {
+  if (!a.entity) return undefined;
+  const rule = resolveStateColor(a.stateColor, state);
+  if (rule) return cssColor(rule);
+  if (a.activeColor && entityIsActive(a.entity, state)) return cssColor(a.activeColor);
+  return undefined;
+}
+
+/**
  * Whether a device should be omitted from the **live card** right now
  * (issue #55): it asked to appear only while active, and it isn't. An item
  * with no entity can never be active, so a hide-when-inactive item without
@@ -1151,11 +1167,15 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
  * `color`/`opacity` are config-supplied style values, so they go through the
  * same injection allowlist as every other color/number field (see css-safe.ts).
  */
-export function renderArea(a: Area): SVGTemplateResult {
+export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
+  // `liveColor` has already been through the allowlist by areaColor(); when it
+  // is present the area is "live", so activeOpacity (if set) applies instead of
+  // the resting opacity.
+  const opacity = liveColor !== undefined ? a.activeOpacity ?? a.opacity : a.opacity;
   return svg`<polygon points=${pts}
-                       fill=${cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
-                       fill-opacity=${cssNumber(a.opacity, DEFAULT_AREA_OPACITY)} />`;
+                       fill=${liveColor ?? cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
+                       fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)} />`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,6 +12,7 @@ import type {
   AreaPoint,
   RenderHass,
   HassEntity,
+  FloorItem,
 } from "./types";
 import {
   FURNITURE_COLOR,
@@ -19,8 +20,10 @@ import {
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_OPACITY,
   DEFAULT_AREA_BORDER_WIDTH,
-  LIGHT_MIN_OPACITY,
-  LIGHT_MAX_OPACITY,
+  DEFAULT_GLOW_RADIUS,
+  DEFAULT_GLOW_COLOR,
+  GLOW_MIN_OPACITY,
+  GLOW_MAX_OPACITY,
   getFloors,
   trackerAxisFraction,
 } from "./types";
@@ -92,7 +95,6 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     // shouldUpdate drops every hass tick that only moved an unwatched entity.
     for (const a of f.areas) {
       if (a.entity) ids.add(a.entity);
-      if (a.lightEntity) ids.add(a.lightEntity);
     }
     for (const tr of f.trackers) {
       for (const s of [tr.xSensor, tr.ySensor]) {
@@ -168,26 +170,6 @@ export function resolveStateColor(
   rules: readonly StateColorRule[] | undefined,
   raw: unknown,
 ): string | undefined {
-  return matchStateColor(rules, raw)?.color;
-}
-
-/** A matched {@link StateColorRule}, and whether it named a condition. */
-export interface StateColorMatch {
-  color: string;
-  /**
-   * True for a rule that actually tested the value (`above` or `state`), false
-   * for the catch-all. Callers that rank a rule against another source of
-   * color use this: a catch-all means "no opinion about right now", so it must
-   * not outrank a live reading (issue #6).
-   */
-  specific: boolean;
-}
-
-/** {@link resolveStateColor}, but reporting which tier matched. */
-export function matchStateColor(
-  rules: readonly StateColorRule[] | undefined,
-  raw: unknown,
-): StateColorMatch | undefined {
   if (!rules?.length) return undefined;
   const n = typeof raw === "number" ? raw : Number(raw);
   const numeric = typeof raw !== "boolean" && raw !== "" && raw != null && Number.isFinite(n);
@@ -211,10 +193,7 @@ export function matchStateColor(
       fallback = rule.color;
     }
   }
-  if (exact !== undefined) return { color: exact, specific: true };
-  if (best) return { color: best.color, specific: true };
-  if (fallback !== undefined) return { color: fallback, specific: false };
-  return undefined;
+  return exact ?? best?.color ?? fallback;
 }
 
 /**
@@ -234,42 +213,63 @@ export function furnitureColor(f: Furniture, state: string | undefined): string 
   return undefined;
 }
 
-/** How an {@link Area} should paint right now. Empty = leave it static. */
-export interface AreaPaint {
-  /** Live color, already through the style-injection allowlist (#64). */
-  color?: string;
-  /** Live fill opacity. Only a light sets this; other sources use `activeOpacity`. */
-  opacity?: number;
+/**
+ * Resolve the live fill color for an {@link Area} bound to an entity (issue #6),
+ * mirroring {@link furnitureColor}: `stateColor` rules win, then `activeColor`
+ * while the entity is active, else undefined so the static `color` applies.
+ *
+ * Returns a value already through the style-injection allowlist (#64), because
+ * it flows straight into a `fill` attribute.
+ */
+export function areaColor(a: Area, state: string | undefined): string | undefined {
+  if (!a.entity) return undefined;
+  const rule = resolveStateColor(a.stateColor, state);
+  if (rule) return cssColor(rule);
+  if (a.activeColor && entityIsActive(a.entity, state)) return cssColor(a.activeColor);
+  return undefined;
+}
+
+/** The light a device casts right now: a color and how strong at the center. */
+export interface GlowPaint {
+  /** Already through the style-injection allowlist (#64). */
+  color: string;
+  /** Opacity at the center of the pool, fading to 0 at the rim. */
+  opacity: number;
 }
 
 /**
- * What an associated light contributes to its room's fill (issue #6).
+ * What a light contributes as a cast pool (issue #6), or undefined for "casts
+ * nothing".
  *
- * Lights vary wildly in what they can report, so this degrades in rungs rather
- * than demanding `rgb_color` and doing nothing without it — on a real install
- * most lights are brightness-only or on/off-only switches:
+ * Lights vary in what they can report, so this degrades in rungs rather than
+ * demanding `rgb_color` and doing nothing without it — on a real install most
+ * lights are brightness-only or plain on/off switches:
  *
- * 1. **color-capable** — paint `rgb_color`. Home Assistant derives it even for
- *    `color_temp`-only bulbs, so a warm-white bulb still reads as amber.
- * 2. **brightness-only** — no color of its own, so keep the room's color and
- *    let `brightness` drive the opacity.
- * 3. **on/off-only** — no color and no brightness: just go fully lit.
+ * 1. **color-capable** — its own `rgb_color`. Home Assistant derives one even
+ *    for `color_temp`-only bulbs, so warm white still reads as amber.
+ * 2. **brightness-only** — `glowColor` (a warm white by default), with
+ *    `brightness` driving the strength.
+ * 3. **on/off-only** — `glowColor` at full strength.
  *
- * A light that is off, `unavailable` or `unknown` returns undefined and the
- * room falls back to its resting color — failing closed like every other
- * state reader here, so a dead sensor never leaves a room looking lit.
+ * A light that is off, `unavailable` or `unknown` casts nothing — failing
+ * closed like every other state reader here, so a dead bulb never leaves a
+ * pool of light lying on the floor.
  */
-export function areaLightPaint(light: HassEntity | undefined): AreaPaint | undefined {
+export function glowPaint(
+  item: Pick<FloorItem, "glowColor">,
+  light: HassEntity | undefined,
+): GlowPaint | undefined {
   if (!light || light.state !== "on") return undefined;
   const attrs = (light.attributes ?? {}) as Record<string, unknown>;
 
-  // brightness is 0-255 and absent on on/off-only lights, where "on" is full.
+  // brightness is 0-255, and absent on on/off-only lights where "on" is full.
   const raw = attrs.brightness;
-  const bright = typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, Math.min(255, raw)) : undefined;
+  const bright =
+    typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, Math.min(255, raw)) : undefined;
   const opacity =
     bright === undefined
-      ? LIGHT_MAX_OPACITY
-      : LIGHT_MIN_OPACITY + (LIGHT_MAX_OPACITY - LIGHT_MIN_OPACITY) * (bright / 255);
+      ? GLOW_MAX_OPACITY
+      : GLOW_MIN_OPACITY + (GLOW_MAX_OPACITY - GLOW_MIN_OPACITY) * (bright / 255);
 
   const rgb = attrs.rgb_color;
   if (Array.isArray(rgb) && rgb.length >= 3) {
@@ -277,56 +277,34 @@ export function areaLightPaint(light: HassEntity | undefined): AreaPaint | undef
     if ([r, g, b].every((c) => typeof c === "number" && Number.isFinite(c))) {
       const chan = (c: number) => Math.max(0, Math.min(255, Math.round(c)));
       // Built from clamped integers, so it cannot carry a payload — but it
-      // still goes through the allowlist, since every color reaching an
-      // attribute here does.
+      // still goes through the allowlist, as every color here does.
       const color = cssColor(`rgb(${chan(r as number)}, ${chan(g as number)}, ${chan(b as number)})`);
       if (color) return { color, opacity };
     }
   }
-  // Rungs 2 and 3: no color to offer, only a brightness.
-  return { opacity };
+  return { color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR), opacity };
 }
 
 /**
- * Resolve how an {@link Area} paints right now (issue #6). Precedence, highest
- * first:
+ * A light's cast pool: a radial gradient fading from `paint.color` at the
+ * device's position to fully transparent at `glowRadius`.
  *
- * 1. a **conditional rule that tested the value** — `above` or `state`. An
- *    alarm must show through a lit room.
- * 2. the **associated light**, if it is on.
- * 3. **`activeColor`** while `entity` is active.
- * 4. a **catch-all** `stateColor` rule — it means "resting color", so it ranks
- *    below anything that knows about right now. Ranking it at (1) would mask
- *    the light on every config, because rule lists conventionally end with one.
- * 5. nothing — the static `color` applies.
- *
- * Colors come back already through the allowlist (#64), since they flow
- * straight into `fill`/`stroke`.
+ * Each pool carries `mix-blend-mode: screen` so overlapping lights **add**
+ * rather than the topmost one winning — two lamps in one room brighten where
+ * they meet, and a warm and a cool lamp blend between them, which is how real
+ * light behaves. The caller must isolate the layer (see `.fp-glows` in the
+ * card) so the pools mix with each other and not with the plan beneath.
  */
-export function resolveAreaPaint(
-  a: Area,
-  state: string | undefined,
-  light?: HassEntity,
-): AreaPaint {
-  const match = a.entity ? matchStateColor(a.stateColor, state) : undefined;
-  if (match?.specific) {
-    const color = cssColor(match.color);
-    // A rejected color must not swallow the rung; fall through to the light.
-    if (color) return { color };
-  }
-  if (a.lightEntity) {
-    const lit = areaLightPaint(light);
-    if (lit) return lit;
-  }
-  if (a.entity && a.activeColor && entityIsActive(a.entity, state)) {
-    const color = cssColor(a.activeColor);
-    if (color) return { color };
-  }
-  if (match && !match.specific) {
-    const color = cssColor(match.color);
-    if (color) return { color };
-  }
-  return {};
+export function renderGlow(item: FloorItem, paint: GlowPaint, gradientId: string): SVGTemplateResult {
+  const r = cssNumber(item.glowRadius, DEFAULT_GLOW_RADIUS);
+  return svg`
+    <radialGradient id=${gradientId} gradientUnits="userSpaceOnUse"
+                    cx=${item.x} cy=${item.y} r=${r}>
+      <stop offset="0" stop-color=${paint.color} stop-opacity=${paint.opacity} />
+      <stop offset="1" stop-color=${paint.color} stop-opacity="0" />
+    </radialGradient>
+    <circle class="fp-glow" cx=${item.x} cy=${item.y} r=${r}
+            fill=${`url(#${gradientId})`} />`;
 }
 
 /**
@@ -1280,36 +1258,29 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
  * `color`/`opacity` are config-supplied style values, so they go through the
  * same injection allowlist as every other color/number field (see css-safe.ts).
  */
-export function renderArea(a: Area, paint?: AreaPaint): SVGTemplateResult {
+export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
-  // Colors in `paint` have already been through the allowlist by
-  // resolveAreaPaint(). A paint with only an opacity still counts as live — a
-  // brightness-only light lights the room in the room's own color.
-  const liveColor = paint?.color;
-  const live = paint !== undefined && (paint.color !== undefined || paint.opacity !== undefined);
+  // `liveColor` has already been through the allowlist by areaColor(). When it
+  // is present the area is "live" and `highlight` decides whether that color
+  // lands on the fill, the outline, or both.
+  const live = liveColor !== undefined;
   const target = a.highlight ?? "fill";
   const liveFill = live && target !== "border";
-  const liveBorder = live && liveColor !== undefined && target !== "fill";
+  const liveBorder = live && target !== "fill";
 
-  // A light states its own opacity (brightness); otherwise `activeOpacity`
-  // lifts the room while it is live. Both are fill concerns only.
-  const opacity = liveFill ? paint?.opacity ?? a.activeOpacity ?? a.opacity : a.opacity;
+  // activeOpacity is a fill concern, so it only applies when the fill is live.
+  const opacity = liveFill ? a.activeOpacity ?? a.opacity : a.opacity;
   const stroke = liveBorder
     ? liveColor
     : a.borderColor
       ? cssColorOr(a.borderColor, "none")
       : undefined;
 
-  // A live fill without a color of its own (a brightness-only light) keeps the
-  // room's own color and varies only the opacity.
-  const fill = liveFill && liveColor ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)");
-  // A rejected borderColor lands here as "none"; don't give it a width.
-  const outlined = stroke !== undefined && stroke !== "none";
   return svg`<polygon points=${pts}
-                       fill=${fill}
+                       fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
                        stroke=${stroke ?? "none"}
-                       stroke-width=${outlined ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
+                       stroke-width=${stroke ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_TRACKER_DOT_SIZE,
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_OPACITY,
+  DEFAULT_AREA_BORDER_WIDTH,
   getFloors,
   trackerAxisFraction,
 } from "./types";
@@ -1169,13 +1170,27 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
  */
 export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
-  // `liveColor` has already been through the allowlist by areaColor(); when it
-  // is present the area is "live", so activeOpacity (if set) applies instead of
-  // the resting opacity.
-  const opacity = liveColor !== undefined ? a.activeOpacity ?? a.opacity : a.opacity;
+  // `liveColor` has already been through the allowlist by areaColor(). When it
+  // is present the area is "live" and `highlight` decides whether that color
+  // lands on the fill, the outline, or both.
+  const live = liveColor !== undefined;
+  const target = a.highlight ?? "fill";
+  const liveFill = live && target !== "border";
+  const liveBorder = live && target !== "fill";
+
+  // activeOpacity is a fill concern, so it only applies when the fill is live.
+  const opacity = liveFill ? a.activeOpacity ?? a.opacity : a.opacity;
+  const stroke = liveBorder
+    ? liveColor
+    : a.borderColor
+      ? cssColorOr(a.borderColor, "none")
+      : undefined;
+
   return svg`<polygon points=${pts}
-                       fill=${liveColor ?? cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
-                       fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)} />`;
+                       fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
+                       fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
+                       stroke=${stroke ?? "none"}
+                       stroke-width=${stroke ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -11,6 +11,7 @@ import type {
   Area,
   AreaPoint,
   RenderHass,
+  HassEntity,
 } from "./types";
 import {
   FURNITURE_COLOR,
@@ -18,6 +19,8 @@ import {
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_OPACITY,
   DEFAULT_AREA_BORDER_WIDTH,
+  LIGHT_MIN_OPACITY,
+  LIGHT_MAX_OPACITY,
   getFloors,
   trackerAxisFraction,
 } from "./types";
@@ -83,6 +86,13 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     // first-painted color forever.
     for (const fu of f.furniture) {
       if (fu.entity) ids.add(fu.entity);
+    }
+    // Entity-bound areas (issue #6) — same reasoning as furniture above: miss
+    // these and a room's color is painted once and then frozen, because
+    // shouldUpdate drops every hass tick that only moved an unwatched entity.
+    for (const a of f.areas) {
+      if (a.entity) ids.add(a.entity);
+      if (a.lightEntity) ids.add(a.lightEntity);
     }
     for (const tr of f.trackers) {
       for (const s of [tr.xSensor, tr.ySensor]) {
@@ -158,6 +168,26 @@ export function resolveStateColor(
   rules: readonly StateColorRule[] | undefined,
   raw: unknown,
 ): string | undefined {
+  return matchStateColor(rules, raw)?.color;
+}
+
+/** A matched {@link StateColorRule}, and whether it named a condition. */
+export interface StateColorMatch {
+  color: string;
+  /**
+   * True for a rule that actually tested the value (`above` or `state`), false
+   * for the catch-all. Callers that rank a rule against another source of
+   * color use this: a catch-all means "no opinion about right now", so it must
+   * not outrank a live reading (issue #6).
+   */
+  specific: boolean;
+}
+
+/** {@link resolveStateColor}, but reporting which tier matched. */
+export function matchStateColor(
+  rules: readonly StateColorRule[] | undefined,
+  raw: unknown,
+): StateColorMatch | undefined {
   if (!rules?.length) return undefined;
   const n = typeof raw === "number" ? raw : Number(raw);
   const numeric = typeof raw !== "boolean" && raw !== "" && raw != null && Number.isFinite(n);
@@ -181,7 +211,10 @@ export function resolveStateColor(
       fallback = rule.color;
     }
   }
-  return exact ?? best?.color ?? fallback;
+  if (exact !== undefined) return { color: exact, specific: true };
+  if (best) return { color: best.color, specific: true };
+  if (fallback !== undefined) return { color: fallback, specific: false };
+  return undefined;
 }
 
 /**
@@ -201,20 +234,99 @@ export function furnitureColor(f: Furniture, state: string | undefined): string 
   return undefined;
 }
 
+/** How an {@link Area} should paint right now. Empty = leave it static. */
+export interface AreaPaint {
+  /** Live color, already through the style-injection allowlist (#64). */
+  color?: string;
+  /** Live fill opacity. Only a light sets this; other sources use `activeOpacity`. */
+  opacity?: number;
+}
+
 /**
- * Resolve the live fill color for an {@link Area} bound to an entity (issue #6),
- * mirroring {@link furnitureColor}: `stateColor` rules win, then `activeColor`
- * while the entity is active, else undefined so the static `color` applies.
+ * What an associated light contributes to its room's fill (issue #6).
  *
- * Returns a value already through the style-injection allowlist (#64), because
- * it flows straight into a `fill` attribute.
+ * Lights vary wildly in what they can report, so this degrades in rungs rather
+ * than demanding `rgb_color` and doing nothing without it — on a real install
+ * most lights are brightness-only or on/off-only switches:
+ *
+ * 1. **color-capable** — paint `rgb_color`. Home Assistant derives it even for
+ *    `color_temp`-only bulbs, so a warm-white bulb still reads as amber.
+ * 2. **brightness-only** — no color of its own, so keep the room's color and
+ *    let `brightness` drive the opacity.
+ * 3. **on/off-only** — no color and no brightness: just go fully lit.
+ *
+ * A light that is off, `unavailable` or `unknown` returns undefined and the
+ * room falls back to its resting color — failing closed like every other
+ * state reader here, so a dead sensor never leaves a room looking lit.
  */
-export function areaColor(a: Area, state: string | undefined): string | undefined {
-  if (!a.entity) return undefined;
-  const rule = resolveStateColor(a.stateColor, state);
-  if (rule) return cssColor(rule);
-  if (a.activeColor && entityIsActive(a.entity, state)) return cssColor(a.activeColor);
-  return undefined;
+export function areaLightPaint(light: HassEntity | undefined): AreaPaint | undefined {
+  if (!light || light.state !== "on") return undefined;
+  const attrs = (light.attributes ?? {}) as Record<string, unknown>;
+
+  // brightness is 0-255 and absent on on/off-only lights, where "on" is full.
+  const raw = attrs.brightness;
+  const bright = typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, Math.min(255, raw)) : undefined;
+  const opacity =
+    bright === undefined
+      ? LIGHT_MAX_OPACITY
+      : LIGHT_MIN_OPACITY + (LIGHT_MAX_OPACITY - LIGHT_MIN_OPACITY) * (bright / 255);
+
+  const rgb = attrs.rgb_color;
+  if (Array.isArray(rgb) && rgb.length >= 3) {
+    const [r, g, b] = rgb;
+    if ([r, g, b].every((c) => typeof c === "number" && Number.isFinite(c))) {
+      const chan = (c: number) => Math.max(0, Math.min(255, Math.round(c)));
+      // Built from clamped integers, so it cannot carry a payload — but it
+      // still goes through the allowlist, since every color reaching an
+      // attribute here does.
+      const color = cssColor(`rgb(${chan(r as number)}, ${chan(g as number)}, ${chan(b as number)})`);
+      if (color) return { color, opacity };
+    }
+  }
+  // Rungs 2 and 3: no color to offer, only a brightness.
+  return { opacity };
+}
+
+/**
+ * Resolve how an {@link Area} paints right now (issue #6). Precedence, highest
+ * first:
+ *
+ * 1. a **conditional rule that tested the value** — `above` or `state`. An
+ *    alarm must show through a lit room.
+ * 2. the **associated light**, if it is on.
+ * 3. **`activeColor`** while `entity` is active.
+ * 4. a **catch-all** `stateColor` rule — it means "resting color", so it ranks
+ *    below anything that knows about right now. Ranking it at (1) would mask
+ *    the light on every config, because rule lists conventionally end with one.
+ * 5. nothing — the static `color` applies.
+ *
+ * Colors come back already through the allowlist (#64), since they flow
+ * straight into `fill`/`stroke`.
+ */
+export function resolveAreaPaint(
+  a: Area,
+  state: string | undefined,
+  light?: HassEntity,
+): AreaPaint {
+  const match = a.entity ? matchStateColor(a.stateColor, state) : undefined;
+  if (match?.specific) {
+    const color = cssColor(match.color);
+    // A rejected color must not swallow the rung; fall through to the light.
+    if (color) return { color };
+  }
+  if (a.lightEntity) {
+    const lit = areaLightPaint(light);
+    if (lit) return lit;
+  }
+  if (a.entity && a.activeColor && entityIsActive(a.entity, state)) {
+    const color = cssColor(a.activeColor);
+    if (color) return { color };
+  }
+  if (match && !match.specific) {
+    const color = cssColor(match.color);
+    if (color) return { color };
+  }
+  return {};
 }
 
 /**
@@ -1168,29 +1280,36 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
  * `color`/`opacity` are config-supplied style values, so they go through the
  * same injection allowlist as every other color/number field (see css-safe.ts).
  */
-export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
+export function renderArea(a: Area, paint?: AreaPaint): SVGTemplateResult {
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
-  // `liveColor` has already been through the allowlist by areaColor(). When it
-  // is present the area is "live" and `highlight` decides whether that color
-  // lands on the fill, the outline, or both.
-  const live = liveColor !== undefined;
+  // Colors in `paint` have already been through the allowlist by
+  // resolveAreaPaint(). A paint with only an opacity still counts as live — a
+  // brightness-only light lights the room in the room's own color.
+  const liveColor = paint?.color;
+  const live = paint !== undefined && (paint.color !== undefined || paint.opacity !== undefined);
   const target = a.highlight ?? "fill";
   const liveFill = live && target !== "border";
-  const liveBorder = live && target !== "fill";
+  const liveBorder = live && liveColor !== undefined && target !== "fill";
 
-  // activeOpacity is a fill concern, so it only applies when the fill is live.
-  const opacity = liveFill ? a.activeOpacity ?? a.opacity : a.opacity;
+  // A light states its own opacity (brightness); otherwise `activeOpacity`
+  // lifts the room while it is live. Both are fill concerns only.
+  const opacity = liveFill ? paint?.opacity ?? a.activeOpacity ?? a.opacity : a.opacity;
   const stroke = liveBorder
     ? liveColor
     : a.borderColor
       ? cssColorOr(a.borderColor, "none")
       : undefined;
 
+  // A live fill without a color of its own (a brightness-only light) keeps the
+  // room's own color and varies only the opacity.
+  const fill = liveFill && liveColor ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)");
+  // A rejected borderColor lands here as "none"; don't give it a width.
+  const outlined = stroke !== undefined && stroke !== "none";
   return svg`<polygon points=${pts}
-                       fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
+                       fill=${fill}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
                        stroke=${stroke ?? "none"}
-                       stroke-width=${stroke ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
+                       stroke-width=${outlined ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,6 +245,26 @@ export interface FloorItem {
   rippleColor?: string;
   /** Max ripple ring diameter in pixels. Default 80. */
   rippleSize?: number;
+  /**
+   * Cast a pool of light onto the plan from this device's position (issue #6).
+   *
+   * The room is not tinted as a whole — the light falls where the device sits,
+   * so several lights in one room each cast their own pool and the pools mix
+   * where they overlap. That handles an open-plan room, or one lamp warm and
+   * another cool, which a single room-wide fill cannot express.
+   *
+   * The device's own `x`/`y` are the position, so a light icon already placed
+   * on the plan needs nothing but this flag.
+   */
+  glow?: boolean;
+  /** Radius of the cast pool in canvas units. Default {@link DEFAULT_GLOW_RADIUS}. */
+  glowRadius?: number;
+  /**
+   * Color for a light that cannot report one — a brightness-only or on/off
+   * bulb. A color-capable light always paints its own `rgb_color` instead.
+   * Defaults to {@link DEFAULT_GLOW_COLOR}, a warm white.
+   */
+  glowColor?: string;
   /** Lovelace actions. Defaults: tap = toggle (controllable domains) or more-info; hold/double = none. */
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
@@ -492,28 +512,9 @@ export interface Area {
    */
   entity?: string;
   /**
-   * A light in this room whose own color paints it (issue #6) — the bird's-eye
-   * view where you compare the tones set across rooms. Independent of
-   * {@link entity}, so a room can take its color from the light while a smoke
-   * detector on `entity` still overrides it.
-   *
-   * Not every light can report a color, so this degrades in rungs (see
-   * `areaLightPaint`): a color-capable light paints its `rgb_color`; a
-   * brightness-only light keeps the room's own color and varies the opacity;
-   * an on/off-only light just goes to full {@link activeOpacity}. An off or
-   * unavailable light paints nothing, leaving the room at its resting
-   * {@link color}.
-   */
-  lightEntity?: string;
-  /**
    * Threshold/state colors for the fill, in the same shape as
-   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state.
-   *
-   * A rule that names an `above` threshold or an exact `state` outranks
-   * {@link lightEntity}, so an alarm still shows through a lit room. A
-   * catch-all rule (neither `above` nor `state`) deliberately ranks *below*
-   * the light — it reads as "the resting color", and letting it outrank the
-   * light would silently mask it, since most rule lists end with one.
+   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state; takes
+   * precedence over {@link activeColor} and {@link color}.
    */
   stateColor?: StateColorRule[];
   /** Fill color while `entity` is active. Used when no {@link stateColor} rule matches. */
@@ -554,16 +555,19 @@ export function areaFiltersEntities(
 export const DEFAULT_AREA_OPACITY = 0.25;
 export const DEFAULT_AREA_BORDER_WIDTH = 3;
 
+/** Radius of a light's cast pool, in canvas units (issue #6). */
+export const DEFAULT_GLOW_RADIUS = 140;
+/** Warm white, for a light that cannot report a color of its own. */
+export const DEFAULT_GLOW_COLOR = "#ffd9a0";
 /**
- * Opacity band a light's `brightness` maps into (issue #6).
+ * Opacity band a light's `brightness` maps into at the center of its pool.
  *
- * Not 0–1: a room dimmed to 10% would be all but invisible, and "I can't see
- * the room" is a worse reading than "the room is dim". The floor keeps a lit
- * room legible, and the ceiling keeps a fully-lit room from swamping the
- * icons drawn on top of it.
+ * Not 0–1: a lamp dimmed to 10% would be invisible, and "I can't see it" reads
+ * worse than "it's dim". The ceiling keeps a bright lamp from burying the
+ * furniture and icons it sits on top of.
  */
-export const LIGHT_MIN_OPACITY = 0.15;
-export const LIGHT_MAX_OPACITY = 0.5;
+export const GLOW_MIN_OPACITY = 0.18;
+export const GLOW_MAX_OPACITY = 0.6;
 
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -484,6 +484,27 @@ export interface Area {
    * without a linked `haArea`.
    */
   filterEntities?: boolean;
+  /**
+   * Optional entity that makes the room itself live (issue #6) — a presence
+   * sensor that lights the room while it is occupied, an air quality sensor
+   * that reddens it when readings go bad. Drives {@link stateColor} and
+   * {@link activeColor}; an unbound area is still just a static polygon.
+   */
+  entity?: string;
+  /**
+   * Threshold/state colors for the fill, in the same shape as
+   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state; takes
+   * precedence over {@link activeColor} and {@link color}.
+   */
+  stateColor?: StateColorRule[];
+  /** Fill color while `entity` is active. Used when no {@link stateColor} rule matches. */
+  activeColor?: string;
+  /**
+   * Fill opacity while `entity` resolves a color, 0-1. Lets a room lift out of
+   * the plan while it is live without permanently darkening it when it is not.
+   * Falls back to {@link opacity}.
+   */
+  activeOpacity?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,6 +505,20 @@ export interface Area {
    * Falls back to {@link opacity}.
    */
   activeOpacity?: number;
+  /**
+   * Static outline color for the polygon. No outline is drawn by default, so
+   * existing plans render unchanged.
+   */
+  borderColor?: string;
+  /** Outline width in canvas units. Defaults to {@link DEFAULT_AREA_BORDER_WIDTH}. */
+  borderWidth?: number;
+  /**
+   * Where a resolved live color paints: the `fill` (default, and the only
+   * behaviour before this option existed), the `border`, or `both`. Use
+   * `border` for a room that outlines itself while occupied without tinting
+   * everything inside it — which reads better on a busy plan.
+   */
+  highlight?: "fill" | "border" | "both";
 }
 
 /**
@@ -519,6 +533,7 @@ export function areaFiltersEntities(
 }
 
 export const DEFAULT_AREA_OPACITY = 0.25;
+export const DEFAULT_AREA_BORDER_WIDTH = 3;
 
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -492,9 +492,28 @@ export interface Area {
    */
   entity?: string;
   /**
+   * A light in this room whose own color paints it (issue #6) — the bird's-eye
+   * view where you compare the tones set across rooms. Independent of
+   * {@link entity}, so a room can take its color from the light while a smoke
+   * detector on `entity` still overrides it.
+   *
+   * Not every light can report a color, so this degrades in rungs (see
+   * `areaLightPaint`): a color-capable light paints its `rgb_color`; a
+   * brightness-only light keeps the room's own color and varies the opacity;
+   * an on/off-only light just goes to full {@link activeOpacity}. An off or
+   * unavailable light paints nothing, leaving the room at its resting
+   * {@link color}.
+   */
+  lightEntity?: string;
+  /**
    * Threshold/state colors for the fill, in the same shape as
-   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state; takes
-   * precedence over {@link activeColor} and {@link color}.
+   * {@link FloorItem.stateColor}. Evaluated against `entity`'s state.
+   *
+   * A rule that names an `above` threshold or an exact `state` outranks
+   * {@link lightEntity}, so an alarm still shows through a lit room. A
+   * catch-all rule (neither `above` nor `state`) deliberately ranks *below*
+   * the light — it reads as "the resting color", and letting it outrank the
+   * light would silently mask it, since most rule lists end with one.
    */
   stateColor?: StateColorRule[];
   /** Fill color while `entity` is active. Used when no {@link stateColor} rule matches. */
@@ -534,6 +553,17 @@ export function areaFiltersEntities(
 
 export const DEFAULT_AREA_OPACITY = 0.25;
 export const DEFAULT_AREA_BORDER_WIDTH = 3;
+
+/**
+ * Opacity band a light's `brightness` maps into (issue #6).
+ *
+ * Not 0–1: a room dimmed to 10% would be all but invisible, and "I can't see
+ * the room" is a worse reading than "the room is dim". The floor keeps a lit
+ * room legible, and the ceiling keeps a fully-lit room from swamping the
+ * icons drawn on top of it.
+ */
+export const LIGHT_MIN_OPACITY = 0.15;
+export const LIGHT_MAX_OPACITY = 0.5;
 
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 


### PR DESCRIPTION
Closes #6.

Areas could only take a static `color`/`opacity`, so a room couldn't react to anything. `Furniture` already solved exactly this for #82 with `entity` + `stateColor` + `activeColor` — this applies the same pattern to `Area`, so a room can colour its **fill**, its **outline**, or both from a bound entity.

### What it adds

| Field | |
|---|---|
| `entity` | Bind any entity to the area |
| `stateColor` | Threshold/state rules, same shape as a device's |
| `activeColor` | Color while the entity is active, when no rule matches |
| `activeOpacity` | Fill opacity while live, falling back to `opacity` |
| `borderColor` / `borderWidth` | Static outline — none is drawn by default |
| `highlight` | Where a live color paints: `fill` (default), `border`, `both` |

Two additions beyond furniture's set, both earning their place:

- **`activeOpacity`** — otherwise you must choose between a resting fill strong enough that you notice it change, and one subtle enough not to dominate the plan. A room can sit at `0.12` and lift to `0.35` when it goes active.
- **`highlight`** — filling a whole room is heavy on a busy plan. `highlight: border` lets a room outline itself while occupied without tinting everything inside it. `activeOpacity` stays a fill concern and deliberately does not apply in that mode.

### Implementation

`areaColor()` mirrors `furnitureColor()`: `stateColor` rules win, then `activeColor` while the entity is active, else `undefined` so the static `color` still applies. It returns a value already through the style-injection allowlist (#64), since it flows straight into `fill`/`stroke` attributes.

`renderArea(a, liveColor?)` takes the resolved colour as an optional second argument, so the editor's existing `renderArea(a)` call is untouched. **An area with no entity, no border and no highlight renders exactly as before** — `stroke=none`, `stroke-width=0`.

The editor gets an entity picker on the area form, placed last, matching furniture's reasoning that most areas are just outlines. Colours stay YAML-only, as furniture's do.

### Example

```yaml
areas:
  # Fill lights up green while occupied, and lifts to a stronger fill.
  - id: kitchen
    entity: binary_sensor.kitchen_occupancy
    activeColor: "#4caf50"
    opacity: 0.12
    activeOpacity: 0.35

  # Outline-only: draws a green border while occupied, fill never changes.
  - id: hall
    entity: binary_sensor.hall_occupancy
    activeColor: "#4caf50"
    highlight: border
    borderWidth: 4

  # Threshold a numeric sensor, so the room reddens as air quality drops.
  - id: study
    entity: sensor.study_co2
    stateColor:
      - { above: 1200, color: "#e1243b" }
      - { above: 800, color: "#ff9300" }
      - { color: "#58d32f" }
```

### Tests

16 new tests: rule precedence, the inactive and unbound cases, the css-safe gate on both `activeColor` and `borderColor`, the `activeOpacity` switch, the no-outline default, the border-width fallback, each `highlight` mode, and a live colour overriding a static `borderColor`.

Full suite green at **499 passing**; `tsc --noEmit` and `vite build` both clean.

Happy to rename anything, or to split the outline work out if you'd rather take the fill on its own first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
