### PR TITLE
Walls: per-wall adjustable thickness

### DIFF
--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -533,6 +533,18 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(d).toMatchObject({ x1: 1, y1: 3, x2: 3, y2: 4 });
   });
 
+  it("wall defaults thickness to WALL_THICKNESS and strips it back out at the default", () => {
+    const form = wallForm({ id: "w", x1: 0, y1: 0, x2: 1, y2: 1 });
+    expect(form.data.thickness).toBe(8);
+    expect(form.toPatch({ thickness: 8 })).toEqual({ thickness: undefined });
+    expect(form.toPatch({ thickness: 16 })).toEqual({ thickness: 16 });
+  });
+
+  it("wall reflects a custom thickness in its data", () => {
+    const d = wallForm({ id: "w", x1: 0, y1: 0, x2: 1, y2: 1, thickness: 20 }).data;
+    expect(d.thickness).toBe(20);
+  });
+
   it("project fields are required numbers with min 1", () => {
     const form = projectForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
     const width = form.fields.find((x) => x.name === "width")!;

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -30,6 +30,7 @@ import {
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
+  WALL_THICKNESS,
   badgeContentOf,
   domainIconAnimation,
   isPresenceEntity,
@@ -799,9 +800,27 @@ export function wallForm(w: Wall): FormSpec {
     selector: { number: { mode: "box" } },
   });
   return {
-    fields: [coord("x1", "Start X"), coord("y1", "Start Y"), coord("x2", "End X"), coord("y2", "End Y")],
-    data: { x1: Math.round(w.x1), y1: Math.round(w.y1), x2: Math.round(w.x2), y2: Math.round(w.y2) },
-    toPatch: identity,
+    fields: [
+      coord("x1", "Start X"),
+      coord("y1", "Start Y"),
+      coord("x2", "End X"),
+      coord("y2", "End Y"),
+      {
+        name: "thickness",
+        label: "Thickness",
+        selector: { number: { min: 2, max: 30, step: 1, mode: "slider", unit_of_measurement: "px" } },
+      },
+    ],
+    data: {
+      x1: Math.round(w.x1),
+      y1: Math.round(w.y1),
+      x2: Math.round(w.x2),
+      y2: Math.round(w.y2),
+      thickness: w.thickness ?? WALL_THICKNESS,
+    },
+    // Keep the default out of the YAML so untouched walls stay terse.
+    toPatch: (p) =>
+      "thickness" in p && p.thickness === WALL_THICKNESS ? { ...p, thickness: undefined } : p,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3271,7 +3271,7 @@ export class FloorplanCardEditor extends LitElement {
         <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
               class="wall ${selected ? "selected" : ""}"
               mask=${`url(#${this._wallMaskId})`}
-              stroke-width=${WALL_THICKNESS} stroke-linecap="round" />
+              stroke-width=${w.thickness ?? WALL_THICKNESS} stroke-linecap="round" />
         ${
           selected
             ? svg`

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -475,7 +475,7 @@ export class FloorplanCard extends LitElement {
                 (w) => svg`
                 <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
                       class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
-                      stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
+                      stroke-width=${w.thickness ?? WALL_THICKNESS} stroke-linecap="round" />`
               )}
             </g>
             <!-- Room outlines, above the walls they trace. An area polygon runs

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface Wall {
   y1: number;
   x2: number;
   y2: number;
+  /** Stroke width in virtual units. Defaults to {@link WALL_THICKNESS} (render.ts) when unset. */
+  thickness?: number;
 }
 
 export type OpeningType = "door" | "window";


### PR DESCRIPTION
## Summary
- Adds an optional `thickness` field to `Wall` (defaults to `WALL_THICKNESS` when unset)
- Adds a "Thickness" slider to the wall property panel in the editor, following the same default/strip pattern as other size fields (e.g. item size)
- Both the editor canvas and the live card now render each wall at its own thickness

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (641 tests passing, including new coverage for the thickness field default/patch behavior)
- [x] `npm run build`
- [x] Manually verified in `npm run serve`: selecting a wall shows the Thickness slider, and dragging it live-updates the wall's stroke width in both the editor and the preview pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)