### PR TITLE
Editor: the canvas label the card will draw, and a say in what the badge reads (closes #135, closes #136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ link, so it's obvious *why* the list is short and it takes one click to widen it
 filters nothing, the entity already bound always stays pickable, and an element outside
 every area is never filtered.
 
-The **Labels** toolbar toggle hides the element name labels on the canvas — useful on a
+Devices on the canvas carry **the same label line the live card will draw** — the name
+and/or the state, per that device's **Show name** / **Show state** — so turning one of
+those on is something you can see straight away rather than only after leaving the editor.
+A device set to show neither still gets a label here, dimmed, to keep it tellable apart
+while you drag it around; that greyed-out one is editor-only and the card draws nothing.
+
+The **Labels** toolbar toggle hides either kind on the canvas — useful on a
 dense plan where labels overlap the things you are trying to click. It only affects the
 editor view; the live card is unchanged.
 
@@ -252,6 +258,15 @@ By default it shows an icon badge:
   **2nd entity** at its power sensor: the badge reads `1.2kW` and tapping still toggles
   the switch. A device with no number anywhere keeps its icon, so this can never leave
   an empty circle. *Nothing* is the third setting — no badge at all, label only.
+
+  **Which entity gets read** is worked out for you: the first of the device's entities
+  with a number to show wins, which is why the plug above needs no configuration — its
+  switch reads "on", not a number, so the badge falls through to the power sensor. When
+  the device has a **2nd entity**, a **Badge reads** dropdown appears naming both, so you
+  can overrule that — necessary when the main entity has a number of its own and you want
+  the other one. Once you pick, the card reads that entity and only that entity: if it has
+  nothing to show the badge falls back to its icon rather than quietly showing the other
+  one instead.
 - **Color and icon by state** — the **Color & icon by state** rules restyle the element
   by what the entity reads: both the **icon badge** and the label, whether or not the
   entity is "on" (a temperature sensor never is). Each rule can also swap the **icon**,
@@ -691,6 +706,7 @@ shape it occupies on screen.
 | `glowRadius`  | number                                 | `140`        | Radius of the cast pool at full brightness, in canvas units. A dimmer lamp casts a proportionally smaller pool, down to half this. |
 | `glowColor`   | string                                 | `#ffd9a0`    | Color for a bulb that can't report one. A color-capable light always uses its own. |
 | `badgeContent` | `icon` \| `value` \| `none`           | `icon`       | What the badge holds. `value` draws the device's reading inside it (see **Value in the badge**), falling back to the icon when there is no number; `none` hides the badge, leaving the label. |
+| `badgeEntity` | `primary` \| `secondary`               | automatic    | Which entity a `value` badge reads. Unset picks the first with a number to show. Set, only that entity is read — no falling back to the other. |
 | `showIcon`    | boolean                                | `true`       | **Deprecated** — superseded by `badgeContent`. Still honoured when `badgeContent` is unset: `false` means `none`. |
 | `hideWhenInactive` | boolean                           | `false`      | Hide the device on the card while its entity is inactive (issue #55). Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -327,6 +327,69 @@ describe("itemForm", () => {
     expect(f.toPatch({ size: 40, badgeMode: "value" }).size).toBe(40);
   });
 
