### PR TITLE
Glow: stop slicing the pool beside long walls, and let brightness set its reach (closes #123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ shape it occupies on screen.
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
 | `glow`        | boolean                                | `false`      | Cast a pool of light onto the plan from this device (lights only). See **Cast light**. |
-| `glowRadius`  | number                                 | `140`        | Radius of the cast pool, in canvas units.              |
+| `glowRadius`  | number                                 | `140`        | Radius of the cast pool at full brightness, in canvas units. A dimmer lamp casts a proportionally smaller pool, down to half this. |
 | `glowColor`   | string                                 | `#ffd9a0`    | Color for a bulb that can't report one. A color-capable light always uses its own. |
 | `badgeContent` | `icon` \| `value` \| `none`           | `icon`       | What the badge holds. `value` draws the device's reading inside it (see **Value in the badge**), falling back to the icon when there is no number; `none` hides the badge, leaving the label. |
 | `showIcon`    | boolean                                | `true`       | **Deprecated** — superseded by `badgeContent`. Still honoured when `badgeContent` is unset: `false` means `none`. |
@@ -718,6 +718,14 @@ something sensible:
 Home Assistant derives an `rgb_color` even for `color_temp`-only bulbs, so a warm-white
 bulb still reads as amber. Brightness maps into a **0.18–0.6** opacity band rather than
 0–1: a lamp dimmed to 10% would otherwise be invisible.
+
+**Brightness also sets how far the light reaches**, not just how strong it is — dimming a
+lamp draws its pool in, the way dimming one does in a room. `glowRadius` is the size at
+**full brightness**, and the pool shrinks to no less than half that as the lamp dims, so a
+lamp at 5% still reads as a dim lamp rather than vanishing under its own icon. A bulb that
+reports no brightness (plain on/off) always casts the full radius. The dashed radius guide
+in the editor shows the configured, full-brightness size — it is the handle for the value
+you are setting.
 
 The pools are drawn above the room fills but below furniture and walls, so light reads as
 cast onto the floor rather than painted over the plan. `glow` is independent of the icon —

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2749,6 +2749,12 @@ export class FloorplanCardEditor extends LitElement {
                 // unlit light would otherwise be blind, now that an off light
                 // correctly draws nothing. Editor-only chrome, like the
                 // tracker zone outline.
+                //
+                // Deliberately the *configured* radius, not the brightness-
+                // scaled one (issue #123): this is the handle for the value you
+                // are setting, which is the pool's size at full brightness. A
+                // guide that shrank as the bulb dimmed would move while you
+                // dragged it, and would never show the size you actually typed.
                 floor.items.map((it) =>
                   it.glow && this._isSel("item", it.id)
                     ? svg`<circle class="glow-guide" cx=${it.x} cy=${it.y}

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_GLOW_COLOR,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
+  GLOW_MIN_RADIUS,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   SUN_ELEVATION_NIGHT,
@@ -2181,6 +2182,18 @@ describe("shutterStyleOf (issue #74)", () => {
 describe("glowPaint (issue #6)", () => {
   const light = (state: string, attributes: Record<string, unknown> = {}) =>
     ({ entity_id: "light.x", state, attributes }) as never;
+  const flattenSunDim = (node: unknown): string => {
+    if (node == null || typeof node === "boolean") return "";
+    if (Array.isArray(node)) return node.map(flattenSunDim).join("");
+    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+      const { strings, values } = node as { strings: string[]; values: unknown[] };
+      return strings.reduce(
+        (acc, s, i) => acc + s + (i < values.length ? flattenSunDim(values[i]) : ""),
+        "",
+      );
+    }
+    return String(node);
+  };
 
   it("paints a color-capable light's own rgb", () => {
     const paint = glowPaint({}, light("on", { rgb_color: [255, 170, 80], brightness: 255 }));
@@ -2239,6 +2252,55 @@ describe("glowPaint (issue #6)", () => {
 
   it("clamps out-of-range channels instead of trusting the integration", () => {
     expect(glowPaint({}, light("on", { rgb_color: [300, -20, 12.6] }))?.color).toBe("rgb(255, 0, 13)");
+  });
+
+  // Issue #123: dimming should draw the light in, not only thin it.
+  describe("brightness scales the pool's reach (#123)", () => {
+    it("full brightness casts the configured radius, unchanged", () => {
+      expect(glowPaint({ glowRadius: 200 }, light("on", { brightness: 255 }))?.radius).toBe(200);
+    });
+
+    it("a dimmer lamp reaches less far, down to a floor that stays visible", () => {
+      const at = (b: number) => glowPaint({ glowRadius: 200 }, light("on", { brightness: b }))!.radius;
+      expect(at(255)).toBe(200);
+      expect(at(128)).toBeCloseTo(200 * (GLOW_MIN_RADIUS + (1 - GLOW_MIN_RADIUS) * (128 / 255)), 5);
+      expect(at(0)).toBeCloseTo(200 * GLOW_MIN_RADIUS, 5);
+      // Monotonic, and never collapses to a dot under the lamp's own icon.
+      expect(at(0)).toBeLessThan(at(128));
+      expect(at(128)).toBeLessThan(at(255));
+      expect(at(0)).toBeGreaterThan(0);
+    });
+
+    it("a bulb with no brightness to report keeps the full radius", () => {
+      // An on/off-only light: "on" means fully on, so nothing shrinks.
+      expect(glowPaint({ glowRadius: 200 }, light("on"))?.radius).toBe(200);
+    });
+
+    it("defaults and gates the configured radius through css-safe", () => {
+      expect(glowPaint({}, light("on", { brightness: 255 }))?.radius).toBe(DEFAULT_GLOW_RADIUS);
+      // A hostile value falls back rather than reaching the SVG (#64/#65).
+      expect(glowPaint({ glowRadius: "6; evil" as never }, light("on", { brightness: 255 }))?.radius)
+        .toBe(DEFAULT_GLOW_RADIUS);
+    });
+
+    it("the sun-dimming clearing shrinks with the pool, staying the same shape", () => {
+      // These are documented as the same shape by construction; the clearing
+      // reading glowRadius directly would silently break that once the pool
+      // started scaling.
+      const items = [
+        { id: "i1", entity: "light.a", kind: "light", x: 300, y: 200, glow: true, glowRadius: 200 },
+      ] as never;
+      const at = (brightness: number) => {
+        const states = {
+          "light.a": { entity_id: "light.a", state: "on", attributes: { brightness } },
+        } as never;
+        const markup = flattenSunDim(renderSunDimMask(items, states, 1000, 600, "sd"));
+        return Number(/r=(\d+(?:\.\d+)?)/.exec(markup)![1]);
+      };
+      expect(at(255)).toBe(200);
+      expect(at(0)).toBeCloseTo(200 * GLOW_MIN_RADIUS, 5);
+      expect(at(0)).toBeLessThan(at(255));
+    });
   });
 });
 
@@ -2352,6 +2414,56 @@ describe("glowReach — walls block light (issue #108)", () => {
   it("the wall the lamp is mounted on does not black out its own pool", () => {
     // Wall within one wall thickness of the light: non-blocking.
     expect(glowReach(500, 300, 140, [wall(200, 302, 800, 302)])).toBeUndefined();
+  });
+
+  // Issue #123: a wedge of the pool went missing beside long walls. The sweep
+  // only has vertices where it casts rays, and it cast them at the wall's
+  // *declared* endpoints — far outside the swept region for an ordinary room
+  // wall — so nothing sampled the angle where the boundary hands over from the
+  // region's edge to the wall, and the chord across that gap cut the pool.
+  describe("a long wall does not slice the pool (#123)", () => {
+    const r = 140;
+    // An ordinary room wall: 60 below the lamp and running well past the pool.
+    const longWall = [wall(0, 360, 1000, 360)];
+
+    it("lights the whole strip beside the wall, out to the radius", () => {
+      const poly = glowReach(500, 300, r, longWall)!;
+      // 5px above the wall — nothing between these and the lamp — stepping out
+      // to the edge of the radius. Every one must be lit; before the fix the
+      // last three were not.
+      for (const dx of [0, 20, 40, 60, 80, 100, 120]) {
+        const dist = Math.hypot(dx, 55);
+        expect({ dx, dist: Math.round(dist), lit: inside(poly, 500 + dx, 355) }).toEqual({
+          dx,
+          dist: Math.round(dist),
+          lit: true,
+        });
+      }
+    });
+
+    it("still blocks the far side, so the fix did not just delete the clipping", () => {
+      const poly = glowReach(500, 300, r, longWall)!;
+      expect(inside(poly, 500, 380)).toBe(false);
+      expect(inside(poly, 560, 400)).toBe(false);
+    });
+
+    it("samples the angle where the wall enters the swept region", () => {
+      const poly = glowReach(500, 300, r, longWall)!;
+      const angles = poly.map((p) => (Math.atan2(p.y - 300, p.x - 500) * 180) / Math.PI);
+      // The hand-over sits at atan2(60, 141.4) ≈ 23°, not at the declared
+      // endpoint's atan2(60, 500) ≈ 6.8°.
+      expect(angles.some((a) => Math.abs(a - 23.0) < 1)).toBe(true);
+      expect(angles.some((a) => Math.abs(a - 6.8) < 1)).toBe(false);
+    });
+
+    it("leaves a wall that already fits inside the region alone", () => {
+      // Short wall, both endpoints within the sweep: clipping is a no-op, so
+      // the shadow it casts is unchanged.
+      const short = [wall(480, 360, 520, 360)];
+      const poly = glowReach(500, 300, r, short)!;
+      expect(inside(poly, 500, 380)).toBe(false); // directly behind it
+      expect(inside(poly, 600, 380)).toBe(true); // past its end
+    });
   });
 });
 
@@ -2504,7 +2616,7 @@ describe("renderGlowMask — furniture is dimmed, not blacked out (#108, #106)",
 
   it("clips the pool with the reach polygon only when walls are in range", () => {
     const item = { id: "i", entity: "light.x", kind: "light", x: 300, y: 200 } as never;
-    const paint = { color: "#fff", opacity: 0.4 };
+    const paint = { color: "#fff", opacity: 0.4, radius: DEFAULT_GLOW_RADIUS };
     const withWall = flatten(renderGlow(item, paint, "g1", [{ id: "w", x1: 0, y1: 260, x2: 1000, y2: 260 }]));
     expect(withWall).toContain("<clipPath");
     expect(withWall).toContain("clip-path=url(#g1-clip)");
@@ -2534,7 +2646,10 @@ describe("editorGlowPaint (issue #108)", () => {
     expect(editorGlowPaint({}, undefined)).toEqual({
       color: DEFAULT_GLOW_COLOR,
       opacity: GLOW_MAX_OPACITY,
+      // No state to read a brightness from: the configured size, unscaled.
+      radius: DEFAULT_GLOW_RADIUS,
     });
+    expect(editorGlowPaint({ glowRadius: 200 }, undefined)?.radius).toBe(200);
     expect(editorGlowPaint({ glowColor: "#00ff00" }, undefined)?.color).toBe("#00ff00");
   });
 });
@@ -2553,7 +2668,9 @@ describe("renderGlow (issue #6)", () => {
     ({ id: "i", entity: "light.x", kind: "light", x: 300, y: 200, ...extra }) as never;
 
   it("centers the pool on the device and fades to nothing at the rim", () => {
-    const markup = flatten(renderGlow(item(), { color: "rgb(1, 2, 3)", opacity: 0.5 }, "g1"));
+    const markup = flatten(
+      renderGlow(item(), { color: "rgb(1, 2, 3)", opacity: 0.5, radius: DEFAULT_GLOW_RADIUS }, "g1"),
+    );
     expect(markup).toContain("cx=300");
     expect(markup).toContain("cy=200");
     expect(markup).toContain(`r=${DEFAULT_GLOW_RADIUS}`);
@@ -2563,14 +2680,20 @@ describe("renderGlow (issue #6)", () => {
     expect(markup).toContain('fill=url(#g1)');
   });
 
-  it("honors glowRadius, and gates a garbage one through css-safe", () => {
-    expect(flatten(renderGlow(item({ glowRadius: 250 }), { color: "#fff", opacity: 0.4 }, "g"))).toContain("r=250");
-    expect(flatten(renderGlow(item({ glowRadius: "6; evil" }), { color: "#fff", opacity: 0.4 }, "g")))
-      .toContain(`r=${DEFAULT_GLOW_RADIUS}`);
+  it("draws at the radius the paint carries, not the configured one (#123)", () => {
+    // The size is brightness-scaled in glowPaint, so renderGlow must use what
+    // it is handed — reading item.glowRadius here again would silently undo it.
+    const markup = flatten(
+      renderGlow(item({ glowRadius: 250 }), { color: "#fff", opacity: 0.4, radius: 137 }, "g"),
+    );
+    expect(markup).toContain("r=137");
+    expect(markup).not.toContain("r=250");
   });
 
   it("carries the class the blend mode hangs off, or lights would not mix", () => {
-    expect(flatten(renderGlow(item(), { color: "#fff", opacity: 0.4 }, "g"))).toContain('class="fp-glow"');
+    expect(
+      flatten(renderGlow(item(), { color: "#fff", opacity: 0.4, radius: DEFAULT_GLOW_RADIUS }, "g")),
+    ).toContain('class="fp-glow"');
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { nothing } from "lit";
+import { html, nothing } from "lit";
 import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
 import {
   FURNITURE_DEFAULT_SIZE,
@@ -77,6 +77,53 @@ import {
   renderGlow,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
+
+/**
+ * Render a Lit template to the string it would emit, for asserting on markup.
+ *
+ * One copy on purpose. There were nine, in three variants that had already
+ * drifted: the weakest stringified Lit's `nothing` **symbol** into the markup
+ * as the literal text "Symbol(lit-nothing)", which is how a vacuous assertion
+ * slipped through once before (#111) — a test looking for an absent value
+ * found that text and passed. This is the strict variant: `nothing`, null and
+ * booleans all render as nothing at all, which is what the browser does.
+ *
+ * Note the output is Lit's *interpolated* form, so attribute values come out
+ * unquoted — assertions read `toContain("fill=#4caf50")`, not `fill="#4caf50"`.
+ */
+const flattenMarkup = (node: unknown): string => {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "symbol") return "";
+  if (Array.isArray(node)) return node.map(flattenMarkup).join("");
+  if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+    const { strings, values } = node as { strings: string[]; values: unknown[] };
+    return strings.reduce(
+      (acc, s, i) => acc + s + (i < values.length ? flattenMarkup(values[i]) : ""),
+      "",
+    );
+  }
+  return String(node);
+};
+
+describe("flattenMarkup — the test helper itself", () => {
+  // Every markup assertion in this file runs through it, so a weakened copy
+  // would not fail loudly: it would quietly make assertions pass. This is the
+  // guard on the consolidation.
+  it("renders Lit's omit sentinel as nothing at all, not as its symbol text", () => {
+    expect(flattenMarkup(nothing)).toBe("");
+    expect(flattenMarkup(html`<i a=${nothing}></i>`)).toBe("<i a=></i>");
+    expect(flattenMarkup(html`<i a=${nothing}></i>`)).not.toContain("Symbol");
+  });
+
+  it("drops null, undefined and booleans, as the browser does", () => {
+    for (const v of [null, undefined, true, false]) expect(flattenMarkup(v)).toBe("");
+  });
+
+  it("still interpolates real values, so assertions are not vacuous", () => {
+    expect(flattenMarkup(html`<i a=${"x"} b=${2}></i>`)).toBe("<i a=x b=2></i>");
+    expect(flattenMarkup([html`<a></a>`, html`<b></b>`])).toBe("<a></a><b></b>");
+  });
+});
 
 describe("snapToWall", () => {
   const hWall = { x1: 0, y1: 0, x2: 100, y2: 0 }; // horizontal
@@ -1183,17 +1230,8 @@ describe("plan rotation (issue #33)", () => {
 
 describe("fishTank glyph scales with its size (issue #72 review)", () => {
   /** Flatten a Lit template (and nested ones) back to markup. */
-  const flatten = (node: unknown): string => {
-    if (node == null || node === false) return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const bubbleRadius = (w: number, h: number) => {
-    const markup = flatten(renderFurniture({ id: "f", type: "fishTank", x: 0, y: 0, w, h }));
+    const markup = flattenMarkup(renderFurniture({ id: "f", type: "fishTank", x: 0, y: 0, w, h }));
     return Number(markup.match(/<circle[^>]*\sr=([\d.]+)/)?.[1]);
   };
 
@@ -1208,7 +1246,7 @@ describe("fishTank glyph scales with its size (issue #72 review)", () => {
   // whole drawing — base shape and detail strokes alike, not just the outline.
   describe("renderFurniture color override", () => {
     const markupOf = (override?: string) =>
-      flatten(
+      flattenMarkup(
         renderFurniture(
           { id: "f", type: "plant", x: 0, y: 0, w: 40, h: 40, color: "#111111" },
           override,
@@ -1647,32 +1685,23 @@ describe("polygonCentroid", () => {
 
 describe("renderArea", () => {
   /** Flatten a Lit template back to markup (see the fishTank glyph test above). */
-  const flatten = (node: unknown): string => {
-    if (node == null || node === false) return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
 
   it("emits the vertex points and the default fill/opacity", () => {
-    const markup = flatten(renderArea({ id: "a", points: square }));
+    const markup = flattenMarkup(renderArea({ id: "a", points: square }));
     expect(markup).toContain("points=0,0 10,0 10,10 0,10");
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
     expect(markup).toContain("fill-opacity=0.25");
   });
 
   it("honors a custom color and opacity", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000", opacity: 0.6 }));
+    const markup = flattenMarkup(renderArea({ id: "a", points: square, color: "#ff0000", opacity: 0.6 }));
     expect(markup).toContain("fill=#ff0000");
     expect(markup).toContain("fill-opacity=0.6");
   });
 
   it("falls back to the default color for an unsafe value (css-safe gate)", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderArea({ id: "a", points: square, color: "red;position:fixed;inset:0" })
     );
     expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
@@ -1680,19 +1709,19 @@ describe("renderArea", () => {
   });
 
   it("uses the live fill color over the resting one (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, color: "#ff0000" }, "#4caf50"));
+    const markup = flattenMarkup(renderArea({ id: "a", points: square, color: "#ff0000" }, "#4caf50"));
     expect(markup).toContain("fill=#4caf50");
     expect(markup).not.toContain("fill=#ff0000");
   });
 
   it("applies activeOpacity only while live (#6)", () => {
     const a = { id: "a", points: square, opacity: 0.2, activeOpacity: 0.7 };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.7");
-    expect(flatten(renderArea(a))).toContain("fill-opacity=0.2");
+    expect(flattenMarkup(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.7");
+    expect(flattenMarkup(renderArea(a))).toContain("fill-opacity=0.2");
   });
 
   it("keeps the resting opacity when activeOpacity is unset (#6)", () => {
-    const markup = flatten(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
+    const markup = flattenMarkup(renderArea({ id: "a", points: square, opacity: 0.2 }, "#4caf50"));
     expect(markup).toContain("fill-opacity=0.2");
   });
 
@@ -1704,7 +1733,7 @@ describe("renderArea", () => {
       { id: "a", points: square, highlight: "both" },
     ];
     for (const a of cases) {
-      const markup = flatten(renderArea(a, "#4caf50"));
+      const markup = flattenMarkup(renderArea(a, "#4caf50"));
       expect(markup).toContain('stroke="none"');
       expect(markup).toContain('stroke-width="0"');
       expect(markup).not.toContain("stroke=#123456");
@@ -1713,7 +1742,7 @@ describe("renderArea", () => {
 
   it("highlight=border leaves the fill at rest (#6)", () => {
     const a = { id: "a", points: square, color: "#ff0000", highlight: "border" as const };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill=#ff0000");
+    expect(flattenMarkup(renderArea(a, "#4caf50"))).toContain("fill=#ff0000");
   });
 
   it("highlight=border ignores activeOpacity, which is a fill concern (#6)", () => {
@@ -1724,26 +1753,17 @@ describe("renderArea", () => {
       activeOpacity: 0.7,
       highlight: "border" as const,
     };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
+    expect(flattenMarkup(renderArea(a, "#4caf50"))).toContain("fill-opacity=0.2");
   });
 
   it("highlight=both still paints the live fill (#6)", () => {
     const a = { id: "a", points: square, highlight: "both" as const };
-    expect(flatten(renderArea(a, "#4caf50"))).toContain("fill=#4caf50");
+    expect(flattenMarkup(renderArea(a, "#4caf50"))).toContain("fill=#4caf50");
   });
 });
 
 describe("renderAreaBorder", () => {
   /** Flatten a Lit template back to markup (see the fishTank glyph test above). */
-  const flatten = (node: unknown): string => {
-    if (node == null || node === false) return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
 
   it("draws nothing by default (#6)", () => {
@@ -1758,13 +1778,13 @@ describe("renderAreaBorder", () => {
   });
 
   it("never fills — the fill is renderArea's pass, below the walls", () => {
-    const markup = flatten(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
+    const markup = flattenMarkup(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
     expect(markup).toContain('fill="none"');
     expect(markup).toContain("points=0,0 10,0 10,10 0,10");
   });
 
   it("honors a static borderColor and borderWidth (#6)", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderAreaBorder({ id: "a", points: square, borderColor: "#123456", borderWidth: 5 })
     );
     expect(markup).toContain("stroke=#123456");
@@ -1772,7 +1792,7 @@ describe("renderAreaBorder", () => {
   });
 
   it("falls back to the thinner default width for a static border (#6)", () => {
-    const markup = flatten(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
+    const markup = flattenMarkup(renderAreaBorder({ id: "a", points: square, borderColor: "#123456" }));
     expect(markup).toContain("stroke-width=3");
   });
 
@@ -1780,14 +1800,14 @@ describe("renderAreaBorder", () => {
     // The wall is centered on the line the polygon follows, so the room owns
     // half of it. Anything wider spills onto the floor and over furniture.
     const a = { id: "a", points: square, highlight: "border" as const };
-    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain(
+    expect(flattenMarkup(renderAreaBorder(a, "#4caf50"))).toContain(
       `stroke-width=${WALL_THICKNESS / 2}`
     );
   });
 
   it("lets an explicit borderWidth override the live default", () => {
     const a = { id: "a", points: square, highlight: "border" as const, borderWidth: 2 };
-    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke-width=2");
+    expect(flattenMarkup(renderAreaBorder(a, "#4caf50"))).toContain("stroke-width=2");
   });
 
   it("keeps a live border inside the opening cut, so it never crosses a doorway", () => {
@@ -1797,14 +1817,14 @@ describe("renderAreaBorder", () => {
     // paints straight across every door and window on the plan.
     const reach = (WALL_THICKNESS + 4) / 2;
     const a = { id: "a", points: square, highlight: "border" as const };
-    const drawn = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    const drawn = flattenMarkup(renderAreaBorder(a, "#4caf50", "c"));
     const visible = Number(/stroke-width=([\d.]+)/.exec(drawn)![1]) / 2;
     expect(visible).toBeLessThanOrEqual(reach);
   });
 
   it("clips a live border to its own room, so a shared wall splits", () => {
     const a = { id: "a", points: square, highlight: "border" as const };
-    const markup = flatten(renderAreaBorder(a, "#4caf50", "clip-1"));
+    const markup = flattenMarkup(renderAreaBorder(a, "#4caf50", "clip-1"));
     expect(markup).toContain('<clipPath id=clip-1>');
     expect(markup).toContain("clip-path=url(#clip-1)");
   });
@@ -1812,11 +1832,11 @@ describe("renderAreaBorder", () => {
   it("draws a clipped border at double width, so borderWidth is what is seen", () => {
     const a = { id: "a", points: square, highlight: "border" as const };
     // Half of the stroke is clipped away, leaving the room's half-wall showing.
-    expect(flatten(renderAreaBorder(a, "#4caf50", "c"))).toContain(
+    expect(flattenMarkup(renderAreaBorder(a, "#4caf50", "c"))).toContain(
       `stroke-width=${WALL_THICKNESS}`
     );
     const wide = { ...a, borderWidth: 5 };
-    expect(flatten(renderAreaBorder(wide, "#4caf50", "c"))).toContain("stroke-width=10");
+    expect(flattenMarkup(renderAreaBorder(wide, "#4caf50", "c"))).toContain("stroke-width=10");
   });
 
   it("carries the CSS hooks under its own class, so fill and outline differ (#105)", () => {
@@ -1826,7 +1846,7 @@ describe("renderAreaBorder", () => {
       highlight: "border" as const,
       entity: "binary_sensor.hall_occupancy",
     };
-    const markup = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    const markup = flattenMarkup(renderAreaBorder(a, "#4caf50", "c"));
     expect(markup).toContain('class="fp-area-border"');
     expect(markup).toContain("data-id=area_hall");
     expect(markup).toContain("data-entity=binary_sensor.hall_occupancy");
@@ -1836,7 +1856,7 @@ describe("renderAreaBorder", () => {
     // A <clipPath> paints nothing, so a rule matching one would appear to do
     // nothing at all. Only the drawn polygon carries the hooks.
     const a = { id: "area_hall", points: square, highlight: "border" as const };
-    const markup = flatten(renderAreaBorder(a, "#4caf50", "c"));
+    const markup = flattenMarkup(renderAreaBorder(a, "#4caf50", "c"));
     expect(markup).toContain("<clipPath");
     expect(markup.match(/data-id=/g)).toHaveLength(1);
     expect(markup.match(/class="fp-area-border"/g)).toHaveLength(1);
@@ -1844,7 +1864,7 @@ describe("renderAreaBorder", () => {
 
   it("never clips a static border — decoration is drawn as authored (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#123456" };
-    const markup = flatten(renderAreaBorder(a, undefined, "clip-1"));
+    const markup = flattenMarkup(renderAreaBorder(a, undefined, "clip-1"));
     expect(markup).not.toContain("clip-path");
     expect(markup).toContain("stroke-width=3");
   });
@@ -1857,24 +1877,24 @@ describe("renderAreaBorder", () => {
 
   it("highlight=border paints the live color (#6)", () => {
     const a = { id: "a", points: square, highlight: "border" as const };
-    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
+    expect(flattenMarkup(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
   });
 
   it("highlight=both paints the outline too (#6)", () => {
     const a = { id: "a", points: square, highlight: "both" as const };
-    expect(flatten(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
+    expect(flattenMarkup(renderAreaBorder(a, "#4caf50"))).toContain("stroke=#4caf50");
   });
 
   it("a live color overrides a static borderColor when it targets the border (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
-    const markup = flatten(renderAreaBorder(a, "#4caf50"));
+    const markup = flattenMarkup(renderAreaBorder(a, "#4caf50"));
     expect(markup).toContain("stroke=#4caf50");
     expect(markup).not.toContain("#111111");
   });
 
   it("keeps the static borderColor while the area is at rest (#6)", () => {
     const a = { id: "a", points: square, borderColor: "#111111", highlight: "border" as const };
-    expect(flatten(renderAreaBorder(a))).toContain("stroke=#111111");
+    expect(flattenMarkup(renderAreaBorder(a))).toContain("stroke=#111111");
   });
 });
 
@@ -1913,18 +1933,9 @@ describe("areaColor", () => {
 });
 
 describe("renderWallMask region (issue #102)", () => {
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
 
   it("states its own region instead of inheriting the viewport default", () => {
-    const markup = flatten(renderWallMask([], 1000, 600, "m1"));
+    const markup = flattenMarkup(renderWallMask([], 1000, 600, "m1"));
     const mask = markup.slice(markup.indexOf("<mask"), markup.indexOf(">", markup.indexOf("<mask")));
     // Without these, the region falls back to -10%..110% of the viewport, which
     // the rotated card swaps — clipping walls past x=660 on a 1000x600 plan.
@@ -1937,7 +1948,7 @@ describe("renderWallMask region (issue #102)", () => {
   it("covers the whole plan even where the viewport is narrower than it", () => {
     // A 90°-rotated 1000x600 plan is drawn into a 600x1000 viewport, so the
     // region must reach plan x=1000 regardless of that 600.
-    const markup = flatten(renderWallMask([], 1000, 600, "m2"));
+    const markup = flattenMarkup(renderWallMask([], 1000, 600, "m2"));
     const nums = [...markup.matchAll(/(?:x|y|width|height)=(-?\d+)/g)].map((m) => Number(m[1]));
     const right = 1000 + 8;
     expect(Math.max(...nums)).toBeGreaterThanOrEqual(right);
@@ -1994,23 +2005,13 @@ describe("sunBrightness (issue #113)", () => {
 });
 
 describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () => {
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (typeof node === "symbol") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, x, i) => acc + x + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const lamp = (extra = {}) =>
     ({ id: "i1", entity: "light.a", kind: "light", x: 200, y: 150, glow: true, ...extra }) as never;
   const on = (attributes: Record<string, unknown> = { brightness: 255 }) =>
     ({ "light.a": { entity_id: "light.a", state: "on", attributes } }) as never;
 
   it("clears fully at the centre and fades to nothing at the radius", () => {
-    const markup = flatten(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
+    const markup = flattenMarkup(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
     // Black hides the dim; white keeps it. Full brightness clears completely.
     expect(markup).toContain('stop-opacity=1');
     expect(markup).toContain('stop-opacity="0"');
@@ -2020,13 +2021,13 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
   });
 
   it("honours a custom glowRadius, so clearing and pool share a shape", () => {
-    const markup = flatten(renderSunDimMask([lamp({ glowRadius: 90 })], on(), 1000, 600, "sd"));
+    const markup = flattenMarkup(renderSunDimMask([lamp({ glowRadius: 90 })], on(), 1000, 600, "sd"));
     expect(markup).toContain("r=90");
   });
 
   it("clears in proportion to brightness, like the pool itself", () => {
     const at = (brightness: number) => {
-      const m = flatten(renderSunDimMask([lamp()], on({ brightness }), 1000, 600, "sd"));
+      const m = flattenMarkup(renderSunDimMask([lamp()], on({ brightness }), 1000, 600, "sd"));
       return Number(/stop-opacity=([\d.]+)/.exec(m)?.[1]);
     };
     expect(at(255)).toBeCloseTo(1, 5);
@@ -2052,23 +2053,23 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
   });
 
   it("states its own region, so rotation cannot clip the clearing (issue #102)", () => {
-    const markup = flatten(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
+    const markup = flattenMarkup(renderSunDimMask([lamp()], on(), 1000, 600, "sd"));
     expect(markup).toContain("width=1016");
     expect(markup).toContain("height=616");
   });
 
   it("clips the clearing at walls, like the pool it mirrors (issue #108)", () => {
     const walls = [{ id: "w", x1: 300, y1: 0, x2: 300, y2: 400 }];
-    const withWalls = flatten(
+    const withWalls = flattenMarkup(
       renderSunDimMask([lamp({ x: 190, glowRadius: 200 })], on(), 600, 400, "sd", walls)
     );
     expect(withWalls).toContain("<clipPath");
     expect(withWalls).toContain("clip-path=url(#sd-0-clip)");
     // No wall in reach: a plain circle, no clip, no wasted work.
-    const noWalls = flatten(renderSunDimMask([lamp()], on(), 600, 400, "sd", []));
+    const noWalls = flattenMarkup(renderSunDimMask([lamp()], on(), 600, 400, "sd", []));
     expect(noWalls).not.toContain("<clipPath");
     const farWall = [{ id: "w", x1: 9000, y1: 0, x2: 9000, y2: 400 }];
-    expect(flatten(renderSunDimMask([lamp()], on(), 600, 400, "sd", farWall))).not.toContain("<clipPath");
+    expect(flattenMarkup(renderSunDimMask([lamp()], on(), 600, 400, "sd", farWall))).not.toContain("<clipPath");
   });
 
   it("hangs the clip id off the gradient id, so it stays pinned too (issue #119)", () => {
@@ -2087,7 +2088,7 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
         "light.c": { entity_id: "light.c", state: "on", attributes: { brightness: 255 } },
       }) as never;
     const clips = (bOn: boolean) => {
-      const m = flatten(renderSunDimMask(items, states(bOn), 600, 400, "sd", walls));
+      const m = flattenMarkup(renderSunDimMask(items, states(bOn), 600, 400, "sd", walls));
       return [...m.matchAll(/id=(sd-\d+-clip)/g)].map((x) => x[1]);
     };
     expect(clips(false)).toEqual(["sd-0-clip", "sd-2-clip"]);
@@ -2114,7 +2115,7 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
       }) as never;
 
     const idsFor = (bOn: boolean) => {
-      const m = flatten(renderSunDimMask(items, states(bOn), 1000, 600, "sd"));
+      const m = flattenMarkup(renderSunDimMask(items, states(bOn), 1000, 600, "sd"));
       return [...m.matchAll(/id=(sd-\d+)/g)].map((x) => x[1]);
     };
     // C is index 2 and must stay sd-2 whether or not B is lit.
@@ -2122,7 +2123,7 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
     expect(idsFor(true)).toEqual(["sd-0", "sd-1", "sd-2"]);
 
     // And each circle still points at its own lamp's gradient.
-    const off = flatten(renderSunDimMask(items, states(false), 1000, 600, "sd"));
+    const off = flattenMarkup(renderSunDimMask(items, states(false), 1000, 600, "sd"));
     expect(off).toContain("cx=750");
     expect(off).toContain("url(#sd-2)");
     expect(off).not.toContain("sd-1");
@@ -2130,7 +2131,7 @@ describe("renderSunDimMask — lit rooms hold back the night (issue #113)", () =
 
   it("gives each lamp its own gradient id, so pools do not share a falloff", () => {
     const two = [lamp(), lamp({ id: "i2", x: 700 })];
-    const markup = flatten(renderSunDimMask(two, on(), 1000, 600, "sd"));
+    const markup = flattenMarkup(renderSunDimMask(two, on(), 1000, 600, "sd"));
     expect(markup).toContain("id=sd-0");
     expect(markup).toContain("id=sd-1");
   });
@@ -2182,18 +2183,6 @@ describe("shutterStyleOf (issue #74)", () => {
 describe("glowPaint (issue #6)", () => {
   const light = (state: string, attributes: Record<string, unknown> = {}) =>
     ({ entity_id: "light.x", state, attributes }) as never;
-  const flattenSunDim = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (Array.isArray(node)) return node.map(flattenSunDim).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce(
-        (acc, s, i) => acc + s + (i < values.length ? flattenSunDim(values[i]) : ""),
-        "",
-      );
-    }
-    return String(node);
-  };
 
   it("paints a color-capable light's own rgb", () => {
     const paint = glowPaint({}, light("on", { rgb_color: [255, 170, 80], brightness: 255 }));
@@ -2294,7 +2283,7 @@ describe("glowPaint (issue #6)", () => {
         const states = {
           "light.a": { entity_id: "light.a", state: "on", attributes: { brightness } },
         } as never;
-        const markup = flattenSunDim(renderSunDimMask(items, states, 1000, 600, "sd"));
+        const markup = flattenMarkup(renderSunDimMask(items, states, 1000, 600, "sd"));
         return Number(/r=(\d+(?:\.\d+)?)/.exec(markup)![1]);
       };
       expect(at(255)).toBe(200);
@@ -2468,22 +2457,10 @@ describe("glowReach — walls block light (issue #108)", () => {
 });
 
 describe("styling hooks reach the DOM (issue #105)", () => {
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    // Lit's `nothing` is a symbol; stringifying it would put the literal text
-    // "Symbol(lit-nothing)" in the markup, which is not what renders.
-    if (typeof node === "symbol") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];
 
   it("an area carries its config id, type class and bound entity", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderArea({ id: "area_a5r5nwl", points: square, entity: "binary_sensor.smoke" } as never)
     );
     expect(markup).toContain('class="fp-area"');
@@ -2495,9 +2472,9 @@ describe("styling hooks reach the DOM (issue #105)", () => {
 
   it("every entity-bindable element answers the same [data-entity] selector", () => {
     const ent = "light.kitchen";
-    const area = flatten(renderArea({ id: "a", points: square, entity: ent } as never));
-    const furn = flatten(renderFurniture({ id: "f", type: "sofa", x: 0, y: 0, w: 10, h: 10, entity: ent } as never));
-    const open = flatten(
+    const area = flattenMarkup(renderArea({ id: "a", points: square, entity: ent } as never));
+    const furn = flattenMarkup(renderFurniture({ id: "f", type: "sofa", x: 0, y: 0, w: 10, h: 10, entity: ent } as never));
+    const open = flattenMarkup(
       renderOpening({ id: "o", type: "door", x: 0, y: 0, length: 40, angle: 0, entity: ent } as never,
         { color: "#888", accent: "#0f0" } as never)
     );
@@ -2505,7 +2482,7 @@ describe("styling hooks reach the DOM (issue #105)", () => {
   });
 
   it("furniture carries its id, its type class and its entity", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderFurniture({ id: "furn_3j66s50", type: "sofa", x: 0, y: 0, w: 10, h: 10, entity: "light.k" } as never)
     );
     expect(markup).toContain("fp-furniture fp-furniture-sofa");
@@ -2514,7 +2491,7 @@ describe("styling hooks reach the DOM (issue #105)", () => {
   });
 
   it("an opening carries its id and door/window class", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderOpening(
         { id: "door_1", type: "door", x: 0, y: 0, length: 40, angle: 0, entity: "binary_sensor.d" } as never,
         { color: "#888", accent: "#0f0" } as never
@@ -2555,7 +2532,7 @@ describe("styling hooks reach the DOM (issue #105)", () => {
   });
 
   it("a hostile id stays one harmless token instead of a second class", () => {
-    const markup = flatten(renderArea({ id: 'x" class="fp-wall', points: square } as never));
+    const markup = flattenMarkup(renderArea({ id: 'x" class="fp-wall', points: square } as never));
     // The class list is untouched, and the id collapses to a single token —
     // no quote to close the attribute, no space to start another class.
     expect(markup).toContain('class="fp-area"');
@@ -2566,18 +2543,9 @@ describe("styling hooks reach the DOM (issue #105)", () => {
 });
 
 describe("renderGlowMask — furniture is dimmed, not blacked out (#108, #106)", () => {
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
 
   const twoPieces = () =>
-    flatten(
+    flattenMarkup(
       renderGlowMask(
         [
           { id: "s", type: "sofa", x: 300, y: 200, w: 100, h: 50, angle: 90 },
@@ -2617,10 +2585,10 @@ describe("renderGlowMask — furniture is dimmed, not blacked out (#108, #106)",
   it("clips the pool with the reach polygon only when walls are in range", () => {
     const item = { id: "i", entity: "light.x", kind: "light", x: 300, y: 200 } as never;
     const paint = { color: "#fff", opacity: 0.4, radius: DEFAULT_GLOW_RADIUS };
-    const withWall = flatten(renderGlow(item, paint, "g1", [{ id: "w", x1: 0, y1: 260, x2: 1000, y2: 260 }]));
+    const withWall = flattenMarkup(renderGlow(item, paint, "g1", [{ id: "w", x1: 0, y1: 260, x2: 1000, y2: 260 }]));
     expect(withWall).toContain("<clipPath");
     expect(withWall).toContain("clip-path=url(#g1-clip)");
-    const noWall = flatten(renderGlow(item, paint, "g2", []));
+    const noWall = flattenMarkup(renderGlow(item, paint, "g2", []));
     expect(noWall).not.toContain("<clipPath");
   });
 });
@@ -2655,20 +2623,11 @@ describe("editorGlowPaint (issue #108)", () => {
 });
 
 describe("renderGlow (issue #6)", () => {
-  const flatten = (node: unknown): string => {
-    if (node == null || typeof node === "boolean") return "";
-    if (Array.isArray(node)) return node.map(flatten).join("");
-    if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
-      const { strings, values } = node as { strings: string[]; values: unknown[] };
-      return strings.reduce((acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""), "");
-    }
-    return String(node);
-  };
   const item = (extra: Record<string, unknown> = {}) =>
     ({ id: "i", entity: "light.x", kind: "light", x: 300, y: 200, ...extra }) as never;
 
   it("centers the pool on the device and fades to nothing at the rim", () => {
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderGlow(item(), { color: "rgb(1, 2, 3)", opacity: 0.5, radius: DEFAULT_GLOW_RADIUS }, "g1"),
     );
     expect(markup).toContain("cx=300");
@@ -2683,7 +2642,7 @@ describe("renderGlow (issue #6)", () => {
   it("draws at the radius the paint carries, not the configured one (#123)", () => {
     // The size is brightness-scaled in glowPaint, so renderGlow must use what
     // it is handed — reading item.glowRadius here again would silently undo it.
-    const markup = flatten(
+    const markup = flattenMarkup(
       renderGlow(item({ glowRadius: 250 }), { color: "#fff", opacity: 0.4, radius: 137 }, "g"),
     );
     expect(markup).toContain("r=137");
@@ -2692,7 +2651,7 @@ describe("renderGlow (issue #6)", () => {
 
   it("carries the class the blend mode hangs off, or lights would not mix", () => {
     expect(
-      flatten(renderGlow(item(), { color: "#fff", opacity: 0.4, radius: DEFAULT_GLOW_RADIUS }, "g")),
+      flattenMarkup(renderGlow(item(), { color: "#fff", opacity: 0.4, radius: DEFAULT_GLOW_RADIUS }, "g")),
     ).toContain('class="fp-glow"');
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_ITEM_SIZE,
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
+  GLOW_MIN_RADIUS,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   getFloors,
@@ -267,6 +268,16 @@ export interface GlowPaint {
   color: string;
   /** Opacity at the center of the pool, fading to 0 at the rim. */
   opacity: number;
+  /**
+   * How far the pool actually reaches, in canvas units (issue #123): the
+   * configured `glowRadius` scaled by the lamp's brightness.
+   *
+   * Carried on the paint rather than recomputed by each caller so the pool and
+   * the sun-dimming clearing cannot disagree about the same lamp's size — they
+   * are documented as the same shape by construction, and two copies of this
+   * arithmetic is exactly how that stops being true.
+   */
+  radius: number;
 }
 
 /**
@@ -286,9 +297,15 @@ export interface GlowPaint {
  * A light that is off, `unavailable` or `unknown` casts nothing — failing
  * closed like every other state reader here, so a dead bulb never leaves a
  * pool of light lying on the floor.
+ *
+ * Brightness drives the pool's **reach** as well as its strength (issue #123):
+ * dimming a lamp draws the light in rather than only thinning it, which is what
+ * dimming actually looks like. The configured `glowRadius` is the full-brightness
+ * size, so nothing changes for a lamp at 100% or for a bulb that reports no
+ * brightness at all.
  */
 export function glowPaint(
-  item: Pick<FloorItem, "glowColor">,
+  item: Pick<FloorItem, "glowColor" | "glowRadius">,
   light: HassEntity | undefined,
 ): GlowPaint | undefined {
   if (!light || light.state !== "on") return undefined;
@@ -302,6 +319,11 @@ export function glowPaint(
     bright === undefined
       ? GLOW_MAX_OPACITY
       : GLOW_MIN_OPACITY + (GLOW_MAX_OPACITY - GLOW_MIN_OPACITY) * (bright / 255);
+  // Same shape as the opacity band above, and a floor for the same reason: a
+  // lamp dimmed to 10% should read as dim, not as switched off.
+  const radius =
+    cssNumber(item.glowRadius, DEFAULT_GLOW_RADIUS) *
+    (bright === undefined ? 1 : GLOW_MIN_RADIUS + (1 - GLOW_MIN_RADIUS) * (bright / 255));
 
   const rgb = attrs.rgb_color;
   if (Array.isArray(rgb) && rgb.length >= 3) {
@@ -311,10 +333,10 @@ export function glowPaint(
       // Built from clamped integers, so it cannot carry a payload — but it
       // still goes through the allowlist, as every color here does.
       const color = cssColor(`rgb(${chan(r as number)}, ${chan(g as number)}, ${chan(b as number)})`);
-      if (color) return { color, opacity };
+      if (color) return { color, opacity, radius };
     }
   }
-  return { color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR), opacity };
+  return { color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR), opacity, radius };
 }
 
 /**
@@ -364,11 +386,15 @@ export function lightBadgePaint(light: HassEntity | undefined): string | undefin
  * unconditionally, and every off light washed the canvas at full strength.
  */
 export function editorGlowPaint(
-  item: Pick<FloorItem, "glowColor">,
+  item: Pick<FloorItem, "glowColor" | "glowRadius">,
   state: HassEntity | undefined,
 ): GlowPaint | undefined {
   if (state) return glowPaint(item, state);
-  return { color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR), opacity: GLOW_MAX_OPACITY };
+  return {
+    color: cssColorOr(item.glowColor, DEFAULT_GLOW_COLOR),
+    opacity: GLOW_MAX_OPACITY,
+    radius: cssNumber(item.glowRadius, DEFAULT_GLOW_RADIUS),
+  };
 }
 
 /**
@@ -407,12 +433,65 @@ function rayWallHit(cx: number, cy: number, dx: number, dy: number, w: Wall): nu
 }
 
 /**
+ * Clip a segment to an axis-aligned box (Liang–Barsky), or undefined when it
+ * falls entirely outside. Used by {@link glowReach} — see the note there on
+ * why the sweep needs the clipped wall rather than the configured one.
+ */
+function clipWallToBox(
+  w: Wall,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+): Wall | undefined {
+  const dx = w.x2 - w.x1;
+  const dy = w.y2 - w.y1;
+  const p = [-dx, dx, -dy, dy];
+  const q = [w.x1 - minX, maxX - w.x1, w.y1 - minY, maxY - w.y1];
+  let t0 = 0;
+  let t1 = 1;
+  for (let i = 0; i < 4; i++) {
+    if (p[i] === 0) {
+      if (q[i] < 0) return undefined; // parallel to this edge and outside it
+      continue;
+    }
+    const t = q[i] / p[i];
+    if (p[i] < 0) {
+      if (t > t1) return undefined;
+      if (t > t0) t0 = t;
+    } else {
+      if (t < t0) return undefined;
+      if (t < t1) t1 = t;
+    }
+  }
+  return {
+    ...w,
+    x1: w.x1 + t0 * dx,
+    y1: w.y1 + t0 * dy,
+    x2: w.x1 + t1 * dx,
+    y2: w.y1 + t1 * dy,
+  };
+}
+
+/**
  * How far a light at (cx,cy) actually reaches (issue #108): the visibility
  * polygon of the walls that fall inside its radius, so a pool stops at a wall
  * instead of washing into the next room. Classic angular sweep — a ray toward
  * each wall endpoint (and just past it, so light grazes corners), cut at the
  * nearest wall it hits; a bounding box just beyond the radius keeps every ray
  * finite, and the circle itself still bounds the final shape.
+ *
+ * **Blocking walls are clipped to that box first (issue #123).** The sweep's
+ * only vertices are the angles of the segment endpoints it is given, and the
+ * boundary between two of them is drawn as a straight chord. An ordinary room
+ * wall runs well past the pool, so its *declared* endpoints sit outside the
+ * box at the wrong angle entirely, and no ray is ever cast where the wall
+ * actually enters the lit region — the point where the boundary hands over
+ * from the box to the wall. The chord spanning that gap sliced a wedge out of
+ * the pool beside every long wall: the reported artifact. Clipping makes the
+ * wall's endpoints *be* those hand-over points, so the sweep samples them.
+ * A wall already inside the box is unchanged, which is why short walls never
+ * showed this.
  *
  * The wall the lamp is mounted on must not black out its own pool, so walls
  * closer than one wall thickness are treated as non-blocking. Returns
@@ -437,7 +516,13 @@ export function glowReach(
     { id: "b3", x1: cx + m, y1: cy + m, x2: cx - m, y2: cy + m },
     { id: "b4", x1: cx - m, y1: cy + m, x2: cx - m, y2: cy - m },
   ];
-  const all = [...blocking, ...bounds];
+  // Trim each wall to the swept region so its endpoints land where it enters
+  // that region — those are the silhouette vertices the sweep has to sample.
+  const clipped = blocking
+    .map((w) => clipWallToBox(w, cx - m, cy - m, cx + m, cy + m))
+    .filter((w): w is Wall => w !== undefined);
+  if (!clipped.length) return undefined;
+  const all = [...clipped, ...bounds];
   const pts: Array<{ x: number; y: number; a: number }> = [];
   for (const s of all) {
     for (const [ex, ey] of [
@@ -470,7 +555,9 @@ export function renderGlow(
   gradientId: string,
   walls?: readonly Wall[],
 ): SVGTemplateResult {
-  const r = cssNumber(item.glowRadius, DEFAULT_GLOW_RADIUS);
+  // Brightness-scaled (issue #123), computed once on the paint so the pool and
+  // the sun-dimming clearing are the same size for the same lamp.
+  const r = paint.radius;
   // Walls block light (issue #108): clip the pool to what the lamp can see.
   const reach = walls?.length ? glowReach(item.x, item.y, r, walls) : undefined;
   const clipId = `${gradientId}-clip`;
@@ -525,15 +612,20 @@ export function renderSunDimMask(
 ): SVGTemplateResult | typeof nothing {
   // Strength per item, by INDEX — undefined where the lamp contributes nothing.
   // Deliberately not compacted: see the map below.
-  const strengths = items.map((it) => {
+  const clearings = items.map((it) => {
     if (!it.glow) return undefined;
     const paint = glowPaint(it, states?.[it.entity]);
     if (!paint) return undefined;
-    // Normalized against the glow's own ceiling, so a full-brightness lamp
-    // clears the dim entirely and a dim one clears proportionally.
-    return Math.max(0, Math.min(1, paint.opacity / GLOW_MAX_OPACITY));
+    return {
+      // Normalized against the glow's own ceiling, so a full-brightness lamp
+      // clears the dim entirely and a dim one clears proportionally.
+      strength: Math.max(0, Math.min(1, paint.opacity / GLOW_MAX_OPACITY)),
+      // Straight off the paint, so the clearing tracks the pool as it shrinks
+      // with brightness (issue #123) instead of staying at the configured size.
+      radius: paint.radius,
+    };
   });
-  if (!strengths.some((v) => v !== undefined)) return nothing;
+  if (!clearings.some((v) => v !== undefined)) return nothing;
 
   const pad = WALL_THICKNESS;
   return svg`
@@ -552,9 +644,9 @@ export function renderSunDimMask(
           // hard-edged disc at full strength rather than a soft falloff, and
           // it only bites lamps positioned *after* the one that toggled —
           // which is what made it look intermittent.
-          const strength = strengths[i];
-          if (strength === undefined) return nothing;
-          const r = cssNumber(it.glowRadius, DEFAULT_GLOW_RADIUS);
+          const clearing = clearings[i];
+          if (clearing === undefined) return nothing;
+          const { strength, radius: r } = clearing;
           const gid = `${id}-${i}`;
           // Walls stop the clearing exactly as they stop the pool (issue #108),
           // reusing the same visibility polygon — otherwise a lit room lifts

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,6 +611,18 @@ export const GLOW_MIN_OPACITY = 0.18;
 export const GLOW_MAX_OPACITY = 0.6;
 
 /**
+ * Smallest share of its configured `glowRadius` a lamp's pool shrinks to as it
+ * dims (issue #123). Dimming a lamp draws the light *in* as well as thinning
+ * it, which is what dimming looks like in a room.
+ *
+ * Floored for the same reason {@link GLOW_MIN_OPACITY} is: a lamp at 5% would
+ * otherwise collapse to a dot under its own icon and read as switched off.
+ * `glowRadius` stays the full-brightness size, so a lamp at 100% — and any
+ * bulb that reports no brightness at all — is unaffected.
+ */
+export const GLOW_MIN_RADIUS = 0.5;
+
+/**
  * How far a light's `brightness` may darken its **badge** colour (issue #106,
  * @ombre33): a lamp at full brightness badges its true `rgb_color`, one dimmed
  * to nothing badges this fraction of it.


### PR DESCRIPTION
Closes #123.

## The artifact

Reproduced with a lamp 60 units above an ordinary room wall. Points 5px above the wall — unobstructed, well inside the radius — came back unlit:

```
dx=0    dist=55   lit=true
dx=60   dist=81   lit=true
dx=80   dist=97   lit=FALSE   <- nothing blocks these
dx=120  dist=132  lit=FALSE
```

**It is not the light-escaping-at-an-angle logic**, which was the natural suspect. The sweep's only vertices are the angles it casts rays at, and the boundary between two of them is drawn as a straight chord. It cast those rays at each wall's *declared* endpoints — and an ordinary room wall runs well past the pool, so its endpoints sit outside the swept region entirely. In the repro the ray went to `(1000, 360)` at **6.8°**, while the boundary actually hands over from the region's edge to the wall at **23°**. Nothing sampled the hand-over, and the chord spanning that gap sliced the wedge off.

The fix is to clip blocking walls to the swept region first, so their endpoints *are* the hand-over points. The vertex dump before and after:

```
before:  a=  6.8  d=142.4   <- wrong angle: the wall's far endpoint
after:   a= 23.0  d=153.6   <- where the wall actually enters the region
```

A wall that already fits inside the region is unchanged by the clip — which is exactly why short walls never showed this, and why it only ever appeared next to long ones.

Verified on the rendered card afterwards: sampling the strip just above the wall gives a smooth symmetric falloff from the centre to zero at exactly the radius, with **max left/right asymmetry of 1/255**.

## Brightness sets the reach

Your idea from the thread. Dimming a lamp now draws its pool in as well as thinning it:

| brightness | radius (configured 140) |
|---|---|
| 100% | 140 |
| 50% | 105 |
| 4% | 73 |

`glowRadius` is the full-brightness size, so a lamp at 100% — and any bulb that reports no brightness at all — is unchanged. Floored at half for the same reason the opacity band has a floor: a lamp at 5% should read as dim, not as collapsed to a dot under its own icon.

The radius rides on `GlowPaint` rather than being recomputed by each caller, so the pool and the sun-dimming clearing cannot disagree about the same lamp's size. They are documented as the same shape by construction, and two copies of that arithmetic is precisely how that stops being true. The css-safe gate on a hostile `glowRadius` moved along with it and keeps its test.

The editor's radius guide deliberately keeps showing the **configured** size — it is the handle for the value you are setting, and a guide that shrank as the bulb dimmed would move while you dragged it.

## Not doing

Cast light on `switch` entities, also raised on this issue. You answered that in the thread with template light entities and @tripletschiee took that route, so this leaves it alone rather than contradicting your own answer.

## Checks

- `tsc`, **630 tests**, `npm run build` green; duplication sweep clean.
- 9 of the new tests fail against the pre-fix source; the two that pass are deliberate no-change guards (the far side of the wall still dark, a short wall's shadow unchanged) — without those, "delete the clipping entirely" would also pass.

## Note on branching

#125 was squash-merged while this was in progress, so this branches fresh from `main` (`9e91326`) rather than continuing the old branch — otherwise the PR would have re-presented the whole #106 diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)