### PR TITLE
Devices: icon per state rule, and the reading inside the badge (closes #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,42 @@ By default it shows an icon badge:
   makes a wall of lights, covers and switches hard to read. Set **Active color**
   per device to tell them apart at a glance — lights yellow, covers purple,
   thermostats orange. Ripples follow it unless you set a ripple color too.
-- **Color by state** — the **Color by state** rules color the element by what the
-  entity reads: both the **icon badge** and the label, whether or not the entity is
-  "on" (a temperature sensor never is). Add rules in the editor, or in YAML:
+- **Value in the badge** — set **Badge shows** to *Value* and the device draws its
+  reading inside the badge instead of an icon: a thermostat reads `21°` in the same
+  circle your state rules already paint red while it's heating, with no text line
+  hanging underneath. The card picks the reading per domain, so there is nothing to
+  configure — a climate shows its current temperature (its *state* is the mode,
+  "heat"), a humidifier its humidity, a sensor its own value. Long units are dropped
+  to keep the number legible: `°C` becomes `°`, CO₂ reads plainly as `780`.
+
+  An **Attribute** you set wins when it's a number, so you can colour by one reading
+  and display another — `attribute: hvac_action` colours the badge by whether the
+  boiler is firing while the badge still shows the temperature. For a smart plug, point
+  **2nd entity** at its power sensor: the badge reads `1.2kW` and tapping still toggles
+  the switch. A device with no number anywhere keeps its icon, so this can never leave
+  an empty circle. *Nothing* is the third setting — no badge at all, label only.
+- **Color and icon by state** — the **Color & icon by state** rules restyle the element
+  by what the entity reads: both the **icon badge** and the label, whether or not the
+  entity is "on" (a temperature sensor never is). Each rule can also swap the **icon**,
+  so blinds get an open glyph and a closed one:
+
+  ```yaml
+  stateColor:
+    - state: open
+      color: "#4caf50"
+      icon: mdi:blinds-open
+    - state: closed
+      color: "#9e9e9e"
+      icon: mdi:blinds
+  ```
+
+  `icon` is optional — a rule without one only changes the colour, exactly as before.
+  A matching rule's icon beats the device's fixed **icon** override, which is what makes
+  a custom icon and state-dependent icons usable together; previously setting one froze
+  the glyph for good. (Covers that carry a **device class** already get open/closed icons
+  with no rules at all — this is for everything else, and for a third state.)
+
+  Add rules in the editor, or in YAML:
 
   ```yaml
   stateColor:
@@ -615,9 +648,9 @@ shape it occupies on screen.
 | `secondaryEntity` | string                             | —            | Optional 2nd entity shown alongside (e.g. humidity).   |
 | `attribute`   | string                                 | —            | Show this attribute of `entity` instead of its state (e.g. `current_temperature`). |
 | `secondaryAttribute` | string                          | —            | Attribute for the 2nd reading — from `secondaryEntity`, or from `entity` when none. |
-| `stateColor`  | rule[]                                 | —            | Colors for the badge and label (regardless of on/off; beats `activeColor`): `[{above: 26, color: red}, {color: white}]`. A rule matches `above: <n>` or `state: <value>`; an exact state beats a threshold, the highest matching `above` beats a lower one, and a rule with neither is the default. |
+| `stateColor`  | rule[]                                 | —            | Colors for the badge and label (regardless of on/off; beats `activeColor`): `[{above: 26, color: red}, {color: white}]`. A rule matches `above: <n>` or `state: <value>`; an exact state beats a threshold, the highest matching `above` beats a lower one, and a rule with neither is the default. A rule may also carry an optional `icon`, which beats the device's own `icon` while that rule matches. |
 | `x`, `y`      | number                                 | —            | Position.                                              |
-| `kind`        | light/switch/sensor/binary_sensor/climate/cover/generic | inferred | Used for the default icon.            |
+| `kind`        | light/switch/sensor/binary_sensor/climate/cover/media_player/fan/camera/lock/humidifier/vacuum/generic | inferred | Used for the default icon. |
 | `icon`        | string                                 | entity icon  | Override mdi icon.                                     |
 | `name`        | string                                 | friendly name| Label / tooltip override.                             |
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
@@ -630,7 +663,8 @@ shape it occupies on screen.
 | `glow`        | boolean                                | `false`      | Cast a pool of light onto the plan from this device (lights only). See **Cast light**. |
 | `glowRadius`  | number                                 | `140`        | Radius of the cast pool, in canvas units.              |
 | `glowColor`   | string                                 | `#ffd9a0`    | Color for a bulb that can't report one. A color-capable light always uses its own. |
-| `showIcon`    | boolean                                | `true`       | Show the icon badge.                                   |
+| `badgeContent` | `icon` \| `value` \| `none`           | `icon`       | What the badge holds. `value` draws the device's reading inside it (see **Value in the badge**), falling back to the icon when there is no number; `none` hides the badge, leaving the label. |
+| `showIcon`    | boolean                                | `true`       | **Deprecated** — superseded by `badgeContent`. Still honoured when `badgeContent` is unset: `false` means `none`. |
 | `hideWhenInactive` | boolean                           | `false`      | Hide the device on the card while its entity is inactive (issue #55). Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ By default it shows an icon badge:
   makes a wall of lights, covers and switches hard to read. Set **Active color**
   per device to tell them apart at a glance — lights yellow, covers purple,
   thermostats orange. Ripples follow it unless you set a ripple color too.
+- **Lights badge themselves** — a bulb that reports an `rgb_color` wears it: a lamp set to
+  green gets a green badge, and the badge darkens as the lamp dims, so you can read the
+  room's lighting from the badges alone. Nothing to configure, and nothing changes for a
+  bulb that has no color to report (a plain on/off or brightness-only light keeps the theme
+  color). The full order is **state rules → Active color → the bulb's own color → the
+  theme** — anything you set by hand still wins.
+- **The icon stays readable** — the glyph (or the value) picks black or white to suit
+  whatever the badge ended up painted, so a white state color no longer hides a white icon
+  on a dark theme. A color the card can't resolve on its own — `var(--accent)`,
+  `color-mix(...)`, a gradient — keeps the theme's text color as before.
 - **Value in the badge** — set **Badge shows** to *Value* and the device draws its
   reading inside the badge instead of an icon: a thermostat reads `21°` in the same
   circle your state rules already paint red while it's heating, with no text line
@@ -717,10 +727,13 @@ at the walls of its room instead of washing into the next one, and spills throug
 gap the way real light does. The result is an irregular shape rather than a clean circle —
 that's the point. A lamp with no wall inside its radius stays a plain circle.
 
-**Furniture keeps its own color.** Light falls on the floor, not on the furniture drawn over
-it: furniture footprints are cut out of the pools, so a sofa under a lit lamp stays its base
-gray rather than turning the color of the light. Only entity-bound furniture with
-`stateColor` / `activeColor` ever changes color.
+**Light lands on furniture, at half strength.** A table under a lit lamp is lit — but it
+picks up only about half the color cast the open floor beside it gets, so it still reads as
+furniture rather than turning into the color of the light. This is a deliberate middle:
+furniture line art is translucent, so at full strength a warm pool shone straight through
+and every sofa in the room looked highlighted, while cutting furniture out of the pool
+entirely made a lit table *darker* than the floor around it — a shadow. Only entity-bound
+furniture with `stateColor` / `activeColor` ever changes color outright.
 
 Pools never intercept clicks — a device under a lit lamp stays tappable, and in the editor
 rooms under one stay selectable.

--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cssColor, cssIdent, cssEntityId } from "./css-safe";
+import { cssColor, cssIdent, cssEntityId, cssIcon } from "./css-safe";
 import { furnitureColor } from "./render";
 import type { Furniture } from "./types";
 
@@ -211,5 +211,46 @@ describe("cssIdent / cssEntityId — styling hooks (issue #105)", () => {
   it("cssEntityId still drops what would break the attribute selector", () => {
     expect(cssEntityId('light.k"]{}')).toBe("light.k");
     expect(cssEntityId("")).toBeUndefined();
+  });
+});
+
+describe("cssIcon — icon names (issue #106)", () => {
+  it("accepts the icon names people actually type", () => {
+    expect(cssIcon("mdi:blinds-open")).toBe("mdi:blinds-open");
+    expect(cssIcon("mdi:thermostat")).toBe("mdi:thermostat");
+    expect(cssIcon("mdi:smoke-detector-variant-alert")).toBe("mdi:smoke-detector-variant-alert");
+    expect(cssIcon("  mdi:fire  ")).toBe("mdi:fire");
+    // Custom icon sets are a real HA feature, not just mdi.
+    expect(cssIcon("phu:cable-cat5")).toBe("phu:cable-cat5");
+    expect(cssIcon("mdi:battery-90")).toBe("mdi:battery-90");
+  });
+
+  it("validates rather than strips: a non-icon must not survive as something", () => {
+    // The trap this guards: stripping '"><script>' leaves "script", which is
+    // harmless in the DOM but has silently displaced the caller's fallback
+    // icon. Callers rely on undefined to move to the next candidate.
+    for (const junk of [
+      '"><script>',
+      "mdi:blinds; color:red",
+      "mdi:a b",
+      "mdi:",
+      ":blinds",
+      "blinds",
+      "mdi::blinds",
+      "mdi:blinds-",
+      "-mdi:blinds",
+      "url(https://evil/x)",
+      "",
+      "   ",
+    ]) {
+      expect(cssIcon(junk)).toBeUndefined();
+    }
+  });
+
+  it("returns undefined for non-strings", () => {
+    expect(cssIcon(undefined)).toBeUndefined();
+    expect(cssIcon(null)).toBeUndefined();
+    expect(cssIcon(42)).toBeUndefined();
+    expect(cssIcon({ icon: "mdi:fire" })).toBeUndefined();
   });
 });

--- a/src/css-safe.adversarial.test.ts
+++ b/src/css-safe.adversarial.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cssColor, cssIdent, cssEntityId, cssIcon } from "./css-safe";
+import { cssColor, cssIdent, cssEntityId, cssIcon, contrastText } from "./css-safe";
 import { furnitureColor } from "./render";
 import type { Furniture } from "./types";
 
