### PR TITLE
Devices: one badge dropdown, ripple for presence only (closes #127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,16 @@ By default it shows an icon badge:
   itself uses. An explicit icon on the entity, or an **icon** override on the device,
   still wins.
 - **Make it yours** — override the **icon** (with autocomplete + live preview), set a
-  custom **name**, change the **size**, **rotate** it, or hide the icon entirely.
+  custom **name**, change the **size**, or **rotate** it. The icon sits at the bottom
+  of the device's options, next to the state rules that can swap it.
+- **One badge control** — **Badge shows** is the single dropdown for what the device
+  draws: an icon (**still**, **spinning** or **pulsing**), its **Value**, or **Nothing**
+  at all.
 - **Icons that move** — while an entity is active its icon can animate, the way
-  Home Assistant's own Tile card does it: by default a running **fan spins** and an
-  active **media player** (playing, or simply on) or **vacuum** (cleaning /
-  returning) **pulses**. The **Animate icon**
-  dropdown per device switches to `none`, or forces `spin` / `pulse` on any entity
+  Home Assistant's own Tile card does it: a running **fan** spins and an active
+  **media player** (playing, or simply on) or **vacuum** (cleaning / returning) pulses,
+  with no setup — those devices simply open on *Icon, spinning* / *Icon, pulsing*.
+  Change the dropdown to turn it off, or to force an animation on any other entity
   (a spinning icon still only plays while the entity is actually active — an
   unavailable fan never spins). Respects the OS *reduced motion* preference.
 - **Label line** — **Show state** displays the live value (sensors do this by
@@ -298,6 +302,12 @@ By default it shows an icon badge:
   a device is never badged one color and ringed another), so the editor hides the
   **Active color** field once rules exist rather than leaving a control that would
   silently lose.
+
+  A rule's `icon` works the other way round: it is optional, and a rule without one
+  keeps the device's own **Icon** — so colouring by state costs you nothing if the
+  glyph never changes, and you never name the same icon in every row. That is why the
+  **Icon** field stays visible next to the rules (it is still what they fall back to)
+  while **Active color** disappears.
 - **Only when active** — tick it and the device disappears from the card while its
   entity is off/idle, so a busy room only shows what's actually doing something.
   "Active" is the same domain-aware test the badge highlight uses (a lock counts as
@@ -311,9 +321,8 @@ By default it shows an icon badge:
 
 ### Presence ripples
 
-For motion/occupancy/presence sensors, switch a device's **Display** mode from *Icon
-badge* to **Ripple** or **Icon + ripple**. Instead of a static icon it draws animated
-concentric rings:
+Turn on a device's **Ripple** toggle and it draws animated concentric rings behind the
+badge — set **Badge shows** to *Nothing* for the rings alone:
 
 - **Active** (sensor on) → the rings continuously pulse outward and fade, drawing the
   eye to where motion is happening.
@@ -321,8 +330,13 @@ concentric rings:
   marked without being distracting.
 
 You can set the **ripple color** and **ripple size** per device, so e.g. a calm blue
-ring in the living room and a warmer one by the entrance. It works with any entity that
-reports an on/off-like state, not just presence sensors.
+ring in the living room and a warmer one by the entrance.
+
+The toggle only appears on devices that detect presence — a `binary_sensor` whose
+**device class** is `motion`, `occupancy` or `presence`, or a `device_tracker` /
+`person` — the same way **Cast light** only appears on lights. A ring is a claim that
+someone is there, so it is offered where that claim can be true. The underlying
+`display` key still works on any entity if you write it in YAML.
 
 <img width="540" height="304" alt="ripple_demo_gif" src="https://github.com/user-attachments/assets/e43949cf-13a2-48f8-804d-73738299475f" />
 
@@ -667,8 +681,8 @@ shape it occupies on screen.
 | `name`        | string                                 | friendly name| Label / tooltip override.                             |
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
-| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn.                               |
-| `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. |
+| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`), and offers it on presence devices only — in YAML it works on any entity. |
+| `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. The editor spells this as the icon options of **Badge shows**, showing `auto` as the animation it resolves to rather than offering the word. |
 | `activeColor` | string                                 | theme color  | Badge color while the device is on — lets domains be told apart at a glance. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color (ripple modes). Falls back to `activeColor`, then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |

--- a/README.md
+++ b/README.md
@@ -324,9 +324,10 @@ By default it shows an icon badge:
 Turn on a device's **Ripple** toggle and it draws animated concentric rings behind the
 badge — set **Badge shows** to *Nothing* for the rings alone:
 
-- **Active** (sensor on) → the rings continuously pulse outward and fade, drawing the
-  eye to where motion is happening.
-- **Idle** (sensor off) → the rings stop and only a faint dot remains, so the spot stays
+- **Active** (presence detected — the sensor reads on, the tracker reads home) → the
+  rings continuously pulse outward and fade, drawing the eye to where motion is
+  happening.
+- **Idle** (clear) → the rings stop and only a faint dot remains, so the spot stays
   marked without being distracting.
 
 You can set the **ripple color** and **ripple size** per device, so e.g. a calm blue

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -183,24 +183,25 @@ describe("itemForm", () => {
     expect(names({ ...item, kind: "sensor", entity: "sensor.temp" } as FloorItem)).not.toContain("glow");
   });
 
-  it("hides ripple size for badge display, shows it otherwise", () => {
-    expect(itemForm(item).fields.map((x) => x.name)).not.toContain("rippleSize");
-    expect(
-      itemForm({ ...item, display: "ripple" } as FloorItem).fields.map((x) => x.name)
-    ).toContain("rippleSize");
-  });
-
-  it("offers the icon-animation dropdown defaulting to auto", () => {
-    const f = itemForm(item).fields.find((x) => x.name === "iconAnimation");
-    expect(f).toBeDefined();
-    const opts = (f!.selector as { select: { options: { value: string }[] } }).select.options.map(
-      (o) => o.value
-    );
-    expect(opts).toEqual(["auto", "none", "spin", "pulse"]);
-    expect(itemForm(item).data.iconAnimation).toBe("auto");
-    expect(itemForm({ ...item, iconAnimation: "spin" } as FloorItem).data.iconAnimation).toBe(
-      "spin"
-    );
+  it("offers Ripple on presence devices only, sized behind the toggle (#127)", () => {
+    const motion = { ...item, entity: "binary_sensor.hall", kind: "binary_sensor" } as FloorItem;
+    const names = (it: FloorItem, dc?: string) => itemForm(it, undefined, dc).fields.map((x) => x.name);
+    // A light is not something that detects presence, whatever it can do.
+    expect(names(item)).not.toContain("ripple");
+    expect(names(item, "motion")).not.toContain("ripple");
+    // Nor is a binary sensor whose class says door / leak / nothing at all.
+    expect(names(motion)).not.toContain("ripple");
+    expect(names(motion, "door")).not.toContain("ripple");
+    for (const dc of ["motion", "occupancy", "presence"]) {
+      expect(names(motion, dc)).toContain("ripple");
+    }
+    expect(names({ ...item, entity: "device_tracker.phone" } as FloorItem)).toContain("ripple");
+    // Size only once the ring is actually on, exactly like Cast light's radius.
+    expect(names(motion, "motion")).not.toContain("rippleSize");
+    const ringed = { ...motion, display: "iconRipple" } as FloorItem;
+    expect(names(ringed, "motion")).toContain("rippleSize");
+    // A ring set on something else still reads back, so toPatch keeps it.
+    expect(itemForm({ ...item, display: "iconRipple" } as FloorItem).data.ripple).toBe(true);
   });
 
   it("offers Show name, and Label size only while a label line renders (#61, #59)", () => {
@@ -236,33 +237,99 @@ describe("itemForm", () => {
 
   it("data presents effective defaults", () => {
     const d = itemForm(item).data;
-    expect(d.badgeContent).toBe("icon");
+    expect(d.badgeMode).toBe("icon");
+    expect(d.ripple).toBe(false);
     expect(d.showState).toBe(false);
-    expect(d.display).toBe("badge");
     expect(d.angle).toBe(0);
   });
 
-  it("replaces the Show icon toggle with a three-way Badge shows dropdown (#106)", () => {
+  it("merges Display, Animate icon and Badge shows into one dropdown (#127)", () => {
     const names = itemForm(item).fields.map((x) => x.name);
-    expect(names).toContain("badgeContent");
+    // The three switches it stands in for are gone from the form…
+    expect(names).not.toContain("display");
+    expect(names).not.toContain("iconAnimation");
+    expect(names).not.toContain("badgeContent");
     expect(names).not.toContain("showIcon");
-    const f = itemForm(item).fields.find((x) => x.name === "badgeContent")!;
+    expect(names).toContain("badgeMode");
+    const f = itemForm(item).fields.find((x) => x.name === "badgeMode")!;
     const opts = (f.selector as { select: { options: { value: string }[] } }).select.options.map(
       (o) => o.value
     );
-    expect(opts).toEqual(["icon", "value", "none"]);
+    // No "auto": the menu names the animation, never the config's word for
+    // "whatever this domain does" (#127).
+    expect(opts).toEqual(["icon", "spin", "pulse", "value", "none"]);
   });
 
-  it("migrates a legacy showIcon config, and retires the key once touched (#106)", () => {
-    // An untouched legacy config still reads as "no badge"…
-    const legacy = itemForm({ ...item, showIcon: false } as FloorItem);
-    expect(legacy.data.badgeContent).toBe("none");
-    // …and choosing anything in the new dropdown drops the old key, so the two
-    // can never be edited into disagreeing.
-    const patch = legacy.toPatch({ badgeContent: "value" });
-    expect(patch).toEqual({ badgeContent: "value", showIcon: undefined });
-    // Unrelated edits leave it alone.
-    expect(legacy.toPatch({ size: 40 })).toEqual({ size: 40 });
+  it("shows the animation auto resolves to, not the word auto (#127)", () => {
+    const mode = (entity: string, it: Partial<FloorItem> = {}) =>
+      itemForm({ ...item, entity, ...it } as FloorItem).data.badgeMode;
+    // Untouched configs: the dropdown reads what the card is already playing.
+    expect(mode("fan.ceiling")).toBe("spin");
+    expect(mode("media_player.tv")).toBe("pulse");
+    expect(mode("vacuum.robo")).toBe("pulse");
+    expect(mode("light.a")).toBe("icon");
+    // An explicit "auto" reads the same as no key at all…
+    expect(mode("fan.ceiling", { iconAnimation: "auto" })).toBe("spin");
+    // …while "none" is the user saying "still", even on a fan.
+    expect(mode("fan.ceiling", { iconAnimation: "none" })).toBe("icon");
+    // Picking "still" writes the key that turns the domain default off.
+    expect(itemForm({ ...item, entity: "fan.ceiling" } as FloorItem).toPatch({ badgeMode: "icon" })
+      .iconAnimation).toBe("none");
+  });
+
+  it("reads the badge mode off the three keys it replaced (#127)", () => {
+    const mode = (it: Partial<FloorItem>) => itemForm({ ...item, ...it } as FloorItem).data.badgeMode;
+    expect(mode({})).toBe("icon");
+    expect(mode({ iconAnimation: "none" })).toBe("icon");
+    expect(mode({ iconAnimation: "spin" })).toBe("spin");
+    expect(mode({ iconAnimation: "pulse" })).toBe("pulse");
+    expect(mode({ badgeContent: "value" })).toBe("value");
+    expect(mode({ badgeContent: "none" })).toBe("none");
+    // A legacy showIcon: false still reads as "no badge" (issue #106).
+    expect(mode({ showIcon: false })).toBe("none");
+    // Ripple-only draws no badge at all, whatever badgeContent says.
+    expect(mode({ display: "ripple", badgeContent: "icon" })).toBe("none");
+    expect(mode({ display: "iconRipple", iconAnimation: "spin" })).toBe("spin");
+    // The ring is read off `display` alone.
+    expect(itemForm({ ...item, display: "iconRipple" } as FloorItem).data.ripple).toBe(true);
+    expect(itemForm({ ...item, display: "ripple" } as FloorItem).data.ripple).toBe(true);
+  });
+
+  it("expands the merged dropdown back into display/animation/content (#127)", () => {
+    const f = itemForm(item);
+    expect(f.toPatch({ badgeMode: "spin" })).toEqual({
+      badgeContent: "icon",
+      iconAnimation: "spin",
+      display: "badge",
+      showIcon: undefined,
+    });
+    // "Still" is an animation choice, not a missing one.
+    expect(f.toPatch({ badgeMode: "icon" }).iconAnimation).toBe("none");
+    // Value/Nothing say nothing about animation, so the stored one survives a
+    // trip through them.
+    expect(f.toPatch({ badgeMode: "value" })).toEqual({
+      badgeContent: "value",
+      display: "badge",
+      showIcon: undefined,
+    });
+    // The ring toggle alone is still a complete statement about `display`:
+    // the mode comes off the item.
+    expect(f.toPatch({ ripple: true }).display).toBe("iconRipple");
+    expect(
+      itemForm({ ...item, badgeContent: "none" } as FloorItem).toPatch({ ripple: true }).display
+    ).toBe("ripple");
+    expect(
+      itemForm({ ...item, display: "iconRipple" } as FloorItem).toPatch({ ripple: false }).display
+    ).toBe("badge");
+    // Both at once, and unrelated edits, pass through untouched.
+    expect(f.toPatch({ badgeMode: "none", ripple: true }).display).toBe("ripple");
+    expect(f.toPatch({ size: 40 })).toEqual({ size: 40 });
+    expect(f.toPatch({ size: 40, badgeMode: "value" }).size).toBe(40);
+  });
+
+  it("moves the icon out of the form, next to the rules that override it (#127)", () => {
+    expect(itemForm(item).fields.map((x) => x.name)).not.toContain("icon");
+    expect(itemForm(item).data.icon).toBeUndefined();
   });
 
   it("scopes the entity/secondaryEntity pickers to the area's entities when given", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -487,7 +487,9 @@ export function itemForm(
     fields.push({
       name: "ripple",
       label: "Ripple",
-      helper: "Draws a pulsing ring while the sensor detects something",
+      // "Presence detected" rather than "the sensor is on": this is offered to
+      // a device_tracker and a person too, and neither of those is a sensor.
+      helper: "Draws a pulsing ring while presence is detected here",
       selector: { boolean: {} },
     });
     if (ripple) {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -31,7 +31,8 @@ import {
 import {
   DEFAULT_LABEL_SIZE,
   badgeContentOf,
-  defaultIcon,
+  domainIconAnimation,
+  isPresenceEntity,
   normalizePlanRotation,
   openingMotion,
   sliderStyleOf,
@@ -355,8 +356,81 @@ function areaScopeHelper(scope: AreaEntityScope | undefined, base?: string): str
   return base ? `${base}. ${note}` : note;
 }
 
-export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
-  const display = it.display ?? "badge";
+/**
+ * The badge as one choice (issue #127), collapsing the three switches that
+ * used to spell it out — `display`, `badgeContent` and `iconAnimation`.
+ *
+ * They were never three independent questions: `iconAnimation` only means
+ * something while the badge holds an icon, `badgeContent` means nothing at all
+ * while `display: ripple` draws no badge, and picking "Value" left an "Animate
+ * icon" dropdown on screen that did nothing. What is left is one question —
+ * *what is in the badge* — with the animation as three of its answers.
+ *
+ * The ring is the one genuinely separate axis (a spinning fan icon inside a
+ * ripple is a real combination), so it stays its own toggle rather than
+ * becoming options that would multiply this list by two.
+ *
+ * There is no `auto`: "auto" is a fact about the config format, not about what
+ * the user is looking at. The dropdown names the animation the card is
+ * actually playing — a fan reads *spinning*, a media player *pulsing* — by
+ * resolving `auto` through {@link domainIconAnimation}. Nothing about the card
+ * changes; `auto` stays the default `render.ts` applies to configs nobody has
+ * touched.
+ *
+ * The config keys are untouched: this is the editor's view of them, so every
+ * existing YAML — including combinations this dropdown cannot name — keeps
+ * rendering exactly as before.
+ */
+export type BadgeMode = "icon" | "spin" | "pulse" | "value" | "none";
+
+/** {@link BadgeMode} for an item, reading the three keys it stands in for. */
+function badgeModeOf(it: FloorItem): BadgeMode {
+  // A ripple-only device draws no badge, whatever `badgeContent` says.
+  if ((it.display ?? "badge") === "ripple") return "none";
+  const content = badgeContentOf(it);
+  if (content !== "icon") return content;
+  const anim = it.iconAnimation ?? "auto";
+  if (anim === "spin" || anim === "pulse") return anim;
+  // "auto" (and an absent key) shows as whatever it resolves to for this
+  // entity, so the menu never says one thing while the badge does another.
+  return anim === "auto" ? (domainIconAnimation(it.entity) ?? "icon") : "icon";
+}
+
+/** Whether the device draws a ripple ring — the other half of `display`. */
+export function itemHasRipple(it: FloorItem): boolean {
+  return (it.display ?? "badge") !== "badge";
+}
+
+/** The three config keys implied by a badge mode + ring choice. */
+function badgeModePatch(mode: BadgeMode, ripple: boolean): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    badgeContent: mode === "value" ? "value" : mode === "none" ? "none" : "icon",
+    // Touching the badge retires the `showIcon` boolean it replaced (issue
+    // #106), so a migrated config carries one setting rather than two that
+    // could later be edited into disagreeing. Configs nobody touches keep
+    // working through badgeContentOf's fallback.
+    showIcon: undefined,
+    display: !ripple ? "badge" : mode === "none" ? "ripple" : "iconRipple",
+  };
+  // Only the icon modes say anything about animation; "Value"/"Nothing" leave
+  // the stored setting alone, so switching away and back does not lose it.
+  if (mode !== "value" && mode !== "none") out.iconAnimation = mode === "icon" ? "none" : mode;
+  return out;
+}
+
+/**
+ * `deviceClass` is the entity's HA device class, the one hass-derived fact the
+ * device form needs: it is what separates a motion sensor from a door contact,
+ * and so decides whether the ripple ring is offered at all (issue #127). The
+ * editor reads it off `hass` at the call site, as it already does for openings.
+ */
+export function itemForm(
+  it: FloorItem,
+  areaScope?: AreaEntityScope,
+  deviceClass?: string
+): FormSpec {
+  const ripple = itemHasRipple(it);
+  const presence = isPresenceEntity(it.entity, deviceClass);
   const fields: FormField[] = [
     {
       name: "entity",
@@ -383,7 +457,8 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       helper: "From the second entity, or this entity if none",
       selector: { attribute: { entity_id: it.secondaryEntity || it.entity } },
     },
-    { name: "icon", label: "Icon", selector: { icon: { placeholder: defaultIcon(it.kind) } } },
+    // The icon is *not* here: it sits by the state rules that can override it
+    // (issue #127), rendered by the editor next to them.
     { name: "name", label: "Name", selector: { text: {} } },
     {
       name: "size",
@@ -392,32 +467,38 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
     },
     angleField(),
     {
-      name: "display",
-      label: "Display",
+      name: "badgeMode",
+      label: "Badge shows",
+      helper:
+        "Animations play only while the entity is active. Value puts the reading in the badge, falling back to the icon when there is no number",
       selector: dropdown(
-        opt("badge", "Icon badge"),
-        opt("ripple", "Ripple"),
-        opt("iconRipple", "Icon + ripple")
-      ),
-    },
-    {
-      name: "iconAnimation",
-      label: "Animate icon",
-      helper: "Plays only while the entity is active",
-      selector: dropdown(
-        opt("auto", "Auto (fan spins; media & vacuum pulse)"),
-        opt("none", "None"),
-        opt("spin", "Spin"),
-        opt("pulse", "Pulse")
+        opt("icon", "Icon, still"),
+        opt("spin", "Icon, spinning"),
+        opt("pulse", "Icon, pulsing"),
+        opt("value", "Value"),
+        opt("none", "Nothing")
       ),
     },
   ];
-  if (display !== "badge") {
+  // A presence device can ring the spot it watches (issue #127) — the same
+  // shape of option as "Cast light" below, offered only where it means
+  // something. A ring on a thermostat says "someone is here", which is a lie.
+  if (presence) {
     fields.push({
-      name: "rippleSize",
-      label: "Ripple size",
-      selector: { number: { min: 40, max: 400, step: 4, mode: "slider", unit_of_measurement: "px" } },
+      name: "ripple",
+      label: "Ripple",
+      helper: "Draws a pulsing ring while the sensor detects something",
+      selector: { boolean: {} },
     });
+    if (ripple) {
+      fields.push({
+        name: "rippleSize",
+        label: "Ripple size",
+        selector: {
+          number: { min: 40, max: 400, step: 4, mode: "slider", unit_of_measurement: "px" },
+        },
+      });
+    }
   }
   // A light can cast a pool of light onto the plan from where it sits (issue
   // #6). Offered only for lights, since nothing else has a color to cast.
@@ -445,12 +526,6 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
     }
   }
   fields.push(
-    {
-      name: "badgeContent",
-      label: "Badge shows",
-      helper: "Value puts the reading in the badge; falls back to the icon when there is no number",
-      selector: dropdown(opt("icon", "Icon"), opt("value", "Value"), opt("none", "Nothing")),
-    },
     {
       name: "hideWhenInactive",
       label: "Only when active",
@@ -493,17 +568,15 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       secondaryEntity: it.secondaryEntity ?? "",
       attribute: it.attribute ?? "",
       secondaryAttribute: it.secondaryAttribute ?? "",
-      icon: it.icon ?? "",
       name: it.name ?? "",
       size: it.size ?? DEFAULT_ITEM_SIZE,
       angle: it.angle ?? 0,
-      display,
-      iconAnimation: it.iconAnimation ?? "auto",
+      badgeMode: badgeModeOf(it),
+      ripple,
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       glow: it.glow ?? false,
       glowRadius: it.glowRadius ?? DEFAULT_GLOW_RADIUS,
       glowColor: it.glowColor ?? "",
-      badgeContent: badgeContentOf(it),
       hideWhenInactive: it.hideWhenInactive ?? false,
       showState: it.showState ?? false,
       showName: it.showName ?? false,
@@ -512,12 +585,20 @@ export function itemForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
       hold_action: it.hold_action,
       double_tap_action: it.double_tap_action,
     },
-    // Touching "Badge shows" retires the `showIcon` boolean it replaced (issue
-    // #106), so a migrated config carries one setting rather than two that
-    // could later be edited into disagreeing. Configs nobody touches keep
-    // working through badgeContentOf's fallback.
-    toPatch: (patch) =>
-      "badgeContent" in patch ? { ...patch, showIcon: undefined } : patch,
+    // "Badge shows" and "Ripple" are the editor's spelling of three config
+    // keys (issue #127) — expand them back. Either control alone is a complete
+    // statement about both, so the untouched one is read off the item.
+    toPatch: (patch) => {
+      if (!("badgeMode" in patch) && !("ripple" in patch)) return patch;
+      const { badgeMode, ripple: ring, ...rest } = patch;
+      return {
+        ...rest,
+        ...badgeModePatch(
+          (badgeMode as BadgeMode | undefined) ?? badgeModeOf(it),
+          ring === undefined ? ripple : !!ring
+        ),
+      };
+    },
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -71,6 +71,7 @@ import {
   entityIsActive,
   lightBadgePaint,
   itemRawValue,
+  isPresenceEntity,
   badgeContentOf,
   badgeValue,
   badgeValueSize,
@@ -112,6 +113,7 @@ import {
   furnitureForm,
   isLiveField,
   itemForm,
+  itemHasRipple,
   normalizeFormPatch,
   openingForm,
   projectForm,
@@ -1852,6 +1854,50 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * The glyph a device shows when no state rule names one — what a rule's
+   * empty icon box falls back to. Resolved exactly as the card resolves it,
+   * with the rules removed so a currently-matching rule cannot report itself
+   * as the default.
+   */
+  private _itemDefaultIcon(it: FloorItem): string {
+    const st = it.entity ? this.hass?.states[it.entity] : undefined;
+    return resolveItemIcon(
+      { ...it, stateColor: undefined },
+      st,
+      it.entity ? this.hass?.entities?.[it.entity]?.icon : undefined
+    );
+  }
+
+  /**
+   * The device's icon, rendered here rather than up in the form (issue #127):
+   * it is the same setting the state rules below override, so it belongs
+   * beside them — like "Active color" beside the colours those rules replace.
+   *
+   * Unlike the colour it stays on screen once rules exist, because rules do
+   * *not* replace it: a rule with no icon of its own falls through to this
+   * one, which is what lets someone colour by state without naming the same
+   * glyph in every row. Hiding it would strand a setting that is still
+   * drawing.
+   */
+  private _renderItemIconRow(it: FloorItem): TemplateResult {
+    const title = "Icon for this device; a state rule below can swap it";
+    return html`
+      <div class="row wide">
+        <label title=${title}>Icon</label>
+        ${this._renderIconPicker(it.icon ?? "", (icon) => this._updateItem(it.id, { icon: icon || undefined }), {
+          // The entity's own glyph, so leaving the box empty is visibly a
+          // choice rather than a blank.
+          placeholder: this._itemDefaultIcon(it),
+          title,
+        })}
+      </div>
+      ${it.stateColor?.length
+        ? html`<p class="hint rule-note">Shown while no rule below names an icon of its own.</p>`
+        : nothing}
+    `;
+  }
+
+  /**
    * The "Color by state" block (issues #68, #79, #82): a list of rules, each
    * one a condition and a colour, plus an "Add rule" button.
    *
@@ -1867,7 +1913,7 @@ export class FloorplanCardEditor extends LitElement {
   private _renderStateColorRules(
     rules: StateColorRule[] | undefined,
     onChange: (next: StateColorRule[] | undefined) => void,
-    opts?: { icons?: boolean }
+    opts?: { icons?: boolean; iconPlaceholder?: string }
   ): TemplateResult {
     const list = rules ?? [];
     const patch = (i: number, part: Partial<StateColorRule>): void => {
@@ -1934,7 +1980,13 @@ export class FloorplanCardEditor extends LitElement {
               @change=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
             />
             ${opts?.icons
-              ? this._renderIconPicker(rule.icon ?? "", (icon) => patch(i, { icon: icon || undefined }))
+              ? // Empty means "keep the device's icon", so the device's icon is
+                // the placeholder — the rule shows what leaving it blank gives
+                // you, and colour-only rules need no icon at all (issue #127).
+                this._renderIconPicker(rule.icon ?? "", (icon) => patch(i, { icon: icon || undefined }), {
+                  placeholder: opts.iconPlaceholder,
+                  title: "Icon while this rule matches — empty keeps the device's own",
+                })
               : nothing}
             <button
               class="rule-remove"
@@ -3064,23 +3116,29 @@ export class FloorplanCardEditor extends LitElement {
    * Icon field for the hand-rolled rows (issue #106), mirroring
    * {@link _renderEntityPicker}: HA's searchable picker when the frontend has
    * registered it, a plain text input otherwise. Used by the state-rule list,
-   * which cannot go through `ha-form` because it is repeatable.
+   * which cannot go through `ha-form` because it is repeatable, and by the
+   * device's own icon row that sits beside it (issue #127).
    */
-  private _renderIconPicker(value: string, onChange: (icon: string) => void): TemplateResult {
+  private _renderIconPicker(
+    value: string,
+    onChange: (icon: string) => void,
+    opts?: { placeholder?: string; title?: string }
+  ): TemplateResult {
     if (customElements.get("ha-icon-picker")) {
       return html`<ha-icon-picker
         class="rule-icon"
         .hass=${this.hass}
         .value=${value}
-        placeholder="Icon"
+        placeholder=${opts?.placeholder ?? "Icon"}
+        title=${opts?.title ?? nothing}
         @value-changed=${(e: CustomEvent) => onChange((e.detail.value as string) ?? "")}
       ></ha-icon-picker>`;
     }
     return html`<input
       type="text"
       class="rule-icon"
-      placeholder="mdi:blinds"
-      title="Icon while this rule matches (optional)"
+      placeholder=${opts?.placeholder ?? "mdi:blinds"}
+      title=${opts?.title ?? nothing}
       .value=${value}
       @change=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
     />`;
@@ -3410,7 +3468,7 @@ export class FloorplanCardEditor extends LitElement {
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     // Live preview: the icon animates exactly when the card would animate it
-    // (entity currently active), so the "Animate icon" dropdown shows its
+    // (entity currently active), so the "Badge shows" dropdown shows its
     // effect without leaving the editor.
     const anim = resolveIconAnimation(it, st?.state);
     const badge = html`<div
@@ -3601,8 +3659,13 @@ export class FloorplanCardEditor extends LitElement {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
       const areaEntities = this._areaEntitiesAt(it.x, it.y);
+      // The entity's device class decides whether this is a presence device,
+      // and so whether the ripple is on offer at all (issue #127).
+      const deviceClass = it.entity
+        ? (this.hass?.states[it.entity]?.attributes?.device_class as string | undefined)
+        : undefined;
       return html`
-        ${this._renderForm(itemForm(it, areaEntities), (patch, live) => {
+        ${this._renderForm(itemForm(it, areaEntities, deviceClass), (patch, live) => {
           // Any entity change re-derives the item kind (icon defaults etc.) —
           // including clearing it, which resets kind to "generic".
           if ("entity" in patch && typeof patch.entity === "string") {
@@ -3626,7 +3689,7 @@ export class FloorplanCardEditor extends LitElement {
               onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
               onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
             })}
-        ${(it.display ?? "badge") !== "badge"
+        ${isPresenceEntity(it.entity, deviceClass) && itemHasRipple(it)
           ? this._renderColorRow({
               label: "Ripple color",
               value: it.rippleColor,
@@ -3636,13 +3699,14 @@ export class FloorplanCardEditor extends LitElement {
               onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
             })
           : nothing}
+        ${this._renderItemIconRow(it)}
         ${this._renderStateColorRules(
           it.stateColor,
           (stateColor) => this._updateItem(it.id, { stateColor }),
           // Only a device draws a glyph, so only a device's rules offer an
           // icon — furniture and areas share this rule shape but paint
           // polygons (issue #106).
-          { icons: true }
+          { icons: true, iconPlaceholder: this._itemDefaultIcon(it) }
         )}
       `;
     }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -57,6 +57,8 @@ import {
   badgeValue,
   badgeValueSize,
   resolveIconAnimation,
+  domainIconAnimation,
+  isPresenceEntity,
   itemIconSize,
   normalizePlanRotation,
   rotatedCanvasSize,
@@ -1072,6 +1074,50 @@ describe("resolveIconAnimation (issue #48)", () => {
 
   it("none disables the domain default", () => {
     expect(resolveIconAnimation({ entity: "fan.ceiling", iconAnimation: "none" }, "on")).toBeUndefined();
+  });
+});
+
+describe("domainIconAnimation (issue #127)", () => {
+  it("names what auto means, so the editor can offer it by name", () => {
+    expect(domainIconAnimation("fan.ceiling")).toBe("spin");
+    expect(domainIconAnimation("media_player.tv")).toBe("pulse");
+    expect(domainIconAnimation("vacuum.robo")).toBe("pulse");
+    expect(domainIconAnimation("light.a")).toBeUndefined();
+    expect(domainIconAnimation(undefined)).toBeUndefined();
+  });
+
+  it("is the same table resolveIconAnimation applies, so the two cannot drift", () => {
+    // Active fan, nothing configured → auto → spin, both ways round.
+    expect(resolveIconAnimation({ entity: "fan.ceiling" }, "on")).toBe(
+      domainIconAnimation("fan.ceiling"),
+    );
+  });
+});
+
+describe("isPresenceEntity (issue #127)", () => {
+  it("accepts the binary-sensor classes that mean someone is there", () => {
+    for (const dc of ["motion", "occupancy", "presence"]) {
+      expect(isPresenceEntity("binary_sensor.hall", dc)).toBe(true);
+    }
+  });
+
+  it("accepts trackers and people on their domain alone", () => {
+    expect(isPresenceEntity("device_tracker.phone", undefined)).toBe(true);
+    expect(isPresenceEntity("person.sam", undefined)).toBe(true);
+  });
+
+  it("rejects sensors that detect something else, and an unclassed one", () => {
+    expect(isPresenceEntity("binary_sensor.front_door", "door")).toBe(false);
+    expect(isPresenceEntity("binary_sensor.leak", "moisture")).toBe(false);
+    // No class at all could be anything — guessing from the name would ring
+    // doorbells and smoke alarms.
+    expect(isPresenceEntity("binary_sensor.presence", undefined)).toBe(false);
+  });
+
+  it("rejects other domains, whatever class they carry", () => {
+    expect(isPresenceEntity("light.a", "motion")).toBe(false);
+    expect(isPresenceEntity("sensor.motion", "motion")).toBe(false);
+    expect(isPresenceEntity(undefined, "motion")).toBe(false);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -852,6 +852,19 @@ const AUTO_ICON_ANIMATION: Record<string, "spin" | "pulse"> = {
 };
 
 /**
+ * What `iconAnimation: "auto"` means for an entity — the animation its domain
+ * plays by default, or undefined for the domains that stay still.
+ *
+ * Exported so the editor can *name* it (issue #127): its dropdown offers no
+ * "auto" option, and instead shows a fan as "spinning" and a media player as
+ * "pulsing" — the animation the card is already playing. Both sides therefore
+ * read the domain defaults from this one table.
+ */
+export function domainIconAnimation(entity: string | undefined): "spin" | "pulse" | undefined {
+  return AUTO_ICON_ANIMATION[entity?.split(".")[0] ?? ""];
+}
+
+/**
  * Which animation an item's icon should play right now, or undefined for
  * none. Shared by card and editor. Never animates an inactive (or
  * unavailable) entity — including when the config forces "spin"/"pulse": a
@@ -866,7 +879,33 @@ export function resolveIconAnimation(
   if (mode === "none") return undefined;
   if (!entityIsActive(item.entity, state)) return undefined;
   if (mode === "spin" || mode === "pulse") return mode;
-  return AUTO_ICON_ANIMATION[item.entity?.split(".")[0] ?? ""];
+  return domainIconAnimation(item.entity);
+}
+
+/**
+ * Device classes that mean "something is here" — the sensors a ripple ring was
+ * drawn for (issue #127). `motion` and `occupancy` are HA's own binary-sensor
+ * classes; `presence` is the home/away one.
+ */
+const PRESENCE_DEVICE_CLASSES = new Set(["motion", "occupancy", "presence"]);
+
+/**
+ * Whether a device detects presence, and so should be offered the ripple ring
+ * (issue #127) — the same shape of gate as "Cast light" on a `light`.
+ *
+ * A `device_tracker` or `person` qualifies on its domain alone; a
+ * `binary_sensor` needs the device class to say so, which is what separates a
+ * motion sensor from a door contact or a leak detector. A binary sensor with
+ * no device class set is therefore *not* presence: it could be anything, and
+ * guessing from the entity id would ring doorbells and smoke alarms.
+ */
+export function isPresenceEntity(
+  entity: string | undefined,
+  deviceClass: string | undefined,
+): boolean {
+  const domain = entity?.split(".")[0];
+  if (domain === "device_tracker" || domain === "person") return true;
+  return domain === "binary_sensor" && !!deviceClass && PRESENCE_DEVICE_CLASSES.has(deviceClass);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,7 +241,13 @@ export interface FloorItem {
   size?: number;
   /** Icon rotation in degrees. Default 0. */
   angle?: number;
-  /** How the device is drawn. Default "badge". */
+  /**
+   * How the device is drawn. Default "badge".
+   *
+   * The ripple modes render on any entity. The editor only *offers* them on a
+   * presence device (issue #127) — a ring says "someone is there" — so a ring
+   * on anything else is a YAML-only choice.
+   */
   display?: ItemDisplay;
   /**
    * Animate the icon while the entity is active (issue #48). "auto" (the
@@ -250,6 +256,11 @@ export interface FloorItem {
    * means `playing` or plain `on`, matching the badge highlight);
    * "spin"/"pulse" force that animation (still only while active); "none"
    * disables it.
+   *
+   * "auto" has no counterpart in the editor's menu (issue #127): it shows the
+   * animation auto resolves to for this entity instead of the word, and writes
+   * that value on any edit. The default stays "auto" for configs nobody has
+   * touched, so nothing about the card changed.
    */
   iconAnimation?: IconAnimation;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,8 +259,9 @@ export interface FloorItem {
    *
    * "auto" has no counterpart in the editor's menu (issue #127): it shows the
    * animation auto resolves to for this entity instead of the word, and writes
-   * that value on any edit. The default stays "auto" for configs nobody has
-   * touched, so nothing about the card changed.
+   * that value out the moment the badge dropdown is touched. Editing anything
+   * else leaves the key alone, so a config keeps its "auto" — and its meaning —
+   * until someone actually decides about the animation.
    */
   iconAnimation?: IconAnimation;
   /**


### PR DESCRIPTION
Closes #127.

## 1. Three switches become one

**Display**, **Animate icon** and **Badge shows** were never three independent questions — the animation only means something while the badge holds an icon, the badge content means nothing at all while `display: ripple` draws no badge, and picking *Value* left an animation dropdown on screen that did nothing.

One **Badge shows** dropdown now:

| Option | Config it writes |
|---|---|
| Icon, still | `badgeContent: icon`, `iconAnimation: none` |
| Icon, spinning | `badgeContent: icon`, `iconAnimation: spin` |
| Icon, pulsing | `badgeContent: icon`, `iconAnimation: pulse` |
| Value | `badgeContent: value` |
| Nothing | `badgeContent: none` |

There is no *auto*. "Auto" is a fact about the config format, not about what you are looking at: the menu names the animation the card is actually playing, so a fan with nothing configured reads **Icon, spinning** and a media player **Icon, pulsing** — resolved through the same domain table `resolveIconAnimation` uses, via a new exported `domainIconAnimation()`, so the two can't drift.

## 2. Ripple is for presence devices

The ring is the one genuinely separate axis (a spinning fan icon inside a ripple is a real combination), so it stays a checkbox rather than becoming options that would double the list. It is now offered only where the claim it makes can be true — a `binary_sensor` classed `motion` / `occupancy` / `presence`, a `device_tracker`, or a `person` — gated exactly as **Cast light** is gated to lights, with **Ripple size** and **Ripple color** revealed underneath like the glow controls.

New `isPresenceEntity(entity, deviceClass)` in `render.ts`; `itemForm` takes the device class as a third argument, which the editor reads off `hass` at the call site as it already does for openings.

## 3. The icon moved down to its state rules

The **Icon** field left the top of the form and now sits directly above **Color & icon by state** — it is the setting those rules override. Each rule's icon box shows the device's resolved glyph as its **placeholder**, so leaving it empty visibly means "keep the default" and a colour-only rule needs no icon at all.

Unlike **Active color**, the icon stays visible once rules exist, with a hint underneath. Rules do *not* replace it: a rule with no icon of its own falls through to it, which is exactly what lets you colour by state without naming the same glyph in every row. Hiding it would strand a setting that is still drawing.

## Nothing about the card changed

`display`, `iconAnimation` and `badgeContent` are untouched, `auto` remains the default `render.ts` applies to configs nobody has edited, and the whole `resolveIconAnimation` test suite passes unmodified — which is the proof. A ripple already set on a non-presence entity keeps rendering; it is just YAML-only from here, which the README now says instead of inviting it.

## Verification

`npm run typecheck`, `npm test` (629 pass), `npm run build` clean. Driven in the dev harness with a mock motion sensor:

| Device | Ripple row | Badge shows |
|---|---|---|
| `light.living_room` | absent | `Icon, still` |
| `fan.ceiling_fan` | absent | `Icon, spinning` (nothing stored) |
| `binary_sensor.hall_motion` (class `motion`) | present | `Icon, still` |
| `binary_sensor.door_lock` (class `lock`) | absent | `Icon, still` |

Checking Ripple wrote `display: iconRipple` and revealed size + colour; *Nothing* gave `display: ripple`; unchecking gave `display: badge`. A light already carrying `iconRipple` kept its ring through an unrelated badge edit.

## One thing to know

A `binary_sensor` with **no** `device_class` set does not get the ripple checkbox, even if it is a presence sensor by name — guessing from the entity id would ring doorbells and smoke alarms. Worth a follow-up if that turns out to bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)