### PR TITLE
Sun dimming: pin each lamp's clearing gradient to its item index

### DIFF
--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1763,6 +1763,40 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
     expect(markup).toContain("height=616");
   });
 
+  it("keeps every lamp's gradient id pinned to its item index, not its rank", () => {
+    // The bug this guards: compacting the list to only-lit lamps shifted every
+    // later lamp's DOM position when one toggled, rewriting the id on an
+    // existing <radialGradient> and stranding the circle that referenced it on
+    // a stale paint server — a hard-edged disc at full strength instead of a
+    // falloff. Only lamps *after* the toggled one were affected, which is what
+    // made it look intermittent.
+    const items = [
+      lamp({ id: "A", entity: "light.a", x: 150 }),
+      lamp({ id: "B", entity: "light.b", x: 450 }),
+      lamp({ id: "C", entity: "light.c", x: 750 }),
+    ];
+    const states = (bOn: boolean) =>
+      ({
+        "light.a": { entity_id: "light.a", state: "on", attributes: { brightness: 255 } },
+        "light.b": { entity_id: "light.b", state: bOn ? "on" : "off", attributes: {} },
+        "light.c": { entity_id: "light.c", state: "on", attributes: { brightness: 255 } },
+      }) as never;
+
+    const idsFor = (bOn: boolean) => {
+      const m = flatten(renderSunDimMask(items, states(bOn), 1000, 600, "sd"));
+      return [...m.matchAll(/id=(sd-\d+)/g)].map((x) => x[1]);
+    };
+    // C is index 2 and must stay sd-2 whether or not B is lit.
+    expect(idsFor(false)).toEqual(["sd-0", "sd-2"]);
+    expect(idsFor(true)).toEqual(["sd-0", "sd-1", "sd-2"]);
+
+    // And each circle still points at its own lamp's gradient.
+    const off = flatten(renderSunDimMask(items, states(false), 1000, 600, "sd"));
+    expect(off).toContain("cx=750");
+    expect(off).toContain("url(#sd-2)");
+    expect(off).not.toContain("sd-1");
+  });
+
   it("gives each lamp its own gradient id, so pools do not share a falloff", () => {
     const two = [lamp(), lamp({ id: "i2", x: 700 })];
     const markup = flatten(renderSunDimMask(two, on(), 1000, 600, "sd"));

--- a/src/render.ts
+++ b/src/render.ts
@@ -465,16 +465,17 @@ export function renderSunDimMask(
   height: number,
   id: string,
 ): SVGTemplateResult | typeof nothing {
-  const lit = items.flatMap((it, i) => {
-    if (!it.glow) return [];
+  // Strength per item, by INDEX — undefined where the lamp contributes nothing.
+  // Deliberately not compacted: see the map below.
+  const strengths = items.map((it) => {
+    if (!it.glow) return undefined;
     const paint = glowPaint(it, states?.[it.entity]);
-    if (!paint) return [];
+    if (!paint) return undefined;
     // Normalized against the glow's own ceiling, so a full-brightness lamp
     // clears the dim entirely and a dim one clears proportionally.
-    const strength = Math.max(0, Math.min(1, paint.opacity / GLOW_MAX_OPACITY));
-    return [{ it, i, strength }];
+    return Math.max(0, Math.min(1, paint.opacity / GLOW_MAX_OPACITY));
   });
-  if (!lit.length) return nothing;
+  if (!strengths.some((v) => v !== undefined)) return nothing;
 
   const pad = WALL_THICKNESS;
   return svg`
@@ -483,7 +484,18 @@ export function renderSunDimMask(
             x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}>
         <rect x=${-pad} y=${-pad} width=${width + pad * 2} height=${height + pad * 2}
               fill="white" />
-        ${lit.map(({ it, i, strength }) => {
+        ${items.map((it, i) => {
+          // One slot per item, holes included — exactly how the glow layer
+          // itself is emitted. Compacting the list instead shifts every later
+          // lamp's DOM position when one toggles, which rewrites the `id` on
+          // an existing <radialGradient> and leaves the circle that referenced
+          // it pointing at a paint server the browser has already cached under
+          // that name. The symptom is a lamp suddenly clearing the dim as a
+          // hard-edged disc at full strength rather than a soft falloff, and
+          // it only bites lamps positioned *after* the one that toggled —
+          // which is what made it look intermittent.
+          const strength = strengths[i];
+          if (strength === undefined) return nothing;
           const r = cssNumber(it.glowRadius, DEFAULT_GLOW_RADIUS);
           const gid = `${id}-${i}`;
           return svg`


### PR DESCRIPTION
Fixes a bug in the sun dimming that shipped with #118.

### The report

At night, with some lights on and clearing the dim around themselves, toggling a *different* light made the already-on lights clear the dim as a **hard-edged disc at full strength** instead of a soft falloff. Intermittent.

### Cause — mine, introduced in #118

`renderSunDimMask` compacted the lamp list with `flatMap`, so the children it emitted were ranked among *lit* lamps rather than slotted per item. Toggling a lamp shifts every later lamp's position, and Lit reconciles an unkeyed array **by position** — so it rewrote the `id` on an existing `<radialGradient>` and appended a new one, leaving the circle that referenced that id pointing at a paint server the browser had already cached under that name.

A stale or unresolved paint server renders the circle as **flat black**. Flat black in this mask means the dim is removed *completely* across the whole radius: max brightness, hard edge.

Caught it by diffing the mask DOM across a toggle. Lamp C's gradient sat at array position 1 as `…sundim-2`; after toggling B, that same element had been rewritten to B's values:

```
cx 750 → 450,  r 200 → 120
```

**Why it looked intermittent:** only lamps positioned *after* the toggled one have their ids rewritten. Toggle the last lamp in the config and nothing happens; toggle the first and every other lamp misbehaves.

### Fix

Emit one slot per item with `nothing` in the holes — which is exactly how the glow layer itself is written a few lines away in `floorplan-card.ts`:

```js
${active.items.map((it, i) => {
  if (!it.glow) return nothing;
  ...
})}
```

That convention is *why* the pools never had this bug. I broke it when writing the mask and didn't notice.

### Verification

Toggling B four times, watching C — the lamp that used to break:

| | result |
| --- | --- |
| C's gradient across all four toggles | `sundim-2 cx=750 r=200 stops=1->0`, unchanged |
| always the same DOM element | ✅ |
| never became a solid disc | ✅ |
| never inherited B's radius | ✅ |

The regression test asserts ids stay pinned to item index rather than rank. I confirmed it **fails** when the ranking behaviour is restored — a test that passed either way would be worthless for this bug.

**575 tests**, `tsc --noEmit` and `vite build` clean.

### Worth knowing

The same trap applies anywhere else we build SVG `id`s from a filtered list. The glow layer and this mask are both safe now, but it's worth checking if we add another `<defs>`-based layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)