### PR TITLE
Follow the real sun: dim the plan at dusk, brighten it at dawn (closes #113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,8 +976,27 @@ A few deliberate choices:
   than one that is merely dim. Set it lower if you want a darker house.
 - **It fails bright.** If `sun.sun` is missing or unreadable the plan stays at full
   brightness, rather than being stranded dark with nothing on screen to explain why.
-- **Cast-light pools dim with the plan.** They still stand out against the darkened rooms,
-  but if you want them to blaze at night, raise `sunBrightnessMin`.
+
+### Lit rooms hold back the night
+
+A flat dim would darken a lit room as much as an empty one — multiplying the whole picture,
+contrast included — so a lamp would end up *less* noticeable at night than at noon. Instead,
+**light withholds the dim**: any device with **Cast light** on clears the darkness around
+itself, full at the centre and diffusing to nothing at its `glowRadius`, the same shape and
+falloff as the pool it casts.
+
+The result is a dark house with genuinely lit rooms. Measured against the same spot in an
+unlit room, a lamp's contrast goes from **100 by day to 116 at night** on a dark theme, and
+from 25 to 106 on a light one — where a flat dim would have cut both to 45%.
+
+Strength follows brightness the way the pool does: a full-brightness lamp clears completely,
+one dimmed to nothing clears about a third. A light that is off, `unavailable`, or has no
+Cast light enabled clears nothing.
+
+One limitation: the clearing is a plain circle, so it bleeds a little through a wall into the
+next room — measured at roughly 6% of the lit room's brightness just past the wall, fading to
+nothing within about 80 units. The pools themselves already stop at walls; the clearing does
+not yet.
 
 Toggle it in the editor under **Project → Follow the sun**; the two brightness sliders
 appear once it is on.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ automatically to the card and screen size.
   An optional occupancy `binary_sensor` per axis gates the animation so the
   marker hides cleanly when the room is empty. The zone outline is visible only
   in the editor — the live card shows just the animation.
+- **Follow the sun** — optionally dim the whole plan through dusk and brighten it through
+  dawn, tracking your Home Assistant's own sunrise and sunset rather than the viewer's
+  browser. Device icons stay at full brightness, so a night plan reads as a dark house
+  with its lit rooms glowing.
 - **Text labels** and a configurable **canvas background color**.
 - **Background image** — drop in a floor-plan image (per floor) and trace walls, doors and
   devices over it, with adjustable opacity.
@@ -514,6 +518,9 @@ The editor writes this config for you; manual editing is optional.
 | `grid`       | number   | `20`               | Gap between grid lines, in canvas units (so on a 1000-wide canvas, `20` ≈ 50 columns). A **smaller** number means a **finer** grid with more lines. |
 | `snap`       | number   | follows `grid`     | Snap step for placement / drag / nudge / wall drawing, in canvas units. Omit to snap to the visible grid; set `0` for free placement; set any other number for a custom step. The editor shows a custom step as a **percentage of the grid** (e.g. `50` % of a `20` grid is stored here as `10`), but the value here is always absolute. |
 | `rotation`   | number   | `0`                | Rotate the displayed card by `90`, `180` or `270` degrees — e.g. a landscape plan on a portrait wall tablet. Editing always shows the plan as drawn. Icons and labels stay upright. |
+| `sunDimming` | boolean | `false` | Dim the plan through dusk and brighten it through dawn, following the **Home Assistant instance's** sunrise and sunset (not the browser's). See **Follow the sun**. |
+| `sunBrightnessMin` | number | `0.45` | Plan brightness once the sun is fully down, 0–1. Only used when `sunDimming` is on. |
+| `sunBrightnessMax` | number | `1` | Plan brightness in full daylight, 0–1. Only used when `sunDimming` is on. |
 | `background` | string   | card background    | Canvas background color (CSS / hex).         |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
