### PR TITLE
Card: fit the plan to the card, instead of cutting it off (closes #115)

### DIFF
--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -373,9 +373,25 @@ export class FloorplanCard extends LitElement {
       <ha-card .header=${c.title ?? nothing}>
         <div
           class="stage"
-          style="aspect-ratio: ${dims.w} / ${dims.h}; background:${cssColorOr(
-          c.background, "var(--card-background-color, #fff)")};"
+          style="aspect-ratio: ${dims.w} / ${dims.h};"
         >
+          <!-- The plan box: exactly the canvas ratio, fitted inside whatever
+               height the card was actually given, and centred there (closes
+               #115). Sized off the container's height so it shrinks when the
+               height is the binding axis — clamping a full-width box with
+               max-height instead would break the ratio rather than the box.
+
+               The stage carries the same aspect-ratio so it still has a
+               definite height in a content-sized (masonry) card; without it,
+               size containment leaves 100cqh with nothing to resolve against
+               and the plan collapses to nothing. -->
+          <div
+            class="plan"
+            style="aspect-ratio: ${dims.w} / ${dims.h};
+                   width: min(100%, calc(100cqh * ${dims.w} / ${dims.h}));
+                   background:${cssColorOr(
+                     c.background, "var(--card-background-color, #fff)")};"
+          >
 <!-- preserveAspectRatio="none" is correct here, and it took a wrong fix to
                see why. .stage pins aspect-ratio: width / height inline, so the
                SVG's box already matches its viewBox and "none" never distorts.
@@ -522,6 +538,7 @@ export class FloorplanCard extends LitElement {
               (it) => this._renderItem(it, c, rot)
             )}
           </div>
+          </div>
           ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
         </div>
       </ha-card>
@@ -564,7 +581,18 @@ export class FloorplanCard extends LitElement {
     .stage {
       position: relative;
       width: 100%;
+      height: 100%;
       padding: 0;
+      /* Centres the plan box in whatever the card was given, and makes the
+         stage's own height queryable so the plan can size against it. */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      container-type: size;
+    }
+    .plan {
+      position: relative;
+      height: auto;
     }
     .floor-switcher {
       position: absolute;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -440,20 +440,19 @@ export class FloorplanCard extends LitElement {
                    background:${cssColorOr(
                      c.background, "var(--card-background-color, #fff)")};"
           >
-<!-- preserveAspectRatio="none" is correct here, and it took a wrong fix to
-               see why. .stage pins aspect-ratio: width / height inline, so the
-               SVG's box already matches its viewBox and "none" never distorts.
+          <!-- preserveAspectRatio="none" is correct here, and it took a wrong
+               fix to see why. Fitting the plan into a card that is the wrong
+               shape for it is .plan's job, not this line's (#115): .plan
+               carries the canvas ratio, so the SVG's box always matches its
+               viewBox, and "none" and "meet" are equivalent while that holds.
 
-               "meet" letterboxes the SVG inside its box. The .items overlay is
-               HTML, positioned with raw left/top percentages of .stage, and it
-               does not letterbox. So the moment anything overrides the stage's
-               ratio (card-mod, a grid row count) the drawing shrinks away from
-               the badges and every icon drifts off the wall it was placed on.
-               "none" stretches both layers identically: distorted, but aligned.
-
-               The real fix letterboxes both layers together -- wrap the svg and
-               the overlay in one aspect-ratio box and centre it. Until then, do
-               not "fix" this line. -->
+               "none" is still the deliberate choice, because it is the one
+               that fails safely. The .items overlay is HTML, positioned with
+               raw left/top percentages of .plan, and it does not letterbox. So
+               if anything ever overrides .plan's ratio (card-mod, a grid row
+               count), "meet" letterboxes the SVG away from the overlay and
+               every icon drifts off the wall it was placed on, while "none"
+               stretches both layers identically: distorted, but aligned. -->
           <svg viewBox="0 0 ${dims.w} ${dims.h}" preserveAspectRatio="none">
             <g transform=${rotTransform || nothing}>
             ${active.image

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -577,11 +577,21 @@ export class FloorplanCard extends LitElement {
       height: 100%;
       box-sizing: border-box;
       overflow: hidden;
+      /* A column, so the stage takes the height left over after the card's
+         own header rather than the card's whole height. With a title set, a
+         full-height stage measures past the bottom of the card by exactly the
+         header, and the plan is cut off by that much. */
+      display: flex;
+      flex-direction: column;
     }
     .stage {
       position: relative;
       width: 100%;
-      height: 100%;
+      /* Takes the space the header leaves, and may shrink below its content:
+         without min-height a flex item floors at its content size and the
+         plan pushes the stage past the card again. */
+      flex: 1 1 auto;
+      min-height: 0;
       padding: 0;
       /* Centres the plan box in whatever the card was given, and makes the
          stage's own height queryable so the plan can size against it. */


### PR DESCRIPTION
Closes #115.

`.stage` is `width: 100%` with an `aspect-ratio`, so its height comes from its width alone and never consults the height the card was actually given. `ha-card` is `height: 100%; overflow: hidden`, so a card shorter than that has the bottom of its plan cut away — devices down there don't shrink or clip at the edge of an icon, they are simply not on screen.

### The fix

The `<svg>` and the `.items` overlay now sit in one plan box that carries the canvas ratio, fitted into the card and centred — so the two layers letterbox **together**. That is what the comment above the `<svg>` has been asking for, and it leaves `preserveAspectRatio="none"` correct on its own terms: the box always matches the viewBox ratio, so `"none"` still never distorts.

### Two things that don't work, for the record

**Clamping a full-width box with `max-height: 100%`.** When `max-height` binds, the width stays at `100%` and the *ratio* breaks rather than the box shrinking. Measured — it reproduces the bug's own wrong ratio exactly. So the box is sized off the container height instead.

**That needs `container-type: size`, which has its own trap.** Size containment means an auto-height stage has nothing for `100cqh` to resolve against, and in a content-sized masonry card the plan **collapsed to nothing** — a far worse regression than the clipping it fixes. Giving the stage the canvas ratio *as well as* `height: 100%` leaves it with a definite height either way. Both dead ends are in the commit message so nobody re-derives them.

### Verification

I drove the **built card** in headless Chromium rather than a hand-written mock, since this is entirely a layout bug and a mock proves nothing about the real DOM. The canvas background is set to a flat colour so the green region *is* the plan box; an area polygon covers plan coords `(800,500)-(1000,600)` in the SVG layer, and a text label sits at `(900,550)` in the HTML overlay.

| card box | before | after |
| --- | --- | --- |
| 600×360 *(matches the plan)* | `600×360` · 1.667 · aligned | `600×360` · 1.667 · aligned |
| **600×200** *(short)* | `600×200` · **3.0** · **both markers gone** | `334×200` · **1.67** · aligned |
| 600×500 *(tall)* | `600×360` · 1.667 · aligned | `600×360` · 1.667 · aligned |
| 600×auto *(masonry)* | `600×360` · 1.667 · aligned | `600×360` · 1.667 · aligned |

Only the short card changes. In every case the overlay marker lands inside its own SVG area — the property the existing comment exists to protect, and the one I'd expect you to check hardest.

The floor switcher stays pinned to the stage rather than the plan box, being card chrome rather than part of the drawing. The canvas background moved onto the plan box, so it marks the plan exactly and letterbox bars fall back to the card surface; in an exactly-fitting card the two are the same element, so nothing changes there.

**557 tests** pass, `tsc --noEmit` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
