### PR TITLE
Wardrobe: any number of door panels, so a fitted run isn't a row of boxes (issue #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,13 +472,22 @@ without turning into the color of the light. Pools never intercept clicks.
 
 ### Furniture
 
-`{ id, type, x, y, w, h, angle?, hand?, color?, entity?, activeColor?, stateColor? }`
+`{ id, type, x, y, w, h, angle?, hand?, doors?, color?, entity?, activeColor?, stateColor? }`
 
 `type` is one of `table`, `roundTable`, `desk`, `chair`, `sofa`, `sectional`, `bed`,
 `wardrobe`, `rug`, `plant`, `fridge`, `stove`, `sink`, `dishwasher`, `washer`, `dryer`,
 `toilet`, `bathtub`, `vanity`, `stairs`, `tv`, `piano`, `fishTank`, `hotTub`,
 `waterHeater`, `airHandler`. `color` defaults to gray so furniture reads differently from
 walls; `hand` (`left` / `right`) picks which end an L-shaped `sectional`'s chaise sits on.
+
+A **wardrobe** takes `doors` (1–12, default 2) for how many panels the front is divided
+into, so a fitted run doesn't have to be faked with a row of boxes. Doors pair up from the
+left and their handles meet at the seam between them; an odd count ends in a single door,
+so seven reads as three double bays plus one.
+
+```yaml
+{ id: closet, type: wardrobe, x: 240, y: 90, w: 420, h: 55, doors: 7 }
+```
 
 Bind an **entity** and `stateColor` / `activeColor` recolor the whole diagram — a plant
 goes red when its soil sensor says it needs watering, a cabinet highlights while its

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -592,6 +592,38 @@ describe("textForm / furnitureForm / trackerForm", () => {
     expect(form.fields.map((x) => x.name)).not.toContain("hand");
     expect("hand" in form.data).toBe(false);
   });
+
+  it("wardrobe offers a door count, defaulting to the classic pair (#90)", () => {
+    const form = furnitureForm({ id: "f", type: "wardrobe", x: 0, y: 0, w: 10, h: 10 } as never);
+    expect(form.fields.map((x) => x.name)).toContain("doors");
+    expect(form.data).toMatchObject({ doors: 2 });
+  });
+
+  it("wardrobe door count is bounded, so the field can't ask for a comb", () => {
+    const form = furnitureForm({ id: "f", type: "wardrobe", x: 0, y: 0, w: 10, h: 10 } as never);
+    expect(form.fields.find((x) => x.name === "doors")!.selector).toEqual({
+      number: { min: 1, max: 12, mode: "box" },
+    });
+  });
+
+  it("keeps a configured door count instead of resetting it", () => {
+    const form = furnitureForm({
+      id: "f",
+      type: "wardrobe",
+      x: 0,
+      y: 0,
+      w: 10,
+      h: 10,
+      doors: 7,
+    } as never);
+    expect(form.data).toMatchObject({ doors: 7 });
+  });
+
+  it("non-wardrobe furniture has no door field or data", () => {
+    const form = furnitureForm({ id: "f", type: "table", x: 0, y: 0, w: 10, h: 10 } as never);
+    expect(form.fields.map((x) => x.name)).not.toContain("doors");
+    expect("doors" in form.data).toBe(false);
+  });
 });
 
 describe("wallForm / projectForm / floorImageForm", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -29,6 +29,9 @@ import {
   DEFAULT_SUN_MIN,
   DEFAULT_SUN_MAX,
   DEFAULT_PRESS_EFFECT,
+  WARDROBE_DOORS_DEFAULT,
+  WARDROBE_DOORS_MIN,
+  WARDROBE_DOORS_MAX,
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
@@ -697,6 +700,24 @@ export function furnitureForm(f: Furniture, areaScope?: AreaEntityScope): FormSp
             },
           ]
         : []),