@@ -211,6 +211,91 @@ describe("cssIdent / cssEntityId — styling hooks (issue #105)", () => {
   it("cssEntityId still drops what would break the attribute selector", () => {
     expect(cssEntityId('light.k"]{}')).toBe("light.k");
     expect(cssEntityId("")).toBeUndefined();
+  });
+});
+
+// @MrMcFlyy on #106: "if i set it on white background, when it's open, the
+// icon is white on white". The badge background comes from config; the ink was
+// pinned to the theme. They are independent, so the ink has to follow.
+describe("contrastText — the glyph stays readable (issue #106)", () => {
+  const DARK = "#212121";
+  const LIGHT = "#ffffff";
+
+  it("puts dark ink on a pale badge and light ink on a dark one", () => {
+    expect(contrastText("#ffffff")).toBe(DARK);
+    expect(contrastText("white")).toBe(DARK);
+    expect(contrastText("#000000")).toBe(LIGHT);
+    expect(contrastText("black")).toBe(LIGHT);
+    // The exact report: a white cover rule no longer eats its own icon.
+    expect(contrastText("#fff")).toBe(DARK);
+  });
+
+  it("judges by luminance, not brightness — yellow is pale, blue is dark", () => {
+    expect(contrastText("yellow")).toBe(DARK);
+    expect(contrastText("#fdd835")).toBe(DARK); // the theme's own active yellow
+    expect(contrastText("blue")).toBe(LIGHT);
+    expect(contrastText("navy")).toBe(LIGHT);
+    // Pure red looks vivid but is dark by luminance — and dark ink genuinely
+    // wins on it (5.25:1 against white's 4.0:1), which is why this is decided
+    // by comparing ratios rather than by eye.
+    expect(contrastText("red")).toBe(DARK);
+    expect(contrastText("#4caf50")).toBe(DARK); // the README's blinds-open green
+    expect(contrastText("#9e9e9e")).toBe(DARK); // the furniture gray
+  });
+
+  it("reads every colour form the card actually emits", () => {
+    // lightBadgePaint and glowPaint both emit this exact shape.
+    expect(contrastText("rgb(0, 0, 0)")).toBe(LIGHT);
+    expect(contrastText("rgb(255, 255, 255)")).toBe(DARK);
+    expect(contrastText("rgba(0, 0, 0, 0.5)")).toBe(LIGHT);
+    expect(contrastText("rgb(255 255 255)")).toBe(DARK); // modern space form
+    expect(contrastText("rgb(100%, 100%, 100%)")).toBe(DARK);
+    expect(contrastText("#ffffffff")).toBe(DARK); // 8-digit hex
+  });
+
+  it("gives up on anything it cannot actually resolve, keeping today's behaviour", () => {
+    // This is the important half: picking an ink for a colour we cannot see
+    // would be worse than leaving the theme's. All of these are legal config.
+    for (const opaque of [
+      "var(--primary-color)",
+      "var(--a, var(--b, #fff))",
+      "rgb(var(--rgb-primary-color))",
+      "color-mix(in srgb, red 50%, blue)",
+      "linear-gradient(#fff, #000)",
+      "rebeccapurple", // a real colour, just not in the table
+      "#12345",
+      "not-a-color",
+      "",
+      "   ",
+    ]) {
+      expect(contrastText(opaque)).toBeUndefined();
+    }
+    expect(contrastText(undefined)).toBeUndefined();
+    expect(contrastText(42)).toBeUndefined();
+  });
+
+  it("actually improves contrast rather than just changing it", () => {
+    // Relative luminance and the WCAG ratio, computed independently of the
+    // implementation, over the full grey ramp: the chosen ink must never be
+    // the worse of the two options.
+    const lum = (hex: string) => {
+      const ch = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+      const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+      const [r, g, b] = ch.map(lin);
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    };
+    const ratio = (a: string, b: string) => {
+      const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+    for (let v = 0; v <= 255; v++) {
+      const bg = `#${v.toString(16).padStart(2, "0").repeat(3)}`;
+      const ink = contrastText(bg)!;
+      expect(ink).toBeDefined();
+      const other = ink === DARK ? LIGHT : DARK;
+      expect({ bg, ink, chosen: +ratio(bg, ink).toFixed(3) }).toMatchObject({ bg, ink });
+      expect(ratio(bg, ink)).toBeGreaterThanOrEqual(ratio(bg, other));
+    }
   });
 });
 

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -121,6 +121,113 @@ export function cssIdent(value: unknown): string | undefined {
 }
 
 /**
+ * The CSS colour names that turn up in real floorplan configs — the README's
+ * own examples use `red`, `green`, `white` and `gray`. Not the full 148-name
+ * list: this exists so {@link contrastText} can judge a hand-typed colour, and
+ * an unlisted name simply falls back to the theme's foreground rather than
+ * being guessed at.
+ */
+const NAMED_COLORS: Record<string, [number, number, number]> = {
+  white: [255, 255, 255], black: [0, 0, 0], red: [255, 0, 0], green: [0, 128, 0],
+  lime: [0, 255, 0], blue: [0, 0, 255], navy: [0, 0, 128], yellow: [255, 255, 0],
+  orange: [255, 165, 0], gold: [255, 215, 0], purple: [128, 0, 128], pink: [255, 192, 203],
+  brown: [165, 42, 42], maroon: [128, 0, 0], olive: [128, 128, 0], teal: [0, 128, 128],
+  cyan: [0, 255, 255], aqua: [0, 255, 255], magenta: [255, 0, 255], fuchsia: [255, 0, 255],
+  silver: [192, 192, 192], gray: [128, 128, 128], grey: [128, 128, 128],
+  lightgray: [211, 211, 211], lightgrey: [211, 211, 211],
+  darkgray: [169, 169, 169], darkgrey: [169, 169, 169],
+  transparent: [255, 255, 255],
+};
+
+/** RGB channels of a colour we can actually read, else undefined. */
+function parseRgb(value: string): [number, number, number] | undefined {
+  const v = value.trim().toLowerCase();
+  const named = NAMED_COLORS[v];
+  if (named) return named;
+
+  const hex = /^#([0-9a-f]{3,8})$/i.exec(v);
+  if (hex) {
+    const h = hex[1];
+    if (h.length === 3 || h.length === 4) {
+      return [0, 1, 2].map((i) => parseInt(h[i] + h[i], 16)) as [number, number, number];
+    }
+    if (h.length === 6 || h.length === 8) {
+      return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as [number, number, number];
+    }
+    return undefined;
+  }
+
+  // rgb()/rgba(), both the legacy comma form and the modern space form.
+  const fn = /^rgba?\(([^)]*)\)$/.exec(v);
+  if (fn) {
+    const parts = fn[1].split(/[\s,/]+/).filter((s) => s !== "");
+    if (parts.length < 3) return undefined;
+    const nums = parts.slice(0, 3).map((p) => {
+      // A percentage channel is still a channel.
+      if (p.endsWith("%")) {
+        const pct = Number(p.slice(0, -1));
+        return Number.isFinite(pct) ? (pct / 100) * 255 : NaN;
+      }
+      return Number(p);
+    });
+    if (nums.some((n) => !Number.isFinite(n))) return undefined;
+    return nums.map((n) => Math.max(0, Math.min(255, n))) as [number, number, number];
+  }
+  return undefined;
+}
+
+/** WCAG relative luminance (sRGB), 0 = black, 1 = white. */
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/**
+ * The dark ink and the light ink a badge chooses between — the same pair the
+ * theme already uses, so an unresolvable colour falling back to
+ * `--text-primary-color` looks no different.
+ */
+const INK_DARK = "#212121";
+const INK_LIGHT = "#ffffff";
+const LUM_DARK = relativeLuminance([0x21, 0x21, 0x21]);
+const LUM_LIGHT = relativeLuminance([0xff, 0xff, 0xff]);
+
+/**
+ * Black or white text for a known background colour (issue #106) — or
+ * `undefined` when the background is not something we can read.
+ *
+ * A device badge paints its background from config (a state rule, an active
+ * colour, a bulb's own colour) while its foreground was pinned to the theme's
+ * `--text-primary-color`. On a dark theme that ink is near-white, so a pale
+ * badge swallowed its own icon: *"if i set it on white background, when it's
+ * open, the icon is white on white"*. The two are independent, so the
+ * foreground has to follow the background rather than the theme.
+ *
+ * The `undefined` return is the important half. `var(--accent)`, `color-mix()`
+ * and gradients are all legal here and none can be resolved without the live
+ * computed style, so those badges keep the theme ink exactly as they do today.
+ * Picking an ink for a colour we cannot see would be worse than not trying.
+ *
+ * Decided by comparing the two actual WCAG contrast ratios rather than by a
+ * luminance threshold. A threshold has to be derived from the inks — the usual
+ * 0.179 crossover assumes pure black, and ours is `#212121`, which moves it to
+ * ~0.212 — so the constant and the inks could drift apart silently. Comparing
+ * the ratios cannot.
+ */
+export function contrastText(color: unknown): string | undefined {
+  if (typeof color !== "string") return undefined;
+  const rgb = parseRgb(color);
+  if (!rgb) return undefined;
+  const bg = relativeLuminance(rgb);
+  const ratio = (ink: number) =>
+    (Math.max(bg, ink) + 0.05) / (Math.min(bg, ink) + 0.05);
+  return ratio(LUM_DARK) >= ratio(LUM_LIGHT) ? INK_DARK : INK_LIGHT;
+}
+
+/**
  * An icon name for `<ha-icon icon="…">` (issue #106), or `undefined` when the
  * value is not one.
  *

--- a/src/css-safe.ts
+++ b/src/css-safe.ts
@@ -121,6 +121,30 @@ export function cssIdent(value: unknown): string | undefined {
 }
 
 /**
+ * An icon name for `<ha-icon icon="…">` (issue #106), or `undefined` when the
+ * value is not one.
+ *
+ * Not a style sink — Lit escapes attribute values — so unlike {@link cssColor}
+ * this is not about breakout. It is about the fallback chain staying honest.
+ * `ha-icon` resolves `set:name` against a registered icon set, and anything
+ * else yields a console error and an empty circle.
+ *
+ * Deliberately **validates rather than strips**, which is the difference
+ * between this and {@link cssIdent}. Stripping `"><script>` leaves `script` —
+ * harmless, but still a non-icon that has now displaced the icon the caller
+ * would otherwise have fallen back to. Callers use the `undefined` to move on
+ * to the next candidate, so a value that cannot render must not survive as
+ * *something*.
+ */
+const ICON_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*:[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+
+export function cssIcon(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim();
+  return ICON_NAME.test(v) ? v : undefined;
+}
+
+/**
  * An entity id for a `data-entity` attribute (issue #105). Separate from
  * {@link cssIdent} because an entity id is `domain.object_id` and the dot is
  * load-bearing — `[data-entity="light.kitchen"]` is the selector people will

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -236,10 +236,33 @@ describe("itemForm", () => {
 
   it("data presents effective defaults", () => {
     const d = itemForm(item).data;
-    expect(d.showIcon).toBe(true);
+    expect(d.badgeContent).toBe("icon");
     expect(d.showState).toBe(false);
     expect(d.display).toBe("badge");
     expect(d.angle).toBe(0);
+  });
+
+  it("replaces the Show icon toggle with a three-way Badge shows dropdown (#106)", () => {
+    const names = itemForm(item).fields.map((x) => x.name);
+    expect(names).toContain("badgeContent");
+    expect(names).not.toContain("showIcon");
+    const f = itemForm(item).fields.find((x) => x.name === "badgeContent")!;
+    const opts = (f.selector as { select: { options: { value: string }[] } }).select.options.map(
+      (o) => o.value
+    );
+    expect(opts).toEqual(["icon", "value", "none"]);
+  });
+
+  it("migrates a legacy showIcon config, and retires the key once touched (#106)", () => {
+    // An untouched legacy config still reads as "no badge"…
+    const legacy = itemForm({ ...item, showIcon: false } as FloorItem);
+    expect(legacy.data.badgeContent).toBe("none");
+    // …and choosing anything in the new dropdown drops the old key, so the two
+    // can never be edited into disagreeing.
+    const patch = legacy.toPatch({ badgeContent: "value" });
+    expect(patch).toEqual({ badgeContent: "value", showIcon: undefined });
+    // Unrelated edits leave it alone.
+    expect(legacy.toPatch({ size: 40 })).toEqual({ size: 40 });
   });
 
   it("scopes the entity/secondaryEntity pickers to the area's entities when given", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -30,6 +30,7 @@ import {
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
+  badgeContentOf,
   defaultIcon,
   normalizePlanRotation,
   openingMotion,
@@ -444,7 +445,12 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
     }
   }
   fields.push(
-    { name: "showIcon", label: "Show icon", selector: { boolean: {} } },
+    {
+      name: "badgeContent",
+      label: "Badge shows",
+      helper: "Value puts the reading in the badge; falls back to the icon when there is no number",
+      selector: dropdown(opt("icon", "Icon"), opt("value", "Value"), opt("none", "Nothing")),
+    },
     {
       name: "hideWhenInactive",
       label: "Only when active",
@@ -497,7 +503,7 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       glow: it.glow ?? false,
       glowRadius: it.glowRadius ?? DEFAULT_GLOW_RADIUS,
       glowColor: it.glowColor ?? "",
-      showIcon: it.showIcon ?? true,
+      badgeContent: badgeContentOf(it),
       hideWhenInactive: it.hideWhenInactive ?? false,
       showState: it.showState ?? false,
       showName: it.showName ?? false,
@@ -506,7 +512,12 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       hold_action: it.hold_action,
       double_tap_action: it.double_tap_action,
     },
-    toPatch: identity,
+    // Touching "Badge shows" retires the `showIcon` boolean it replaced (issue
+    // #106), so a migrated config carries one setting rather than two that
+    // could later be edited into disagreeing. Configs nobody touches keep
+    // working through badgeContentOf's fallback.
+    toPatch: (patch) =>
+      "badgeContent" in patch ? { ...patch, showIcon: undefined } : patch,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -68,6 +68,8 @@ import {
   kindFromEntity,
   resolveItemIcon,
   resolveStateColor,
+  entityIsActive,
+  lightBadgePaint,
   itemRawValue,
   badgeContentOf,
   badgeValue,
@@ -80,7 +82,7 @@ import {
   collectWatchedEntities,
   hassRenderInputsChanged,
 } from "./render";
-import { cssColor, cssColorOr, cssNumber } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber, contrastText } from "./css-safe";
 import {
   ENDPOINT_SNAP,
   applyDelta,
@@ -3395,7 +3397,16 @@ export class FloorplanCardEditor extends LitElement {
     const stateColor = cssColor(resolveStateColor(it.stateColor, rawValue));
     // …and the same badge contents, so "Badge shows: Value" previews here too.
     const value = badgeContentOf(it) === "value" ? badgeValue(this.hass, it) : undefined;
-    const rippleColor = it.rippleColor ?? stateColor ?? "var(--primary-color, #03a9f4)";
+    // The active colour — the one the user set, else the bulb's own colour
+    // (issue #106). The canvas never previewed either, so setting "Active
+    // color" changed nothing here and a coloured lamp would have looked plain;
+    // both are the same one line, so both land together.
+    const active = entityIsActive(it.entity, st?.state);
+    const activeColor = active ? (cssColor(it.activeColor) ?? lightBadgePaint(st)) : undefined;
+    // Ink that reads on whatever the badge ends up painted, same rule as the card.
+    const badgeInk = contrastText(stateColor ?? activeColor);
+    const rippleColor =
+      it.rippleColor ?? stateColor ?? activeColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     // Live preview: the icon animates exactly when the card would animate it
@@ -3403,9 +3414,15 @@ export class FloorplanCardEditor extends LitElement {
     // effect without leaving the editor.
     const anim = resolveIconAnimation(it, st?.state);
     const badge = html`<div
-      class="badge ${showIcon ? "" : "ghost"} ${stateColor ? "state-colored" : ""}"
+      class="badge ${showIcon ? "" : "ghost"} ${stateColor
+        ? "state-colored"
+        : active
+          ? "active-colored"
+          : ""}"
       style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(it.angle, 0)}deg);${
         stateColor ? `--fp-state:${stateColor};` : ""
+      }${activeColor ? `--fp-active:${activeColor};` : ""}${
+        badgeInk ? `--fp-ink:${badgeInk};` : ""
       }"
     >
       ${value
@@ -5030,7 +5047,18 @@ export class FloorplanCardEditor extends LitElement {
     .edit-item .badge.state-colored {
       background: var(--fp-state);
       border-color: var(--fp-state);
-      color: var(--text-primary-color, #212121);
+      color: var(--fp-ink, var(--text-primary-color, #212121));
+    }
+    /* An active device, painted exactly as the card paints it (issue #106):
+       the device's active colour, else a colour-capable bulb's own, else the
+       theme's active yellow — the same fallback chain as .item.on .badge.
+       The canvas previewed none of this before, so setting "Active color"
+       changed nothing here and a coloured lamp looked plain. Below
+       .state-colored, which is the more specific statement. */
+    .edit-item .badge.active-colored {
+      background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
+      border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
+      color: var(--fp-ink, var(--text-primary-color, #212121));
     }
     .state-color-rule select {
       flex: 0 0 96px;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -68,6 +68,10 @@ import {
   kindFromEntity,
   resolveItemIcon,
   resolveStateColor,
+  itemRawValue,
+  badgeContentOf,
+  badgeValue,
+  badgeValueSize,
   itemHiddenWhenInactive,
   resolveIconAnimation,
   itemIconSize,
@@ -1860,7 +1864,8 @@ export class FloorplanCardEditor extends LitElement {
    */
   private _renderStateColorRules(
     rules: StateColorRule[] | undefined,
-    onChange: (next: StateColorRule[] | undefined) => void
+    onChange: (next: StateColorRule[] | undefined) => void,
+    opts?: { icons?: boolean }
   ): TemplateResult {
     const list = rules ?? [];
     const patch = (i: number, part: Partial<StateColorRule>): void => {
@@ -1869,7 +1874,12 @@ export class FloorplanCardEditor extends LitElement {
     };
     return html`
       <div class="row wide state-colors">
-        <label title="Color the element by what its entity reads">Color by state</label>
+        <label
+          title=${opts?.icons
+            ? "Color the badge — and optionally swap its icon — by what the entity reads"
+            : "Color the element by what its entity reads"}
+          >${opts?.icons ? "Color & icon by state" : "Color by state"}</label
+        >
       </div>
       ${list.map((rule, i) => {
         const mode = typeof rule.state === "string" ? "state" : typeof rule.above === "number" ? "above" : "else";
@@ -1921,6 +1931,9 @@ export class FloorplanCardEditor extends LitElement {
               .value=${rule.color ?? ""}
               @change=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
             />
+            ${opts?.icons
+              ? this._renderIconPicker(rule.icon ?? "", (icon) => patch(i, { icon: icon || undefined }))
+              : nothing}
             <button
               class="rule-remove"
               aria-label="Remove rule"
@@ -3045,6 +3058,32 @@ export class FloorplanCardEditor extends LitElement {
     />`;
   }
 
+  /**
+   * Icon field for the hand-rolled rows (issue #106), mirroring
+   * {@link _renderEntityPicker}: HA's searchable picker when the frontend has
+   * registered it, a plain text input otherwise. Used by the state-rule list,
+   * which cannot go through `ha-form` because it is repeatable.
+   */
+  private _renderIconPicker(value: string, onChange: (icon: string) => void): TemplateResult {
+    if (customElements.get("ha-icon-picker")) {
+      return html`<ha-icon-picker
+        class="rule-icon"
+        .hass=${this.hass}
+        .value=${value}
+        placeholder="Icon"
+        @value-changed=${(e: CustomEvent) => onChange((e.detail.value as string) ?? "")}
+      ></ha-icon-picker>`;
+    }
+    return html`<input
+      type="text"
+      class="rule-icon"
+      placeholder="mdi:blinds"
+      title="Icon while this rule matches (optional)"
+      .value=${value}
+      @change=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
+    />`;
+  }
+
   /** Toggle the full-screen workspace. */
   private _toggleFullscreen(): void {
     this._fullscreen = !this._fullscreen;
@@ -3348,14 +3387,14 @@ export class FloorplanCardEditor extends LitElement {
     const icon = resolveItemIcon(it, st, it.entity ? this.hass?.entities?.[it.entity]?.icon : undefined);
     const label = it.name || it.entity || it.kind;
     const size = cssNumber(it.size, DEFAULT_ITEM_SIZE);
-    const showIcon = it.showIcon ?? true;
+    const showIcon = badgeContentOf(it) !== "none";
     const display = it.display ?? "badge";
     // Same resolution as the card, so the canvas shows the colour the plan
     // will actually render (state rules first, then the active colour).
-    const rawValue = it.attribute
-      ? (st?.attributes as Record<string, unknown> | undefined)?.[it.attribute]
-      : st?.state;
+    const rawValue = itemRawValue(it, st);
     const stateColor = cssColor(resolveStateColor(it.stateColor, rawValue));
+    // …and the same badge contents, so "Badge shows: Value" previews here too.
+    const value = badgeContentOf(it) === "value" ? badgeValue(this.hass, it) : undefined;
     const rippleColor = it.rippleColor ?? stateColor ?? "var(--primary-color, #03a9f4)";
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
@@ -3369,11 +3408,15 @@ export class FloorplanCardEditor extends LitElement {
         stateColor ? `--fp-state:${stateColor};` : ""
       }"
     >
-      <ha-icon
-        class=${anim ? `anim-${anim}` : ""}
-        icon=${icon}
-        style="--mdc-icon-size:${itemIconSize(size)}px;"
-      ></ha-icon>
+      ${value
+        ? html`<span class="badge-value" style="font-size:${badgeValueSize(size, value)}px;"
+            >${value}</span
+          >`
+        : html`<ha-icon
+            class=${anim ? `anim-${anim}` : ""}
+            icon=${icon}
+            style="--mdc-icon-size:${itemIconSize(size)}px;"
+          ></ha-icon>`}
     </div>`;
 
     // Editor always previews the ripple animated so its effect is visible.
@@ -3576,8 +3619,13 @@ export class FloorplanCardEditor extends LitElement {
               onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
             })
           : nothing}
-        ${this._renderStateColorRules(it.stateColor, (stateColor) =>
-          this._updateItem(it.id, { stateColor })
+        ${this._renderStateColorRules(
+          it.stateColor,
+          (stateColor) => this._updateItem(it.id, { stateColor }),
+          // Only a device draws a glyph, so only a device's rules offer an
+          // icon — furniture and areas share this rule shape but paint
+          // polygons (issue #106).
+          { icons: true }
         )}
       `;
     }
@@ -4442,6 +4490,14 @@ export class FloorplanCardEditor extends LitElement {
       color: var(--primary-text-color);
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
     }
+    /* Mirrors the card's .badge-value (issue #106) — the canvas must show the
+       reading exactly as the plan will draw it. */
+    .badge-value {
+      font-weight: 600;
+      line-height: 1;
+      letter-spacing: -0.02em;
+      white-space: nowrap;
+    }
     /* Hidden on the live card right now (issue #55): faded and dashed here so
        it reads as deliberately absent from the card, while staying selectable. */
     .edit-item.card-hidden {
@@ -4994,6 +5050,13 @@ export class FloorplanCardEditor extends LitElement {
     .row.state-color-rule input.rule-color-text {
       flex: 1 1 60px;
       min-width: 60px;
+    }
+    /* The optional icon (issue #106) takes the rule's second line rather than
+       competing for the first: the condition and the colour are what you scan,
+       and an icon picker needs room for its name to be readable. */
+    .row.state-color-rule .rule-icon {
+      flex: 1 1 100%;
+      min-width: 0;
     }
     .state-color-rule .rule-remove,
     .state-color-add button {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -42,6 +42,10 @@ import {
   entityIsActive,
   itemBadgeLabel,
   resolveStateColor,
+  itemRawValue,
+  badgeContentOf,
+  badgeValue,
+  badgeValueSize,
   itemHiddenWhenInactive,
   itemLabelSize,
   hassRenderInputsChanged,
@@ -234,16 +238,24 @@ export class FloorplanCard extends LitElement {
       item,
       item.entity ? this.hass?.states[item.entity]?.state : undefined,
     );
+    // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
+    // state colour, ripple stacking all unchanged — with the glyph swapped for
+    // the number. A device with nothing numeric to show keeps its icon.
+    const value = badgeContentOf(item) === "value" ? badgeValue(this.hass, item) : undefined;
     return html`
       <div
         class="badge"
         style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(item.angle, 0)}deg);"
       >
-        <ha-icon
-          class=${anim ? `anim-${anim}` : ""}
-          icon=${this._itemIcon(item)}
-          style="--mdc-icon-size:${itemIconSize(size)}px;"
-        ></ha-icon>
+        ${value
+          ? html`<span class="badge-value" style="font-size:${badgeValueSize(size, value)}px;"
+              >${value}</span
+            >`
+          : html`<ha-icon
+              class=${anim ? `anim-${anim}` : ""}
+              icon=${this._itemIcon(item)}
+              style="--mdc-icon-size:${itemIconSize(size)}px;"
+            ></ha-icon>`}
       </div>
     `;
   }
@@ -256,16 +268,15 @@ export class FloorplanCard extends LitElement {
     // Threshold color (issue #68), judged on the displayed value (attribute
     // when set, else the state). cssColor gates the config string (#64).
     const st = item.entity ? this.hass?.states[item.entity] : undefined;
-    const rawValue = item.attribute
-      ? (st?.attributes as Record<string, unknown> | undefined)?.[item.attribute]
-      : st?.state;
+    const rawValue = itemRawValue(item, st);
     // One resolved colour drives the whole element (issue #79 follow-up): the
     // label *and* the badge. A sensor is never "on", so tying the badge to the
     // active state alone left threshold colours invisible on exactly the
     // devices they were written for.
     const stateColor = cssColor(resolveStateColor(item.stateColor, rawValue));
     const labelColor = stateColor;
-    const showIcon = item.showIcon ?? true;
+    // "none" is the old `showIcon: false` — no badge, label only (issue #106).
+    const showIcon = badgeContentOf(item) !== "none";
     const display = item.display ?? "badge";
     // Per-device active color (issue #79). Ripples follow it too, so a device
     // given one color does not come out yellow-badged with a blue ring.
@@ -770,6 +781,16 @@ export class FloorplanCard extends LitElement {
       justify-content: center;
       color: var(--primary-text-color);
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+    /* The reading standing in for the icon (issue #106). Inherits the badge's
+       text color, so every rule that recolours a badge — active, --fp-state —
+       carries the number with it and needs no counterpart here. The negative
+       tracking buys back the width a 4-glyph reading like 1.2kW needs. */
+    .badge-value {
+      font-weight: 600;
+      line-height: 1;
+      letter-spacing: -0.02em;
+      white-space: nowrap;
     }
     /*
      * --fp-active is the item's own activeColor (issue #79) when it sets one;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, svg, nothing, type TemplateResult, type Property
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor, Area } from "./types";
-import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, contrastText } from "./css-safe";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -34,6 +34,7 @@ import {
   renderAreaBorder,
   areaColor,
   glowPaint,
+  lightBadgePaint,
   renderGlow,
   renderGlowMask,
   renderSunDimMask,
@@ -282,9 +283,18 @@ export class FloorplanCard extends LitElement {
     // given one color does not come out yellow-badged with a blue ring.
     // State rules win over the fixed active colour — they are the more
     // specific statement about what this element should look like right now.
-    const activeColor = cssColor(item.activeColor);
+    // A colour-capable bulb badges itself its own colour, dimmed with its
+    // brightness (issue #106, @ombre33) — but only below anything the user
+    // stated explicitly, and only when the bulb actually reports a colour.
+    const lightColor = lightBadgePaint(st);
+    const activeColor = cssColor(item.activeColor) ?? lightColor;
     const rippleColor =
-      item.rippleColor ?? stateColor ?? item.activeColor ?? "var(--primary-color, #03a9f4)";
+      item.rippleColor ?? stateColor ?? item.activeColor ?? lightColor ?? "var(--primary-color, #03a9f4)";
+    // Ink that can actually be read on whatever the badge ended up painted
+    // (issue #106, @MrMcFlyy): a white state colour used to take the theme's
+    // white icon with it. undefined for a colour we cannot resolve — a
+    // var()/color-mix()/gradient keeps the theme ink, exactly as before.
+    const badgeInk = contrastText(stateColor ?? activeColor);
     const rippleSize = item.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     let visual: TemplateResult | typeof nothing = nothing;
@@ -313,7 +323,7 @@ export class FloorplanCard extends LitElement {
           ? `--fp-state:${stateColor};`
           : ""}${activeColor
           ? `--fp-active:${activeColor};`
-          : ""}"
+          : ""}${badgeInk ? `--fp-ink:${badgeInk};` : ""}"
         title=${this._label(item)}
         role="button"
         tabindex="0"
@@ -800,7 +810,7 @@ export class FloorplanCard extends LitElement {
     .item.on .badge {
       background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
       border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
-      color: var(--text-primary-color, #212121);
+      color: var(--fp-ink, var(--text-primary-color, #212121));
     }
     /* A resolved state colour paints the badge whatever the on/off state —
        thresholds exist for sensors, which are never "on". Declared *after* the
@@ -808,7 +818,7 @@ export class FloorplanCard extends LitElement {
     .item.state-colored .badge {
       background: var(--fp-state);
       border-color: var(--fp-state);
-      color: var(--text-primary-color, #212121);
+      color: var(--fp-ink, var(--text-primary-color, #212121));
     }
     ha-icon {
       --mdc-icon-size: 22px;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_GLOW_COLOR,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
+  BADGE_MIN_LIGHTNESS,
+  FURNITURE_GLOW_TRANSMISSION,
   SUN_ELEVATION_NIGHT,
   SUN_ELEVATION_DAY,
 } from "./types";
@@ -66,6 +68,7 @@ import {
   WALL_THICKNESS,
   areaColor,
   glowPaint,
+  lightBadgePaint,
   editorGlowPaint,
   glowReach,
   renderGlowMask,
@@ -2239,6 +2242,65 @@ describe("glowPaint (issue #6)", () => {
   });
 });
 
+// @ombre33 on #106: every badge is the theme yellow while the lamps are green,
+// blue and pink. The badge should look like the bulb.
+describe("lightBadgePaint (#106)", () => {
+  const light = (state: string, attributes: Record<string, unknown> = {}) =>
+    ({ entity_id: "light.x", state, attributes }) as never;
+
+  it("wears a colour-capable bulb's own rgb at full brightness", () => {
+    expect(lightBadgePaint(light("on", { rgb_color: [0, 200, 100], brightness: 255 }))).toBe(
+      "rgb(0, 200, 100)",
+    );
+  });
+
+  it("darkens with brightness, down to a floor that is still recognisably the bulb", () => {
+    const full = lightBadgePaint(light("on", { rgb_color: [200, 100, 50], brightness: 255 }));
+    const half = lightBadgePaint(light("on", { rgb_color: [200, 100, 50], brightness: 128 }));
+    const off = lightBadgePaint(light("on", { rgb_color: [200, 100, 50], brightness: 0 }));
+    expect(full).toBe("rgb(200, 100, 50)");
+    // Each channel scaled by the same factor — the hue is preserved, only the
+    // lightness moves.
+    expect(half).toBe(
+      `rgb(${[200, 100, 50]
+        .map((c) => Math.round(c * (BADGE_MIN_LIGHTNESS + (1 - BADGE_MIN_LIGHTNESS) * (128 / 255))))
+        .join(", ")})`,
+    );
+    expect(off).toBe(
+      `rgb(${[200, 100, 50].map((c) => Math.round(c * BADGE_MIN_LIGHTNESS)).join(", ")})`,
+    );
+    // The floor is the point: a barely-lit lamp is still identifiable.
+    expect(off).not.toBe("rgb(0, 0, 0)");
+  });
+
+  it("leaves a bulb that reports no colour completely alone", () => {
+    // The no-surprise guarantee, and the reason this is not glowPaint: that one
+    // falls back to a warm white, which would repaint every plain bulb amber.
+    expect(lightBadgePaint(light("on", { brightness: 255 }))).toBeUndefined();
+    expect(lightBadgePaint(light("on"))).toBeUndefined();
+    expect(glowPaint({}, light("on"))?.color).toBe(DEFAULT_GLOW_COLOR);
+  });
+
+  it("paints nothing when off, unavailable, unknown or missing (fails closed)", () => {
+    expect(lightBadgePaint(light("off", { rgb_color: [255, 0, 0] }))).toBeUndefined();
+    expect(lightBadgePaint(light("unavailable", { rgb_color: [255, 0, 0] }))).toBeUndefined();
+    expect(lightBadgePaint(light("unknown", { rgb_color: [255, 0, 0] }))).toBeUndefined();
+    expect(lightBadgePaint(undefined)).toBeUndefined();
+  });
+
+  it("ignores a malformed rgb_color rather than emitting a broken colour", () => {
+    expect(lightBadgePaint(light("on", { rgb_color: [255, 0] }))).toBeUndefined();
+    expect(lightBadgePaint(light("on", { rgb_color: "red;position:fixed" }))).toBeUndefined();
+    expect(lightBadgePaint(light("on", { rgb_color: [null, 1, 2] }))).toBeUndefined();
+  });
+
+  it("clamps out-of-range channels instead of trusting the integration", () => {
+    expect(lightBadgePaint(light("on", { rgb_color: [300, -20, 12.6], brightness: 255 }))).toBe(
+      "rgb(255, 0, 13)",
+    );
+  });
+});
+
 describe("glowReach — walls block light (issue #108)", () => {
   const wall = (x1: number, y1: number, x2: number, y2: number, id = "w") => ({ id, x1, y1, x2, y2 });
   // Even-odd point-in-polygon, for asserting what the light can reach.
@@ -2391,7 +2453,7 @@ describe("styling hooks reach the DOM (issue #105)", () => {
   });
 });
 
-describe("renderGlowMask — furniture stays base gray (issue #108)", () => {
+describe("renderGlowMask — furniture is dimmed, not blacked out (#108, #106)", () => {
   const flatten = (node: unknown): string => {
     if (node == null || typeof node === "boolean") return "";
     if (Array.isArray(node)) return node.map(flatten).join("");
@@ -2402,8 +2464,8 @@ describe("renderGlowMask — furniture stays base gray (issue #108)", () => {
     return String(node);
   };
 
-  it("punches a black rotated rect per furniture piece, ellipse for round types", () => {
-    const markup = flatten(
+  const twoPieces = () =>
+    flatten(
       renderGlowMask(
         [
           { id: "s", type: "sofa", x: 300, y: 200, w: 100, h: 50, angle: 90 },
@@ -2414,12 +2476,30 @@ describe("renderGlowMask — furniture stays base gray (issue #108)", () => {
         "gm"
       )
     );
-    expect(markup).toContain('id=gm');
-    expect(markup).toContain('fill="black"');
+
+  it("shades a rotated rect per furniture piece, ellipse for round types", () => {
+    const markup = twoPieces();
+    expect(markup).toContain("id=gm");
     expect(markup).toContain("rotate(90 300 200)");
     expect(markup).toContain("<ellipse");
     // Explicit region, not the viewport default (the issue #102 lesson).
     expect(markup).toContain("width=1016");
+  });
+
+  // This is the guard in *both* directions, and the reason the level is a
+  // named constant. Each end of this dial has shipped as a bug: fully lit was
+  // #108 (every sofa read as highlighted), fully dark was #106 (a lit table
+  // came out as a shadow). Only a value strictly between the two is correct.
+  it("blocks some of the light but not all of it", () => {
+    const markup = twoPieces();
+    expect(FURNITURE_GLOW_TRANSMISSION).toBeGreaterThan(0);
+    expect(FURNITURE_GLOW_TRANSMISSION).toBeLessThan(1);
+    // A solid black hole (a shadow) or no shape at all (a flood) would both
+    // fail here: furniture must paint, and paint partially.
+    const blocked = 1 - FURNITURE_GLOW_TRANSMISSION;
+    expect(markup).toContain(`fill-opacity=${blocked}`);
+    expect(markup).not.toContain('fill-opacity="1"');
+    expect(markup).not.toContain('fill="black"');
   });
 
   it("clips the pool with the reach polygon only when walls are in range", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -50,6 +50,10 @@ import {
   isEntityOn,
   entityIsActive,
   resolveItemIcon,
+  matchStateRule,
+  badgeContentOf,
+  badgeValue,
+  badgeValueSize,
   resolveIconAnimation,
   itemIconSize,
   normalizePlanRotation,
@@ -699,6 +703,79 @@ describe("isEntityOn / resolveItemIcon", () => {
       resolveItemIcon(item, { state: "on", attributes: { icon: "mdi:from-entity" } }, undefined)
     ).toBe("mdi:from-entity");
   });
+
+  // Issue #106: "you can not only change the color, but also the icon
+  // depending on the state" — blinds open vs. blinds closed.
+  describe("icon from a state rule (#106)", () => {
+    const blind = {
+      entity: "cover.blind",
+      kind: "cover" as const,
+      stateColor: [
+        { state: "open", color: "#4caf50", icon: "mdi:blinds-open" },
+        { state: "closed", color: "#9e9e9e", icon: "mdi:blinds" },
+      ],
+    };
+    const st = (state: string) => ({ state, attributes: {} });
+
+    it("swaps the glyph with the state", () => {
+      expect(resolveItemIcon(blind, st("open"))).toBe("mdi:blinds-open");
+      expect(resolveItemIcon(blind, st("closed"))).toBe("mdi:blinds");
+    });
+
+    it("beats a config icon — which used to freeze the glyph outright", () => {
+      const pinned = { ...blind, icon: "mdi:pinned" };
+      expect(resolveItemIcon(pinned, st("open"))).toBe("mdi:blinds-open");
+      // No rule matches: the config icon is still in charge.
+      expect(resolveItemIcon(pinned, st("opening"))).toBe("mdi:pinned");
+    });
+
+    it("a rule with no icon changes nothing (colour-only rules are unaffected)", () => {
+      const colourOnly = { ...blind, stateColor: [{ state: "open", color: "#4caf50" }] };
+      expect(resolveItemIcon(colourOnly, st("open"))).toBe(
+        entityDefaultIcon("cover.blind", undefined, true) ?? defaultIcon("cover")
+      );
+      expect(resolveItemIcon({ ...colourOnly, icon: "mdi:pinned" }, st("open"))).toBe("mdi:pinned");
+    });
+
+    it("judges the rule on the same reading the colour uses (an attribute when set)", () => {
+      const climate = {
+        entity: "climate.hall",
+        kind: "climate" as const,
+        attribute: "hvac_action",
+        stateColor: [{ state: "heating", color: "red", icon: "mdi:fire" }],
+      };
+      expect(resolveItemIcon(climate, { state: "heat", attributes: { hvac_action: "heating" } })).toBe(
+        "mdi:fire"
+      );
+      expect(resolveItemIcon(climate, { state: "heat", attributes: { hvac_action: "idle" } })).toBe(
+        defaultIcon("climate")
+      );
+    });
+
+    it("drops an unusable icon rather than rendering an empty box", () => {
+      const hostile = {
+        ...blind,
+        icon: "mdi:fallback",
+        stateColor: [{ state: "open", color: "red", icon: '"><script>' }],
+      };
+      const icon = resolveItemIcon(hostile, st("open"));
+      expect(icon).toBe("mdi:fallback");
+      expect(icon).not.toContain("<");
+    });
+
+    it("a threshold rule can carry an icon too", () => {
+      const battery = {
+        entity: "sensor.battery",
+        kind: "sensor" as const,
+        stateColor: [
+          { above: 80, color: "green", icon: "mdi:battery" },
+          { color: "red", icon: "mdi:battery-alert" },
+        ],
+      };
+      expect(resolveItemIcon(battery, st("95"))).toBe("mdi:battery");
+      expect(resolveItemIcon(battery, st("12"))).toBe("mdi:battery-alert");
+    });
+  });
 });
 
 describe("collectWatchedEntities", () => {
@@ -1283,6 +1360,219 @@ describe("resolveStateColor (issue #68)", () => {
       expect(resolveStateColor(rules, "anything")).toBe("red");
       expect(resolveStateColor(rules, "")).toBe("red");
     });
+  });
+
+  // The colour and the icon (#106) must come off the *same* matched rule, so
+  // the matcher returns the rule and resolveStateColor is a wrapper over it.
+  describe("matchStateRule (#106)", () => {
+    it("returns the very rule object that supplied the colour", () => {
+      const hot = { above: 26, color: "red", icon: "mdi:fire" };
+      const rs = [hot, { above: 24, color: "orange" }, { color: "white" }];
+      expect(matchStateRule(rs, 30)).toBe(hot);
+      expect(matchStateRule(rs, 30)?.icon).toBe("mdi:fire");
+      // …and the wrapper still answers exactly as it did.
+      expect(resolveStateColor(rs, 30)).toBe(hot.color);
+    });
+
+    it("agrees with resolveStateColor across the whole precedence table", () => {
+      const rs = [
+        { above: 26, color: "red" },
+        { above: 24, color: "orange" },
+        { state: "heat", color: "blue" },
+        { color: "white" },
+      ];
+      for (const v of [30, 25, 20, "heat", "HEAT", "", null, undefined, true, "nonsense"]) {
+        expect(matchStateRule(rs, v)?.color).toBe(resolveStateColor(rs, v));
+      }
+    });
+
+    it("no rules, no match", () => {
+      expect(matchStateRule(undefined, 1)).toBeUndefined();
+      expect(matchStateRule([], 1)).toBeUndefined();
+    });
+  });
+});
+
+describe("badgeContentOf (#106)", () => {
+  it("defaults to the icon", () => {
+    expect(badgeContentOf({})).toBe("icon");
+    expect(badgeContentOf({ showIcon: true })).toBe("icon");
+  });
+
+  it("honours a legacy showIcon: false as 'no badge'", () => {
+    expect(badgeContentOf({ showIcon: false })).toBe("none");
+  });
+
+  it("an explicit badgeContent wins over the boolean it replaced", () => {
+    expect(badgeContentOf({ badgeContent: "value", showIcon: false })).toBe("value");
+    expect(badgeContentOf({ badgeContent: "icon", showIcon: false })).toBe("icon");
+    expect(badgeContentOf({ badgeContent: "none", showIcon: true })).toBe("none");
+  });
+
+  it("ignores a junk value rather than blanking the badge", () => {
+    expect(badgeContentOf({ badgeContent: "bogus" as never })).toBe("icon");
+    expect(badgeContentOf({ badgeContent: "bogus" as never, showIcon: false })).toBe("none");
+  });
+});
+
+describe("badgeValue (#106)", () => {
+  const hass = (states: Record<string, { state: string; attributes?: object }>) =>
+    ({
+      states: Object.fromEntries(
+        Object.entries(states).map(([id, s]) => [id, { entity_id: id, attributes: {}, ...s }]),
+      ),
+    }) as unknown as RenderHass;
+
+  it("shows a thermostat's temperature — its state is a mode, not a number", () => {
+    const h = hass({
+      "climate.hall": { state: "heat", attributes: { current_temperature: 21.4 } },
+    });
+    expect(badgeValue(h, { entity: "climate.hall" })).toBe("21°");
+  });
+
+  // The case from the issue: colour by hvac_action, still read the temperature.
+  it("falls through a non-numeric configured attribute to the domain reading", () => {
+    const h = hass({
+      "climate.hall": {
+        state: "heat",
+        attributes: { hvac_action: "heating", current_temperature: 21.4 },
+      },
+    });
+    expect(badgeValue(h, { entity: "climate.hall", attribute: "hvac_action" })).toBe("21°");
+  });
+
+  it("uses a numeric configured attribute when there is one", () => {
+    const h = hass({
+      "climate.hall": { state: "heat", attributes: { temperature: 19, current_temperature: 21.4 } },
+    });
+    expect(badgeValue(h, { entity: "climate.hall", attribute: "temperature" })).toBe("19");
+  });
+
+  it("reads a sensor's own state, with a compact unit", () => {
+    const h = hass({
+      "sensor.co2": { state: "780", attributes: { unit_of_measurement: "ppm" } },
+      "sensor.temp": { state: "17.94", attributes: { unit_of_measurement: "°C" } },
+      "sensor.hum": { state: "45.2", attributes: { unit_of_measurement: "%" } },
+      "sensor.lux": { state: "1200", attributes: { unit_of_measurement: "lx" } },
+      "sensor.aqi": { state: "12", attributes: { unit_of_measurement: "µg/m³" } },
+    });
+    expect(badgeValue(h, { entity: "sensor.co2" })).toBe("780"); // ppm dropped
+    expect(badgeValue(h, { entity: "sensor.temp" })).toBe("18°"); // °C collapses
+    expect(badgeValue(h, { entity: "sensor.hum" })).toBe("45%");
+    expect(badgeValue(h, { entity: "sensor.lux" })).toBe("1200lx");
+    expect(badgeValue(h, { entity: "sensor.aqi" })).toBe("12"); // too long to fit
+  });
+
+  it("keeps one decimal only for small non-integers", () => {
+    const h = hass({
+      "sensor.power": { state: "1.24", attributes: { unit_of_measurement: "kW" } },
+      "sensor.big": { state: "1234.6", attributes: { unit_of_measurement: "W" } },
+      "sensor.whole": { state: "9", attributes: {} },
+    });
+    expect(badgeValue(h, { entity: "sensor.power" })).toBe("1.2kW");
+    // Watts fold into kW rather than becoming a five-glyph reading.
+    expect(badgeValue(h, { entity: "sensor.big" })).toBe("1.2kW");
+    expect(badgeValue(h, { entity: "sensor.whole" })).toBe("9");
+  });
+
+  // A smart plug: the switch has no reading, its power sensor does.
+  it("falls back to the secondary entity, which is what makes a plug work", () => {
+    const h = hass({
+      "switch.plug": { state: "on" },
+      "sensor.plug_power": { state: "1240", attributes: { unit_of_measurement: "W" } },
+    });
+    expect(
+      badgeValue(h, { entity: "switch.plug", secondaryEntity: "sensor.plug_power" }),
+    ).toBe("1.2kW");
+  });
+
+  it("returns undefined when nothing numeric exists, so the badge keeps its icon", () => {
+    const h = hass({
+      "light.kitchen": { state: "on" },
+      "cover.blind": { state: "closed" },
+      "sensor.dead": { state: "unavailable", attributes: { unit_of_measurement: "°C" } },
+      "sensor.blank": { state: "" },
+    });
+    expect(badgeValue(h, { entity: "light.kitchen" })).toBeUndefined();
+    expect(badgeValue(h, { entity: "cover.blind" })).toBeUndefined();
+    expect(badgeValue(h, { entity: "sensor.dead" })).toBeUndefined();
+    expect(badgeValue(h, { entity: "sensor.blank" })).toBeUndefined();
+    expect(badgeValue(h, { entity: "" })).toBeUndefined();
+    expect(badgeValue(undefined, { entity: "sensor.temp" })).toBeUndefined();
+  });
+
+  it("does not borrow the state's unit for an unrelated attribute", () => {
+    const h = hass({
+      "sensor.temp": { state: "18", attributes: { unit_of_measurement: "°C", battery_level: 87 } },
+    });
+    expect(badgeValue(h, { entity: "sensor.temp", attribute: "battery_level" })).toBe("87");
+  });
+
+  it("a humidifier reads its current humidity", () => {
+    const h = hass({ "humidifier.bed": { state: "on", attributes: { current_humidity: 44 } } });
+    expect(badgeValue(h, { entity: "humidifier.bed" })).toBe("44%");
+  });
+});
+
+describe("badgeValueSize (#106)", () => {
+  // Measured advance widths for the badge's 600-weight face, in units of
+  // font-size. Sizing must keep the rendered text inside the circle for every
+  // one of these — the bug this replaced sized by string length, which put
+  // "1240W" 3.2px outside an 18px badge.
+  const MEASURED: Record<string, number> = {
+    "9°": 1.18,
+    "21°": 1.66,
+    "-12°": 2.17,
+    "45%": 2.38,
+    "100%": 2.91,
+    "782": 1.95,
+    "9999": 2.76,
+    "1240W": 3.54,
+    "1.2kW": 3.07,
+    "12.5A": 2.88,
+  };
+
+  it("keeps the rendered text inside the badge at every realistic size", () => {
+    for (const badge of [24, 30, 34, 48, 80]) {
+      for (const [text, perPx] of Object.entries(MEASURED)) {
+        const size = badgeValueSize(badge, text);
+        const width = size * perPx;
+        // Either it fits, or sizing hit the documented 6px legibility floor —
+        // below which shrinking further would trade an overhang for a smudge.
+        const ok = width <= badge - 3 || size === 6;
+        expect({ badge, text, size, width: +width.toFixed(1), ok }).toEqual({
+          badge, text, size, width: +width.toFixed(1), ok: true,
+        });
+      }
+    }
+  });
+
+  it("sizes by glyph width, not string length", () => {
+    // Same length, very different widths: all three must not get one size.
+    const sizes = ["21°", "782", "45%"].map((t) => badgeValueSize(34, t));
+    expect(new Set(sizes).size).toBeGreaterThan(1);
+    // The narrowest reading gets the largest type.
+    expect(badgeValueSize(34, "21°")).toBeGreaterThan(badgeValueSize(34, "45%"));
+    expect(badgeValueSize(34, "45%")).toBeGreaterThan(badgeValueSize(34, "1240W"));
+  });
+
+  it("gives the default badge a legible 21° and a fitting 1240W", () => {
+    expect(badgeValueSize(34, "21°")).toBe(14);
+    expect(badgeValueSize(34, "1240W")).toBe(8);
+  });
+
+  it("caps short readings so 9° does not balloon, and floors long ones at 6px", () => {
+    // 46% of 80 is 36.8 → 37, nudged down to 36 for the badge's even parity.
+    expect(badgeValueSize(80, "9°")).toBe(36);
+    // A 5-glyph reading in a tiny badge hits the legibility floor rather than
+    // shrinking into a smudge; it wants a bigger badge instead.
+    expect(badgeValueSize(18, "1240W")).toBe(6);
+  });
+
+  it("shares itemIconSize's parity nudge, and survives a junk size", () => {
+    expect(badgeValueSize(34, "21°") % 2).toBe(0);
+    expect(badgeValueSize(19, "9°") % 2).toBe(1);
+    expect(badgeValueSize("40px;color:red" as never, "21°")).toBe(badgeValueSize(34, "21°"));
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -7,6 +7,7 @@ import type {
   ItemKind,
   IconAnimation,
   StateColorRule,
+  BadgeContent,
   Furniture,
   Tracker,
   Area,
@@ -28,12 +29,13 @@ import {
   DEFAULT_SUN_MAX,
   DEFAULT_GLOW_RADIUS,
   DEFAULT_GLOW_COLOR,
+  DEFAULT_ITEM_SIZE,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
   getFloors,
   trackerAxisFraction,
 } from "./types";
-import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId } from "./css-safe";
+import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, cssIcon } from "./css-safe";
 
 export const WALL_THICKNESS = 8;
 
@@ -182,30 +184,46 @@ export function resolveStateColor(
   rules: readonly StateColorRule[] | undefined,
   raw: unknown,
 ): string | undefined {
+  return matchStateRule(rules, raw)?.color;
+}
+
+/**
+ * The rule that applies to a value, by the precedence documented on
+ * {@link resolveStateColor} — which is now a one-line wrapper around this.
+ *
+ * Split out for issue #106: a rule can carry an `icon` as well as a `color`,
+ * and both must come from the *same* matched rule. Re-running the precedence
+ * once per property would be two chances to drift apart, and would quietly
+ * allow one rule's colour beside another rule's icon.
+ */
+export function matchStateRule(
+  rules: readonly StateColorRule[] | undefined,
+  raw: unknown,
+): StateColorRule | undefined {
   if (!rules?.length) return undefined;
   const n = typeof raw === "number" ? raw : Number(raw);
   const numeric = typeof raw !== "boolean" && raw !== "" && raw != null && Number.isFinite(n);
   const text = raw == null ? "" : String(raw).trim().toLowerCase();
-  let exact: string | undefined;
+  let exact: StateColorRule | undefined;
   let best: StateColorRule | undefined;
-  let fallback: string | undefined;
+  let fallback: StateColorRule | undefined;
   for (const rule of rules) {
     if (!rule || typeof rule !== "object" || typeof rule.color !== "string") continue;
     if (typeof rule.state === "string" && rule.state !== "") {
       // First matching state rule wins, so an earlier rule shadows a later
       // duplicate — the same "first one listed" reading as the default rule.
       if (exact === undefined && text !== "" && rule.state.trim().toLowerCase() === text) {
-        exact = rule.color;
+        exact = rule;
       }
     } else if (typeof rule.above === "number") {
       if (numeric && n > rule.above && (!best || rule.above > (best.above ?? -Infinity))) {
         best = rule;
       }
     } else if (fallback === undefined) {
-      fallback = rule.color;
+      fallback = rule;
     }
   }
-  return exact ?? best?.color ?? fallback;
+  return exact ?? best ?? fallback;
 }
 
 /**
@@ -831,10 +849,30 @@ export function entityDefaultIcon(
 }
 
 /**
- * Icon precedence shared by card and editor: config override → the user's
- * entity-registry icon → entity's explicit icon → device_class-implied icon
- * ("show as") → the kind default. The on-state comes from {@link entityIsActive},
- * so domains that never say "on" (lock/vacuum/camera) reach their active icons here.
+ * The value an item's rules are judged on: the chosen `attribute` when set
+ * (issue #70), else the plain state. Shared by card and editor so the colour
+ * and the icon can never be resolved from two different readings.
+ */
+export function itemRawValue(
+  item: { entity?: string; attribute?: string },
+  st: { state: string; attributes: Record<string, unknown> } | undefined,
+): unknown {
+  if (!st) return undefined;
+  return item.attribute ? st.attributes?.[item.attribute] : st.state;
+}
+
+/**
+ * Icon precedence shared by card and editor: matching state rule's icon →
+ * config override → the user's entity-registry icon → entity's explicit icon →
+ * device_class-implied icon ("show as") → the kind default. The on-state comes
+ * from {@link entityIsActive}, so domains that never say "on" (lock/vacuum/camera)
+ * reach their active icons here.
+ *
+ * A state rule's icon (issue #106) sits *above* the config `icon` for the same
+ * reason its colour already beats `activeColor`: it is the more specific
+ * statement about what this device looks like right now. It also undoes a trap
+ * — setting a config `icon` used to return early here, freezing the glyph and
+ * silently disabling every state-dependent icon below.
  *
  * The registry override lives at `hass.entities[id].icon` and never reaches
  * `attributes.icon`, so a user who set an icon in Settings → Entities sees it
@@ -843,11 +881,23 @@ export function entityDefaultIcon(
  * takes the state object, not `hass`.
  */
 export function resolveItemIcon(
-  item: { entity?: string; kind: ItemKind; icon?: string },
+  item: {
+    entity?: string;
+    kind: ItemKind;
+    icon?: string;
+    attribute?: string;
+    stateColor?: StateColorRule[];
+  },
   st: { state: string; attributes: Record<string, unknown> } | undefined,
   registryIcon?: string,
 ): string {
-  if (item.icon) return item.icon;
+  // Config strings, so the icon goes through the allowlist (#106): an
+  // unusable value falls through to the next candidate rather than rendering
+  // an empty box.
+  const ruleIcon = cssIcon(matchStateRule(item.stateColor, itemRawValue(item, st))?.icon);
+  if (ruleIcon) return ruleIcon;
+  const configIcon = cssIcon(item.icon);
+  if (configIcon) return configIcon;
   // No entity bound (issue #39: devices that exist physically but not in HA):
   // nothing to derive from, fall straight through to the kind default.
   if (!item.entity) return defaultIcon(item.kind);
@@ -875,6 +925,205 @@ export function itemIconSize(badgeSize: number): number {
   let s = Math.round(b * 0.62);
   if (s % 2 !== b % 2) s += 1;
   return Math.max(2, s);
+}
+
+/**
+ * What a device's badge holds, resolving {@link FloorItem.badgeContent} against
+ * the `showIcon` boolean it replaced (issue #106). One function so the card,
+ * the editor canvas and the form cannot drift on the migration rule: an
+ * explicit `badgeContent` wins, else a legacy `showIcon: false` means "no
+ * badge", else the icon as always.
+ */
+export function badgeContentOf(item: {
+  badgeContent?: BadgeContent;
+  showIcon?: boolean;
+}): BadgeContent {
+  if (item.badgeContent === "icon" || item.badgeContent === "value" || item.badgeContent === "none")
+    return item.badgeContent;
+  return item.showIcon === false ? "none" : "icon";
+}
+
+/**
+ * The reading a domain shows in its badge when the config does not name one,
+ * with the compact unit that goes with it (issue #106). A thermostat's *state*
+ * is its mode — "heat" — so without this the one device the issue was opened
+ * about would have no number to show.
+ *
+ * The unit is spelled out here rather than read from the entity: `climate` has
+ * no `unit_of_measurement` attribute at all (HA carries the temperature unit on
+ * the system config), so there is nothing to read.
+ */
+const DOMAIN_BADGE_READING: Record<string, { attribute: string; unit: string }> = {
+  climate: { attribute: "current_temperature", unit: "°" },
+  water_heater: { attribute: "current_temperature", unit: "°" },
+  humidifier: { attribute: "current_humidity", unit: "%" },
+};
+
+/** A finite number from a state/attribute value, or undefined. Booleans and blanks are not readings. */
+function numericReading(raw: unknown): number | undefined {
+  if (raw == null || typeof raw === "boolean") return undefined;
+  if (typeof raw === "string" && raw.trim() === "") return undefined;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * A unit short enough to sit inside a 34px circle, or "" to drop it. Degrees
+ * collapse to `°` (the C/F is not in doubt on your own floorplan) and
+ * concentrations lose their unit entirely — CO₂ reads `780`, because `780ppm`
+ * does not fit and the number alone is what people recognise. Anything longer
+ * than three characters is dropped rather than shrinking the number to fit.
+ */
+function compactUnit(unit: unknown): string {
+  if (typeof unit !== "string") return "";
+  const u = unit.trim();
+  if (u === "°C" || u === "°F" || u === "K") return "°";
+  if (u === "ppm" || u === "ppb") return "";
+  return u.length <= 3 ? u : "";
+}
+
+/** Round for the badge: whole numbers, keeping one decimal only where it carries meaning. */
+function compactNumber(n: number): string {
+  return Math.abs(n) < 10 && !Number.isInteger(n) ? n.toFixed(1) : String(Math.round(n));
+}
+
+/**
+ * Fold a big reading into the next unit up, so a plug reads `1.2kW` instead of
+ * `1240W`. Four digits and a unit letter is the widest thing a badge ever has
+ * to hold, and power sensors report watts, so this is the common case rather
+ * than an exotic one. Only W→kW: it is the pair this card actually meets, and
+ * a general unit-prefix engine would be guessing at units it has never seen.
+ */
+function scaleUnit(n: number, unit: string): { n: number; unit: string } {
+  if (unit === "W" && Math.abs(n) >= 1000) return { n: n / 1000, unit: "kW" };
+  return { n, unit };
+}
+
+/** A reading and its own unit, compacted and scaled for the badge. */
+function formatReading(n: number, rawUnit: unknown): string {
+  const scaled = scaleUnit(n, compactUnit(rawUnit));
+  return compactNumber(scaled.n) + scaled.unit;
+}
+
+/**
+ * The number to draw inside a device's badge (issue #106), or undefined when
+ * the device has no numeric reading — in which case the badge keeps its icon,
+ * so turning this on can never leave an empty circle.
+ *
+ * Candidates are tried in order and the first *numeric* one wins:
+ *
+ * 1. the configured `attribute`;
+ * 2. the domain's default reading ({@link DOMAIN_BADGE_READING});
+ * 3. the entity's state;
+ * 4. the secondary entity's reading — which is what makes a smart plug work: a
+ *    `switch` item with `secondaryEntity: sensor.plug_power` shows `1.2kW` and
+ *    still toggles the switch on tap.
+ *
+ * The numeric gate at every step is what makes step 1 safe to put first. The
+ * thermostat in the issue is coloured by `attribute: hvac_action`, whose value
+ * is "heating" — text, so it falls through and the badge still shows the
+ * temperature. Colouring by one reading and displaying another needs no extra
+ * config because of this.
+ *
+ * Deliberately *not* routed through `hass.formatEntityState`: that applies the
+ * user's display precision and the full unit ("21.5 °C"), which is exactly what
+ * does not fit in a badge. This is the one place reading `state` raw is correct.
+ */
+export function badgeValue(
+  hass: RenderHass | undefined,
+  item: {
+    entity?: string;
+    attribute?: string;
+    secondaryEntity?: string;
+    secondaryAttribute?: string;
+  },
+): string | undefined {
+  if (!hass || !item.entity) return undefined;
+  const st = hass.states[item.entity];
+  const attrs = st?.attributes as Record<string, unknown> | undefined;
+  const reading = DOMAIN_BADGE_READING[item.entity.split(".")[0]];
+
+  if (item.attribute) {
+    const n = numericReading(attrs?.[item.attribute]);
+    // A unit only when we know it belongs to *this* attribute:
+    // `unit_of_measurement` describes the state, not an arbitrary attribute, so
+    // borrowing it here would label a battery percentage "°C".
+    if (n !== undefined)
+      return compactNumber(n) + (item.attribute === reading?.attribute ? reading.unit : "");
+  }
+  if (reading) {
+    const n = numericReading(attrs?.[reading.attribute]);
+    if (n !== undefined) return compactNumber(n) + reading.unit;
+  }
+  const own = numericReading(st?.state);
+  if (own !== undefined) return formatReading(own, attrs?.unit_of_measurement);
+
+  // Same secondary resolution as the label line ({@link itemStateText}), so the
+  // two never disagree about which entity the second reading comes from.
+  const secondaryEntity = item.secondaryEntity ?? (item.secondaryAttribute ? item.entity : undefined);
+  if (!secondaryEntity) return undefined;
+  const sec = hass.states[secondaryEntity];
+  const secAttrs = sec?.attributes as Record<string, unknown> | undefined;
+  if (item.secondaryAttribute) {
+    const n = numericReading(secAttrs?.[item.secondaryAttribute]);
+    return n === undefined ? undefined : compactNumber(n);
+  }
+  const n = numericReading(sec?.state);
+  return n === undefined ? undefined : formatReading(n, secAttrs?.unit_of_measurement);
+}
+
+/**
+ * Advance width per character, in units of font-size, for the badge's 600-weight
+ * face. Measured off the rendered card rather than guessed, and rounded *up* at
+ * every entry so the estimate errs wide and the text never overflows the circle.
+ *
+ * Character width is what matters here, not character count: `45%` is wider
+ * than `9999`, and `21°` is narrower than `782`. Sizing by string length — the
+ * obvious first approach — put `1240W` 3.2px outside an 18px badge.
+ */
+const GLYPH_WIDTH: Record<string, number> = { ".": 0.28, "-": 0.38, "°": 0.45, "%": 1.0, k: 0.58 };
+/**
+ * Taken at the *small* end: a font's advance width per font-pixel grows as the
+ * size shrinks (a digit measures 0.637 at 16px but 0.688 at 6px), so the large
+ * figure would under-budget exactly the badges with least room to spare.
+ */
+const DIGIT_WIDTH = 0.7;
+/** Unit letters (W, A, V, lx…) — uppercase is the wide case, so assume it. */
+const LETTER_WIDTH = 0.85;
+
+function estimatedWidth(text: string): number {
+  let w = 0;
+  for (const ch of text) {
+    w += GLYPH_WIDTH[ch] ?? (ch >= "0" && ch <= "9" ? DIGIT_WIDTH : LETTER_WIDTH);
+  }
+  return w;
+}
+
+/**
+ * Font size for a value badge, shared by card and editor: the largest size at
+ * which the reading still fits inside the circle, capped so a short value like
+ * `9°` does not balloon. Uses the same parity nudge as {@link itemIconSize} so
+ * the text box centres on a whole pixel.
+ *
+ * The default 34px badge reads `21°` at 16px, `45%` at 12px and `1240W` at 8px.
+ *
+ * The 6px floor is a legibility floor, not a fitting one: below it nothing is
+ * readable anyway, so a long reading in a very small badge is allowed to reach
+ * the rim rather than shrinking into a smudge. A 5-glyph value wants a badge of
+ * about 30px or more.
+ */
+export function badgeValueSize(badgeSize: number, text: string): number {
+  const b = Math.round(cssNumber(badgeSize, DEFAULT_ITEM_SIZE));
+  // The 1.5px border each side, plus breathing room off the curve.
+  const usable = Math.max(0, b - 6);
+  const fit = estimatedWidth(text) > 0 ? usable / estimatedWidth(text) : b;
+  let s = Math.round(Math.min(b * 0.46, fit));
+  // Nudge *down* to the badge's parity, where itemIconSize nudges up: this
+  // size was just clamped to a width budget, and rounding up would spend a
+  // pixel the reading does not have. (9999 in a 24px badge overflowed by 1.1px
+  // when this went the other way.)
+  if (s % 2 !== b % 2) s -= 1;
+  return Math.max(6, s);
 }
 
 /** Infer a sensible item kind from an entity id's domain. */

--- a/src/render.ts
+++ b/src/render.ts
@@ -32,6 +32,8 @@ import {
   DEFAULT_ITEM_SIZE,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
+  BADGE_MIN_LIGHTNESS,
+  FURNITURE_GLOW_TRANSMISSION,
   getFloors,
   trackerAxisFraction,
 } from "./types";
@@ -316,6 +318,43 @@ export function glowPaint(
 }
 
 /**
+ * The colour a light's **badge** should wear (issue #106, @ombre33): its own
+ * `rgb_color`, darkened toward black in step with `brightness`, or `undefined`
+ * to leave the badge exactly as it is today.
+ *
+ * Deliberately *not* {@link glowPaint}, which looks almost identical. That one
+ * falls back to `glowColor` / {@link DEFAULT_GLOW_COLOR} so a pool always has a
+ * colour to cast; reusing it here would turn every plain on/off bulb's badge
+ * warm amber — a look change on installs that never asked for one. Only a
+ * light that genuinely reports a colour changes appearance.
+ *
+ * Brightness scales the channels rather than the alpha on purpose: a
+ * translucent badge composites against the *plan* behind it, so the same lamp
+ * would read differently over a dark room than over a light one.
+ */
+export function lightBadgePaint(light: HassEntity | undefined): string | undefined {
+  if (!light || light.state !== "on") return undefined;
+  const attrs = (light.attributes ?? {}) as Record<string, unknown>;
+  const rgb = attrs.rgb_color;
+  if (!Array.isArray(rgb) || rgb.length < 3) return undefined;
+  const [r, g, b] = rgb;
+  if (![r, g, b].every((c) => typeof c === "number" && Number.isFinite(c))) return undefined;
+
+  const raw = attrs.brightness;
+  const bright =
+    typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, Math.min(255, raw)) : undefined;
+  const factor =
+    bright === undefined
+      ? 1
+      : BADGE_MIN_LIGHTNESS + (1 - BADGE_MIN_LIGHTNESS) * (bright / 255);
+
+  const chan = (c: number) => Math.max(0, Math.min(255, Math.round((c as number) * factor)));
+  // Built from clamped integers, so it cannot carry a payload — but it still
+  // goes through the allowlist, as every colour here does.
+  return cssColor(`rgb(${chan(r as number)}, ${chan(g as number)}, ${chan(b as number)})`);
+}
+
+/**
  * {@link glowPaint} as the **editor** should apply it (issue #108).
  *
  * The editor must trust the entity when there is one — an off light draws
@@ -545,12 +584,22 @@ export function renderSunDimMask(
 }
 
 /**
- * A `<mask>` for the whole glow layer that punches out every furniture
- * footprint (issue #108): furniture keeps its base gray instead of reading
- * as "active" whenever a lamp near it is on. The line-art fills at ~0.12
- * opacity, so a warm pool under a sofa tinted the entire sofa — the report
- * that opened the issue. Round-based types cut an ellipse, everything else
- * its rotated rect.
+ * A `<mask>` for the whole glow layer that **dims** the light over every
+ * furniture footprint. Round-based types cut an ellipse, everything else its
+ * rotated rect.
+ *
+ * This is a dial with a reported bug at each end, which is why it is a grey
+ * and not `black` ({@link FURNITURE_GLOW_TRANSMISSION}):
+ *
+ * - Full light (no mask at all) was **#108**. Furniture line art fills at ~0.12
+ *   opacity and draws *above* this layer, so a warm pool shone straight through
+ *   and every sofa in the room read as highlighted-active.
+ * - No light (a solid `black` hole, the first fix for that) turned furniture
+ *   into a *shadow* — a lit table came out darker than the floor around it,
+ *   which is what @MrMcFlyy reported on #106.
+ *
+ * Half-strength keeps both away: light visibly lands on a table, while the
+ * furniture's own gray still reads as gray rather than taking the pool's hue.
  *
  * The region is stated explicitly rather than inherited — the viewport
  * default clipped walls under rotation once already (issue #102).
@@ -571,11 +620,15 @@ export function renderGlowMask(
         ${furniture.map((f) => {
           const rot = f.angle ? `rotate(${f.angle} ${f.x} ${f.y})` : undefined;
           const roundBase = f.type === "roundTable" || f.type === "plant" || f.type === "waterHeater";
+          // A mask's luminance is its transmission, and the region is already
+          // white ("all the light"). So furniture paints *black* at the share
+          // it blocks, leaving the share it lets through.
+          const blocked = 1 - FURNITURE_GLOW_TRANSMISSION;
           return roundBase
             ? svg`<ellipse cx=${f.x} cy=${f.y} rx=${f.w / 2} ry=${f.h / 2}
-                           fill="black" transform=${rot ?? nothing} />`
+                           fill="#000" fill-opacity=${blocked} transform=${rot ?? nothing} />`
             : svg`<rect x=${f.x - f.w / 2} y=${f.y - f.h / 2} width=${f.w} height=${f.h}
-                        fill="black" transform=${rot ?? nothing} />`;
+                        fill="#000" fill-opacity=${blocked} transform=${rot ?? nothing} />`;
         })}
       </mask>
     </defs>`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,8 +209,26 @@ export interface FloorItem {
   showName?: boolean;
   /** Label line font size in pixels (issue #59). Default 12. */
   labelSize?: number;
-  /** Show the icon badge. When false only the state/label shows. Default true. */
+  /**
+   * @deprecated Superseded by {@link badgeContent} (issue #106), which is the
+   * same switch with a third position. Still honoured when `badgeContent` is
+   * absent, so every existing config keeps rendering identically —
+   * {@link badgeContentOf} owns that fallback.
+   */
   showIcon?: boolean;
+  /**
+   * What the badge holds (issue #106):
+   *
+   * - `"icon"` (default) — the glyph, as always;
+   * - `"value"` — the device's reading, rounded and compact, *inside* the
+   *   badge: a thermostat reads `21°` in the same circle `stateColor` already
+   *   paints red while it heats, instead of a text line hanging underneath.
+   *   Which reading is worked out per domain by {@link badgeValue}; when
+   *   nothing numeric is available the badge falls back to its icon, so this
+   *   can never leave an empty circle;
+   * - `"none"` — no badge at all, label only (the old `showIcon: false`).
+   */
+  badgeContent?: BadgeContent;
   /**
    * Hide this device on the live card while its entity is inactive (issue
    * #55), so a busy room only shows what is actually doing something. The
@@ -273,6 +291,9 @@ export interface FloorItem {
 
 export type ItemDisplay = "badge" | "ripple" | "iconRipple";
 
+/** What a device badge holds — see {@link FloorItem.badgeContent} (issue #106). */
+export type BadgeContent = "icon" | "value" | "none";
+
 /**
  * One colour rule for {@link FloorItem.stateColor} / {@link Furniture.stateColor}.
  *
@@ -287,6 +308,15 @@ export interface StateColorRule {
   /** Applies when the value equals this exactly (case-insensitive). */
   state?: string;
   color: string;
+  /**
+   * Icon to show while this rule matches (issue #106) — "blinds open" and
+   * "blinds closed" as two glyphs, not just two colours. Optional: a rule
+   * without one only changes the colour, exactly as before.
+   *
+   * Only {@link FloorItem} reads this; furniture and areas share this rule
+   * shape but draw polygons, so an `icon` on their rules is ignored.
+   */
+  icon?: string;
 }
 
 export type IconAnimation = "auto" | "none" | "spin" | "pulse";

--- a/src/types.ts
+++ b/src/types.ts
@@ -610,6 +610,30 @@ export const DEFAULT_GLOW_COLOR = "#ffd9a0";
 export const GLOW_MIN_OPACITY = 0.18;
 export const GLOW_MAX_OPACITY = 0.6;
 
+/**
+ * How far a light's `brightness` may darken its **badge** colour (issue #106,
+ * @ombre33): a lamp at full brightness badges its true `rgb_color`, one dimmed
+ * to nothing badges this fraction of it.
+ *
+ * A floor, not zero, for the same reason {@link GLOW_MIN_OPACITY} is: a badge
+ * that fades to black is a badge you can no longer identify, and a barely-lit
+ * lamp should still read as *that* lamp.
+ */
+export const BADGE_MIN_LIGHTNESS = 0.45;
+
+/**
+ * How much of a light pool passes **through** furniture (issue #106,
+ * @MrMcFlyy) — see {@link renderGlowMask}, which paints this as the mask's
+ * grey level.
+ *
+ * A dial, not a switch, and both ends have been reported as bugs. At 1 a warm
+ * pool floods every sofa in the room and furniture reads as highlighted, which
+ * is #108. At 0 furniture is a hole in the light — darker than the floor
+ * around it, so a lit table looks shadowed, which is what reopened this. In
+ * between, light lands on furniture while its own gray still reads as gray.
+ */
+export const FURNITURE_GLOW_TRANSMISSION = 0.5;
+
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 
 export const DEFAULT_ITEM_SIZE = 34;


### PR DESCRIPTION
Closes #106.

@MrMcFlyy asked for two things, with a [mockup](https://github.com/nicosandller/easy-floorplan/issues/106#issuecomment-5177230125): a thermostat badge with the temperature *in* it rather than a text line underneath, and different icons for blinds open vs. closed. Their own summary was the right framing — *"you can not only change the color, but also the icon depending on the state."*

Both land here, and between them they add **one** row to the device form, which was the constraint: that panel is already crowded.

## 1. Icon per state rule

`StateColorRule` gains an optional `icon`. The "Color by state" list people already use becomes "Color & icon by state", with one more box per row:

```yaml
stateColor:
  - state: open
    color: "#4caf50"
    icon: mdi:blinds-open
  - state: closed
    color: "#9e9e9e"
    icon: mdi:blinds
```

No new panel, no new concept, and it works for any device — a lock, a washing machine, a sensor above a threshold — not just covers.

`resolveStateColor` is now a one-line wrapper over a new `matchStateRule`, so the colour and the icon always come off the **same** matched rule. Resolving the precedence separately for each would be two chances to drift, and would quietly allow one rule's colour beside another rule's icon.

A rule's icon sits **above** the config `icon`, for the same reason its colour already beats `activeColor`: it is the more specific statement about right now. That also undoes a trap worth calling out — setting a config `icon` used to `return` early in `resolveItemIcon`, freezing the glyph and silently disabling every state-dependent icon below it. A custom icon and state-dependent icons are now usable together.

## 2. The reading inside the badge

`badgeContent: icon | value | none` replaces the `showIcon` boolean, which is deprecated and still honoured when unset — so every existing config renders identically, and in the form it is the *same row*, now a three-way dropdown.

`badgeValue()` picks the reading per domain and stops at the first **numeric** candidate:

1. the configured `attribute`
2. the domain's default reading (`climate` → `current_temperature`, `humidifier` → `current_humidity`)
3. the entity's own state
4. the secondary entity's reading

That numeric gate is what makes step 1 safe to put first, and it handles the mockup's own case: colouring a thermostat by `attribute: hvac_action` gives `"heating"` — text — so it falls through and the badge still shows the temperature. **You can colour by one reading and display another with no extra config.**

Step 4 is what makes a smart plug work: a `switch` with `secondaryEntity: sensor.plug_power` reads `1.2kW` and still toggles the switch on tap. And when nothing numeric turns up anywhere, the badge keeps its icon — this can never leave an empty circle.

Deliberately *not* routed through `hass.formatEntityState`: that applies display precision and the full unit (`21.5 °C`), which is exactly what does not fit in a 34px circle.

### Two things worth flagging

**Sizing measures glyphs, not characters.** My first pass sized by string length and it was wrong — `45%` is wider than `9999`, and `21°` is narrower than `782`. It put `1240W` 3.2px *outside* an 18px badge. The widths are now measured off the rendered card and rounded up, and the parity nudge goes *down* where `itemIconSize` goes up, since this size has just been clamped to a width budget. Remaining known limit: a 5-glyph reading in an 18px badge hits the 6px legibility floor and grazes the rim by 0.4px — below that it would be a smudge rather than a number, so it wants a bigger badge.

**`cssIcon` validates rather than strips**, unlike its `cssIdent` neighbour. My own test caught why: stripping `"><script>` leaves `script` — harmless in the DOM, but it has now displaced the icon the caller would otherwise have fallen back to. Callers rely on `undefined` to move to the next candidate, so a value that cannot render must not survive as *something*.

`collectWatchedEntities` needs no change — `entity` and `secondaryEntity` were already watched and climate attributes ride on the primary state object. Flagging it explicitly because a miss there paints once and freezes (it bit #82, #6 and #113).

## Verification

- `tsc --noEmit`, 609 tests, `npm run build` all green; duplication sweep clean.
- Every new regression test was **run against `main` first** — 26 of them fail there; the two that don't are deliberate no-change guards.
- Dev harness, 15 fixtures: values, icons, colours and font sizes **identical** between the card and the editor canvas (the `_renderItemOverlay` duplication is the standing trap here).
- Measured rendered text width vs. badge width at 18 / 24 / 34 / 80px.
- Rotation 90°: badge stays `rotate(0deg)` so the number is upright, while an item with its own `angle: 45` keeps it.
- Legacy `showIcon: false` still renders label-only; items still clickable.

Also fixed in passing: the README's `kind` row still listed only the original 7 kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)