+  // Issue #136: which of a device's two entities the value badge reads.
+  describe("Badge reads (#136)", () => {
+    const plug = {
+      ...item,
+      entity: "switch.plug",
+      secondaryEntity: "sensor.plug_power",
+      badgeContent: "value",
+    } as FloorItem;
+    const names = (it: FloorItem, src?: Parameters<typeof itemForm>[3]) =>
+      itemForm(it, undefined, undefined, src).fields.map((x) => x.name);
+
+    it("appears only when the badge shows a value AND there is a second entity", () => {
+      expect(names(plug)).toContain("badgeEntity");
+      // Nothing to choose between with one entity.
+      expect(names({ ...plug, secondaryEntity: undefined } as FloorItem)).not.toContain(
+        "badgeEntity",
+      );
+      // Nothing to read at all when the badge holds an icon or nothing.
+      expect(names({ ...plug, badgeContent: "icon" } as FloorItem)).not.toContain("badgeEntity");
+      expect(names({ ...plug, badgeContent: "none" } as FloorItem)).not.toContain("badgeEntity");
+      // A ripple-only device draws no badge, so the question is moot there too.
+      expect(names({ ...plug, display: "ripple" } as FloorItem)).not.toContain("badgeEntity");
+    });
+
+    it("opens on the entity the badge is actually reading, not a bare default", () => {
+      // The trap: this plug's badge shows its power sensor through the
+      // fallback, with no badgeEntity stored. A form defaulting to "primary"
+      // would name the switch while the badge shows watts — and the next
+      // unrelated edit would save that and drop the reading to an icon.
+      const asRead = itemForm(plug, undefined, undefined, { source: "secondary" });
+      expect(asRead.data.badgeEntity).toBe("secondary");
+      // A stored choice always wins over the live reading.
+      expect(
+        itemForm({ ...plug, badgeEntity: "primary" } as FloorItem, undefined, undefined, {
+          source: "secondary",
+        }).data.badgeEntity,
+      ).toBe("primary");
+    });
+
+    it("names the entities, with no 'Automatic' among them (#127's precedent)", () => {
+      const field = itemForm(plug, undefined, undefined, {
+        source: "secondary",
+        primaryLabel: "Kitchen plug",
+        secondaryLabel: "Kitchen plug power",
+      }).fields.find((x) => x.name === "badgeEntity")!;
+      const opts = (field.selector as { select: { options: { value: string; label: string }[] } })
+        .select.options;
+      expect(opts.map((o) => o.value)).toEqual(["primary", "secondary"]);
+      expect(opts.map((o) => o.label)).toEqual(["Kitchen plug", "Kitchen plug power"]);
+      expect(opts.map((o) => o.value)).not.toContain("auto");
+    });
+
+    it("falls back to entity ids when hass has no friendly names", () => {
+      const field = itemForm(plug).fields.find((x) => x.name === "badgeEntity")!;
+      const opts = (field.selector as { select: { options: { label: string }[] } }).select.options;
+      expect(opts.map((o) => o.label)).toEqual(["switch.plug", "sensor.plug_power"]);
+    });
+
+    it("passes the choice straight through as a config key", () => {
+      expect(itemForm(plug).toPatch({ badgeEntity: "secondary" }).badgeEntity).toBe("secondary");
+    });
+  });
+
   it("moves the icon out of the form, next to the rules that override it (#127)", () => {
     expect(itemForm(item).fields.map((x) => x.name)).not.toContain("icon");
     expect(itemForm(item).data.icon).toBeUndefined();

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -7,6 +7,7 @@
  */
 import type {
   Area,
+  BadgeEntity,
   Floor,
   FloorItem,
   FloorText,
@@ -419,15 +420,35 @@ function badgeModePatch(mode: BadgeMode, ripple: boolean): Record<string, unknow
 }
 
 /**
+ * What the badge is reading *right now*, for the "Badge reads" row (issue
+ * #136). Resolved off `hass` at the call site, like {@link itemForm}'s
+ * `deviceClass`, because this file stays pure.
+ *
+ * `source` is load-bearing rather than cosmetic. A plug whose badge shows its
+ * power sensor through {@link badgeReading}'s fallback has no `badgeEntity`
+ * stored, so a dropdown defaulting to "primary" would name the switch while
+ * the badge shows watts — and the next unrelated edit would write that down
+ * and drop the reading to an icon.
+ */
+export interface BadgeSourceInfo {
+  source: BadgeEntity;
+  /** Friendly names, falling back to the entity ids when hass has none. */
+  primaryLabel?: string;
+  secondaryLabel?: string;
+}
+
+/**
  * `deviceClass` is the entity's HA device class, the one hass-derived fact the
  * device form needs: it is what separates a motion sensor from a door contact,
  * and so decides whether the ripple ring is offered at all (issue #127). The
  * editor reads it off `hass` at the call site, as it already does for openings.
+ * `badgeSource` is the second such fact — see {@link BadgeSourceInfo}.
  */
 export function itemForm(
   it: FloorItem,
   areaScope?: AreaEntityScope,
-  deviceClass?: string
+  deviceClass?: string,
+  badgeSource?: BadgeSourceInfo
 ): FormSpec {
   const ripple = itemHasRipple(it);
   const presence = isPresenceEntity(it.entity, deviceClass);
@@ -480,6 +501,24 @@ export function itemForm(
       ),
     },
   ];
+  // Which entity the value comes from (issue #136) — offered only where it is
+  // a real question: the badge has to be showing a value, and the device has
+  // to have a second entity to choose between. Most devices never see this.
+  //
+  // The options name the entities rather than offering an "Automatic", the
+  // precedent from #127's dropdown above: "auto" is a fact about the config
+  // format, not about what the user is looking at.
+  if (badgeModeOf(it) === "value" && it.secondaryEntity) {
+    fields.push({
+      name: "badgeEntity",
+      label: "Badge reads",
+      helper: "Which of this device's entities the badge shows",
+      selector: dropdown(
+        opt("primary", badgeSource?.primaryLabel || it.entity || "Main entity"),
+        opt("secondary", badgeSource?.secondaryLabel || it.secondaryEntity)
+      ),
+    });
+  }
   // A presence device can ring the spot it watches (issue #127) — the same
   // shape of option as "Cast light" below, offered only where it means
   // something. A ring on a thermostat says "someone is here", which is a lie.
@@ -574,6 +613,10 @@ export function itemForm(
       size: it.size ?? DEFAULT_ITEM_SIZE,
       angle: it.angle ?? 0,
       badgeMode: badgeModeOf(it),
+      // The stored choice, else the entity the badge is *actually* reading —
+      // never a bare "primary" default, which would contradict the canvas for
+      // every device relying on the fallback. See {@link BadgeSourceInfo}.
+      badgeEntity: it.badgeEntity ?? badgeSource?.source ?? "primary",
       ripple,
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       glow: it.glow ?? false,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -73,7 +73,9 @@ import {
   itemRawValue,
   isPresenceEntity,
   badgeContentOf,
+  editorItemLabel,
   badgeValue,
+  badgeReading,
   badgeValueSize,
   itemHiddenWhenInactive,
   resolveIconAnimation,
@@ -3451,7 +3453,10 @@ export class FloorplanCardEditor extends LitElement {
     const st = it.entity ? this.hass?.states[it.entity] : undefined;
     // Pass the registry icon here too, so the editor preview matches the card.
     const icon = resolveItemIcon(it, st, it.entity ? this.hass?.entities?.[it.entity]?.icon : undefined);
-    const label = it.name || it.entity || it.kind;
+    // The card's own label line when it has one, else a dim editor-only
+    // stand-in so devices stay tellable apart (issue #135). The rule lives in
+    // render.ts, where it can be unit-tested.
+    const { text: label, live: cardLabel } = editorItemLabel(this.hass, it);
     const size = cssNumber(it.size, DEFAULT_ITEM_SIZE);
     const showIcon = badgeContentOf(it) !== "none";
     const display = it.display ?? "badge";
@@ -3527,14 +3532,18 @@ export class FloorplanCardEditor extends LitElement {
         @pointercancel=${this._onPointerCancel}
       >
         ${visual}
-        <!-- Identification while editing; the Labels toolbar toggle hides it
-             on dense plans (issue #52), and its size previews the card's
-             labelSize (issue #59). -->
+        <!-- The card's own label line when there is one (issue #135), so
+             turning Show state on is visible here rather than only after
+             leaving the editor; otherwise the dim identification fallback.
+             The Labels toolbar toggle hides either on dense plans (issue
+             #52), and the size previews the card's labelSize (issue #59). -->
         ${this._hideLabels
           ? nothing
           : html`<span
-              class="ilabel"
-              style="font-size:${it.labelSize != null ? itemLabelSize(it.labelSize) : 11}px;"
+              class="ilabel ${cardLabel ? "live" : ""}"
+              style="font-size:${cardLabel || it.labelSize != null
+                ? itemLabelSize(it.labelSize)
+                : 11}px;${cardLabel && stateColor ? `color:${stateColor};` : ""}"
               >${label}</span
             >`}
       </div>
@@ -3670,8 +3679,19 @@ export class FloorplanCardEditor extends LitElement {
       const deviceClass = it.entity
         ? (this.hass?.states[it.entity]?.attributes?.device_class as string | undefined)
         : undefined;
+      // What the badge is reading right now, so the "Badge reads" row can open
+      // on it rather than on a guess (issue #136). Same "resolve off hass at
+      // the call site" arrangement as deviceClass above.
+      const friendly = (id?: string) =>
+        (id ? (this.hass?.states[id]?.attributes?.friendly_name as string | undefined) : undefined) ??
+        id;
+      const badgeSource = {
+        source: badgeReading(this.hass, it)?.source ?? "primary",
+        primaryLabel: friendly(it.entity),
+        secondaryLabel: friendly(it.secondaryEntity),
+      } as const;
       return html`
-        ${this._renderForm(itemForm(it, areaEntities, deviceClass), (patch, live) => {
+        ${this._renderForm(itemForm(it, areaEntities, deviceClass, badgeSource), (patch, live) => {
           // Any entity change re-derives the item kind (icon defaults etc.) —
           // including clearing it, which resets kind to "generic".
           if ("entity" in patch && typeof patch.entity === "string") {
@@ -4939,6 +4959,16 @@ export class FloorplanCardEditor extends LitElement {
       max-width: 120px;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    /* The card's own label line, drawn as the card draws it (issue #135):
+       full-strength ink, and no width clamp — the card has none, and clipping
+       is exactly what would make a long label look right here and wrong live.
+       The unclamped variant is the one you are checking; the dim fallback
+       above stays clamped, being editor chrome rather than a preview. */
+    .ilabel.live {
+      color: var(--primary-text-color);
+      max-width: none;
+      overflow: visible;
     }
     /* The panel ("Project" config) and the new element-edit area share the
        same boxed look so the two sections below the canvas read as siblings. */

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -45,6 +45,7 @@ import {
   entityStateText,
   itemStateText,
   itemBadgeLabel,
+  editorItemLabel,
   itemHiddenWhenInactive,
   resolveStateColor,
   itemLabelSize,
@@ -56,6 +57,7 @@ import {
   matchStateRule,
   badgeContentOf,
   badgeValue,
+  badgeReading,
   badgeValueSize,
   resolveIconAnimation,
   domainIconAnimation,
@@ -660,6 +662,67 @@ describe("itemBadgeLabel (issues #61, #59)", () => {
     expect(
       itemBadgeLabel(named(), { entity: "", kind: "sensor", showName: true, name: "Detector" }),
     ).toBe("Detector");
+  });
+});
+
+// Issue #135: the editing canvas showed an id where the card shows a state, so
+// turning "Show state" on changed nothing you could see without leaving it.
+describe("editorItemLabel (#135)", () => {
+  const named = () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).friendly_name = "Living Temp";
+    return h;
+  };
+
+  it("draws the card's own line whenever the card draws one", () => {
+    const sensor = { entity: TEMP, kind: "sensor" as const };
+    expect(editorItemLabel(named(), sensor)).toEqual({ text: "17.9 °C", live: true });
+    // …and matches the card exactly, rather than approximating it.
+    expect(editorItemLabel(named(), sensor).text).toBe(itemBadgeLabel(named(), sensor));
+
+    const withName = { entity: TEMP, kind: "light" as const, showName: true, showState: true };
+    expect(editorItemLabel(named(), withName)).toEqual({
+      text: itemBadgeLabel(named(), withName),
+      live: true,
+    });
+  });
+
+  it("falls back to an editor-only name when the card would draw nothing", () => {
+    // A light shows no label by default. Without this the canvas would be a
+    // field of identical circles with nothing to drag-and-tell-apart.
+    const light = { entity: "light.kitchen", kind: "light" as const };
+    expect(itemBadgeLabel(named(), light)).toBe("");
+    expect(editorItemLabel(named(), light)).toEqual({ text: "light.kitchen", live: false });
+    // A configured name wins over the entity id, as it always did.
+    expect(editorItemLabel(named(), { ...light, name: "Ceiling" })).toEqual({
+      text: "Ceiling",
+      live: false,
+    });
+    // Nothing bound at all: the kind is the last resort (issue #39).
+    expect(editorItemLabel(named(), { entity: "", kind: "generic" as const })).toEqual({
+      text: "generic",
+      live: false,
+    });
+  });
+
+  it("`live` is what separates a preview from editor chrome", () => {
+    // The flag drives the dim styling, so it must never be true for a label
+    // the card will not render — that is the whole signal.
+    const off = editorItemLabel(named(), { entity: TEMP, kind: "light" as const });
+    expect(off.live).toBe(false);
+    const on = editorItemLabel(named(), {
+      entity: TEMP,
+      kind: "light" as const,
+      showState: true,
+    });
+    expect(on.live).toBe(true);
+  });
+
+  it("survives having no hass at all, as the editor does outside HA", () => {
+    expect(editorItemLabel(undefined, { entity: "light.k", kind: "light" as const })).toEqual({
+      text: "light.k",
+      live: false,
+    });
   });
 });
 
@@ -1599,6 +1662,111 @@ describe("badgeValue (#106)", () => {
   it("a humidifier reads its current humidity", () => {
     const h = hass({ "humidifier.bed": { state: "on", attributes: { current_humidity: 44 } } });
     expect(badgeValue(h, { entity: "humidifier.bed" })).toBe("44%");
+  });
+
+  // Issue #136: the guess was usually right, but it was only a guess and
+  // nothing said which entity it landed on.
+  describe("choosing which entity the badge reads (#136)", () => {
+    const plug = () =>
+      hass({
+        "switch.plug": { state: "on" },
+        "sensor.plug_power": { state: "1240", attributes: { unit_of_measurement: "W" } },
+      });
+    const twoSensors = () =>
+      hass({
+        "sensor.a": { state: "21.4", attributes: { unit_of_measurement: "°C" } },
+        "sensor.b": { state: "63", attributes: { unit_of_measurement: "%" } },
+      });
+
+    it("reports which entity the reading came from", () => {
+      // The plug's switch says "on" — not a number — so the badge is showing
+      // the power sensor. The form has to be able to say so.
+      expect(badgeReading(plug(), { entity: "switch.plug", secondaryEntity: "sensor.plug_power" }))
+        .toEqual({ text: "1.2kW", source: "secondary" });
+      expect(badgeReading(twoSensors(), { entity: "sensor.a", secondaryEntity: "sensor.b" }))
+        .toEqual({ text: "21°", source: "primary" });
+    });
+
+    it("badgeValue is exactly badgeReading's text, across the whole chain", () => {
+      const cases = [
+        { entity: "switch.plug", secondaryEntity: "sensor.plug_power" },
+        { entity: "sensor.a", secondaryEntity: "sensor.b" },
+        { entity: "sensor.a", secondaryEntity: "sensor.b", badgeEntity: "secondary" as const },
+        { entity: "switch.plug", badgeEntity: "primary" as const },
+        { entity: "nope.missing" },
+      ];
+      for (const item of cases) {
+        const h = { ...plug().states, ...twoSensors().states };
+        const both = { states: h } as unknown as RenderHass;
+        expect(badgeValue(both, item)).toBe(badgeReading(both, item)?.text);
+      }
+    });
+
+    it("an explicit secondary wins even when the primary has a number of its own", () => {
+      // The case with no expression at all before this: the fallback never
+      // reached the second sensor, because the first one answered.
+      const h = twoSensors();
+      expect(badgeValue(h, { entity: "sensor.a", secondaryEntity: "sensor.b" })).toBe("21°");
+      expect(
+        badgeValue(h, { entity: "sensor.a", secondaryEntity: "sensor.b", badgeEntity: "secondary" }),
+      ).toBe("63%");
+    });
+
+    it("an explicit choice does not fall through to the other entity", () => {
+      // Asked for the switch, which has no number: the badge shows its icon
+      // rather than quietly showing a different device's reading.
+      const h = plug();
+      const item = { entity: "switch.plug", secondaryEntity: "sensor.plug_power" } as const;
+      expect(badgeValue(h, { ...item, badgeEntity: "primary" })).toBeUndefined();
+      // …and the reverse: an unreadable secondary does not borrow the primary.
+      expect(
+        badgeValue(hass({ "sensor.a": { state: "21" }, "switch.b": { state: "on" } }), {
+          entity: "sensor.a",
+          secondaryEntity: "switch.b",
+          badgeEntity: "secondary",
+        }),
+      ).toBeUndefined();
+    });
+
+    it("an absent badgeEntity reproduces the old chain exactly", () => {
+      // The back-compat guard: every config written before this key existed.
+      const h = { ...plug().states, ...twoSensors().states };
+      const both = { states: h } as unknown as RenderHass;
+      expect(badgeValue(both, { entity: "switch.plug", secondaryEntity: "sensor.plug_power" }))
+        .toBe("1.2kW");
+      expect(badgeValue(both, { entity: "sensor.a", secondaryEntity: "sensor.b" })).toBe("21°");
+      expect(badgeValue(both, { entity: "sensor.a" })).toBe("21°");
+    });
+
+    it("an explicit primary still gets its attribute and domain reading", () => {
+      const h = hass({
+        "climate.hall": {
+          state: "heat",
+          attributes: { hvac_action: "heating", current_temperature: 21.4 },
+        },
+        "sensor.hum": { state: "44", attributes: { unit_of_measurement: "%" } },
+      });
+      const item = { entity: "climate.hall", secondaryEntity: "sensor.hum" } as const;
+      // Domain reading, not the mode.
+      expect(badgeValue(h, { ...item, badgeEntity: "primary" })).toBe("21°");
+      // A non-numeric configured attribute still falls through to it.
+      expect(
+        badgeValue(h, { ...item, attribute: "hvac_action", badgeEntity: "primary" }),
+      ).toBe("21°");
+    });
+
+    it("secondaryAttribute still resolves against the primary when no second entity", () => {
+      const h = hass({
+        "climate.hall": { state: "heat", attributes: { current_humidity: 44 } },
+      });
+      expect(
+        badgeValue(h, {
+          entity: "climate.hall",
+          secondaryAttribute: "current_humidity",
+          badgeEntity: "secondary",
+        }),
+      ).toBe("44");
+    });
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,6 +8,7 @@ import type {
   IconAnimation,
   StateColorRule,
   BadgeContent,
+  BadgeEntity,
   Furniture,
   Tracker,
   Area,
@@ -777,6 +778,33 @@ export function itemBadgeLabel(
 }
 
 /**
+ * The label the **editor canvas** puts under a device (issue #135), and whether
+ * it is the card's own (`live`) or an editor-only stand-in.
+ *
+ * The canvas used to draw `name || entity || kind` always, so a device read
+ * `light.kitchen` here and `21.5 °C` on the card, and turning "Show state" on
+ * changed nothing you could see without leaving the editor. So it draws the
+ * card's line whenever the card draws one.
+ *
+ * When the card draws nothing — both label toggles off — the canvas still needs
+ * something, or a plan of unnamed devices becomes a field of identical circles
+ * with nothing to tell them apart while dragging. That stand-in is rendered
+ * dimmed, the same way a `hideWhenInactive` device is faded: the signal is
+ * "this is a note to you, the card will not draw it".
+ *
+ * Lives here rather than in the editor so the rule is pinned by a test —
+ * `editor.ts` has no render-test harness.
+ */
+export function editorItemLabel(
+  hass: RenderHass | undefined,
+  item: Parameters<typeof itemBadgeLabel>[1] & { kind: ItemKind },
+): { text: string; live: boolean } {
+  const card = itemBadgeLabel(hass, item);
+  if (card) return { text: card, live: true };
+  return { text: item.name || item.entity || item.kind, live: false };
+}
+
+/**
  * Clamp a config `labelSize` to the editor's 8–40 px range at the render
  * sink. The editor already clamps, but a hand-edited / imported config
  * bypasses it — and this value lands in an inline `style` attribute.
@@ -1215,45 +1243,98 @@ function formatReading(n: number, rawUnit: unknown): string {
  */
 export function badgeValue(
   hass: RenderHass | undefined,
-  item: {
-    entity?: string;
-    attribute?: string;
-    secondaryEntity?: string;
-    secondaryAttribute?: string;
-  },
+  item: BadgeReadingItem,
 ): string | undefined {
+  return badgeReading(hass, item)?.text;
+}
+
+/** The shape {@link badgeReading} needs off a {@link FloorItem}. */
+export interface BadgeReadingItem {
+  entity?: string;
+  attribute?: string;
+  secondaryEntity?: string;
+  secondaryAttribute?: string;
+  badgeEntity?: BadgeEntity;
+}
+
+/** What a badge is showing, and which of the device's entities it came from. */
+export interface BadgeReading {
+  text: string;
+  source: BadgeEntity;
+}
+
+/**
+ * {@link badgeValue}, plus **which entity it read** (issue #136).
+ *
+ * The editor needs the source, not just the text: its "Badge reads" dropdown
+ * has to open on the entity the badge is actually showing. Defaulting that
+ * dropdown to "primary" would state the opposite of what is on screen for a
+ * plug whose reading arrives through the fallback below — and the first
+ * unrelated edit would save that as fact and drop the reading to an icon.
+ *
+ * So this is the one resolution and {@link badgeValue} is a wrapper over it,
+ * the same shape as {@link matchStateRule} / {@link resolveStateColor} in this
+ * file and for the same reason: two copies of a precedence chain are two
+ * chances for the badge and the form to disagree about it.
+ */
+export function badgeReading(
+  hass: RenderHass | undefined,
+  item: BadgeReadingItem,
+): BadgeReading | undefined {
   if (!hass || !item.entity) return undefined;
-  const st = hass.states[item.entity];
-  const attrs = st?.attributes as Record<string, unknown> | undefined;
-  const reading = DOMAIN_BADGE_READING[item.entity.split(".")[0]];
 
-  if (item.attribute) {
-    const n = numericReading(attrs?.[item.attribute]);
-    // A unit only when we know it belongs to *this* attribute:
-    // `unit_of_measurement` describes the state, not an arbitrary attribute, so
-    // borrowing it here would label a battery percentage "°C".
-    if (n !== undefined)
-      return compactNumber(n) + (item.attribute === reading?.attribute ? reading.unit : "");
-  }
-  if (reading) {
-    const n = numericReading(attrs?.[reading.attribute]);
-    if (n !== undefined) return compactNumber(n) + reading.unit;
-  }
-  const own = numericReading(st?.state);
-  if (own !== undefined) return formatReading(own, attrs?.unit_of_measurement);
-
-  // Same secondary resolution as the label line ({@link itemStateText}), so the
-  // two never disagree about which entity the second reading comes from.
+  // The secondary, resolved as the label line resolves it ({@link itemStateText}),
+  // so the two never disagree about which entity the second reading comes from.
   const secondaryEntity = item.secondaryEntity ?? (item.secondaryAttribute ? item.entity : undefined);
-  if (!secondaryEntity) return undefined;
-  const sec = hass.states[secondaryEntity];
-  const secAttrs = sec?.attributes as Record<string, unknown> | undefined;
-  if (item.secondaryAttribute) {
-    const n = numericReading(secAttrs?.[item.secondaryAttribute]);
-    return n === undefined ? undefined : compactNumber(n);
+
+  const primary = (): string | undefined => {
+    const st = hass.states[item.entity as string];
+    const attrs = st?.attributes as Record<string, unknown> | undefined;
+    const reading = DOMAIN_BADGE_READING[(item.entity as string).split(".")[0]];
+    if (item.attribute) {
+      const n = numericReading(attrs?.[item.attribute]);
+      // A unit only when we know it belongs to *this* attribute:
+      // `unit_of_measurement` describes the state, not an arbitrary attribute,
+      // so borrowing it here would label a battery percentage "°C".
+      if (n !== undefined)
+        return compactNumber(n) + (item.attribute === reading?.attribute ? reading.unit : "");
+    }
+    if (reading) {
+      const n = numericReading(attrs?.[reading.attribute]);
+      if (n !== undefined) return compactNumber(n) + reading.unit;
+    }
+    const own = numericReading(st?.state);
+    return own === undefined ? undefined : formatReading(own, attrs?.unit_of_measurement);
+  };
+
+  const secondary = (): string | undefined => {
+    if (!secondaryEntity) return undefined;
+    const sec = hass.states[secondaryEntity];
+    const secAttrs = sec?.attributes as Record<string, unknown> | undefined;
+    if (item.secondaryAttribute) {
+      const n = numericReading(secAttrs?.[item.secondaryAttribute]);
+      return n === undefined ? undefined : compactNumber(n);
+    }
+    const n = numericReading(sec?.state);
+    return n === undefined ? undefined : formatReading(n, secAttrs?.unit_of_measurement);
+  };
+
+  // An explicit choice reads that entity and stops. Falling through to the
+  // other one would quietly show a different device than the one asked for;
+  // no number at all is honest, and the badge draws its icon instead.
+  if (item.badgeEntity === "secondary") {
+    const text = secondary();
+    return text === undefined ? undefined : { text, source: "secondary" };
   }
-  const n = numericReading(sec?.state);
-  return n === undefined ? undefined : formatReading(n, secAttrs?.unit_of_measurement);
+  if (item.badgeEntity === "primary") {
+    const text = primary();
+    return text === undefined ? undefined : { text, source: "primary" };
+  }
+
+  const own = primary();
+  if (own !== undefined) return { text: own, source: "primary" };
+  const other = secondary();
+  return other === undefined ? undefined : { text: other, source: "secondary" };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,23 @@ export interface FloorItem {
    */
   badgeContent?: BadgeContent;
   /**
+   * Which of this device's own entities the badge reads while
+   * `badgeContent: "value"` (issue #136) — the main `entity`, or
+   * {@link secondaryEntity}.
+   *
+   * Absent means "work it out", which is what {@link badgeValue} has always
+   * done: the first candidate with a number wins, so a switch that reads "on"
+   * already falls through to its power sensor. That guess is usually right,
+   * but it is only a guess, and there was no way to overrule it when the main
+   * entity happens to be numeric too.
+   *
+   * Set, it is the *only* entity read. No falling back to the other one:
+   * having asked for the power sensor, being shown the switch instead would
+   * be worse than being shown the icon — which is what a device with no
+   * number to display falls back to anyway.
+   */
+  badgeEntity?: BadgeEntity;
+  /**
    * Hide this device on the live card while its entity is inactive (issue
    * #55), so a busy room only shows what is actually doing something. The
    * editor always draws it — dimmed — or it could never be selected again.
@@ -305,6 +322,13 @@ export type ItemDisplay = "badge" | "ripple" | "iconRipple";
 
 /** What a device badge holds — see {@link FloorItem.badgeContent} (issue #106). */
 export type BadgeContent = "icon" | "value" | "none";
+
+/**
+ * Which of a device's two entities feeds its value badge — see
+ * {@link FloorItem.badgeEntity} (issue #136). Named by role rather than by
+ * entity id so renaming an entity in Home Assistant cannot orphan the choice.
+ */
+export type BadgeEntity = "primary" | "secondary";
 
 /**
  * One colour rule for {@link FloorItem.stateColor} / {@link Furniture.stateColor}.


### PR DESCRIPTION
Closes #135. Closes #136.

Both are UI-streamlining issues about the same thing — the editor telling you the truth about what you are configuring — so they share a PR.

## #135 — the canvas showed an id where the card shows a state

The overlay drew `name || entity || kind`, always, while the card draws `itemBadgeLabel` — the name and/or the live state. So a device read `light.kitchen` on the canvas and `21.5 °C` on the card, and turning on **Show state** changed nothing you could see without leaving the editor.

The canvas now draws the card's own line whenever the card draws one, at the card's size and ink. When the card would draw nothing — both toggles off — it falls back to the old identification text, **dimmed**. That fallback earns its keep: a plan of unnamed devices would otherwise be a field of identical circles with nothing to tell them apart while dragging. Dimming is the signal that the card won't render it — the same one a `hideWhenInactive` device already uses.

Measured across ten fixtures, editor vs. card:

| fixture | card | editor |
|---|---|---|
| sensor, default | `21.4 °C` · 12px · `#212121` | **identical** |
| Show state on | `on` · 12px · `#212121` | **identical** |
| Show name on | `Kitchen light` | **identical** |
| both on | `Hall temp · 21.4 °C` | **identical** |
| both off | *(none)* | `light.kitchen` · 11px · grey **[dim]** |
| both off, named | *(none)* | `Ceiling` **[dim]** |

Toggling **Show state** flips the canvas from `light.kitchen` (dim) to `on` (live) immediately, which is the actual complaint. Labels toggle still hides both kinds; anchoring unchanged at rotation 90 (2px below the badge, centred, no rotation on the label).

**Nothing else on the canvas was wrong**, and it would have been easy to over-fix given the issue says "as close as possible". The always-animated ripple, the faded `hideWhenInactive` device, the ghost badge for *Nothing*, the glow radius guide, and `editorGlowPaint` lighting a bulb with no readable state are all deliberate — each makes something editable or visible that otherwise would not be. Left alone.

The rule lives in `render.ts` as `editorItemLabel` rather than inline in the overlay, because `editor.ts` has no render-test harness and this behaviour deserved pinning.

## #136 — no way to say which entity the badge reads

Your switch-plus-power-sensor example already worked — but **by accident**. `badgeValue` walks a chain, and a switch reading `"on"` is not a number, so it fell through to the sensor. The guess is usually right. It was still a guess, with no way to overrule it when the main entity has a number of its own, and nothing anywhere said which entity it had landed on.

`badgeReading` now returns the text *and* its source, with `badgeValue` a wrapper over it — the same split as `matchStateRule`/`resolveStateColor` in this file, for the same reason: two copies of a precedence chain are two chances for the badge and the form to disagree about it.

`badgeEntity` overrules the guess. Set, that entity is the **only** one read — no falling back to the other, because having asked for the power sensor, being shown the switch would be worse than being shown the icon, which is what a device with no number falls back to anyway. Absent, the chain is untouched, so every existing config renders identically.

| device | before | after |
|---|---|---|
| switch + power sensor | `1.2kW` (fallback) | `1.2kW` — unchanged |
| two sensors | `21°`, no way to ask for the other | `21°`, or `63%` with one dropdown |
| `badgeEntity: primary` on the switch | — | icon, **not** the power sensor |

The row appears only when the badge shows a value *and* a second entity exists, and it names the entities rather than offering an "Automatic" — following #127, whose dropdown deliberately has none because *"'auto' is a fact about the config format, not about what the user is looking at"*.

**Its default is load-bearing, not polish.** It opens on the entity the badge is *actually* reading, resolved off `hass` at the call site exactly as `deviceClass` already is. A bare `"primary"` default would name the switch while the badge showed watts — and the first unrelated edit would write that down and silently drop the reading to an icon. Verified end to end: on the plug the dropdown reads **"Kitchen plug power"** with value `secondary`, and changing **Size** to 44 leaves the badge at `1.2kW`.

## A note on the issue text

#136 says a device "can also have up to 2 more" entities. It has exactly one extra (`entity` + `secondaryEntity`), so the selector covers those two — you confirmed that rather than adding a third slot.

## Checks

- `tsc`, **657 tests**, `npm run build` green; duplication sweep clean.
- 12 of the new tests fail against `main`; the rest are deliberate back-compat guards (an absent `badgeEntity` reproducing the old chain, `secondaryAttribute` still resolving against the primary) — without those, "always read the primary" would also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)