@@ -939,6 +946,41 @@ trackers:
       max: 3.5
       presence: { entity: binary_sensor.living_room_presence }
 ```
+
+## Follow the sun
+
+Set **`sunDimming: true`** and the plan dims through dusk and brightens through dawn.
+
+```yaml
+type: custom:easy-floorplan-card
+sunDimming: true
+sunBrightnessMin: 0.45   # brightness once the sun is fully down (default 0.45)
+sunBrightnessMax: 1      # brightness in full daylight (default 1)
+```
+
+It reads **`sun.sun`'s `elevation`** — the angle of the sun above the horizon, which Home
+Assistant computes continuously from your instance's latitude, longitude and clock. That
+matters for two reasons: it is already a smooth signal, so there is no interpolating
+between sunrise and sunset timestamps; and it comes from the **server**, so a phone in
+another timezone showing the same dashboard sees the same picture.
+
+The ramp spans civil twilight, −6° to +6° — roughly the hour around sunrise and sunset
+when the light outside actually changes. Below that is night, above it is day, and the
+curve eases at both ends rather than cornering.
+
+A few deliberate choices:
+
+- **Device icons and labels are not dimmed.** They sit above the dimming layer, so a dark
+  plan stays readable and lit rooms still glow — which is the look worth having at night.
+- **`sunBrightnessMin` defaults to 0.45, not 0.** A plan you cannot read at night is worse
+  than one that is merely dim. Set it lower if you want a darker house.
+- **It fails bright.** If `sun.sun` is missing or unreadable the plan stays at full
+  brightness, rather than being stranded dark with nothing on screen to explain why.
+- **Cast-light pools dim with the plan.** They still stand out against the darkened rooms,
+  but if you want them to blaze at night, raise `sunBrightnessMin`.
+
+Toggle it in the editor under **Project → Follow the sun**; the two brightness sliders
+appear once it is on.
 
 ## Styling hooks (card-mod)
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -11,6 +11,7 @@ import {
   wallForm,
   projectForm,
   projectRotationForm,
+  projectSunForm,
   floorImageForm,
   areaForm,
   areaNameForm,
@@ -555,5 +556,42 @@ describe("area scoping never traps you (issue reported on #83)", () => {
       itemForm(item, { entities: [], name: "Spare" }).fields.find((x) => x.name === "entity")!
         .selector
     ).toEqual({ entity: {} });
+  });
+});
+
+describe("projectSunForm (issue #113)", () => {
+  const cfg = (extra = {}) =>
+    ({ type: "custom:easy-floorplan-card", width: 100, height: 100, ...extra }) as FloorplanCardConfig;
+
+  it("hides the brightness sliders until the option is on", () => {
+    const names = (c: FloorplanCardConfig) => projectSunForm(c).fields.map((f) => f.name);
+    expect(names(cfg())).toEqual(["sunDimming"]);
+    expect(names(cfg({ sunDimming: true }))).toEqual([
+      "sunDimming",
+      "sunBrightnessMin",
+      "sunBrightnessMax",
+    ]);
+  });
+
+  it("presents the effective defaults", () => {
+    expect(projectSunForm(cfg()).data).toMatchObject({
+      sunDimming: false,
+      sunBrightnessMin: 0.45,
+      sunBrightnessMax: 1,
+    });
+    expect(projectSunForm(cfg({ sunDimming: true, sunBrightnessMin: 0.2 })).data)
+      .toMatchObject({ sunDimming: true, sunBrightnessMin: 0.2 });
+  });
+
+  it("switching off clears the sliders it dragged along, not just the toggle", () => {
+    const { toPatch } = projectSunForm(cfg({ sunDimming: true }));
+    expect(toPatch({ sunDimming: false })).toEqual({
+      sunDimming: undefined,
+      sunBrightnessMin: undefined,
+      sunBrightnessMax: undefined,
+    });
+    // Leaving them behind would resurrect stale values on re-enable.
+    expect(toPatch({ sunDimming: true }).sunDimming).toBe(true);
+    expect(toPatch({ sunBrightnessMin: 0.3 })).toEqual({ sunBrightnessMin: 0.3 });
   });
 });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -25,6 +25,8 @@ import {
   DEFAULT_GLOW_RADIUS,
   DEFAULT_TEXT_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
+  DEFAULT_SUN_MIN,
+  DEFAULT_SUN_MAX,
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
@@ -748,6 +750,50 @@ export function projectRotationForm(c: FloorplanCardConfig): FormSpec {
       "rotation" in p
         ? // Stored as a number; 0 means "not rotated", so keep it out of the YAML.
           { ...p, rotation: p.rotation === "0" ? undefined : Number(p.rotation) }
+        : p,
+  };
+}
+
+/**
+ * Follow the real sun (issue #113). Its own form so the editor can put it
+ * beside the other project settings, and so the two brightness sliders appear
+ * only once the toggle is on — they mean nothing otherwise.
+ */
+export function projectSunForm(c: FloorplanCardConfig): FormSpec {
+  const fields: FormField[] = [
+    {
+      name: "sunDimming",
+      label: "Follow the sun",
+      helper: "Dims the plan at night, using your Home Assistant's own sunrise and sunset",
+      selector: { boolean: {} },
+    },
+  ];
+  if (c.sunDimming) {
+    fields.push(
+      {
+        name: "sunBrightnessMin",
+        label: "Night brightness",
+        selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
+      },
+      {
+        name: "sunBrightnessMax",
+        label: "Day brightness",
+        selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
+      }
+    );
+  }
+  return {
+    fields,
+    data: {
+      sunDimming: c.sunDimming ?? false,
+      sunBrightnessMin: c.sunBrightnessMin ?? DEFAULT_SUN_MIN,
+      sunBrightnessMax: c.sunBrightnessMax ?? DEFAULT_SUN_MAX,
+    },
+    // Off is the default, so keep the whole feature out of the YAML until it
+    // is switched on — including the two sliders it drags along with it.
+    toPatch: (p) =>
+      "sunDimming" in p && !p.sunDimming
+        ? { ...p, sunDimming: undefined, sunBrightnessMin: undefined, sunBrightnessMax: undefined }
         : p,
   };
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -110,6 +110,7 @@ import {
   openingForm,
   projectForm,
   projectRotationForm,
+  projectSunForm,
   textForm,
   trackerForm,
   wallForm,
@@ -3486,6 +3487,9 @@ export class FloorplanCardEditor extends LitElement {
           else this._commitFloor(patch as Partial<Floor>);
         })}
         ${this._renderForm(projectRotationForm(this._config), (patch) =>
+          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        )}
+        ${this._renderForm(projectSunForm(this._config), (patch) =>
           this._patchConfig(patch as Partial<FloorplanCardConfig>)
         )}
       </div>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -9,6 +9,8 @@ import {
   DEFAULT_ITEM_SIZE,
   DEFAULT_TEXT_SIZE,
   DEFAULT_RIPPLE_SIZE,
+  DEFAULT_SUN_MIN,
+  DEFAULT_SUN_MAX,
   getFloors,
   trackerPresenceDetected,
 } from "./types";
@@ -17,6 +19,7 @@ import {
   renderOpening,
   renderWallMask,
   imageFitRatio,
+  sunBrightness,
   resolveOpeningAmount,
   openingIsActive,
   openingClickAction,
@@ -369,6 +372,15 @@ export class FloorplanCard extends LitElement {
     const rot = normalizePlanRotation(c.rotation);
     const dims = rotatedCanvasSize(cssNumber(c.width, DEFAULT_WIDTH), cssNumber(c.height, DEFAULT_HEIGHT), rot);
     const rotTransform = planRotationTransform(c.width, c.height, rot);
+    // Follow the real sun (issue #113). Elevation comes from the HA instance,
+    // so every viewer sees the same picture regardless of their own timezone.
+    const sunLevel = c.sunDimming
+      ? sunBrightness(
+          this.hass?.states["sun.sun"]?.attributes?.elevation,
+          cssNumber(c.sunBrightnessMin, DEFAULT_SUN_MIN),
+          cssNumber(c.sunBrightnessMax, DEFAULT_SUN_MAX)
+        )
+      : DEFAULT_SUN_MAX;
     return html`
       <ha-card .header=${c.title ?? nothing}>
         <div
