### PR TITLE
Sun dimming: walls stop the clearing, as they already stop the pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,10 +993,9 @@ Strength follows brightness the way the pool does: a full-brightness lamp clears
 one dimmed to nothing clears about a third. A light that is off, `unavailable`, or has no
 Cast light enabled clears nothing.
 
-One limitation: the clearing is a plain circle, so it bleeds a little through a wall into the
-next room — measured at roughly 6% of the lit room's brightness just past the wall, fading to
-nothing within about 80 units. The pools themselves already stop at walls; the clearing does
-not yet.
+**Walls stop the clearing**, using the same visibility polygon that stops the pools — so a lit
+room brightens itself and not the room next door. Note this treats a wall as solid along its
+whole length: light does not reach through a doorway, for the clearing or for the pool.
 
 Toggle it in the editor under **Project → Follow the sun**; the two brightness sliders
 appear once it is on.

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -387,7 +387,14 @@ export class FloorplanCard extends LitElement {
     // visible after dark than at noon.
     const sunDimMaskId = `${this._glowIdBase}-sundim`;
     const sunDimMask = c.sunDimming
-      ? renderSunDimMask(active.items, this.hass?.states, c.width, c.height, sunDimMaskId)
+      ? renderSunDimMask(
+          active.items,
+          this.hass?.states,
+          c.width,
+          c.height,
+          sunDimMaskId,
+          active.walls
+        )
       : nothing;
     return html`
       <ha-card .header=${c.title ?? nothing}>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1763,6 +1763,43 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
     expect(markup).toContain("height=616");
   });
 
+  it("clips the clearing at walls, like the pool it mirrors (issue #108)", () => {
+    const walls = [{ id: "w", x1: 300, y1: 0, x2: 300, y2: 400 }];
+    const withWalls = flatten(
+      renderSunDimMask([lamp({ x: 190, glowRadius: 200 })], on(), 600, 400, "sd", walls)
+    );
+    expect(withWalls).toContain("<clipPath");
+    expect(withWalls).toContain("clip-path=url(#sd-0-clip)");
+    // No wall in reach: a plain circle, no clip, no wasted work.
+    const noWalls = flatten(renderSunDimMask([lamp()], on(), 600, 400, "sd", []));
+    expect(noWalls).not.toContain("<clipPath");
+    const farWall = [{ id: "w", x1: 9000, y1: 0, x2: 9000, y2: 400 }];
+    expect(flatten(renderSunDimMask([lamp()], on(), 600, 400, "sd", farWall))).not.toContain("<clipPath");
+  });
+
+  it("hangs the clip id off the gradient id, so it stays pinned too (issue #119)", () => {
+    // Same trap as the gradient: a clip id that renumbered on toggle would
+    // strand the circle on a stale clip path.
+    const walls = [{ id: "w", x1: 300, y1: 0, x2: 300, y2: 400 }];
+    const items = [
+      lamp({ id: "A", entity: "light.a", x: 150, glowRadius: 200 }),
+      lamp({ id: "B", entity: "light.b", x: 190, glowRadius: 200 }),
+      lamp({ id: "C", entity: "light.c", x: 200, glowRadius: 200 }),
+    ];
+    const states = (bOn: boolean) =>
+      ({
+        "light.a": { entity_id: "light.a", state: "on", attributes: { brightness: 255 } },
+        "light.b": { entity_id: "light.b", state: bOn ? "on" : "off", attributes: {} },
+        "light.c": { entity_id: "light.c", state: "on", attributes: { brightness: 255 } },
+      }) as never;
+    const clips = (bOn: boolean) => {
+      const m = flatten(renderSunDimMask(items, states(bOn), 600, 400, "sd", walls));
+      return [...m.matchAll(/id=(sd-\d+-clip)/g)].map((x) => x[1]);
+    };
+    expect(clips(false)).toEqual(["sd-0-clip", "sd-2-clip"]);
+    expect(clips(true)).toEqual(["sd-0-clip", "sd-1-clip", "sd-2-clip"]);
+  });
+
   it("keeps every lamp's gradient id pinned to its item index, not its rank", () => {
     // The bug this guards: compacting the list to only-lit lamps shifted every
     // later lamp's DOM position when one toggled, rewriting the id on an

--- a/src/render.ts
+++ b/src/render.ts
@@ -464,6 +464,7 @@ export function renderSunDimMask(
   width: number,
   height: number,
   id: string,
+  walls?: readonly Wall[],
 ): SVGTemplateResult | typeof nothing {
   // Strength per item, by INDEX — undefined where the lamp contributes nothing.
   // Deliberately not compacted: see the map below.
@@ -498,13 +499,28 @@ export function renderSunDimMask(
           if (strength === undefined) return nothing;
           const r = cssNumber(it.glowRadius, DEFAULT_GLOW_RADIUS);
           const gid = `${id}-${i}`;
+          // Walls stop the clearing exactly as they stop the pool (issue #108),
+          // reusing the same visibility polygon — otherwise a lit room lifts
+          // the darkness in the room next door, through the wall between them.
+          // The clip id hangs off `gid`, so it is pinned to the item index and
+          // stays stable when another lamp toggles (issue #119).
+          const reach = walls?.length ? glowReach(it.x, it.y, r, walls) : undefined;
+          const clipId = `${gid}-clip`;
           return svg`
+            ${
+              reach
+                ? svg`<clipPath id=${clipId}>
+                        <polygon points=${reach.map((pt) => `${pt.x},${pt.y}`).join(" ")} />
+                      </clipPath>`
+                : nothing
+            }
             <radialGradient id=${gid} gradientUnits="userSpaceOnUse"
                             cx=${it.x} cy=${it.y} r=${r}>
               <stop offset="0" stop-color="#000" stop-opacity=${strength} />
               <stop offset="1" stop-color="#000" stop-opacity="0" />
             </radialGradient>
-            <circle cx=${it.x} cy=${it.y} r=${r} fill=${`url(#${gid})`} />`;
+            <circle cx=${it.x} cy=${it.y} r=${r} fill=${`url(#${gid})`}
+                    clip-path=${reach ? `url(#${clipId})` : nothing} />`;
         })}
       </mask>
     </defs>`;


### PR DESCRIPTION
Follow-up to #113 / #118 — the limitation I flagged when that landed.

Not difficult, as it turned out: `glowReach()` already computes the visibility polygon that `renderGlow` has clipped pools with since #108, so this is reuse rather than new geometry. The clearing and the pool now derive their shape from the *same* computation instead of merely looking alike.

### Before / after

Profiled across a wall 110 units from a lamp with a 200 radius. Baseline unlit is 14:

| sample past the wall | before | after |
| --- | --- | --- |
| x=310 | 20.9 | **14** |
| x=340 | 17.9 | **14** |
| x=380 | 14.8 | **14** |

Bleed is gone entirely. The falloff *inside* the lit room is untouched — 131 → 83.9 → 58 — and a lamp with no wall in reach still emits no clip at all, so the common case pays nothing.

### Detail worth noting

The clip id hangs off the gradient id, so it inherits the item-index pinning from #119. A clip id that renumbered on toggle would strand the circle on a stale clip path — the same failure that produced the hard-edged discs, just via a different reference. There's a test for it.

### Something I checked rather than assumed

**A doorway does not let light through** — for the clearing *or* for the pool. `glowReach` takes walls only, and a wall segment is unbroken where an opening sits on it. Verified: identical numbers with and without a door in the wall.

That's consistent between the two features, which is what was asked for here. But it does mean an open door won't spill light into a hallway, which some people will expect. Fixing it would mean splitting wall segments at their openings before the sweep — a real change to `glowReach` affecting the pools too, so it belongs in its own issue rather than riding along here. The README now states the behaviour instead of implying otherwise.

**577 tests** (2 new), `tsc --noEmit` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)