+      // Wardrobe only (#90): how many door panels the run is divided into, so
+      // a fitted wall of doors doesn't have to be drawn as a row of boxes.
+      ...(f.type === "wardrobe"
+        ? [
+            {
+              name: "doors",
+              label: "Doors",
+              helper: "Panels across the front — they pair up from the left",
+              selector: {
+                number: {
+                  min: WARDROBE_DOORS_MIN,
+                  max: WARDROBE_DOORS_MAX,
+                  mode: "box" as const,
+                },
+              },
+            },
+          ]
+        : []),
       { name: "w", label: "Width", required: true, selector: { number: { min: 10, mode: "box" } } },
       { name: "h", label: "Height", required: true, selector: { number: { min: 10, mode: "box" } } },
       angleField(),
@@ -713,6 +734,7 @@ export function furnitureForm(f: Furniture, areaScope?: AreaEntityScope): FormSp
     data: {
       type: f.type,
       ...(f.type === "sectional" ? { hand: f.hand ?? "right" } : {}),
+      ...(f.type === "wardrobe" ? { doors: f.doors ?? WARDROBE_DOORS_DEFAULT } : {}),
       w: f.w,
       h: f.h,
       angle: f.angle ?? 0,

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -14,6 +14,9 @@ import {
   FURNITURE_GLOW_TRANSMISSION,
   SUN_ELEVATION_NIGHT,
   SUN_ELEVATION_DAY,
+  WARDROBE_DOORS_DEFAULT,
+  WARDROBE_DOORS_MIN,
+  WARDROBE_DOORS_MAX,
 } from "./types";
 import {
   snapToWall,
@@ -44,6 +47,8 @@ import {
   sectionalPoints,
   SECTIONAL_CHAISE_FRACTION,
   SECTIONAL_SEAT_FRACTION,
+  wardrobeDoorLines,
+  wardrobeDoorCount,
   entityDefaultIcon,
   trackerSensorReading,
   openingInMotion,
@@ -1065,6 +1070,112 @@ describe("sectionalPoints", () => {
   });
 });
 
+describe("wardrobeDoorLines", () => {
+  const w = 200;
+
+  it("draws the historic two-door glyph when nothing is configured", () => {
+    // The pair-meeting-in-the-middle wardrobe every existing config already
+    // has: one seam down the centre, handles at ±0.06w. Issue #90 generalized
+    // this glyph, so it must not have moved.
+    expect(wardrobeDoorLines(w)).toEqual({ seams: [0], handles: [-w * 0.06, w * 0.06] });
+    expect(wardrobeDoorLines(w, 2)).toEqual(wardrobeDoorLines(w));
+  });
+
+  it("splits the front into n panels with n-1 seams", () => {
+    for (const n of [1, 2, 3, 5, 7, 12]) {
+      const { seams, handles } = wardrobeDoorLines(w, n);
+      expect(seams, `${n} doors`).toHaveLength(n - 1);
+      expect(handles, `${n} doors`).toHaveLength(n);
+    }
+  });
+
+  it("spaces the seams evenly across the width", () => {
+    expect(wardrobeDoorLines(w, 4).seams).toEqual([-50, 0, 50]);
+  });
+
+  it("gives a single door one handle rather than a bare box", () => {
+    const { seams, handles } = wardrobeDoorLines(w, 1);
+    expect(seams).toEqual([]);
+    expect(handles).toHaveLength(1);
+  });
+
+  it("pairs handles at the seams they meet on", () => {
+    // Seven doors read as three double bays plus a single: handles 0/1 meet at
+    // seam 0, 2/3 at seam 2, 4/5 at seam 4, and door 6 is left over.
+    const { seams, handles } = wardrobeDoorLines(w, 7);
+    for (const [a, b, seam] of [[0, 1, 0], [2, 3, 2], [4, 5, 4]] as const) {
+      expect(handles[a]).toBeLessThan(seams[seam]);
+      expect(handles[b]).toBeGreaterThan(seams[seam]);
+      // symmetric about the seam they share
+      expect(seams[seam] - handles[a]).toBeCloseTo(handles[b] - seams[seam], 9);
+    }
+    expect(handles[6]).toBeGreaterThan(seams[5]);
+  });
+
+  it("keeps the leftover door's handle off the carcass outline", () => {
+    // The handle inset scales with one door's width, so on a long run an
+    // outward-opening last door would put its handle on the outer edge. The
+    // leftover opens inward instead, landing beside the final seam.
+    for (const n of [3, 5, 7, 11]) {
+      const { seams, handles } = wardrobeDoorLines(w, n);
+      const last = handles[n - 1];
+      const doorW = w / n;
+      expect(last, `${n} doors`).toBeCloseTo(seams[n - 2] + doorW * 0.12, 9);
+      // comfortably clear of the right-hand outline
+      expect(w / 2 - last, `${n} doors`).toBeGreaterThan(doorW / 2);
+    }
+  });
+
+  it("still swings the single door outward, where there is room", () => {
+    // One door has no seam to sit beside, and its inset is a full 12% of the
+    // whole box, so the ordinary outward swing reads fine.
+    expect(wardrobeDoorLines(w, 1).handles).toEqual([w / 2 - w * 0.12]);
+  });
+
+  it("keeps every seam and handle inside the box", () => {
+    for (const n of [1, 2, 3, 7, 12]) {
+      for (const x of [...wardrobeDoorLines(w, n).seams, ...wardrobeDoorLines(w, n).handles]) {
+        expect(Math.abs(x), `${n} doors`).toBeLessThanOrEqual(w / 2 + 1e-9);
+      }
+    }
+  });
+
+  it("never lets a handle drift onto a neighbouring door", () => {
+    for (const n of [1, 2, 3, 7, 12]) {
+      const { handles } = wardrobeDoorLines(w, n);
+      const doorW = w / n;
+      handles.forEach((x, i) => {
+        const left = -w / 2 + doorW * i;
+        expect(x, `door ${i} of ${n}`).toBeGreaterThan(left);
+        expect(x, `door ${i} of ${n}`).toBeLessThan(left + doorW);
+      });
+    }
+  });
+});
+
+describe("wardrobeDoorCount", () => {
+  it("falls back to two for anything a hand-written config might carry", () => {
+    for (const bad of [undefined, NaN, Infinity, -Infinity, "3" as unknown as number]) {
+      expect(wardrobeDoorCount(bad), String(bad)).toBe(WARDROBE_DOORS_DEFAULT);
+    }
+  });
+
+  it("clamps to the supported range instead of drawing a comb", () => {
+    expect(wardrobeDoorCount(0)).toBe(WARDROBE_DOORS_MIN);
+    expect(wardrobeDoorCount(-5)).toBe(WARDROBE_DOORS_MIN);
+    expect(wardrobeDoorCount(999)).toBe(WARDROBE_DOORS_MAX);
+  });
+
+  it("rounds a fractional count to whole doors", () => {
+    expect(wardrobeDoorCount(3.4)).toBe(3);
+    expect(wardrobeDoorCount(3.6)).toBe(4);
+  });
+
+  it("passes a sane count through", () => {
+    expect(wardrobeDoorCount(7)).toBe(7);
+  });
+});
+
 describe("every furniture type renders and has a default size", () => {
   const types: FurnitureType[] = [
     "table", "roundTable", "desk", "chair", "sofa", "bed", "wardrobe", "rug",
@@ -1093,6 +1204,16 @@ describe("every furniture type renders and has a default size", () => {
     for (const hand of ["left", "right"] as const) {
       expect(() =>
         renderFurniture({ id: "s", type: "sectional", x: 0, y: 0, w: 230, h: 180, hand }),
+      ).not.toThrow();
+    }
+  });
+
+  it("renders a wardrobe of any door count, including junk from YAML", () => {
+    const { w, h } = FURNITURE_DEFAULT_SIZE.wardrobe;
+    for (const doors of [undefined, 1, 2, 7, 12, 0, -3, 999, NaN, 3.5]) {
+      expect(() =>
+        renderFurniture({ id: "wd", type: "wardrobe", x: 0, y: 0, w, h, doors }),
+        `doors=${doors}`,
       ).not.toThrow();
     }
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -38,6 +38,9 @@ import {
   DEFAULT_PRESS_EFFECT,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
+  WARDROBE_DOORS_DEFAULT,
+  WARDROBE_DOORS_MIN,
+  WARDROBE_DOORS_MAX,
   getFloors,
   trackerAxisFraction,
 } from "./types";
@@ -2426,6 +2429,60 @@ export function sectionalPoints(
   return hand === "left" ? pts.map(([x, y]) => [-x, y] as [number, number]) : pts;
 }
 
+/** How far a handle sits from its door's opening edge, as a fraction of one door's width. */
+export const WARDROBE_HANDLE_INSET = 0.12;
+
+/**
+ * Normalize a configured door count. Hand-written YAML can carry anything, and
+ * a zero or a NaN here would divide the wardrobe into nothing.
+ */
+export function wardrobeDoorCount(doors: number | undefined): number {
+  if (typeof doors !== "number" || !Number.isFinite(doors)) return WARDROBE_DOORS_DEFAULT;
+  return Math.min(WARDROBE_DOORS_MAX, Math.max(WARDROBE_DOORS_MIN, Math.round(doors)));
+}
+
+/**
+ * Where a wardrobe's seams and handles fall, as x offsets from the centre of a
+ * box `w` units wide (issue #90).
+ *
+ * Doors hang in pairs from the left: door 0 opens to the right and door 1 to
+ * the left, so their handles meet at the seam between them. An odd count
+ * leaves the last door single; it hangs from the outer edge and opens inward,
+ * putting its handle beside the final seam. That last part matters visually —
+ * the inset scales with one door's width, so on a seven-door run an
+ * outward-opening leftover would park its handle right on top of the carcass
+ * outline. A seven-door run therefore reads as three double bays plus one.
+ *
+ * At the default of two this reproduces the pair-meeting-in-the-middle glyph
+ * the card has always drawn, handles included.
+ */
+export function wardrobeDoorLines(
+  w: number,
+  doors?: number,
+): { seams: number[]; handles: number[] } {
+  const n = wardrobeDoorCount(doors);
+  const hw = w / 2;
+  const doorW = w / n;
+  const inset = doorW * WARDROBE_HANDLE_INSET;
+
+  const seams: number[] = [];
+  for (let i = 1; i < n; i++) seams.push(-hw + doorW * i);
+
+  // A lone door at the end of an odd run opens inward, so its handle lands by
+  // the last seam rather than on the outer edge. With a single door there is
+  // no seam to fall beside, and the inset is a full 12% of the box, so that
+  // one keeps the ordinary outward swing.
+  const leftover = n > 1 && n % 2 === 1 ? n - 1 : -1;
+
+  const handles: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const left = -hw + doorW * i;
+    const opensRight = i % 2 === 0 && i !== leftover;
+    handles.push(opensRight ? left + doorW - inset : left + inset);
+  }
+  return { seams, handles };
+}
+
 /**
  * A furniture diagram. `override` is the entity-driven color resolved by the
  * caller (issue #82) — see {@link furnitureColor}; the editor passes nothing
@@ -2533,14 +2590,19 @@ export function renderFurniture(f: Furniture, override?: string): SVGTemplateRes
       detail = svg`<line x1=${-hw} y1=${-hh + h * 0.55} x2=${hw} y2=${-hh + h * 0.55}
                          stroke=${color} stroke-width="1.5" opacity="0.7" />`;
       break;
-    case "wardrobe":
+    case "wardrobe": {
+      // Issue #90: any number of door panels, not just the fitted pair.
+      const { seams, handles } = wardrobeDoorLines(w, f.doors);
       detail = svg`
-        <line x1="0" y1=${-hh} x2="0" y2=${hh} stroke=${color} stroke-width="2" />
-        <line x1=${-w * 0.06} y1=${-h * 0.1} x2=${-w * 0.06} y2=${h * 0.1}
-              stroke=${color} stroke-width="2" />
-        <line x1=${w * 0.06} y1=${-h * 0.1} x2=${w * 0.06} y2=${h * 0.1}
-              stroke=${color} stroke-width="2" />`;
+        ${seams.map(
+          (x) => svg`<line x1=${x} y1=${-hh} x2=${x} y2=${hh} stroke=${color} stroke-width="2" />`,
+        )}
+        ${handles.map(
+          (x) => svg`<line x1=${x} y1=${-h * 0.1} x2=${x} y2=${h * 0.1}
+                           stroke=${color} stroke-width="2" />`,
+        )}`;
       break;
+    }
     case "plant": {
       const r = Math.min(w, h) * 0.18;
       detail = svg`

--- a/src/types.ts
+++ b/src/types.ts
@@ -430,6 +430,13 @@ export interface Furniture {
   type: FurnitureType;
   /** L-shaped sectional only: which side the chaise extends on. Default `right`. */
   hand?: SectionalHand;
+  /**
+   * Wardrobe only (issue #90): how many door panels the run is divided into.
+   * Default 2, which is the classic pair meeting in the middle. Doors pair up
+   * from the left, so an odd count ends in a single door — a seven-door
+   * wardrobe reads as three double bays plus one.
+   */
+  doors?: number;
   x: number;
   y: number;
   /** Width / height in virtual units. */
@@ -722,6 +729,15 @@ export const DEFAULT_TEXT_SIZE = 16;
 export const DEFAULT_RIPPLE_SIZE = 80;
 /** Neutral gray, so furniture reads differently from the walls. Skinnable (#122). */
 export const FURNITURE_COLOR = "var(--fp-skin-furniture, #9e9e9e)";
+
+/**
+ * How many door panels a wardrobe is divided into (issue #90). The default of
+ * two is the classic pair meeting in the middle; a fitted run can be a wall of
+ * them. The bounds keep a hand-written config from asking for a hairline comb.
+ */
+export const WARDROBE_DOORS_DEFAULT = 2;
+export const WARDROBE_DOORS_MIN = 1;
+export const WARDROBE_DOORS_MAX = 12;
 
 /** Default width/height per furniture type, in virtual units. */
 export const FURNITURE_DEFAULT_SIZE: Record<FurnitureType, { w: number; h: number }> = {


### PR DESCRIPTION
Addresses the original request in #90: @gorischek has a wardrobe with seven doors, and
the glyph only knew how to draw two.

The wardrobe hard-coded a two-door front — one seam down the middle, a pair of handles
meeting on it — so a fitted run had to be faked with a row of separate boxes.

### What changed

`doors` (1–12, default 2) divides the front into panels. It follows the `hand`-on-sectional
pattern: an optional field on `Furniture`, a conditional row in `furnitureForm`, and a
conditional branch in the glyph, with the geometry in a pure exported function next to
`sectionalPoints`.

Doors hang in pairs from the left, so each pair's handles meet at the seam between them.
**At the default of two this reproduces the old glyph exactly** — same seam, same handle
offsets — so no existing plan shifts.

An odd count leaves one door over. That one hangs from the outer edge and opens inward, so
its handle lands beside the final seam. Swinging it outward like the others put the handle
on top of the carcass outline: the inset scales with one door's width, so on a seven-door
run "just inside the edge" is nowhere. A single door keeps the outward swing, where a
12%-of-the-box inset still has room.

Counts are rounded and clamped on the way in — a hand-written config can carry a `0` or a
`NaN`, and dividing the front by either draws nothing.

### Verification

`typecheck`, `test` (756) and `build` all pass. Beyond the unit tests I rendered the glyph
at 1/2/3/4/5/7/12 doors and looked at it — that's how the leftover-door handle collision
turned up, since it's correct by the numbers and wrong on screen.

Rebased onto current `main` (2026-08-12) after it moved 15 commits ahead; the conflicts
were three import lists and the furniture section of the README, whose type list had grown
`sectional` / `hand` and the #72 additions. Nothing touched the wardrobe glyph itself, and
`wardrobeDoorLines(w)` still returns exactly what the old hard-coded case drew — a seam at
`0`, handles at `±w * 0.06` — so the default really is unchanged. Re-rendered every count
afterwards to confirm the rebase didn't disturb the drawing.

### Scope

This deliberately does **not** close #90. The thread moved on to a shareable symbol library,
which is a much larger piece of work — I've left a design comment there proposing a shape
for it, but this PR is just the door count so the original reporter isn't blocked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

