### PR TITLE
Emit stable data-id and type classes for CSS targeting (closes #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ editor.
 
 | Element | Class | Attributes |
 | --- | --- | --- |
-| Area | `fp-area` | `data-id` |
+| Area | `fp-area` | `data-id`, `data-entity` |
 | Furniture | `fp-furniture`, `fp-furniture-<type>` | `data-id`, `data-entity` |
 | Door / window | `fp-opening`, `fp-opening-door` \| `fp-opening-window` | `data-id`, `data-entity` |
 | Wall | `wall`, `fp-wall` | `data-id` |

--- a/README.md
+++ b/README.md
@@ -908,6 +908,47 @@ trackers:
       presence: { entity: binary_sensor.living_room_presence }
 ```
 
+## Styling hooks (card-mod)
+
+Every rendered element carries its config `id` as `data-id`, plus a type class — so
+[card-mod](https://github.com/thomasloven/lovelace-card-mod) and any other CSS can target
+it by something stable, instead of by a colour that breaks the moment you change it in the
+editor.
+
+| Element | Class | Attributes |
+| --- | --- | --- |
+| Area | `fp-area` | `data-id` |
+| Furniture | `fp-furniture`, `fp-furniture-<type>` | `data-id`, `data-entity` |
+| Door / window | `fp-opening`, `fp-opening-door` \| `fp-opening-window` | `data-id`, `data-entity` |
+| Wall | `wall`, `fp-wall` | `data-id` |
+| Device | `item`, `fp-item` | `data-id`, `data-entity`, `data-kind` |
+| Text | `text`, `fp-text` | `data-id` |
+| Tracker | `tracker`, `fp-tracker` | `data-id` |
+
+Ids come from the editor (`area_a5r5nwl`, `furn_3j66s50`, …) and are stable across edits.
+An element with no id simply has no `data-id`, rather than `data-id="undefined"`.
+
+```yaml
+type: custom:easy-floorplan-card
+card_mod:
+  style: |
+    /* One specific room */
+    .fp-area[data-id="area_a5r5nwl"] { fill: #62f202; fill-opacity: 0.35; }
+    /* Every sofa on the plan */
+    .fp-furniture-sofa { opacity: 0.5; }
+    /* The element bound to one entity, whatever kind it is */
+    [data-entity="light.kitchen"] { filter: drop-shadow(0 0 6px gold); }
+```
+
+CSS wins over SVG presentation attributes, so `fill` and `fill-opacity` set this way
+override what the card draws.
+
+Two notes. **Colouring a room from a sensor no longer needs CSS** — areas take `entity`,
+`stateColor`, `activeColor` and `activeOpacity` natively; see **Area**. And these hooks are
+a *styling* surface, not an API: the class names are stable, but the SVG structure inside
+an element may change between releases, so prefer selecting the element itself over its
+internals.
+
 ## Development
 
 ```bash

--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cssColor } from "./css-safe";
+import { cssColor, cssIdent, cssEntityId } from "./css-safe";
 import { furnitureColor } from "./render";
 import type { Furniture } from "./types";
 
@@ -170,5 +170,46 @@ describe("entity-driven colors are gated (issues #68, #79, #82)", () => {
   it("a hostile item activeColor does not survive cssColor", () => {
     expect(cssColor(HOSTILE)).toBeUndefined();
     expect(cssColor("#fdd835")).toBe("#fdd835");
+  });
+});
+
+describe("cssIdent / cssEntityId — styling hooks (issue #105)", () => {
+  it("keeps the identifiers the editor actually generates", () => {
+    expect(cssIdent("area_a5r5nwl")).toBe("area_a5r5nwl");
+    expect(cssIdent("furn_3j66s50")).toBe("furn_3j66s50");
+    expect(cssIdent("roundTable")).toBe("roundTable");
+  });
+
+  it("drops whitespace, so a value cannot smuggle in a second class", () => {
+    // "sofa fp-wall" as a type would otherwise style every wall on the plan.
+    expect(cssIdent("sofa fp-wall")).toBe("sofafp-wall");
+    expect(cssIdent("  padded  ")).toBe("padded");
+  });
+
+  it("drops quotes and backslashes, so a selector still matches what was written", () => {
+    expect(cssIdent('a"b')).toBe("ab");
+    expect(cssIdent("a\\b")).toBe("ab");
+    expect(cssIdent("a<b>c")).toBe("abc");
+  });
+
+  it("returns undefined for nothing usable, so the attribute is omitted", () => {
+    // The alternative is data-id="undefined", which is worse than no hook.
+    expect(cssIdent(undefined)).toBeUndefined();
+    expect(cssIdent("")).toBeUndefined();
+    expect(cssIdent("   ")).toBeUndefined();
+    expect(cssIdent("!!!")).toBeUndefined();
+    expect(cssIdent(42)).toBeUndefined();
+  });
+
+  it("cssEntityId keeps the dot, which cssIdent deliberately does not", () => {
+    // [data-entity="light.kitchen"] is the selector people will write.
+    expect(cssEntityId("light.kitchen")).toBe("light.kitchen");
+    expect(cssEntityId("binary_sensor.front_door_contact")).toBe("binary_sensor.front_door_contact");
+    expect(cssIdent("light.kitchen")).toBe("lightkitchen");
+  });
+
+  it("cssEntityId still drops what would break the attribute selector", () => {
+    expect(cssEntityId('light.k"]{}')).toBe("light.k");
+    expect(cssEntityId("")).toBeUndefined();
   });
 });

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -101,3 +101,35 @@ export function cssNumber(value: unknown, fallback: number): number {
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) ? n : fallback;
 }
