### PR TITLE
Glow: furniture keeps its color, light stops at walls, pools never eat clicks (closes #108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,19 @@ cast onto the floor rather than painted over the plan. `glow` is independent of 
 combine it with `showIcon: false` for light with no badge, or with `hideWhenInactive` to
 drop both when the light is off.
 
+**Walls block the light.** A pool is clipped to what the lamp can actually see, so it stops
+at the walls of its room instead of washing into the next one, and spills through a doorway
+gap the way real light does. The result is an irregular shape rather than a clean circle —
+that's the point. A lamp with no wall inside its radius stays a plain circle.
+
+**Furniture keeps its own color.** Light falls on the floor, not on the furniture drawn over
+it: furniture footprints are cut out of the pools, so a sofa under a lit lamp stays its base
+gray rather than turning the color of the light. Only entity-bound furniture with
+`stateColor` / `activeColor` ever changes color.
+
+Pools never intercept clicks — a device under a lit lamp stays tappable, and in the editor
+rooms under one stay selectable.
+
 ### Text
 
 `{ id, x, y, text, size?, color?, angle? }` — `size` px (default 16), `color` CSS/hex,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -53,6 +53,7 @@ import {
   renderWallMask,
   editorGlowPaint,
   renderGlow,
+  renderGlowMask,
   openingDefaultOpen,
   openingMotion,
   shutterStyleOf,
@@ -2711,13 +2712,17 @@ export class FloorplanCardEditor extends LitElement {
                    what you place is what you get. Previewed at full strength
                    with no hass in the editor, so the radius is adjustable
                    without having to turn the real light on. -->
-              <g class="fp-glows">
+              ${renderGlowMask(floor.furniture, c.width, c.height, `${this._wallMaskId}-glowmask`)}
+              <g class="fp-glows"
+                 mask=${floor.furniture.length ? `url(#${this._wallMaskId}-glowmask)` : nothing}>
                 ${floor.items.map((it, i) => {
                   if (!it.glow) return nothing;
                   // An off light draws nothing, as on the card; only a glow
                   // with no readable state previews lit (issue #108).
                   const paint = editorGlowPaint(it, this.hass?.states[it.entity]);
-                  return paint ? renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`) : nothing;
+                  return paint
+                    ? renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`, floor.walls)
+                    : nothing;
                 })}
               </g>
               ${
@@ -4596,6 +4601,18 @@ export class FloorplanCardEditor extends LitElement {
       stroke: var(--primary-color, #03a9f4);
       stroke-width: 2;
       pointer-events: none;
+    }
+    /* Light pools are decoration: they must never intercept a pointer. These
+       are filled circles drawn above the areas, so without this they swallow
+       pointerdown and areas under a lit lamp cannot be selected (issue #108).
+       The blend rules mirror the card's, so the editor previews the same
+       picture it will render — overlapping lamps add rather than stack. */
+    .fp-glows {
+      isolation: isolate;
+      pointer-events: none;
+    }
+    .fp-glow {
+      mix-blend-mode: screen;
     }
     /* Radius guide for the selected cast-light device (issue #108). Outline
        only — it shows how far the light reaches without pretending it is on. */

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -45,14 +45,13 @@ import {
   snapToGridPercent,
   trackerPresenceDetected,
   uid,
-  DEFAULT_GLOW_COLOR,
-  GLOW_MAX_OPACITY,
+  DEFAULT_GLOW_RADIUS,
 } from "./types";
 import {
   WALL_THICKNESS,
   renderOpening,
   renderWallMask,
-  glowPaint,
+  editorGlowPaint,
   renderGlow,
   openingDefaultOpen,
   openingMotion,
@@ -2715,13 +2714,24 @@ export class FloorplanCardEditor extends LitElement {
               <g class="fp-glows">
                 ${floor.items.map((it, i) => {
                   if (!it.glow) return nothing;
-                  const paint = glowPaint(it, this.hass?.states[it.entity]) ?? {
-                    color: cssColorOr(it.glowColor, DEFAULT_GLOW_COLOR),
-                    opacity: GLOW_MAX_OPACITY,
-                  };
-                  return renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`);
+                  // An off light draws nothing, as on the card; only a glow
+                  // with no readable state previews lit (issue #108).
+                  const paint = editorGlowPaint(it, this.hass?.states[it.entity]);
+                  return paint ? renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`) : nothing;
                 })}
               </g>
+              ${
+                // Radius guide for the selected glow (issue #108). Sizing an
+                // unlit light would otherwise be blind, now that an off light
+                // correctly draws nothing. Editor-only chrome, like the
+                // tracker zone outline.
+                floor.items.map((it) =>
+                  it.glow && this._isSel("item", it.id)
+                    ? svg`<circle class="glow-guide" cx=${it.x} cy=${it.y}
+                                  r=${cssNumber(it.glowRadius, DEFAULT_GLOW_RADIUS)} />`
+                    : nothing
+                )
+              }
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
@@ -4585,6 +4595,16 @@ export class FloorplanCardEditor extends LitElement {
       fill: var(--card-background-color, #fff);
       stroke: var(--primary-color, #03a9f4);
       stroke-width: 2;
+      pointer-events: none;
+    }
+    /* Radius guide for the selected cast-light device (issue #108). Outline
+       only — it shows how far the light reaches without pretending it is on. */
+    .glow-guide {
+      fill: none;
+      stroke: var(--primary-color, #03a9f4);
+      stroke-width: 1.5;
+      stroke-dasharray: 6 5;
+      opacity: 0.7;
       pointer-events: none;
     }
     .tracker-draft {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -30,6 +30,7 @@ import {
   areaColor,
   glowPaint,
   renderGlow,
+  renderGlowMask,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -398,11 +399,16 @@ export class FloorplanCard extends LitElement {
                  pools screen-blend with each other (two lamps brighten where
                  they meet) without screening against the plan beneath, which
                  would wash out on a light theme. -->
-            <g class="fp-glows">
+            ${renderGlowMask(active.furniture, c.width, c.height, `${this._glowIdBase}-mask`)}
+            <g class="fp-glows"
+               mask=${active.furniture.length ? `url(#${this._glowIdBase}-mask)` : nothing}>
               ${active.items.map((it, i) => {
                 if (!it.glow) return nothing;
                 const paint = glowPaint(it, this.hass?.states[it.entity]);
-                return paint ? renderGlow(it, paint, `${this._glowIdBase}-${i}`) : nothing;
+                // Walls block the pool (issue #108) — light stops at the room.
+                return paint
+                  ? renderGlow(it, paint, `${this._glowIdBase}-${i}`, active.walls)
+                  : nothing;
               })}
             </g>
             ${active.furniture.map((f) =>
@@ -582,6 +588,11 @@ export class FloorplanCard extends LitElement {
        so two lamps brighten where they meet instead of the topmost winning. */
     .fp-glows {
       isolation: isolate;
+      /* Light is decoration and must never take a click: these are filled
+         circles drawn over the plan, so without this they swallow every tap
+         inside the pool — devices stop responding under a lit lamp, and in
+         the editor whole rooms become unselectable (issue #108). */
+      pointer-events: none;
     }
     .fp-glow {
       mix-blend-mode: screen;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -53,6 +53,7 @@ import {
   renderArea,
   areaColor,
   glowPaint,
+  editorGlowPaint,
   renderGlow,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
@@ -1557,6 +1558,32 @@ describe("glowPaint (issue #6)", () => {
 
   it("clamps out-of-range channels instead of trusting the integration", () => {
     expect(glowPaint({}, light("on", { rgb_color: [300, -20, 12.6] }))?.color).toBe("rgb(255, 0, 13)");
+  });
+});
+
+describe("editorGlowPaint (issue #108)", () => {
+  const light = (state: string, attributes: Record<string, unknown> = {}) =>
+    ({ entity_id: "light.x", state, attributes }) as never;
+
+  it("an OFF light draws nothing in the editor, exactly as on the card", () => {
+    // The v1.1.0 regression: this returned a full-strength warm pool, so five
+    // off living-room lamps washed the whole canvas amber.
+    expect(editorGlowPaint({}, light("off"))).toBeUndefined();
+    expect(editorGlowPaint({}, light("unavailable"))).toBeUndefined();
+    expect(editorGlowPaint({}, light("unknown"))).toBeUndefined();
+  });
+
+  it("an ON light paints exactly what glowPaint says", () => {
+    expect(editorGlowPaint({}, light("on", { rgb_color: [1, 2, 3], brightness: 255 })))
+      .toEqual(glowPaint({}, light("on", { rgb_color: [1, 2, 3], brightness: 255 })));
+  });
+
+  it("only a glow with NO readable state previews lit (outside HA)", () => {
+    expect(editorGlowPaint({}, undefined)).toEqual({
+      color: DEFAULT_GLOW_COLOR,
+      opacity: GLOW_MAX_OPACITY,
+    });
+    expect(editorGlowPaint({ glowColor: "#00ff00" }, undefined)?.color).toBe("#00ff00");
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -54,6 +54,8 @@ import {
   areaColor,
   glowPaint,
   editorGlowPaint,
+  glowReach,
+  renderGlowMask,
   renderGlow,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
@@ -1558,6 +1560,102 @@ describe("glowPaint (issue #6)", () => {
 
   it("clamps out-of-range channels instead of trusting the integration", () => {
     expect(glowPaint({}, light("on", { rgb_color: [300, -20, 12.6] }))?.color).toBe("rgb(255, 0, 13)");
+  });
+});
+
+describe("glowReach — walls block light (issue #108)", () => {
+  const wall = (x1: number, y1: number, x2: number, y2: number, id = "w") => ({ id, x1, y1, x2, y2 });
+  // Even-odd point-in-polygon, for asserting what the light can reach.
+  const inside = (poly: Array<{ x: number; y: number }>, x: number, y: number) => {
+    let hit = false;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const a = poly[i];
+      const b = poly[j];
+      if (a.y > y !== b.y > y && x < ((b.x - a.x) * (y - a.y)) / (b.y - a.y) + a.x) hit = !hit;
+    }
+    return hit;
+  };
+
+  it("no wall in reach: undefined, so the pool stays an unclipped circle", () => {
+    expect(glowReach(500, 300, 140, [])).toBeUndefined();
+    expect(glowReach(500, 300, 140, [wall(0, 0, 1000, 0)])).toBeUndefined();
+  });
+
+  it("a wall between the light and the next room casts a shadow", () => {
+    // Light above a horizontal wall; the wall spans well past the pool.
+    const poly = glowReach(500, 300, 140, [wall(200, 360, 800, 360)])!;
+    expect(poly).toBeDefined();
+    expect(inside(poly, 500, 350)).toBe(true); // near side of the wall: lit
+    expect(inside(poly, 500, 380)).toBe(false); // far side: shadow
+    expect(inside(poly, 500, 200)).toBe(true); // away from the wall: untouched
+  });
+
+  it("light grazes past a wall's end instead of stopping at its angular span", () => {
+    // Wall ends at x=560; past its end the light should keep going.
+    const poly = glowReach(500, 300, 140, [wall(400, 360, 560, 360)])!;
+    expect(inside(poly, 500, 380)).toBe(false); // behind the wall
+    expect(inside(poly, 620, 380)).toBe(true); // around its end
+  });
+
+  it("a light in a closed room stays in the room", () => {
+    const room = [
+      wall(400, 200, 600, 200, "n"),
+      wall(600, 200, 600, 400, "e"),
+      wall(600, 400, 400, 400, "s"),
+      wall(400, 400, 400, 200, "w"),
+    ];
+    const poly = glowReach(500, 300, 300, room)!;
+    expect(inside(poly, 500, 300)).toBe(true);
+    expect(inside(poly, 700, 300)).toBe(false);
+    expect(inside(poly, 500, 500)).toBe(false);
+    expect(inside(poly, 300, 300)).toBe(false);
+  });
+
+  it("the wall the lamp is mounted on does not black out its own pool", () => {
+    // Wall within one wall thickness of the light: non-blocking.
+    expect(glowReach(500, 300, 140, [wall(200, 302, 800, 302)])).toBeUndefined();
+  });
+});
+
+describe("renderGlowMask — furniture stays base gray (issue #108)", () => {
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+
+  it("punches a black rotated rect per furniture piece, ellipse for round types", () => {
+    const markup = flatten(
+      renderGlowMask(
+        [
+          { id: "s", type: "sofa", x: 300, y: 200, w: 100, h: 50, angle: 90 },
+          { id: "t", type: "roundTable", x: 600, y: 300, w: 80, h: 80 },
+        ] as never,
+        1000,
+        600,
+        "gm"
+      )
+    );
+    expect(markup).toContain('id=gm');
+    expect(markup).toContain('fill="black"');
+    expect(markup).toContain("rotate(90 300 200)");
+    expect(markup).toContain("<ellipse");
+    // Explicit region, not the viewport default (the issue #102 lesson).
+    expect(markup).toContain("width=1016");
+  });
+
+  it("clips the pool with the reach polygon only when walls are in range", () => {
+    const item = { id: "i", entity: "light.x", kind: "light", x: 300, y: 200 } as never;
+    const paint = { color: "#fff", opacity: 0.4 };
+    const withWall = flatten(renderGlow(item, paint, "g1", [{ id: "w", x1: 0, y1: 260, x2: 1000, y2: 260 }]));
+    expect(withWall).toContain("<clipPath");
+    expect(withWall).toContain("clip-path=url(#g1-clip)");
+    const noWall = flatten(renderGlow(item, paint, "g2", []));
+    expect(noWall).not.toContain("<clipPath");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,4 @@
-import { svg, html, type SVGTemplateResult, type TemplateResult } from "lit";
+import { svg, html, nothing, type SVGTemplateResult, type TemplateResult } from "lit";
 import type {
   FloorplanCardConfig,
   SectionalHand,
@@ -10,6 +10,7 @@ import type {
   Tracker,
   Area,
   AreaPoint,
+  Wall,
   RenderHass,
   HassEntity,
   FloorItem,
@@ -312,16 +313,152 @@ export function editorGlowPaint(
  * light behaves. The caller must isolate the layer (see `.fp-glows` in the
  * card) so the pools mix with each other and not with the plan beneath.
  */
-export function renderGlow(item: FloorItem, paint: GlowPaint, gradientId: string): SVGTemplateResult {
+/** Perpendicular distance from a point to a wall segment. */
+function pointWallDist(x: number, y: number, w: Wall): number {
+  const dx = w.x2 - w.x1;
+  const dy = w.y2 - w.y1;
+  const len2 = dx * dx + dy * dy;
+  const t = len2 === 0 ? 0 : Math.max(0, Math.min(1, ((x - w.x1) * dx + (y - w.y1) * dy) / len2));
+  const px = w.x1 + t * dx;
+  const py = w.y1 + t * dy;
+  return Math.hypot(x - px, y - py);
+}
+
+/** Distance along a ray from (cx,cy) toward (dx,dy) to a segment, or undefined. */
+function rayWallHit(cx: number, cy: number, dx: number, dy: number, w: Wall): number | undefined {
+  const sx = w.x2 - w.x1;
+  const sy = w.y2 - w.y1;
+  const denom = dx * sy - dy * sx;
+  if (Math.abs(denom) < 1e-12) return undefined; // parallel
+  const qx = w.x1 - cx;
+  const qy = w.y1 - cy;
+  const t = (qx * sy - qy * sx) / denom; // along the ray
+  const u = (qx * dy - qy * dx) / denom; // along the wall
+  if (t <= 1e-9 || u < 0 || u > 1) return undefined;
+  return t;
+}
+
+/**
+ * How far a light at (cx,cy) actually reaches (issue #108): the visibility
+ * polygon of the walls that fall inside its radius, so a pool stops at a wall
+ * instead of washing into the next room. Classic angular sweep — a ray toward
+ * each wall endpoint (and just past it, so light grazes corners), cut at the
+ * nearest wall it hits; a bounding box just beyond the radius keeps every ray
+ * finite, and the circle itself still bounds the final shape.
+ *
+ * The wall the lamp is mounted on must not black out its own pool, so walls
+ * closer than one wall thickness are treated as non-blocking. Returns
+ * undefined when no wall is in reach — the common case, drawn as the plain
+ * circle with no clip at all.
+ */
+export function glowReach(
+  cx: number,
+  cy: number,
+  r: number,
+  walls: readonly Wall[],
+): Array<{ x: number; y: number }> | undefined {
+  const blocking = walls.filter((w) => {
+    const d = pointWallDist(cx, cy, w);
+    return d < r && d > WALL_THICKNESS;
+  });
+  if (!blocking.length) return undefined;
+  const m = r * 1.01;
+  const bounds: Wall[] = [
+    { id: "b1", x1: cx - m, y1: cy - m, x2: cx + m, y2: cy - m },
+    { id: "b2", x1: cx + m, y1: cy - m, x2: cx + m, y2: cy + m },
+    { id: "b3", x1: cx + m, y1: cy + m, x2: cx - m, y2: cy + m },
+    { id: "b4", x1: cx - m, y1: cy + m, x2: cx - m, y2: cy - m },
+  ];
+  const all = [...blocking, ...bounds];
+  const pts: Array<{ x: number; y: number; a: number }> = [];
+  for (const s of all) {
+    for (const [ex, ey] of [
+      [s.x1, s.y1],
+      [s.x2, s.y2],
+    ]) {
+      const base = Math.atan2(ey - cy, ex - cx);
+      for (const a of [base - 1e-4, base, base + 1e-4]) {
+        const dx = Math.cos(a);
+        const dy = Math.sin(a);
+        let best = Infinity;
+        for (const seg of all) {
+          const t = rayWallHit(cx, cy, dx, dy, seg);
+          if (t !== undefined && t < best) best = t;
+        }
+        if (best < Infinity) {
+          pts.push({ x: cx + dx * best, y: cy + dy * best, a });
+        }
+      }
+    }
+  }
+  pts.sort((p, q) => p.a - q.a);
+  const round = (v: number) => Math.round(v * 100) / 100;
+  return pts.map(({ x, y }) => ({ x: round(x), y: round(y) }));
+}
+
+export function renderGlow(
+  item: FloorItem,
+  paint: GlowPaint,
+  gradientId: string,
+  walls?: readonly Wall[],
+): SVGTemplateResult {
   const r = cssNumber(item.glowRadius, DEFAULT_GLOW_RADIUS);
+  // Walls block light (issue #108): clip the pool to what the lamp can see.
+  const reach = walls?.length ? glowReach(item.x, item.y, r, walls) : undefined;
+  const clipId = `${gradientId}-clip`;
   return svg`
+    ${
+      reach
+        ? svg`<clipPath id=${clipId}>
+                <polygon points=${reach.map((p) => `${p.x},${p.y}`).join(" ")} />
+              </clipPath>`
+        : nothing
+    }
     <radialGradient id=${gradientId} gradientUnits="userSpaceOnUse"
                     cx=${item.x} cy=${item.y} r=${r}>
       <stop offset="0" stop-color=${paint.color} stop-opacity=${paint.opacity} />
       <stop offset="1" stop-color=${paint.color} stop-opacity="0" />
     </radialGradient>
     <circle class="fp-glow" cx=${item.x} cy=${item.y} r=${r}
-            fill=${`url(#${gradientId})`} />`;
+            fill=${`url(#${gradientId})`}
+            clip-path=${reach ? `url(#${clipId})` : nothing} />`;
+}
+
+/**
+ * A `<mask>` for the whole glow layer that punches out every furniture
+ * footprint (issue #108): furniture keeps its base gray instead of reading
+ * as "active" whenever a lamp near it is on. The line-art fills at ~0.12
+ * opacity, so a warm pool under a sofa tinted the entire sofa — the report
+ * that opened the issue. Round-based types cut an ellipse, everything else
+ * its rotated rect.
+ *
+ * The region is stated explicitly rather than inherited — the viewport
+ * default clipped walls under rotation once already (issue #102).
+ */
+export function renderGlowMask(
+  furniture: readonly Furniture[],
+  width: number,
+  height: number,
+  id: string,
+): SVGTemplateResult {
+  const pad = WALL_THICKNESS;
+  return svg`
+    <defs>
+      <mask id=${id} maskUnits="userSpaceOnUse"
+            x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}>
+        <rect x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}
+              fill="white" />
+        ${furniture.map((f) => {
+          const rot = f.angle ? `rotate(${f.angle} ${f.x} ${f.y})` : undefined;
+          const roundBase = f.type === "roundTable" || f.type === "plant" || f.type === "waterHeater";
+          return roundBase
+            ? svg`<ellipse cx=${f.x} cy=${f.y} rx=${f.w / 2} ry=${f.h / 2}
+                           fill="black" transform=${rot ?? nothing} />`
+            : svg`<rect x=${f.x - f.w / 2} y=${f.y - f.h / 2} width=${f.w} height=${f.h}
+                        fill="black" transform=${rot ?? nothing} />`;
+        })}
+      </mask>
+    </defs>`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -286,6 +286,23 @@ export function glowPaint(
 }
 
 /**
+ * {@link glowPaint} as the **editor** should apply it (issue #108).
+ *
+ * The editor must trust the entity when there is one — an off light draws
+ * nothing, exactly as on the card. Only a glow with no readable state at all
+ * (no hass, or an entity hass does not know) previews lit, so the feature is
+ * still visible outside Home Assistant. v1.1.0 shipped the fallback applied
+ * unconditionally, and every off light washed the canvas at full strength.
+ */
+export function editorGlowPaint(
+  item: Pick<FloorItem, "glowColor">,
+  state: HassEntity | undefined,
+): GlowPaint | undefined {
+  if (state) return glowPaint(item, state);
+  return { color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR), opacity: GLOW_MAX_OPACITY };
+}
+
+/**
  * A light's cast pool: a radial gradient fading from `paint.color` at the
  * device's position to fully transparent at `glowRadius`.
  *


### PR DESCRIPTION
Closes #108. All regressions from v1.1.0's cast-light feature.

**I got the first read of this wrong.** I shipped an editor-only preview fix and reported it as the bug — but the reported symptom was yellow furniture on the **live card**. I'd sampled while every glow light happened to be `off`, so the card looked clean. With a lamp on it reproduces immediately. Three bugs, one cause: the glow layer is a set of filled circles drawn over the plan, and everything it overlaps inherited its problems.

### 1. Furniture takes the color of the light — the reported bug

Furniture line-art fills at ~0.12 opacity, so a warm pool underneath shows straight through and a plain gray sofa reads yellow, looking exactly like conditional coloring nobody configured.

Furniture footprints are now cut out of the glow layer with a mask: light falls on the floor, furniture keeps its base gray. Only entity-bound furniture ever changes color.

| Sampled point (lamps on) | Before | After |
| --- | --- | --- |
| round table interior | `rgb(191,181,172)` yellowed | `rgb(123,131,158)` base gray |
| sofa interior | `rgb(175,172,175)` yellowed | `rgb(123,131,158)` base gray |
| floor beside the lamp | lit | still lit ✅ |

### 2. Light passes through walls — requested here

Each pool is clipped to the light's **visibility polygon**: an angular sweep over walls within radius, rays cut at the nearest blocker, with a ray either side of every endpoint so light grazes corners and spills through doorway gaps. Irregular by design, as asked.

| Sampled point | Before | After |
| --- | --- | --- |
| behind the kitchen wall | lit through | background ✅ |
| behind the nook wall | lit through | background ✅ |
| through the open kitchen gap | lit | still lit ✅ |

A lamp with no wall inside its radius stays a plain circle and skips the work entirely. Walls within one wall thickness are treated as non-blocking, so the wall a lamp is mounted on can't black out its own pool.

### 3. Areas are no longer selectable

The pools carry `pointer-events: auto` and are drawn **after** the areas, so they swallowed every `pointerdown` inside the pool — areas under a lit lamp couldn't be selected, and on the card a device under one wouldn't respond either. That's why all three symptoms appeared together. Light is decoration: `pointer-events: none` on the layer, card and editor both.

### Also in here

- **Off lights previewed lit in the editor** (the original scope): the editor's no-`hass` fallback also caught lights that were simply off, washing the canvas. Now in a tested helper, `editorGlowPaint` — a readable state is trusted, only an unreadable one previews lit.
- **A dashed radius guide** on the selected glow device, so an unlit lamp can still be sized.
- **The editor never had the blend rules**, so its preview stacked pools instead of adding them. It now mirrors the card.

### Verification and one gap

Rendered-pixel sampling on the reporting plan's shape, for the tables above. **522 tests** (10 new, covering the visibility polygon, the furniture mask and the editor paint decision), typecheck and build clean.

I could not drive a real click in my harness — `elementFromPoint` returns null there regardless of the fix, since the preview pane isn't focused. For #3 I verified that `pointer-events: none` is computed on the pools, which is a CSS guarantee rather than an observed click-through. **Worth confirming area selection by hand** before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)