### PR TITLE
Areas: reach the conditional colors from the editor, not just YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ background):
   corners or another area's corners, and clicking back on the starting point closes the
   shape (3+ points required; Backspace removes the last point while drawing, Escape
   discards the whole outline). Once placed, drag anywhere inside the fill to move the
-  whole room, or drag a corner handle to reshape it — see **Areas**.
+  whole room, or drag a corner handle to reshape it — see **Areas**. Bind an **Entity** in
+  the Element section and the room's conditional-color controls appear beside it — **Active
+  color**, **Active opacity**, **Highlight**, and the **Color by state** rule list — the same
+  set devices and furniture already offer.
 - **+ Add** — one popover for everything droppable: device, text, and all furniture
   types shown as their actual glyphs (pick a sofa by seeing a sofa). The new element is
   selected immediately so the **Element** section is ready for configuring it.
@@ -755,6 +758,8 @@ trackers:
   a linked `haArea`.
 - `entity` — optional entity that makes the room itself live, in the same shape furniture
   uses. Drives `stateColor` and `activeColor`; an unbound area stays a static polygon.
+  Setting it in the editor reveals the colour controls below — on its own it changes
+  nothing, since there is no colour yet for it to resolve.
 - `stateColor` — threshold/state rules for the fill (same shape as a device's
   `stateColor`). Evaluated against `entity`'s state; takes precedence over `activeColor`
   and `color`.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -331,6 +331,32 @@ describe("areaForm", () => {
     expect(d).toMatchObject({ showName: true, opacity: 0.25 });
   });
 
+  it("the conditional-color controls appear once an entity is bound (issue #6)", () => {
+    const names = (a: Area) => areaForm(a).fields.map((f) => f.name);
+    // The Entity picker shipped without these, so binding an entity in the
+    // editor resolved no color and the whole feature looked unimplemented.
+    expect(names(area())).not.toContain("activeOpacity");
+    expect(names(area())).not.toContain("highlight");
+    const bound = names(area({ entity: "binary_sensor.occ" }));
+    expect(bound).toContain("activeOpacity");
+    expect(bound).toContain("highlight");
+  });
+
+  it("active opacity falls back to the resting opacity, highlight to fill", () => {
+    const d = areaForm(area({ entity: "binary_sensor.occ", opacity: 0.1 })).data;
+    expect(d).toMatchObject({ activeOpacity: 0.1, highlight: "fill" });
+    const set = areaForm(area({ entity: "x", activeOpacity: 0.4, highlight: "border" })).data;
+    expect(set).toMatchObject({ activeOpacity: 0.4, highlight: "border" });
+  });
+
+  it("drops the default highlight from the config instead of writing it out", () => {
+    const { toPatch } = areaForm(area({ entity: "binary_sensor.occ" }));
+    expect(toPatch({ highlight: "fill" }).highlight).toBeUndefined();
+    expect(toPatch({ highlight: "border" }).highlight).toBe("border");
+    // Untouched keys survive — it rewrites one field, not the form.
+    expect(toPatch({ highlight: "fill", activeOpacity: 0.5 }).activeOpacity).toBe(0.5);
+  });
+
   it("data reflects an explicit showName/opacity", () => {
     const d = areaForm(area({ name: "Kitchen", showName: false, opacity: 0.5 })).data;
     expect(d).toMatchObject({ showName: false, opacity: 0.5 });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -659,13 +659,39 @@ export function areaForm(a: Area): FormSpec {
         helper: "Optional — lets the room fill change color with a sensor",
         selector: { entity: {} },
       },
+      // Only meaningful once something drives the colour. Offered here rather
+      // than in the editor's colour rows because both are plain selectors, and
+      // "Active opacity" belongs beside "Fill opacity".
+      ...(a.entity
+        ? [
+            {
+              name: "activeOpacity",
+              label: "Active opacity",
+              helper: "Fill opacity while the entity resolves a color",
+              selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
+            },
+            {
+              name: "highlight",
+              label: "Highlight",
+              helper: "Border only outlines the room without tinting what's inside",
+              selector: dropdown(
+                opt("fill", "Fill"),
+                opt("border", "Border only"),
+                opt("both", "Fill and border")
+              ),
+            },
+          ]
+        : []),
     ],
     data: {
       showName: a.showName ?? true,
       opacity: a.opacity ?? DEFAULT_AREA_OPACITY,
       entity: a.entity ?? "",
+      activeOpacity: a.activeOpacity ?? a.opacity ?? DEFAULT_AREA_OPACITY,
+      highlight: a.highlight ?? "fill",
     },
-    toPatch: identity,
+    // "fill" is the default, so keep it out of the YAML.
+    toPatch: (p) => ("highlight" in p && p.highlight === "fill" ? { ...p, highlight: undefined } : p),
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3642,6 +3642,30 @@ export class FloorplanCardEditor extends LitElement {
           onLive: (color) => this._updateAreaLive(a.id, { color }),
           onCommit: (color) => this._updateArea(a.id, { color }),
         })}
