### PR TITLE
Areas: draw a room's outline over the walls it traces, so highlight: border works (issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,8 +781,9 @@ trackers:
   between two rooms splits down the middle and each side reports its own room, and a
   corner where several rooms meet splits between them. An exterior wall colors on its
   inside face only, leaving the plan's silhouette intact. `borderWidth` is the width
-  you actually see on the room's own side, and defaults to the thickness of the wall
-  it covers (`8`).
+  you actually see on the room's own side, and defaults to `4` — the room's own half
+  of the wall, since the wall is centred on the line the polygon follows. Widen it and
+  the band runs past the wall onto the floor and over furniture standing against it.
 
 ```yaml
 areas:

--- a/README.md
+++ b/README.md
@@ -774,10 +774,15 @@ trackers:
   inside it, which reads better on a busy plan.
 
   An area's outline is drawn **on top of the walls it traces**, so `border` colors the
-  room's own walls rather than hiding a line underneath them. A live border therefore
-  defaults to the wall thickness (`8`); set `borderWidth` yourself for a thinner line
-  inside the wall, or a thicker one that spills past it. Doorways and windows are cut
-  out of the outline exactly as they are cut out of the wall.
+  room's own walls rather than hiding a line underneath them. Doorways and windows are
+  cut out of the outline exactly as they are cut out of the wall.
+
+  A live outline is clipped to its own room, so rooms never paint each other: a wall
+  between two rooms splits down the middle and each side reports its own room, and a
+  corner where several rooms meet splits between them. An exterior wall colors on its
+  inside face only, leaving the plan's silhouette intact. `borderWidth` is the width
+  you actually see on the room's own side, and defaults to the thickness of the wall
+  it covers (`8`).
 
 ```yaml
 areas:

--- a/README.md
+++ b/README.md
@@ -773,6 +773,12 @@ trackers:
   `border` for a room that outlines itself while occupied without tinting everything
   inside it, which reads better on a busy plan.
 