@@ -500,6 +512,22 @@ export class FloorplanCard extends LitElement {
                 yPresent: trackerPresenceDetected(this.hass?.states, tr.ySensor?.presence),
               })
             )}
+            <!-- Sun dimming (issue #113). Last inside the rotated group, so it
+                 covers the whole plan; the device overlay below is HTML and
+                 stays at full brightness, keeping icons and state readable at
+                 night. pointer-events:none is not optional — this rect spans
+                 the canvas, and without it every tappable opening underneath
+                 stops responding (the lesson from #108). -->
+            ${
+              c.sunDimming
+                ? svg`<rect class="fp-sun-dim"
+                            x=${-WALL_THICKNESS} y=${-WALL_THICKNESS}
+                            width=${c.width + WALL_THICKNESS * 2}
+                            height=${c.height + WALL_THICKNESS * 2}
+                            fill="#000"
+                            opacity=${1 - sunLevel} />`
+                : nothing
+            }
             </g>
           </svg>
           <div class="items">
@@ -605,6 +633,16 @@ export class FloorplanCard extends LitElement {
     }
     .wall {
       stroke: var(--primary-text-color);
+    }
+    /* Sun dimming (issue #113): decoration, never a pointer target. The
+       transition matters — HA steps the sun elevation every ~30s, and without
+       it dusk arrives as a series of visible jumps rather than a fade. */
+    .fp-sun-dim {
+      pointer-events: none;
+      transition: opacity 2s linear;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .fp-sun-dim { transition: none; }
     }
     /* Light pools (issue #6). "isolation" gives the layer its own compositing
        group, so the pools blend with each other but not with the plan beneath

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -36,6 +36,7 @@ import {
   glowPaint,
   renderGlow,
   renderGlowMask,
+  renderSunDimMask,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -381,6 +382,13 @@ export class FloorplanCard extends LitElement {
           cssNumber(c.sunBrightnessMax, DEFAULT_SUN_MAX)
         )
       : DEFAULT_SUN_MAX;
+    // Lit rooms hold back the night (issue #113): without this the flat dim
+    // multiplies the lit-vs-unlit contrast too, and a lamp ends up *less*
+    // visible after dark than at noon.
+    const sunDimMaskId = `${this._glowIdBase}-sundim`;
+    const sunDimMask = c.sunDimming
+      ? renderSunDimMask(active.items, this.hass?.states, c.width, c.height, sunDimMaskId)
+      : nothing;
     return html`
       <ha-card .header=${c.title ?? nothing}>
         <div
@@ -520,11 +528,12 @@ export class FloorplanCard extends LitElement {
                  stops responding (the lesson from #108). -->
             ${
               c.sunDimming
-                ? svg`<rect class="fp-sun-dim"
+                ? svg`${sunDimMask}<rect class="fp-sun-dim"
                             x=${-WALL_THICKNESS} y=${-WALL_THICKNESS}
                             width=${c.width + WALL_THICKNESS * 2}
                             height=${c.height + WALL_THICKNESS * 2}
                             fill="#000"
+                            mask=${sunDimMask === nothing ? nothing : `url(#${sunDimMaskId})`}
                             opacity=${1 - sunLevel} />`
                 : nothing
             }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -22,6 +22,7 @@ import {
   shutterStyleOf,
   imageFitRatio,
   sunBrightness,
+  renderSunDimMask,
   renderWallMask,
   shutterActive,
   openingClickAction,
@@ -1695,6 +1696,78 @@ describe("sunBrightness (issue #113)", () => {
 
   it("reads a numeric string, as HA attributes sometimes arrive", () => {
     expect(sunBrightness("6", 0.45, 1)).toBeCloseTo(1, 5);
+  });
+});
+
+describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () => {
+  const flatten = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (typeof node === "symbol") return "";
+    if (Array.isArray(node)) return node.map(flatten).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce((acc, x, i) => acc + x + (i < values.length ? flatten(values[i]) : ""), "");
+    }
+    return String(node);
+  };
+  const lamp = (extra = {}) =>
+    ({ id: "i1", entity: "light.a", kind: "light", x: 200, y: 150, glow: true, ...extra }) as never;
+  const on = (attributes: Record<string, unknown> = { brightness: 255 }) =>
+    ({ "light.a": { entity_id: "light.a", state: "on", attributes } }) as never;
+
+  it("clears fully at the centre and fades to nothing at the radius", () => {
+    const markup = flatten(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
+    // Black hides the dim; white keeps it. Full brightness clears completely.
+    expect(markup).toContain('stop-opacity=1');
+    expect(markup).toContain('stop-opacity="0"');
+    expect(markup).toContain('fill="white"');
+    expect(markup).toContain("cx=200");
+    expect(markup).toContain(`r=${DEFAULT_GLOW_RADIUS}`);
+  });
+
+  it("honours a custom glowRadius, so clearing and pool share a shape", () => {
+    const markup = flatten(renderSunDimMask([lamp({ glowRadius: 90 })], on(), 1000, 600, "sd"));
+    expect(markup).toContain("r=90");
+  });
+
+  it("clears in proportion to brightness, like the pool itself", () => {
+    const at = (brightness: number) => {
+      const m = flatten(renderSunDimMask([lamp()], on({ brightness }), 1000, 600, "sd"));
+      return Number(/stop-opacity=([\d.]+)/.exec(m)?.[1]);
+    };
+    expect(at(255)).toBeCloseTo(1, 5);
+    // GLOW_MIN_OPACITY / GLOW_MAX_OPACITY — a lamp dimmed to nothing still
+    // clears about a third, matching the pool it casts.
+    expect(at(0)).toBeCloseTo(GLOW_MIN_OPACITY / GLOW_MAX_OPACITY, 5);
+    expect(at(128)).toBeGreaterThan(at(0));
+    expect(at(128)).toBeLessThan(at(255));
+  });
+
+  it("a light that is off, unavailable or missing clears nothing", () => {
+    const off = { "light.a": { entity_id: "light.a", state: "off", attributes: {} } } as never;
+    expect(renderSunDimMask([lamp()], off, 1000, 600, "sd")).toBe(nothing);
+    const dead = { "light.a": { entity_id: "light.a", state: "unavailable", attributes: {} } } as never;
+    expect(renderSunDimMask([lamp()], dead, 1000, 600, "sd")).toBe(nothing);
+    expect(renderSunDimMask([lamp()], undefined, 1000, 600, "sd")).toBe(nothing);
+  });
+
+  it("a device without Cast light never clears, however bright its entity", () => {
+    // Only glow devices define a radius, so only they can hold back the dark.
+    expect(renderSunDimMask([lamp({ glow: false })], on(), 1000, 600, "sd")).toBe(nothing);
+    expect(renderSunDimMask([], on(), 1000, 600, "sd")).toBe(nothing);
+  });
+
+  it("states its own region, so rotation cannot clip the clearing (issue #102)", () => {
+    const markup = flatten(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
+    expect(markup).toContain("width=1016");
+    expect(markup).toContain("height=616");
+  });
+
+  it("gives each lamp its own gradient id, so pools do not share a falloff", () => {
+    const two = [lamp(), lamp({ id: "i2", x: 700 })];
+    const markup = flatten(renderSunDimMask(two, on(), 1000, 600, "sd"));
+    expect(markup).toContain("id=sd-0");
+    expect(markup).toContain("id=sd-1");
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_GLOW_COLOR,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
+  SUN_ELEVATION_NIGHT,
+  SUN_ELEVATION_DAY,
 } from "./types";
 import {
   snapToWall,
@@ -19,6 +21,7 @@ import {
   shutterAmount,
   shutterStyleOf,
   imageFitRatio,
+  sunBrightness,
   renderWallMask,
   shutterActive,
   openingClickAction,
@@ -1643,6 +1646,67 @@ describe("renderWallMask region (issue #102)", () => {
     const nums = [...markup.matchAll(/(?:x|y|width|height)=(-?\d+)/g)].map((m) => Number(m[1]));
     const right = 1000 + 8;
     expect(Math.max(...nums)).toBeGreaterThanOrEqual(right);
+  });
+});
+
+describe("sunBrightness (issue #113)", () => {
+  it("is min deep at night and max in full daylight", () => {
+    expect(sunBrightness(-40, 0.45, 1)).toBeCloseTo(0.45, 5);
+    expect(sunBrightness(SUN_ELEVATION_NIGHT, 0.45, 1)).toBeCloseTo(0.45, 5);
+    expect(sunBrightness(60, 0.45, 1)).toBeCloseTo(1, 5);
+    expect(sunBrightness(SUN_ELEVATION_DAY, 0.45, 1)).toBeCloseTo(1, 5);
+  });
+
+  it("ramps smoothly and monotonically across civil twilight", () => {
+    const xs = [-6, -4, -2, 0, 2, 4, 6];
+    const ys = xs.map((e) => sunBrightness(e, 0.45, 1));
+    for (let i = 1; i < ys.length; i++) expect(ys[i]).toBeGreaterThan(ys[i - 1]);
+    // Sunset (0°) sits halfway: the ramp is symmetric about the horizon.
+    expect(sunBrightness(0, 0, 1)).toBeCloseTo(0.5, 5);
+  });
+
+  it("eases at both ends rather than cornering", () => {
+    // Smoothstep: near the clamps the rate is slower than in the middle.
+    const nearEnd = sunBrightness(-5, 0, 1) - sunBrightness(-6, 0, 1);
+    const middle = sunBrightness(0.5, 0, 1) - sunBrightness(-0.5, 0, 1);
+    expect(middle).toBeGreaterThan(nearEnd);
+  });
+
+  it("fails bright: a missing or unreadable elevation leaves the plan lit", () => {
+    // The opposite would strand a plan dark with nothing on screen to explain
+    // why — worse than ignoring the feature until sun.sun comes back.
+    expect(sunBrightness(undefined, 0.45, 1)).toBe(1);
+    expect(sunBrightness(null, 0.45, 1)).toBe(1);
+    expect(sunBrightness("unavailable", 0.45, 1)).toBe(1);
+    expect(sunBrightness(Number.NaN, 0.45, 1)).toBe(1);
+    // The nasty ones: all of these coerce to 0, which is mid-ramp, not night.
+    expect(sunBrightness("", 0.45, 1)).toBe(1);
+    expect(sunBrightness("   ", 0.45, 1)).toBe(1);
+    expect(sunBrightness(false, 0.45, 1)).toBe(1);
+    expect(sunBrightness([], 0.45, 1)).toBe(1);
+    // But a real 0° is sunset, and must still ramp.
+    expect(sunBrightness(0, 0.45, 1)).toBeCloseTo(0.725, 3);
+  });
+
+  it("tolerates min and max given the wrong way round", () => {
+    expect(sunBrightness(-40, 1, 0.3)).toBeCloseTo(0.3, 5);
+    expect(sunBrightness(40, 1, 0.3)).toBeCloseTo(1, 5);
+  });
+
+  it("reads a numeric string, as HA attributes sometimes arrive", () => {
+    expect(sunBrightness("6", 0.45, 1)).toBeCloseTo(1, 5);
+  });
+});
+
+describe("collectWatchedEntities watches the sun (issue #113)", () => {
+  const base = { type: "custom:easy-floorplan-card", width: 100, height: 100 } as never;
+
+  it("watches sun.sun only when the option is on", () => {
+    expect(collectWatchedEntities(base).has("sun.sun")).toBe(false);
+    // Without this the plan is lit once and then frozen — the trap #82 and #6
+    // each fell into.
+    expect(collectWatchedEntities({ ...(base as object), sunDimming: true } as never).has("sun.sun"))
+      .toBe(true);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -436,6 +436,69 @@ export function renderGlow(
 }
 
 /**
+ * A `<mask>` for the sun-dimming layer that lets lit rooms hold back the night
+ * (issue #113).
+ *
+ * The dim is one flat black rect, and a flat overlay multiplies the *whole*
+ * image — including the contrast between a lit room and an unlit one. Measured
+ * on the unmasked build, a lamp's pool read at 45% of its daytime contrast
+ * after dark, i.e. exactly `1 - dimOpacity`: lamps became *less* visible at
+ * night, the reverse of both physics and expectation.
+ *
+ * So rather than dimming over the light, the light withholds the dim. Each
+ * Cast-light lamp that is on paints a black radial falloff into this mask —
+ * black hides the dim — full clearing at the pool's centre, diffusing to full
+ * dim at its `glowRadius`. Same centre, same radius, same falloff as
+ * {@link renderGlow}, so the clearing and the pool are the same shape by
+ * construction.
+ *
+ * Strength tracks brightness the way the glow does: a full-brightness lamp
+ * clears completely, a lamp dimmed to nothing clears about a third.
+ *
+ * Only Cast-light devices qualify — they are the ones that define a radius.
+ * Returns `nothing` when no lamp does, so an ordinary plan pays for no mask.
+ */
+export function renderSunDimMask(
+  items: readonly FloorItem[],
+  states: Record<string, HassEntity | undefined> | undefined,
+  width: number,
+  height: number,
+  id: string,
+): SVGTemplateResult | typeof nothing {
+  const lit = items.flatMap((it, i) => {
+    if (!it.glow) return [];
+    const paint = glowPaint(it, states?.[it.entity]);
+    if (!paint) return [];
+    // Normalized against the glow's own ceiling, so a full-brightness lamp
+    // clears the dim entirely and a dim one clears proportionally.
+    const strength = Math.max(0, Math.min(1, paint.opacity / GLOW_MAX_OPACITY));
+    return [{ it, i, strength }];
+  });
+  if (!lit.length) return nothing;
+
+  const pad = WALL_THICKNESS;
+  return svg`
+    <defs>
+      <mask id=${id} maskUnits="userSpaceOnUse"
+            x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}>
+        <rect x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}
+              fill="white" />
+        ${lit.map(({ it, i, strength }) => {
+          const r = cssNumber(it.glowRadius, DEFAULT_GLOW_RADIUS);
+          const gid = `${id}-${i}`;
+          return svg`
+            <radialGradient id=${gid} gradientUnits="userSpaceOnUse"
+                            cx=${it.x} cy=${it.y} r=${r}>
+              <stop offset="0" stop-color="#000" stop-opacity=${strength} />
+              <stop offset="1" stop-color="#000" stop-opacity="0" />
+            </radialGradient>
+            <circle cx=${it.x} cy=${it.y} r=${r} fill=${`url(#${gid})`} />`;
+        })}
+      </mask>
+    </defs>`;
+}
+
+/**
  * A `<mask>` for the whole glow layer that punches out every furniture
  * footprint (issue #108): furniture keeps its base gray instead of reading
  * as "active" whenever a lamp near it is on. The line-art fills at ~0.12

--- a/src/render.ts
+++ b/src/render.ts
@@ -22,6 +22,10 @@ import {
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_OPACITY,
   DEFAULT_AREA_BORDER_WIDTH,
+  SUN_ELEVATION_NIGHT,
+  SUN_ELEVATION_DAY,
+  DEFAULT_SUN_MIN,
+  DEFAULT_SUN_MAX,
   DEFAULT_GLOW_RADIUS,
   DEFAULT_GLOW_COLOR,
   GLOW_MIN_OPACITY,
@@ -77,6 +81,12 @@ export function hassRenderInputsChanged(
 /** Every entity id whose state can change what a plan draws (all floors). */
 export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
   const ids = new Set<string>();
+  // Sun dimming (issue #113) reads sun.sun's elevation. Miss this and the
+  // plan is lit once and then frozen at whatever the sun was doing when the
+  // card loaded — the same trap entity-bound furniture (#82) and areas (#6)
+  // each fell into. HA replaces the state object when the attribute moves,
+  // so identity comparison in hassRenderInputsChanged catches it.
+  if (c.sunDimming) ids.add("sun.sun");
   for (const f of getFloors(c)) {
     for (const o of f.openings) {
       if (o.entity) ids.add(o.entity);
@@ -1368,6 +1378,47 @@ export function planRotationTransform(w: number, h: number, rot: PlanRotation): 
     default:
       return "";
   }
+}
+
+/**
+ * How bright the plan should be for a given sun elevation (issue #113).
+ *
+ * `sun.sun`'s `elevation` is the signal rather than sunrise/sunset timestamps:
+ * Home Assistant already computes it continuously from the instance's own
+ * latitude, longitude and clock, so it is smooth by construction and it comes
+ * from the **server**. A phone in another timezone showing the same dashboard
+ * therefore sees the same picture, which is the point of the issue.
+ *
+ * The ramp spans civil twilight ({@link SUN_ELEVATION_NIGHT} to
+ * {@link SUN_ELEVATION_DAY}) — roughly the hour around sunrise and sunset when
+ * the light outside actually changes. Smoothstepped rather than linear so the
+ * rate eases in and out instead of cornering at each end.
+ *
+ * A missing or unreadable elevation returns `max`: an outage should leave the
+ * plan at full brightness, never stuck dark with no way to tell why.
+ */
+export function sunBrightness(
+  elevation: unknown,
+  min: number = DEFAULT_SUN_MIN,
+  max: number = DEFAULT_SUN_MAX,
+): number {
+  const lo = Math.min(min, max);
+  const hi = Math.max(min, max);
+  // Allowlist the input rather than enumerate the coercions: Number(null),
+  // Number(""), Number(false) and Number([]) are every one of them 0 — finite,
+  // and 0° is the *middle* of this ramp. Left unguarded a dead sun.sun would
+  // not fail bright at all, it would quietly settle the plan at half light and
+  // read as a dusk that never ends. Same trap cssNumber documents.
+  const usable =
+    typeof elevation === "number" ||
+    (typeof elevation === "string" && elevation.trim() !== "");
+  if (!usable) return hi;
+  const e = typeof elevation === "number" ? elevation : Number(elevation);
+  if (!Number.isFinite(e)) return hi;
+  const span = SUN_ELEVATION_DAY - SUN_ELEVATION_NIGHT;
+  const t = Math.max(0, Math.min(1, (e - SUN_ELEVATION_NIGHT) / span));
+  const eased = t * t * (3 - 2 * t);
+  return lo + (hi - lo) * eased;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -552,6 +552,17 @@ export function areaFiltersEntities(
   return !!area?.haArea && (area.filterEntities ?? true);
 }
 
+/**
+ * Sun elevation (degrees) the dimming ramp spans (issue #113). Civil twilight
+ * is -6°, so this covers roughly the hour around sunrise/sunset when the light
+ * outside actually changes — below it is night, above it is day.
+ */
+export const SUN_ELEVATION_NIGHT = -6;
+export const SUN_ELEVATION_DAY = 6;
+/** Plan brightness at night / in daylight when `sunDimming` is on. */
+export const DEFAULT_SUN_MIN = 0.45;
+export const DEFAULT_SUN_MAX = 1;
+
 export const DEFAULT_AREA_OPACITY = 0.25;
 export const DEFAULT_AREA_BORDER_WIDTH = 3;
 
@@ -692,6 +703,26 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   rotation?: number;
   /** Canvas background color (CSS / hex). Falls back to the card background. */
   background?: string;
+  /**
+   * Follow the real sun (issue #113): dim the plan through dusk and brighten
+   * it through dawn, tracking the **Home Assistant instance's** own sunrise
+   * and sunset rather than the viewer's browser.
+   *
+   * Driven by `sun.sun`'s `elevation` attribute, which Home Assistant already
+   * computes continuously from the instance's latitude, longitude and clock.
+   * That is the whole reason not to read timestamps and interpolate: elevation
+   * is the smooth signal, it comes from the server, and a phone in another
+   * timezone showing the same dashboard sees the same picture.
+   */
+  sunDimming?: boolean;
+  /**
+   * Plan brightness once the sun is fully down, 0-1. Default
+   * {@link DEFAULT_SUN_MIN}. Not 0: a plan you cannot read at night is worse
+   * than one that is merely dim.
+   */
+  sunBrightnessMin?: number;
+  /** Plan brightness in full daylight, 0-1. Default {@link DEFAULT_SUN_MAX}. */
+  sunBrightnessMax?: number;
   /**
    * Multi-floor data. When present and non-empty this is the source of truth.
    * When absent, the legacy flat arrays below describe a single implicit floor


### PR DESCRIPTION
Closes #113.

```yaml
type: custom:easy-floorplan-card
sunDimming: true
sunBrightnessMin: 0.45   # once the sun is fully down
sunBrightnessMax: 1      # full daylight
```

Toggle it in the editor under **Project → Follow the sun**; the two sliders appear once it's on.

### Why `elevation` and not sunrise/sunset times

The issue asks for the **HA instance's** local time and sun times, not the browser's. `sun.sun` already carries an `elevation` attribute that Home Assistant computes continuously from the instance's latitude, longitude and clock — so using it settles that requirement by construction rather than by careful timezone handling. It's also already smooth, so there's nothing to interpolate.

A phone in another timezone showing the same dashboard sees the same picture.

The ramp spans civil twilight, **−6° to +6°** — roughly the hour around sunrise and sunset when the light outside actually changes — smoothstepped so the rate eases in and out instead of cornering at each end.

### Where the dim lands

One rect, last inside the rotated group. It covers the plan; the HTML device overlay sits above it and stays at full brightness, so a night plan reads as a dark house with legible icons and its lit rooms still glowing:

| sun elevation | black overlay opacity |
| --- | --- |
| noon (+60°) | `0` |
| day (+6°) | `0` |
| golden (+3°) | `0.086` |
| sunset (0°) | `0.275` |
| dusk (−3°) | `0.464` |
| civil dusk (−6°) | `0.55` |
| night (−30°) | `0.55` |
| night, `sunBrightnessMin: 0.15` | `0.85` |
| option off | no rect at all |

`pointer-events: none`, because a canvas-spanning rect that eats taps is exactly how #108 broke area selection.

### Two traps this had to avoid

**Watched entities.** `sun.sun` joins the watched set when the option is on. Without it the plan would be lit once and then frozen — the same trap entity-bound furniture (#82) and areas (#6) each fell into. Confirmed the card repaints on **pure hass ticks** where only the attribute moves: elevation 20° → 3° → 1° all report state `above_horizon`, and each one repaints.

**Failing bright is harder than it looks.** `Number(null)`, `Number("")`, `Number(false)` and `Number([])` are *every one of them* `0` — and 0° is the **middle** of this ramp, not night. A naive `Number.isFinite` guard would have left a dead `sun.sun` sitting at half light, looking like a dusk that never ends. My own test caught it mid-implementation; the input is now allowlisted to numbers and non-empty strings, and there's a test for each coercion.

### Deliberate choices worth a second opinion

- **`sunBrightnessMin` defaults to `0.45`, not `0`.** A plan you can't read at night is worse than one that's merely dim.
- **Cast-light pools dim with the plan.** They still stand out against darkened rooms (see the screenshot case in the description), but they're not exempt. Exempting them would mean reordering the glow layer above furniture, which would undo the "light cast on the floor" layering from #109 — not worth it for this. Raise `sunBrightnessMin` if you want them to blaze.
- **The editor canvas doesn't dim.** It's an editing surface; dimming it would make night editing worse for no benefit. The card preview in the editor dialog *is* the card, so it does dim.

**567 tests** (13 new), `tsc --noEmit` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)