+
+/**
+ * A config-supplied identifier safe to place in a `class` or `data-*`
+ * attribute (issue #105). Lit escapes attribute values, so this is not about
+ * breakout — it is about the emitted DOM being *predictable*, which is the
+ * whole point of a styling hook: whitespace in a value would silently add
+ * extra classes, and a stray `"` or `\` makes a selector that no longer
+ * matches what the author wrote.
+ *
+ * Keeps letters, digits, `-` and `_`; anything else is dropped. An empty or
+ * non-string value returns `undefined` so callers can emit Lit's `nothing`
+ * and leave the attribute off entirely, rather than `data-id="undefined"`.
+ */
+export function cssIdent(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim().replace(/[^a-zA-Z0-9_-]/g, "");
+  return v === "" ? undefined : v;
+}
+
+/**
+ * An entity id for a `data-entity` attribute (issue #105). Separate from
+ * {@link cssIdent} because an entity id is `domain.object_id` and the dot is
+ * load-bearing — `[data-entity="light.kitchen"]` is the selector people will
+ * write, and stripping the dot would silently make it never match. A dot is
+ * fine in an attribute *value*; it is only a problem in a class name, which is
+ * why the two are not the same function.
+ */
+export function cssEntityId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim().replace(/[^a-zA-Z0-9_.-]/g, "");
+  return v === "" ? undefined : v;
+}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, svg, nothing, type TemplateResult, type Property
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor, Area } from "./types";
-import { cssColor, cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId } from "./css-safe";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -288,7 +288,10 @@ export class FloorplanCard extends LitElement {
     const d = rotatedCanvasSize(c.width, c.height, rot);
     return html`
       <div
-        class="item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""}"
+        class="item fp-item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""}"
+        data-id=${cssIdent(item.id) ?? nothing}
+        data-entity=${cssEntityId(item.entity) ?? nothing}
+        data-kind=${cssIdent(item.kind) ?? nothing}
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;${stateColor
           ? `--fp-state:${stateColor};`
           : ""}${activeColor
@@ -338,7 +341,8 @@ export class FloorplanCard extends LitElement {
     const d = rotatedCanvasSize(c.width, c.height, rot);
     return html`
       <div
-        class="text"
+        class="text fp-text"
+        data-id=${cssIdent(t.id) ?? nothing}
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
                font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
                color:${cssColorOr(t.color, "var(--primary-text-color)")};
@@ -419,7 +423,8 @@ export class FloorplanCard extends LitElement {
               ${active.walls.map(
                 (w) => svg`
                 <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
-                      class="wall" stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
+                      class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
+                      stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
               )}
             </g>
             ${repeat(

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -57,6 +57,7 @@ import {
   editorGlowPaint,
   glowReach,
   renderGlowMask,
+  renderOpening,
   renderGlow,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
@@ -1647,6 +1648,65 @@ describe("glowReach — walls block light (issue #108)", () => {
   it("the wall the lamp is mounted on does not black out its own pool", () => {
     // Wall within one wall thickness of the light: non-blocking.
     expect(glowReach(500, 300, 140, [wall(200, 302, 800, 302)])).toBeUndefined();
+  });
+});
+
+describe("styling hooks reach the DOM (issue #105)", () => {
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+  const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+
+  it("an area carries its config id and a type class", () => {
+    const markup = flatten(renderArea({ id: "area_a5r5nwl", points: square }));
+    expect(markup).toContain('class="fp-area"');
+    expect(markup).toContain("data-id=area_a5r5nwl");
+  });
+
+  it("furniture carries its id, its type class and its entity", () => {
+    const markup = flatten(
+      renderFurniture({ id: "furn_3j66s50", type: "sofa", x: 0, y: 0, w: 10, h: 10, entity: "light.k" } as never)
+    );
+    expect(markup).toContain("fp-furniture fp-furniture-sofa");
+    expect(markup).toContain("data-id=furn_3j66s50");
+    expect(markup).toContain("data-entity=light.k");
+  });
+
+  it("an opening carries its id and door/window class", () => {
+    const markup = flatten(
+      renderOpening(
+        { id: "door_1", type: "door", x: 0, y: 0, length: 40, angle: 0, entity: "binary_sensor.d" } as never,
+        { color: "#888", accent: "#0f0" } as never
+      )
+    );
+    expect(markup).toContain("fp-opening fp-opening-door");
+    expect(markup).toContain("data-id=door_1");
+    expect(markup).toContain("data-entity=binary_sensor.d");
+  });
+
+  it("omits the attribute entirely rather than emitting data-id=undefined", () => {
+    // A hand-written config need not carry ids; "undefined" would be a hook
+    // that silently matches every element that lacks one.
+    const markup = flatten(renderArea({ points: square } as never));
+    expect(markup).not.toContain("undefined");
+    const furn = flatten(renderFurniture({ type: "sofa", x: 0, y: 0, w: 10, h: 10 } as never));
+    expect(furn).not.toContain("undefined");
+  });
+
+  it("a hostile id stays one harmless token instead of a second class", () => {
+    const markup = flatten(renderArea({ id: 'x" class="fp-wall', points: square } as never));
+    // The class list is untouched, and the id collapses to a single token —
+    // no quote to close the attribute, no space to start another class.
+    expect(markup).toContain('class="fp-area"');
+    const id = /data-id=(\S*)/.exec(markup)?.[1];
+    expect(id).toBe("xclassfp-wall");
+    expect(id).not.toMatch(/["'\s=]/);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { nothing } from "lit";
 import type { Furniture, FurnitureType, ItemKind } from "./types";
 import {
   FURNITURE_DEFAULT_SIZE,
@@ -1654,6 +1655,9 @@ describe("glowReach — walls block light (issue #108)", () => {
 describe("styling hooks reach the DOM (issue #105)", () => {
   const flatten = (node: unknown): string => {
     if (node == null || typeof node === "boolean") return "";
+    // Lit's `nothing` is a symbol; stringifying it would put the literal text
+    // "Symbol(lit-nothing)" in the markup, which is not what renders.
+    if (typeof node === "symbol") return "";
     if (Array.isArray(node)) return node.map(flatten).join("");
     if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
       const { strings, values } = node as { strings: string[]; values: unknown[] };
@@ -1706,13 +1710,33 @@ describe("styling hooks reach the DOM (issue #105)", () => {
     expect(markup).toContain("data-entity=binary_sensor.d");
   });
 
-  it("omits the attribute entirely rather than emitting data-id=undefined", () => {
-    // A hand-written config need not carry ids; "undefined" would be a hook
-    // that silently matches every element that lacks one.
-    const markup = flatten(renderArea({ points: square } as never));
-    expect(markup).not.toContain("undefined");
-    const furn = flatten(renderFurniture({ type: "sofa", x: 0, y: 0, w: 10, h: 10 } as never));
-    expect(furn).not.toContain("undefined");
+  it("hands Lit its omit sentinel, so the attribute is absent not \"undefined\"", () => {
+    // A hand-written config need not carry ids, and data-id="undefined" would
+    // be a hook that silently matches every element lacking one.
+    //
+    // Asserting on flattened markup cannot show this: String(nothing) is
+    // "Symbol(lit-nothing)", so a `not.toContain("undefined")` check passes
+    // without the attribute being omitted at all. Assert the slot itself is
+    // Lit's `nothing` — that is the documented contract for removing an
+    // attribute.
+    const slotFor = (tpl: unknown, attr: string): unknown => {
+      const { strings, values } = tpl as { strings: string[]; values: unknown[] };
+      const i = strings.findIndex((s) => s.trimEnd().endsWith(`${attr}=`));
+      expect(i, `no ${attr}= slot found`).toBeGreaterThanOrEqual(0);
+      return values[i];
+    };
+
+    const area = renderArea({ points: square } as never);
+    expect(slotFor(area, "data-id")).toBe(nothing);
+    expect(slotFor(area, "data-entity")).toBe(nothing);
+
+    const furn = renderFurniture({ type: "sofa", x: 0, y: 0, w: 10, h: 10 } as never);
+    expect(slotFor(furn, "data-id")).toBe(nothing);
+    expect(slotFor(furn, "data-entity")).toBe(nothing);
+
+    // And the sentinel really is distinct from the failure it guards against.
+    expect(nothing).not.toBe(undefined);
+    expect(String(nothing)).not.toContain("undefined");
   });
 
   it("a hostile id stays one harmless token instead of a second class", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1663,10 +1663,26 @@ describe("styling hooks reach the DOM (issue #105)", () => {
   };
   const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
 
-  it("an area carries its config id and a type class", () => {
-    const markup = flatten(renderArea({ id: "area_a5r5nwl", points: square }));
+  it("an area carries its config id, type class and bound entity", () => {
+    const markup = flatten(
+      renderArea({ id: "area_a5r5nwl", points: square, entity: "binary_sensor.smoke" } as never)
+    );
     expect(markup).toContain('class="fp-area"');
     expect(markup).toContain("data-id=area_a5r5nwl");
+    // Areas take an entity too (#107), so [data-entity=...] must reach them —
+    // they are the case this issue was actually about.
+    expect(markup).toContain("data-entity=binary_sensor.smoke");
+  });
+
+  it("every entity-bindable element answers the same [data-entity] selector", () => {
+    const ent = "light.kitchen";
+    const area = flatten(renderArea({ id: "a", points: square, entity: ent } as never));
+    const furn = flatten(renderFurniture({ id: "f", type: "sofa", x: 0, y: 0, w: 10, h: 10, entity: ent } as never));
+    const open = flatten(
+      renderOpening({ id: "o", type: "door", x: 0, y: 0, length: 40, angle: 0, entity: ent } as never,
+        { color: "#888", accent: "#0f0" } as never)
+    );
+    for (const m of [area, furn, open]) expect(m).toContain(`data-entity=${ent}`);
   });
 
   it("furniture carries its id, its type class and its entity", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -28,7 +28,7 @@ import {
   getFloors,
   trackerAxisFraction,
 } from "./types";
-import { cssColor, cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId } from "./css-safe";
 
 export const WALL_THICKNESS = 8;
 
@@ -1296,7 +1296,10 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     }`;
   }
   const { sx, sy } = openingMirror(o);
-  return svg`<g transform="translate(${o.x} ${o.y}) rotate(${o.angle})">
+  return svg`<g class=${`fp-opening fp-opening-${cssIdent(o.type) ?? "unknown"}`}
+                data-id=${cssIdent(o.id) ?? nothing}
+                data-entity=${cssEntityId(o.entity) ?? nothing}
+                transform="translate(${o.x} ${o.y}) rotate(${o.angle})">
       <g transform="scale(${sx} ${sy})">${body}</g>
     </g>`;
 }
@@ -1440,7 +1443,8 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
       ? cssColorOr(a.borderColor, "none")
       : undefined;
 
-  return svg`<polygon points=${pts}
+  return svg`<polygon class="fp-area" data-id=${cssIdent(a.id) ?? nothing}
+                       points=${pts}
                        fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
                        stroke=${stroke ?? "none"}
@@ -1736,7 +1740,10 @@ export function renderFurniture(f: Furniture, override?: string): SVGTemplateRes
       detail = svg``;
       break;
   }
-  return svg`<g transform="translate(${f.x} ${f.y}) rotate(${f.angle ?? 0})">${base}${detail}</g>`;
+  return svg`<g class=${`fp-furniture fp-furniture-${cssIdent(f.type) ?? "unknown"}`}
+                data-id=${cssIdent(f.id) ?? nothing}
+                data-entity=${cssEntityId(f.entity) ?? nothing}
+                transform="translate(${f.x} ${f.y}) rotate(${f.angle ?? 0})">${base}${detail}</g>`;
 }
 
 /**
@@ -1905,7 +1912,8 @@ export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTempla
   }
 
   return svg`
-    <g class="tracker ${opts.editing ? "editing" : ""}"
+    <g class="tracker fp-tracker ${opts.editing ? "editing" : ""}"
+       data-id=${cssIdent(t.id) ?? nothing}
        transform="translate(${cx} ${cy}) rotate(${angle})">
       ${zone}${marker}
     </g>`;

--- a/src/render.ts
+++ b/src/render.ts
@@ -1444,6 +1444,7 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
       : undefined;
 
   return svg`<polygon class="fp-area" data-id=${cssIdent(a.id) ?? nothing}
+                       data-entity=${cssEntityId(a.entity) ?? nothing}
                        points=${pts}
                        fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}


### PR DESCRIPTION
Closes #105. Thanks @wisemars — precise issue, and the diagnosis was exactly right.

### What it does

Every rendered element now carries its config `id` as `data-id`, plus a type class:

| Element | Class | Attributes |
| --- | --- | --- |
| Area | `fp-area` | `data-id` |
| Furniture | `fp-furniture`, `fp-furniture-<type>` | `data-id`, `data-entity` |
| Door / window | `fp-opening`, `fp-opening-door` \| `fp-opening-window` | `data-id`, `data-entity` |
| Wall | `wall`, `fp-wall` | `data-id` |
| Device | `item`, `fp-item` | `data-id`, `data-entity`, `data-kind` |
| Text | `text`, `fp-text` | `data-id` |
| Tracker | `tracker`, `fp-tracker` | `data-id` |

The issue named areas, furniture and openings. I did the rest too — stopping short would leave the identical complaint for walls and devices, and it's the same one-liner each. `data-entity` is included because "style whatever is bound to `light.kitchen`" is the rule people actually want to write, and it's the one hook that survives renaming an element.

```yaml
card_mod:
  style: |
    .fp-area[data-id="area_a5r5nwl"] { fill: #62f202; fill-opacity: 0.35; }
    .fp-furniture-sofa { opacity: 0.5; }
    [data-entity="light.kitchen"] { filter: drop-shadow(0 0 6px gold); }
```

### On sanitising

Values pass through two small guards. `cssIdent` keeps `[A-Za-z0-9_-]`; `cssEntityId` also keeps the dot, since entity ids are `domain.object_id` and `[data-entity="light.kitchen"]` is what people will write — stripping the dot would make the hook silently never match. They're deliberately two functions: a dot is fine in an attribute value and wrong in a class name.

To be clear about the threat model — this **isn't** about breakout, since Lit escapes attribute values. It's about the emitted DOM being *predictable*, which is the whole point of a styling hook: whitespace in a value would quietly add a second class (a furniture type of `sofa fp-wall` would restyle every wall). Anything that sanitises to empty emits **no attribute**, per your note — `data-id="undefined"` would be a hook that matches every element lacking an id.

### Verification

On a rendered card, all seven element types resolve by `[data-id="…"]`, `data-entity` resolves the bound entity, and the markup contains no `"undefined"`.

I also checked the use case rather than just the attributes — injecting a card-mod-style block:

| | Before | After |
| --- | --- | --- |
| `.fp-area[data-id=…]` fill | `rgb(217, 202, 254)` | `rgb(0, 255, 0)` |
| fill-opacity | `0.25` | `0.75` |

CSS beats SVG presentation attributes, so `fill` / `fill-opacity` are drivable this way — the thing that made your colour-matching workaround necessary.

**538 tests** (11 new, including that a hostile id collapses to one harmless token and that a missing id omits the attribute), typecheck and build clean.

### Your "related idea" — already shipped

> Adding `entity` + `stateColor` to Area, matching what furniture already supports…

That landed in **v1.1.0**, with the editor UI for it in **v1.1.2**. Areas now take `entity`, `stateColor`, `activeColor`, `activeOpacity` and `highlight` (fill / border / both), all reachable from the visual editor — so a sensor-driven room fill needs no CSS at all now. Worth an upgrade before reaching for card-mod.

One caveat noted in the README: these are a *styling* surface, not an API. The class names are stable, but the SVG structure inside an element may change between releases, so prefer selecting the element over its internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)