+        ${
+          // The colours the bound entity drives. Same shape furniture and
+          // devices already use, and gated the same way — without an entity
+          // there is nothing to condition on. Until this existed the Entity
+          // picker above was inert on its own: areaColor() resolves nothing
+          // without an activeColor or a matching rule, so binding an entity
+          // in the editor changed nothing and the feature looked unbuilt.
+          a.entity
+            ? html`
+                ${this._renderColorRow({
+                  label: "Active color",
+                  title: "Color while the entity is on",
+                  value: a.activeColor,
+                  swatch: "#03a9f4",
+                  placeholder: "(no change)",
+                  onLive: (activeColor) => this._updateAreaLive(a.id, { activeColor }),
+                  onCommit: (activeColor) => this._updateArea(a.id, { activeColor }),
+                })}
+                ${this._renderStateColorRules(a.stateColor, (stateColor) =>
+                  this._updateArea(a.id, { stateColor })
+                )}
+              `
+            : nothing
+        }
         ${a.haArea
           ? html`<div class="row wide">
               <label>Filter entities</label>


### PR DESCRIPTION
Follow-up to #107 / issue #6. Nothing was reverted — the feature works; it just had no UI.

### What was wrong

The data model, renderer and precedence for area conditional coloring all shipped and are correct. The **Area panel** offered only: Show name, Fill opacity, Entity, Color.

So the Entity picker was **inert**:

```ts
export function areaColor(a: Area, state: string | undefined): string | undefined {
  if (!a.entity) return undefined;
  const rule = resolveStateColor(a.stateColor, state);   // no rules → undefined
  if (rule) return cssColor(rule);
  if (a.activeColor && entityIsActive(a.entity, state))  // no activeColor → skip
    return cssColor(a.activeColor);
  return undefined;                                       // ← always lands here
}
```

Bind an entity in the editor and *nothing changes on the plan*, because there's no colour for it to resolve. It was the only control in the editor that does nothing on its own, and the reasonable conclusion from outside was that the feature had never been built.

#107 justified this as *"colours stay YAML-only, as furniture's do"* — but that premise doesn't hold. Furniture has an Active color row **and** the full `_renderStateColorRules` editor, both gated on `f.entity`; devices have the same. Areas were the odd one out. I reviewed that PR and checked the data model, render path and css-safe gating, but never asked whether the thing was reachable from the UI.

### What this adds

All gated on `a.entity`, matching furniture exactly:

| Control | Where |
| --- | --- |
| **Active color** | colour row, beside furniture's |
| **Color by state** rule list | `_renderStateColorRules`, same component |
| **Active opacity** | `areaForm` |
| **Highlight** (Fill / Border only / Fill and border) | `areaForm` |

Active opacity and Highlight go through `areaForm` rather than hand-rolled markup: both are plain selectors, "Active opacity" belongs beside the existing "Fill opacity", and form fields get unit coverage — for precisely the property that failed here, whether the control is reachable at all. `highlight` drops `fill` instead of writing the default into the config.

### Verification

Harness, end to end:

| | Result |
| --- | --- |
| unbound area | none of the four rows appear |
| entity bound | all four appear |
| Active color `#4caf50` set through the UI, occupied | card paints `#4caf50 @ 0.35` |
| same, sensor clear | back to `#ffffff @ 0.15` |
| `highlight: border`, occupied | fill untouched, stroke `#4caf50` width 3 |

**525 tests** (3 new), typecheck and build clean.

### Still YAML-only

`borderColor` / `borderWidth` — the *static* outline, independent of any entity. Left alone to keep this focused on the conditional colours; happy to add them if you want the panel complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)