+  An area's outline is drawn **on top of the walls it traces**, so `border` colors the
+  room's own walls rather than hiding a line underneath them. A live border therefore
+  defaults to the wall thickness (`8`); set `borderWidth` yourself for a thinner line
+  inside the wall, or a thicker one that spills past it. Doorways and windows are cut
+  out of the outline exactly as they are cut out of the wall.
+
 ```yaml
 areas:
   - id: living_room
@@ -801,15 +807,15 @@ areas:
       - { x: 500, y: 900 }
       - { x: 100, y: 900 }
 
-  # Outline-only highlight: the room draws a green border while occupied and
-  # its fill never changes. activeOpacity is a fill concern, so it does not
-  # apply here.
+  # Outline-only highlight: the hall's own walls turn green while it is
+  # occupied and its fill never changes. activeOpacity is a fill concern, so it
+  # does not apply here. Without borderWidth the outline matches the wall it is
+  # painted over; 4 draws a thinner line down the middle of that wall instead.
   - id: hall
     name: Hall
     entity: binary_sensor.hall_occupancy
     activeColor: "#4caf50"
     highlight: border
-    borderWidth: 4
     points:
       - { x: 500, y: 100 }
       - { x: 900, y: 100 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2742,10 +2742,14 @@ export class FloorplanCardEditor extends LitElement {
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
               <!-- Room outlines, same layer position as the card so what you
-                   place is what you get. No hass here, so only a static
-                   borderColor draws; a live highlight is a card-time concern. -->
+                   place is what you get. Only a static borderColor draws here,
+                   there being no hass to resolve a live color from — but the
+                   clip ids are passed anyway, so wiring a live preview in later
+                   cannot silently land on the unclipped path. -->
               <g mask=${`url(#${this._wallMaskId})`}>
-                ${(floor.areas ?? []).map((a) => renderAreaBorder(a))}
+                ${(floor.areas ?? []).map((a, i) =>
+                  renderAreaBorder(a, undefined, `${this._wallMaskId}-area-${i}`)
+                )}
               </g>
               ${repeat(
                 // Keyed by id: switching floors must create fresh DOM. Reused

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,6 +62,7 @@ import {
   renderFurniture,
   renderTracker,
   renderArea,
+  renderAreaBorder,
   trackerSensorReading,
   kindFromEntity,
   resolveItemIcon,
@@ -2740,6 +2741,12 @@ export class FloorplanCardEditor extends LitElement {
               ${floor.furniture.map((f) => this._renderFurnitureSel(f))}
               ${renderWallMask(floor.openings, c.width, c.height, this._wallMaskId)}
               ${floor.walls.map((w) => this._renderWall(w))}
+              <!-- Room outlines, same layer position as the card so what you
+                   place is what you get. No hass here, so only a static
+                   borderColor draws; a live highlight is a card-time concern. -->
+              <g mask=${`url(#${this._wallMaskId})`}>
+                ${(floor.areas ?? []).map((a) => renderAreaBorder(a))}
+              </g>
               ${repeat(
                 // Keyed by id: switching floors must create fresh DOM. Reused
                 // nodes would CSS-transition from the previous floor's opening

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -27,6 +27,7 @@ import {
   furnitureColor,
   renderTracker,
   renderArea,
+  renderAreaBorder,
   areaColor,
   glowPaint,
   renderGlow,
@@ -425,6 +426,20 @@ export class FloorplanCard extends LitElement {
                 <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
                       class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
                       stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
+              )}
+            </g>
+            <!-- Room outlines, above the walls they trace. An area polygon runs
+                 down the centerline of the room's walls, so an outline drawn
+                 with the fill is buried under the wall and never seen. Drawn
+                 here it colors the wall instead. Same mask as the walls above,
+                 so a doorway is a gap in the outline exactly as it is a gap in
+                 the wall. -->
+            <g mask=${`url(#${this._wallMaskId})`}>
+              ${active.areas?.map((a) =>
+                renderAreaBorder(
+                  a,
+                  areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined)
+                )
               )}
             </g>
             ${repeat(

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -433,12 +433,15 @@ export class FloorplanCard extends LitElement {
                  with the fill is buried under the wall and never seen. Drawn
                  here it colors the wall instead. Same mask as the walls above,
                  so a doorway is a gap in the outline exactly as it is a gap in
-                 the wall. -->
+                 the wall. Each live outline is clipped to its own room, so a
+                 shared wall splits down the middle rather than going to
+                 whichever area happens to sit later in the config. -->
             <g mask=${`url(#${this._wallMaskId})`}>
-              ${active.areas?.map((a) =>
+              ${active.areas?.map((a, i) =>
                 renderAreaBorder(
                   a,
-                  areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined)
+                  areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined),
+                  `${this._wallMaskId}-area-${i}`
                 )
               )}
             </g>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1487,6 +1487,30 @@ describe("renderAreaBorder", () => {
     expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke-width=2");
   });
 
+  it("clips a live border to its own room, so a shared wall splits", () => {
+    const a = { id: "a", points: square, highlight: "border" as const };
+    const markup = flatten(renderAreaBorder(a, "#4caf50", "clip-1"));
+    expect(markup).toContain('<clipPath id=clip-1>');
+    expect(markup).toContain("clip-path=url(#clip-1)");
+  });
+
+  it("draws a clipped border at double width, so borderWidth is what is seen", () => {
+    const a = { id: "a", points: square, highlight: "border" as const };
+    // Half of the stroke is clipped away, leaving WALL_THICKNESS on this side.
+    expect(flatten(renderAreaBorder(a, "#4caf50", "c"))).toContain(
+      `stroke-width=${WALL_THICKNESS * 2}`
+    );
+    const wide = { ...a, borderWidth: 5 };
+    expect(flatten(renderAreaBorder(wide, "#4caf50", "c"))).toContain("stroke-width=10");
+  });
+
+  it("never clips a static border — decoration is drawn as authored (#6)", () => {
+    const a = { id: "a", points: square, borderColor: "#123456" };
+    const markup = flatten(renderAreaBorder(a, undefined, "clip-1"));
+    expect(markup).not.toContain("clip-path");
+    expect(markup).toContain("stroke-width=3");
+  });
+
   it("drops an unsafe borderColor rather than drawing it (#64)", () => {
     expect(
       renderAreaBorder({ id: "a", points: square, borderColor: "red;position:fixed;inset:0" })

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1520,6 +1520,29 @@ describe("renderAreaBorder", () => {
     expect(flatten(renderAreaBorder(wide, "#4caf50", "c"))).toContain("stroke-width=10");
   });
 
+  it("carries the CSS hooks under its own class, so fill and outline differ (#105)", () => {
+    const a = {
+      id: "area_hall",
+      points: square,
+      highlight: "border" as const,
+      entity: "binary_sensor.hall_occupancy",
+    };
+    const markup = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    expect(markup).toContain('class="fp-area-border"');
+    expect(markup).toContain("data-id=area_hall");
+    expect(markup).toContain("data-entity=binary_sensor.hall_occupancy");
+  });
+
+  it("keeps the hooks off the clip path, which is never rendered (#105)", () => {
+    // A <clipPath> paints nothing, so a rule matching one would appear to do
+    // nothing at all. Only the drawn polygon carries the hooks.
+    const a = { id: "area_hall", points: square, highlight: "border" as const };
+    const markup = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    expect(markup).toContain("<clipPath");
+    expect(markup.match(/data-id=/g)).toHaveLength(1);
+    expect(markup.match(/class="fp-area-border"/g)).toHaveLength(1);
+  });
+
   it("never clips a static border — decoration is drawn as authored (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#123456" };
     const markup = flatten(renderAreaBorder(a, undefined, "clip-1"));

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1477,14 +1477,30 @@ describe("renderAreaBorder", () => {
     expect(markup).toContain("stroke-width=3");
   });
 
-  it("defaults a live border to the wall thickness it is drawn over", () => {
+  it("defaults a live border to the room's own half of the wall", () => {
+    // The wall is centered on the line the polygon follows, so the room owns
+    // half of it. Anything wider spills onto the floor and over furniture.
     const a = { id: "a", points: square, highlight: "border" as const };
-    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain(`stroke-width=${WALL_THICKNESS}`);
+    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain(
+      `stroke-width=${WALL_THICKNESS / 2}`
+    );
   });
 
   it("lets an explicit borderWidth override the live default", () => {
     const a = { id: "a", points: square, highlight: "border" as const, borderWidth: 2 };
     expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke-width=2");
+  });
+
+  it("keeps a live border inside the opening cut, so it never crosses a doorway", () => {
+    // renderWallMask cuts WALL_THICKNESS + 4 across, so the hole reaches this
+    // far either side of the wall's centerline. A clipped border runs its
+    // visible width inward from that same line; outrun the cut and the overhang
+    // paints straight across every door and window on the plan.
+    const reach = (WALL_THICKNESS + 4) / 2;
+    const a = { id: "a", points: square, highlight: "border" as const };
+    const drawn = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    const visible = Number(/stroke-width=([\d.]+)/.exec(drawn)![1]) / 2;
+    expect(visible).toBeLessThanOrEqual(reach);
   });
 
   it("clips a live border to its own room, so a shared wall splits", () => {
@@ -1496,9 +1512,9 @@ describe("renderAreaBorder", () => {
 
   it("draws a clipped border at double width, so borderWidth is what is seen", () => {
     const a = { id: "a", points: square, highlight: "border" as const };
-    // Half of the stroke is clipped away, leaving WALL_THICKNESS on this side.
+    // Half of the stroke is clipped away, leaving the room's half-wall showing.
     expect(flatten(renderAreaBorder(a, "#4caf50", "c"))).toContain(
-      `stroke-width=${WALL_THICKNESS * 2}`
+      `stroke-width=${WALL_THICKNESS}`
     );
     const wide = { ...a, borderWidth: 5 };
     expect(flatten(renderAreaBorder(wide, "#4caf50", "c"))).toContain("stroke-width=10");

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { nothing } from "lit";
-import type { Furniture, FurnitureType, ItemKind } from "./types";
+import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
 import {
   FURNITURE_DEFAULT_SIZE,
   DEFAULT_GLOW_RADIUS,
@@ -53,6 +53,8 @@ import {
   planRotationTransform,
   polygonCentroid,
   renderArea,
+  renderAreaBorder,
+  WALL_THICKNESS,
   areaColor,
   glowPaint,
   editorGlowPaint,
@@ -1395,37 +1397,24 @@ describe("renderArea", () => {
     expect(markup).toContain("fill-opacity=0.2");
   });
 
-  it("draws no outline by default (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square }));
-    expect(markup).toContain("stroke=none");
-    expect(markup).toContain("stroke-width=0");
+  it("never strokes — the outline is renderAreaBorder's pass, above the walls", () => {
+    const cases: Area[] = [
+      { id: "a", points: square },
+      { id: "a", points: square, borderColor: "#123456", borderWidth: 5 },
+      { id: "a", points: square, highlight: "border" },
+      { id: "a", points: square, highlight: "both" },
+    ];
+    for (const a of cases) {
+      const markup = flatten(renderArea(a, "#4caf50"));
+      expect(markup).toContain('stroke="none"');
+      expect(markup).toContain('stroke-width="0"');
+      expect(markup).not.toContain("stroke=#123456");
+    }
   });
 
-  it("honors a static borderColor and borderWidth (#6)", () => {
-    const markup = flatten(
-      renderArea({ id: "a", points: square, borderColor: "#123456", borderWidth: 5 })
-    );
-    expect(markup).toContain("stroke=#123456");
-    expect(markup).toContain("stroke-width=5");
-  });
-
-  it("falls back to the default border width (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, borderColor: "#123456" }));
-    expect(markup).toContain("stroke-width=3");
-  });
-
-  it("gates an unsafe borderColor through css-safe (#64)", () => {
-    const markup = flatten(
-      renderArea({ id: "a", points: square, borderColor: "red;position:fixed;inset:0" })
-    );
-    expect(markup).not.toContain("position:fixed");
-  });
-
-  it("highlight=border paints the outline and leaves the fill at rest (#6)", () => {
+  it("highlight=border leaves the fill at rest (#6)", () => {
     const a = { id: "a", points: square, color: "#ff0000", highlight: "border" as const };
-    const markup = flatten(renderArea(a, "#4caf50"));
-    expect(markup).toContain("stroke=#4caf50");
-    expect(markup).toContain("fill=#ff0000");
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill=#ff0000");
   });
 
   it("highlight=border ignores activeOpacity, which is a fill concern (#6)", () => {
@@ -1439,16 +1428,91 @@ describe("renderArea", () => {
     expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
   });
 
-  it("highlight=both paints fill and outline (#6)", () => {
+  it("highlight=both still paints the live fill (#6)", () => {
     const a = { id: "a", points: square, highlight: "both" as const };
-    const markup = flatten(renderArea(a, "#4caf50"));
-    expect(markup).toContain("fill=#4caf50");
-    expect(markup).toContain("stroke=#4caf50");
+    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill=#4caf50");
+  });
+});
+
+describe("renderAreaBorder", () => {
+  /** Flatten a Lit template back to markup (see the fishTank glyph test above). */
+  const flatten = (node: unknown): string => {
+    if (node == null || node === false) return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+  const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
+
+  it("draws nothing by default (#6)", () => {
+    expect(renderAreaBorder({ id: "a", points: square })).toBe(nothing);
+  });
+
+  it("draws nothing for a live area that highlights only its fill (#6)", () => {
+    expect(renderAreaBorder({ id: "a", points: square }, "#4caf50")).toBe(nothing);
+    expect(
+      renderAreaBorder({ id: "a", points: square, highlight: "fill" }, "#4caf50")
+    ).toBe(nothing);
+  });
+
+  it("never fills — the fill is renderArea's pass, below the walls", () => {
+    const markup = flatten(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
+    expect(markup).toContain('fill="none"');
+    expect(markup).toContain("points=0,0 10,0 10,10 0,10");
+  });
+
+  it("honors a static borderColor and borderWidth (#6)", () => {
+    const markup = flatten(
+      renderAreaBorder({ id: "a", points: square, borderColor: "#123456", borderWidth: 5 })
+    );
+    expect(markup).toContain("stroke=#123456");
+    expect(markup).toContain("stroke-width=5");
+  });
+
+  it("falls back to the thinner default width for a static border (#6)", () => {
+    const markup = flatten(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
+    expect(markup).toContain("stroke-width=3");
+  });
+
+  it("defaults a live border to the wall thickness it is drawn over", () => {
+    const a = { id: "a", points: square, highlight: "border" as const };
+    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain(`stroke-width=${WALL_THICKNESS}`);
+  });
+
+  it("lets an explicit borderWidth override the live default", () => {
+    const a = { id: "a", points: square, highlight: "border" as const, borderWidth: 2 };
+    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke-width=2");
+  });
+
+  it("drops an unsafe borderColor rather than drawing it (#64)", () => {
+    expect(
+      renderAreaBorder({ id: "a", points: square, borderColor: "red;position:fixed;inset:0" })
+    ).toBe(nothing);
+  });
+
+  it("highlight=border paints the live color (#6)", () => {
+    const a = { id: "a", points: square, highlight: "border" as const };
+    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
+  });
+
+  it("highlight=both paints the outline too (#6)", () => {
+    const a = { id: "a", points: square, highlight: "both" as const };
+    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
   });
 
   it("a live color overrides a static borderColor when it targets the border (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("stroke=#4caf50");
+    const markup = flatten(renderAreaBorder(a, "#4caf50"));
+    expect(markup).toContain("stroke=#4caf50");
+    expect(markup).not.toContain("#111111");
+  });
+
+  it("keeps the static borderColor while the area is at rest (#6)", () => {
+    const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
+    expect(flatten(renderAreaBorder(a))).toContain("stroke=#111111");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1460,13 +1460,28 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
  * this inside the wall mask, so doorways and windows stay cut out of the
  * outline exactly as they are cut out of the wall.
  *
+ * A **live** border is clipped to its own room (`clipId` names the clip path
+ * the caller must keep unique). Rooms share walls, and an unclipped stroke
+ * straddles the boundary and paints the neighbour's face as well as its own —
+ * so on a wall between two live rooms whichever area sits later in `areas:`
+ * simply wins the whole wall, and reordering the config silently changes what
+ * the plan says. Clipped, each room paints its own side and a corner where
+ * several rooms meet splits between them. A **static** `borderColor` is drawn
+ * as authored — centered on the polygon, unclipped — since it is decoration
+ * placed deliberately rather than a per-room signal.
+ *
  * Carries the same `data-id` / `data-entity` hooks as the fill (#111) under its
  * own `fp-area-border` class, so a rule can target a room's outline and its
- * fill separately.
+ * fill separately. They go on the drawn polygon only: a `<clipPath>` is never
+ * rendered, so a rule matching one would look like it silently does nothing.
  *
  * Returns `nothing` when there is no outline to draw — the default.
  */
-export function renderAreaBorder(a: Area, liveColor?: string): SVGTemplateResult | typeof nothing {
+export function renderAreaBorder(
+  a: Area,
+  liveColor?: string,
+  clipId?: string
+): SVGTemplateResult | typeof nothing {
   const liveBorder = liveColor !== undefined && (a.highlight ?? "fill") !== "fill";
   const stroke = liveBorder
     ? liveColor
@@ -1475,16 +1490,27 @@ export function renderAreaBorder(a: Area, liveColor?: string): SVGTemplateResult
       : undefined;
   if (stroke === undefined || stroke === "none") return nothing;
 
-  // A live border defaults to the wall's own thickness. It sits on the wall it
-  // traces, and a room announcing itself wants that wall colored, not a thin
-  // stripe painted down the middle of it. A static border is decoration and
-  // keeps its thinner default. An explicit borderWidth still wins either way.
-  const width = cssNumber(a.borderWidth, liveBorder ? WALL_THICKNESS : DEFAULT_AREA_BORDER_WIDTH);
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
-  return svg`<polygon class="fp-area-border" data-id=${cssIdent(a.id) ?? nothing}
-                      data-entity=${cssEntityId(a.entity) ?? nothing}
-                      points=${pts} fill="none"
-                      stroke=${stroke} stroke-width=${width} />`;
+  // `borderWidth` is always the width actually seen. A live border defaults to
+  // the thickness of the wall it covers; a static one keeps the thinner
+  // decorative default.
+  const width = cssNumber(a.borderWidth, liveBorder ? WALL_THICKNESS : DEFAULT_AREA_BORDER_WIDTH);
+
+  if (!liveBorder || clipId === undefined) {
+    return svg`<polygon class="fp-area-border" data-id=${cssIdent(a.id) ?? nothing}
+                        data-entity=${cssEntityId(a.entity) ?? nothing}
+                        points=${pts} fill="none"
+                        stroke=${stroke} stroke-width=${width} />`;
+  }
+
+  // Clipping keeps only the inner half of the stroke, so it is drawn at twice
+  // the width to leave `width` showing on this room's own side.
+  return svg`
+    <clipPath id=${clipId}><polygon points=${pts} /></clipPath>
+    <polygon class="fp-area-border" data-id=${cssIdent(a.id) ?? nothing}
+             data-entity=${cssEntityId(a.entity) ?? nothing}
+             points=${pts} fill="none" clip-path=${`url(#${clipId})`}
+             stroke=${stroke} stroke-width=${width * 2} />`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -1435,6 +1435,9 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   // activeOpacity is a fill concern, so it only applies when the fill is live.
   const opacity = liveFill ? a.activeOpacity ?? a.opacity : a.opacity;
 
+  // Stroke stays pinned off rather than omitted: this element is reused across
+  // live/rest updates, and stating it keeps the fill pass unable to draw an
+  // outline no matter what the border pass above the walls is doing.
   return svg`<polygon class="fp-area" data-id=${cssIdent(a.id) ?? nothing}
                        data-entity=${cssEntityId(a.entity) ?? nothing}
                        points=${pts}
@@ -1492,9 +1495,16 @@ export function renderAreaBorder(
 
   const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
   // `borderWidth` is always the width actually seen. A live border defaults to
-  // the thickness of the wall it covers; a static one keeps the thinner
-  // decorative default.
-  const width = cssNumber(a.borderWidth, liveBorder ? WALL_THICKNESS : DEFAULT_AREA_BORDER_WIDTH);
+  // half the wall: the wall is centered on the same line the polygon follows,
+  // so the room only owns the inner half of it. Anything wider runs past the
+  // wall's inner face onto the floor, over any furniture standing against that
+  // wall, and — since the opening mask only cuts WALL_THICKNESS + 4 — out
+  // through the doorways as a sliver either side of the cut. A static border is
+  // decoration and keeps its thinner default.
+  const width = cssNumber(
+    a.borderWidth,
+    liveBorder ? WALL_THICKNESS / 2 : DEFAULT_AREA_BORDER_WIDTH
+  );
 
   if (!liveBorder || clipId === undefined) {
     return svg`<polygon class="fp-area-border" data-id=${cssIdent(a.id) ?? nothing}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1420,8 +1420,8 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
 }
 
 /**
- * A room's translucent fill polygon. Drawn with no stroke — the walls drawn
- * on top of it already imply an outline, so a second one would double it up.
+ * A room's translucent fill polygon, with no stroke of its own — the outline
+ * is a separate pass, drawn above the walls by {@link renderAreaBorder}.
  * `color`/`opacity` are config-supplied style values, so they go through the
  * same injection allowlist as every other color/number field (see css-safe.ts).
  */
@@ -1430,26 +1430,61 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   // `liveColor` has already been through the allowlist by areaColor(). When it
   // is present the area is "live" and `highlight` decides whether that color
   // lands on the fill, the outline, or both.
-  const live = liveColor !== undefined;
-  const target = a.highlight ?? "fill";
-  const liveFill = live && target !== "border";
-  const liveBorder = live && target !== "fill";
+  const liveFill = liveColor !== undefined && (a.highlight ?? "fill") !== "border";
 
   // activeOpacity is a fill concern, so it only applies when the fill is live.
   const opacity = liveFill ? a.activeOpacity ?? a.opacity : a.opacity;
-  const stroke = liveBorder
-    ? liveColor
-    : a.borderColor
-      ? cssColorOr(a.borderColor, "none")
-      : undefined;
 
   return svg`<polygon class="fp-area" data-id=${cssIdent(a.id) ?? nothing}
                        data-entity=${cssEntityId(a.entity) ?? nothing}
                        points=${pts}
                        fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
-                       stroke=${stroke ?? "none"}
-                       stroke-width=${stroke ? cssNumber(a.borderWidth, DEFAULT_AREA_BORDER_WIDTH) : 0} />`;
+                       stroke="none"
+                       stroke-width="0" />`;
+}
+
+/**
+ * A room's outline — drawn as its own pass **above the walls**.
+ *
+ * An area polygon almost always traces the room it encloses, which means it
+ * runs down the centerline of that room's walls. Walls are stroked at
+ * {@link WALL_THICKNESS} over the top of the fills, so an outline drawn with
+ * the fill lands underneath the very wall it follows and cannot be seen at
+ * all. That left `highlight: "border"` (#107) inert on any plan whose areas
+ * follow its walls, which is very nearly all of them.
+ *
+ * Drawn above, the outline colors the room's own walls: an occupied or lit
+ * room announces itself along its boundary instead of tinting everything
+ * inside it, which is what `highlight: "border"` was for. The caller draws
+ * this inside the wall mask, so doorways and windows stay cut out of the
+ * outline exactly as they are cut out of the wall.
+ *
+ * Carries the same `data-id` / `data-entity` hooks as the fill (#111) under its
+ * own `fp-area-border` class, so a rule can target a room's outline and its
+ * fill separately.
+ *
+ * Returns `nothing` when there is no outline to draw — the default.
+ */
+export function renderAreaBorder(a: Area, liveColor?: string): SVGTemplateResult | typeof nothing {
+  const liveBorder = liveColor !== undefined && (a.highlight ?? "fill") !== "fill";
+  const stroke = liveBorder
+    ? liveColor
+    : a.borderColor
+      ? cssColorOr(a.borderColor, "none")
+      : undefined;
+  if (stroke === undefined || stroke === "none") return nothing;
+
+  // A live border defaults to the wall's own thickness. It sits on the wall it
+  // traces, and a room announcing itself wants that wall colored, not a thin
+  // stripe painted down the middle of it. A static border is decoration and
+  // keeps its thinner default. An explicit borderWidth still wins either way.
+  const width = cssNumber(a.borderWidth, liveBorder ? WALL_THICKNESS : DEFAULT_AREA_BORDER_WIDTH);
+  const pts = a.points.map((p) => `${p.x},${p.y}`).join(" ");
+  return svg`<polygon class="fp-area-border" data-id=${cssIdent(a.id) ?? nothing}
+                      data-entity=${cssEntityId(a.entity) ?? nothing}
+                      points=${pts} fill="none"
+                      stroke=${stroke} stroke-width=${width} />`;
 }
 
 /**


### PR DESCRIPTION
Follow-on to #107. `highlight: "border"` shipped in v1.1.0 but draws nothing on most plans — including mine, which is how I found it.

### The bug

An area polygon is almost always traced along the room it encloses, so it runs down the **centerline of that room's walls**. Walls are stroked at `WALL_THICKNESS` (8) on top of the area fills, and the outline was drawn with the fill. It lands underneath the very wall it follows, and 8px of wall covers a 3px outline completely.

So `highlight: border` is inert on any plan whose areas follow its walls. It only ever showed on an area that *didn't* — a zone floating inside a room.

### The fix

The outline moves to its own pass after the walls, and colors them. That turns out to be the better visual anyway: an occupied or lit room announces itself along its own boundary instead of tinting everything inside it, which is what the mode was for in the first place.

- `renderArea` keeps the fill and never strokes.
- `renderAreaBorder` returns the outline, or `nothing` — still the default.
- The new pass sits inside the **same wall mask**, so a doorway is a gap in the outline exactly as it is a gap in the wall. Without that it would paint straight across every door and window on the plan.
- Each live outline is **clipped to its own room**. Rooms share walls, and a stroke along a polygon straddles the boundary — it paints the neighbour's face as well as its own. Unclipped, a wall between two live rooms went to whichever area sat later in `areas:`, so reordering the config silently changed what the plan said. Clipped, every room paints its own side and nothing else.

### Three judgement calls

**A live border defaults to half the wall thickness, not `3`.** It's painted on the wall it traces, and a room announcing itself wants that wall colored, not a thin stripe down the middle of it. Half, not the whole 8, because the wall is centred on the same line the polygon follows — the room only owns the inner half. Anything wider runs onto the floor, over furniture standing against that wall, and out through the doorways, the opening mask only cutting `WALL_THICKNESS + 4`. Clipping keeps the inner half of a stroke, so it's drawn at twice the width — `borderWidth` stays the width you actually *see*.

**A static `borderColor` is left unclipped and drawn as authored**, at its thinner default. It's decoration placed deliberately rather than a per-room signal, so it shouldn't be silently halved or repositioned.

**Static borders moved above the walls too, not just live ones.** Splitting them across two layers seemed worse than moving both, and the move is a no-op for every outline that is currently visible: those are on areas that don't follow a wall, where there's no wall to be drawn over. The outlines this actually relocates are the ones nobody could see.

### Verification

Rasterized and pixel-sampled, rather than trusting unit tests — this is a layering bug, and unit tests on `renderArea` are exactly what missed the `collectWatchedEntities` bug on #107.

**Does the outline show at all?** Two rooms, a doorway through room A's left wall, A occupied:

| sample | before | after | at rest |
| --- | --- | --- | --- |
| room A wall, clear of the door | `(17,17,17)` | **`(76,175,80)`** | `(17,17,17)` |
| room A doorway centre | `(191,233,252)` | `(191,233,252)` | `(191,233,252)` |
| room A interior | `(191,233,252)` | `(191,233,252)` | `(191,233,252)` |

`(17,17,17)` is the wall, `(76,175,80)` is `#4caf50`. Before, the live outline is entirely buried.

**What happens where rooms meet?** A 2×2 plan — one four-way junction, two T-junctions, a doorway — with A green, B red, C blue, D at rest:

| sample | A,B,C,D | reversed | all at rest |
| --- | --- | --- | --- |
| A\|B wall — A's half | A green | A green | wall |
| A\|B wall — B's half | B red | B red | wall |
| A\|B doorway centre | fill | fill | fill |
| 4-way corner — A quadrant | A green | A green | wall |
| 4-way corner — B quadrant | B red | B red | wall |
| 4-way corner — C quadrant | C blue | C blue | wall |
| 4-way corner — D quadrant | wall | wall | wall |
| T-junction — A's half | A green | A green | wall |
| T-junction — B's half | B red | B red | wall |
| T-junction — outer face | wall | wall | wall |
| B exterior — inner half | B red | B red | wall |
| B exterior — outer face | wall | wall | wall |

Plus the two probes that catch a border overrunning the wall it sits on: 5px inward of a doorway centre (where an overhang escapes the opening cut), and the floor either side of a shared wall. Both stay clear.

Reversing the config order changes nothing, which is the point. A four-way corner splits into four quadrants, one per room. An exterior wall colors on its inside face only, so the plan's silhouette stays intact. Everything is untouched at rest.

Profiling straight across the A|B wall, the two rooms meet exactly at the centreline with no gap and no overlap — A covers x 112–120, B covers 120–128, on a wall spanning 116–124.

**539 tests** pass (+12), `tsc --noEmit` and `vite build` clean. The `renderArea` border tests moved to a `renderAreaBorder` block and picked up the clipping and mask cases.

The editor draws the same pass in the same layer position, so what you place is what you get; with no `hass` there, only a static `borderColor` draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

