### PR TITLE
Skins: four built-in looks for a plan, and the tokens to build your own (closes #122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ card_mod:
 | `--fp-skin-wall-width` | `8` | Wall stroke width. **Keep this at 10 or below** — a doorway is a 12-unit gap cut through the wall layer, and a wider wall would not be fully cleared by its own door. |
 | `--fp-skin-wall-filter` | `none` | A CSS `filter` on the walls, e.g. `drop-shadow(0 0 4px #22d3ee)` for a neon look. |
 | `--fp-skin-accent` | theme primary color | Ripples, trackers, room fills, active doors, the floor switcher. |
+| `--fp-skin-accent-ink` | theme text-on-primary color | Reading colour on top of `--fp-skin-accent` — today the active floor-switcher button. Set it whenever your accent is pale. |
 | `--fp-skin-active` | theme active color | Badge colour for a device that is on. |
 | `--fp-skin-active-ink` | theme text color | Icon/reading colour on that badge. Set it whenever `--fp-skin-active` is pale. |
 | `--fp-skin-text` | theme text color | Labels, free text, room names, the card title, the editor grid. |
@@ -1157,9 +1158,22 @@ card_mod:
 | `--fp-skin-furniture` | `#9e9e9e` | Furniture with no colour of its own. |
 | `--fp-skin-glow` | `#ffd9a0` | Light-pool colour for a bulb that reports no colour. |
 
-Set them on `ha-card` and the whole plan follows, editor included. They are the same layer the
-built-in skins use, so a `skin:` and a card-mod override compose — the skin supplies the values
-you don't state.
+Set them on `ha-card` and the whole plan follows, editor included. Any token you leave alone keeps
+its default from the table, so you can restyle one thing without restating the rest.
+
+**On top of a built-in skin, add `!important`.** A `skin:` is applied as an inline `style` on the
+card, and an inline declaration outranks a card-mod rule — so without it your override is silently
+ignored, and only while a skin is set:
+
+```yaml
+type: custom:easy-floorplan-card
+skin: tron
+card_mod:
+  style: |
+    ha-card {
+      --fp-skin-accent: #f2aa4c !important;
+    }
+```
 
 ## Styling hooks (card-mod)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ automatically to the card and screen size.
   dawn, tracking your Home Assistant's own sunrise and sunset rather than the viewer's
   browser. Device icons stay at full brightness, so a night plan reads as a dark house
   with its lit rooms glowing.
+- **Skins** — restyle the whole plan from one line of config: `default` follows your Home
+  Assistant theme, `odnetnin` is playful and chunky, `pastel` is soft and low-contrast,
+  `tron` is neon on near-black. Colours you set on an element yourself always win. See
+  **Skins**.
 - **Text labels** and a configurable **canvas background color**.
 - **Background image** — drop in a floor-plan image (per floor) and trace walls, doors and
   devices over it, with adjustable opacity.
@@ -596,7 +600,8 @@ The editor writes this config for you; manual editing is optional.
 | `sunDimming` | boolean | `false` | Dim the plan through dusk and brighten it through dawn, following the **Home Assistant instance's** sunrise and sunset (not the browser's). See **Follow the sun**. |
 | `sunBrightnessMin` | number | `0.45` | Plan brightness once the sun is fully down, 0–1. Only used when `sunDimming` is on. |
 | `sunBrightnessMax` | number | `1` | Plan brightness in full daylight, 0–1. Only used when `sunDimming` is on. |
-| `background` | string   | card background    | Canvas background color (CSS / hex).         |
+| `skin`       | string   | `default`          | Built-in look for the whole plan: `default`, `odnetnin`, `pastel` or `tron`. See **Skins**. |
+| `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see **Floors**).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
 | `walls`      | Wall[]   | `[]`               | Wall segments (single-floor / floor 1).      |
@@ -1090,6 +1095,72 @@ whole length: light does not reach through a doorway, for the clearing or for th
 Toggle it in the editor under **Project → Follow the sun**; the two brightness sliders
 appear once it is on.
 
+## Skins
+
+A skin restyles the whole plan at once — paper, walls, badges, accents — from one line of
+config. Pick one in the editor under **Project → Skin**, or set it by hand:
+
+```yaml
+type: custom:easy-floorplan-card
+skin: tron
+```
+
+| Skin | What it looks like |
+| --- | --- |
+| `default` | Follows your Home Assistant theme, exactly as the card always has. This is what you get with no `skin` set. |
+| `odnetnin` | Playful and chunky: thick charcoal outlines on warm cream paper, rounded-square badges with a hard printed-sticker shadow, a red accent and a bright yellow for anything that's on. |
+| `pastel` | Soft and low-contrast: muted mauve walls on blush paper, peach for active devices. Easy to look at on a dashboard you keep on screen all day. |
+| `tron` | Neon on near-black: thin cyan walls that glow, amber for active devices, light text. Light pools read best here — a lit room genuinely lights up. |
+
+A skin only ever supplies **fallbacks**, so anything you set on an element yourself still wins:
+a room with its own `color`, a device with its own `activeColor`, a `background` on the plan.
+That also means you can switch skins freely without losing the colours you chose by hand.
+
+Two things a skin deliberately does not touch. The **editor's own chrome** — toolbar, panels,
+forms — stays in your Home Assistant theme, so the canvas reads as the plan rather than as more
+editor. And a **background image** covers the skin's paper, as it always has; only the area
+around it changes.
+
+### Rolling your own
+
+Under the hood a skin is a set of CSS custom properties, so [card-mod](#styling-hooks-card-mod)
+can set the same ones and get the same result:
+
+```yaml
+type: custom:easy-floorplan-card
+card_mod:
+  style: |
+    ha-card {
+      --fp-skin-bg: #101820;
+      --fp-skin-wall: #f2aa4c;
+      --fp-skin-text: #f2f2f2;
+      --fp-skin-accent: #f2aa4c;
+    }
+```
+
+| Token | Default | Paints |
+| --- | --- | --- |
+| `--fp-skin-bg` | card background | The canvas paper. |
+| `--fp-skin-card-bg` | card background | The card around the canvas. |
+| `--fp-skin-wall` | theme text color | Walls, and the jambs and leaves of doors and windows. |
+| `--fp-skin-wall-width` | `8` | Wall stroke width. **Keep this at 10 or below** — a doorway is a 12-unit gap cut through the wall layer, and a wider wall would not be fully cleared by its own door. |
+| `--fp-skin-wall-filter` | `none` | A CSS `filter` on the walls, e.g. `drop-shadow(0 0 4px #22d3ee)` for a neon look. |
+| `--fp-skin-accent` | theme primary color | Ripples, trackers, room fills, active doors, the floor switcher. |
+| `--fp-skin-active` | theme active color | Badge colour for a device that is on. |
+| `--fp-skin-active-ink` | theme text color | Icon/reading colour on that badge. Set it whenever `--fp-skin-active` is pale. |
+| `--fp-skin-text` | theme text color | Labels, free text, room names, the card title, the editor grid. |
+| `--fp-skin-badge-bg` | card background | Badge and label-chip background. |
+| `--fp-skin-badge-border` | divider color | Badge border colour. |
+| `--fp-skin-badge-border-width` | `1.5px` | Badge border weight. |
+| `--fp-skin-badge-radius` | `50%` | Badge roundness — `50%` is a circle, `30%` a rounded square. |
+| `--fp-skin-badge-shadow` | `0 1px 3px rgba(0,0,0,0.2)` | Badge shadow. |
+| `--fp-skin-furniture` | `#9e9e9e` | Furniture with no colour of its own. |
+| `--fp-skin-glow` | `#ffd9a0` | Light-pool colour for a bulb that reports no colour. |
+
+Set them on `ha-card` and the whole plan follows, editor included. They are the same layer the
+built-in skins use, so a `skin:` and a card-mod override compose — the skin supplies the values
+you don't state.
+
 ## Styling hooks (card-mod)
 
 Every rendered element carries its config `id` as `data-id`, plus a type class — so
@@ -1140,7 +1211,9 @@ CSS wins over SVG presentation attributes, so `fill` and `fill-opacity` set this
 override what the card draws.
 
 Two notes. **Colouring a room from a sensor no longer needs CSS** — areas take `entity`,
-`stateColor`, `activeColor` and `activeOpacity` natively; see **Area**. And these hooks are
+`stateColor`, `activeColor` and `activeOpacity` natively; see **Area**; and **restyling the
+whole plan no longer needs CSS either** — see **Skins**, whose `--fp-skin-*` tokens are the
+supported way to build a look of your own. And these hooks are
 a *styling* surface, not an API: the class names are stable, but the SVG structure inside
 an element may change between releases, so prefer selecting the element itself over its
 internals.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -11,6 +11,7 @@ import {
   wallForm,
   projectForm,
   projectRotationForm,
+  projectSkinForm,
   projectSunForm,
   floorImageForm,
   areaForm,
@@ -19,6 +20,7 @@ import {
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS } from "./types";
+import { DEFAULT_SKIN, SKINS } from "./skins";
 
 const fields: FormField[] = [
   { name: "name", label: "Name", selector: { text: {} } },
@@ -617,6 +619,38 @@ describe("wallForm / projectForm / floorImageForm", () => {
       rotation: 270,
     } as FloorplanCardConfig);
     expect(rotated.data.rotation).toBe("270");
+  });
+
+  it("skin offers every built-in and keeps the default out of the YAML", () => {
+    const base = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    const form = projectSkinForm(base);
+    expect(form.fields.map((x) => x.name)).toEqual(["skin"]);
+    const options = (form.fields[0].selector.select as { options: { value: string }[] }).options;
+    expect(options.map((o) => o.value)).toEqual(SKINS.map((s) => s.id));
+    expect(form.data.skin).toBe(DEFAULT_SKIN);
+    expect(form.toPatch({ skin: DEFAULT_SKIN })).toEqual({ skin: undefined });
+    expect(form.toPatch({ skin: "tron" })).toEqual({ skin: "tron" });
+  });
+
+  it("skin reads back a skin we don't ship as the default, matching what it renders as", () => {
+    const form = projectSkinForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      skin: "nintendo",
+    } as FloorplanCardConfig);
+    expect(form.data.skin).toBe(DEFAULT_SKIN);
+  });
+
+  it("skin's helper describes the skin currently selected", () => {
+    const tron = SKINS.find((s) => s.id === "tron")!;
+    const form = projectSkinForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      skin: "tron",
+    } as FloorplanCardConfig);
+    expect(form.fields[0].helper).toBe(tron.description);
   });
 
   it("image opacity appears only when an image is set", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -41,6 +41,7 @@ import {
   windowSash,
 } from "./render";
 import { defaultItemAction } from "./actions";
+import { DEFAULT_SKIN, SKINS, findSkin } from "./skins";
 
 /** One ha-form schema item, extended with our label/helper (read by computeLabel). */
 export interface FormField {
@@ -864,6 +865,30 @@ export function projectForm(c: FloorplanCardConfig): FormSpec {
     ],
     data: { title: c.title ?? "", width: c.width, height: c.height, grid: c.grid ?? DEFAULT_GRID },
     toPatch: identity,
+  };
+}
+
+/**
+ * Built-in skins (issue #122). Its own one-field form so the editor can put it
+ * at the top of the Project section, directly above the Background colour it
+ * interacts with — the skin supplies the paper, `background` overrides it.
+ */
+export function projectSkinForm(c: FloorplanCardConfig): FormSpec {
+  const current = findSkin(c.skin) ?? SKINS[0];
+  return {
+    fields: [
+      {
+        name: "skin",
+        label: "Skin",
+        helper: current.description,
+        selector: dropdown(...SKINS.map((s) => opt(s.id, s.label))),
+      },
+    ],
+    // An id we don't ship reads back as Default, matching what it renders as.
+    data: { skin: current.id },
+    toPatch: (p) =>
+      // Default is the absence of a skin, so it stays out of the YAML.
+      "skin" in p && p.skin === DEFAULT_SKIN ? { ...p, skin: undefined } : p,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state, query } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { keyed } from "lit/directives/keyed.js";
 import type {
   HomeAssistant,
   FloorplanCardConfig,
@@ -86,6 +87,7 @@ import {
   hassRenderInputsChanged,
 } from "./render";
 import { cssColor, cssColorOr, cssNumber, contrastText } from "./css-safe";
+import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
 import {
   ENDPOINT_SNAP,
   applyDelta,
@@ -120,6 +122,7 @@ import {
   openingForm,
   projectForm,
   projectRotationForm,
+  projectSkinForm,
   projectSunForm,
   textForm,
   trackerForm,
@@ -2753,8 +2756,15 @@ export class FloorplanCardEditor extends LitElement {
           @wheel=${this._onCanvasWheel}
         >
           <div class="stage" style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
-            c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;">
-            <svg
+            c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;${skinStyle(c.skin)}">
+            <!-- Keyed on the skin, for the repaint reason documented on the
+                 card's SVG (issue #122): a var() inside a presentation
+                 attribute does not repaint when the custom property changes,
+                 so without this the canvas kept the previous skin's doors and
+                 room fills. -->
+            ${keyed(
+              c.skin ?? "",
+              svg`<svg
               viewBox="0 0 ${c.width} ${c.height}"
               preserveAspectRatio="none"
               class=${this._tool}
@@ -2768,7 +2778,7 @@ export class FloorplanCardEditor extends LitElement {
                 y="0"
                 width=${c.width}
                 height=${c.height}
-                fill=${c.background ?? "var(--card-background-color, #fff)"}
+                fill=${c.background ?? SKIN_PAPER}
               />
               ${floor.image
                 ? svg`<image href=${floor.image} x="0" y="0" width=${c.width} height=${c.height}
@@ -2870,7 +2880,8 @@ export class FloorplanCardEditor extends LitElement {
                               class="marquee" />`
                   : nothing
               }
-            </svg>
+            </svg>`
+            )}
             <div class="items">
               ${floor.texts.map((t) => this._renderTextOverlay(t, c))}
               ${floor.items.map((it) => this._renderItemOverlay(it, c))}
@@ -3294,7 +3305,7 @@ export class FloorplanCardEditor extends LitElement {
       <g class="opening-hit"
          @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "opening", id: o.id })}>
         ${renderOpening(o, {
-          color: selected ? "var(--primary-color, #03a9f4)" : "var(--primary-text-color)",
+          color: selected ? "var(--primary-color, #03a9f4)" : SKIN_WALL,
           open: openingDefaultOpen(o),
           // Draw sliding / rolling openings partly open in the editor so the
           // motion is visible — closed, both look like a plain band, which
@@ -3475,7 +3486,7 @@ export class FloorplanCardEditor extends LitElement {
     // Ink that reads on whatever the badge ends up painted, same rule as the card.
     const badgeInk = contrastText(stateColor ?? activeColor);
     const rippleColor =
-      it.rippleColor ?? stateColor ?? activeColor ?? "var(--primary-color, #03a9f4)";
+      it.rippleColor ?? stateColor ?? activeColor ?? SKIN_ACCENT;
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
 
     // Live preview: the icon animates exactly when the card would animate it
@@ -3557,7 +3568,7 @@ export class FloorplanCardEditor extends LitElement {
         class="edit-text ${selected ? "selected" : ""}"
         style="left:${(t.x / c.width) * 100}%; top:${(t.y / c.height) * 100}%;
                font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
-               color:${cssColorOr(t.color, "var(--primary-text-color)")};
+               color:${cssColorOr(t.color, SKIN_TEXT)};
                transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "text", id: t.id })}
         @pointermove=${this._onOverlayMove}
@@ -3607,6 +3618,9 @@ export class FloorplanCardEditor extends LitElement {
           if (live) this._patchConfigLive(patch as Partial<FloorplanCardConfig>);
           else this._patchConfig(patch as Partial<FloorplanCardConfig>);
         })}
+        ${this._renderForm(projectSkinForm(this._config), (patch) =>
+          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        )}
         ${this._renderColorRow({
           label: "Background",
           value: this._config.background,
@@ -4041,7 +4055,13 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
-  static styles = css`
+  // The canvas mirrors the card, so it takes the same --fp-skin-* defaults
+  // (issue #122). A skin overrides them on .stage only — the toolbar, panels
+  // and forms stay in the Home Assistant theme, which is what makes the canvas
+  // read as the plan rather than as more editor chrome.
+  static styles = [
+    skinTokens,
+    css`
     .editor {
       display: flex;
       flex-direction: column;
@@ -4310,7 +4330,7 @@ export class FloorplanCardEditor extends LitElement {
          background image (and on both light and dark themes); non-scaling-stroke
          keeps the lines a crisp ~1px at any canvas size / zoom. Editor-only —
          the live card never draws a grid. */
-      stroke: var(--primary-text-color, #212121);
+      stroke: var(--fp-skin-text, var(--primary-text-color, #212121));
       stroke-opacity: 0.25;
       stroke-width: 1;
       vector-effect: non-scaling-stroke;
@@ -4324,7 +4344,11 @@ export class FloorplanCardEditor extends LitElement {
        is inherited in SVG, setting it to none disabled the entire canvas
        — so no pointerdown reached the wall-draw handler. */
     line.wall {
-      stroke: var(--primary-text-color);
+      stroke: var(--fp-skin-wall, var(--primary-text-color));
+      /* Same skin hooks as the card's .wall, so the canvas draws the weight
+         and glow the plan will actually have. */
+      stroke-width: var(--fp-skin-wall-width, 8);
+      filter: var(--fp-skin-wall-filter, none);
       /* The wide transparent .wall-hit line beneath handles selection/drag.
          Without this, the visible line (painted on top) swallows clicks on the
          wall body, so you could only grab it just *outside* the body. */
@@ -4588,14 +4612,15 @@ export class FloorplanCardEditor extends LitElement {
     .badge {
       width: 34px;
       height: 34px;
-      border-radius: 50%;
-      background: var(--card-background-color, #fff);
-      border: 1.5px solid var(--divider-color, #ccc);
+      border-radius: var(--fp-skin-badge-radius, 50%);
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
+      border: var(--fp-skin-badge-border-width, 1.5px) solid
+        var(--fp-skin-badge-border, var(--divider-color, #ccc));
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--primary-text-color);
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+      color: var(--fp-skin-text, var(--primary-text-color));
+      box-shadow: var(--fp-skin-badge-shadow, 0 1px 3px rgba(0, 0, 0, 0.25));
     }
     /* Mirrors the card's .badge-value (issue #106) — the canvas must show the
        reading exactly as the plan will draw it. */
@@ -4953,7 +4978,7 @@ export class FloorplanCardEditor extends LitElement {
       line-height: 1;
       padding: 1px 4px;
       border-radius: 4px;
-      background: var(--card-background-color, #fff);
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
       color: var(--secondary-text-color);
       white-space: nowrap;
       max-width: 120px;
@@ -4966,7 +4991,7 @@ export class FloorplanCardEditor extends LitElement {
        The unclamped variant is the one you are checking; the dim fallback
        above stays clamped, being editor chrome rather than a preview. */
     .ilabel.live {
-      color: var(--primary-text-color);
+      color: var(--fp-skin-text, var(--primary-text-color));
       max-width: none;
       overflow: visible;
     }
@@ -5156,9 +5181,9 @@ export class FloorplanCardEditor extends LitElement {
        changed nothing here and a coloured lamp looked plain. Below
        .state-colored, which is the more specific statement. */
     .edit-item .badge.active-colored {
-      background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
-      border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
-      color: var(--fp-ink, var(--text-primary-color, #212121));
+      background: var(--fp-active, var(--fp-skin-active, var(--state-light-active-color, var(--state-active-color, #fdd835))));
+      border-color: var(--fp-active, var(--fp-skin-active, var(--state-light-active-color, var(--state-active-color, #fdd835))));
+      color: var(--fp-ink, var(--fp-skin-active-ink, var(--text-primary-color, #212121)));
     }
     .state-color-rule select {
       flex: 0 0 96px;
@@ -5239,7 +5264,8 @@ export class FloorplanCardEditor extends LitElement {
     .ha-link-chip .unlink:hover {
       opacity: 1;
     }
-  `;
+  `,
+  ];
 }
 
 declare global {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, svg, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { keyed } from "lit/directives/keyed.js";
 import type { HomeAssistant, FloorplanCardConfig, FloorItem, FloorText, Floor, Area } from "./types";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, contrastText } from "./css-safe";
 import {
@@ -61,6 +62,7 @@ import {
   type PlanRotation,
 } from "./render";
 import type { Opening } from "./types";
+import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
 import { actionForGesture, executeAction, hasAction } from "./actions";
 import { actionHandler } from "./action-handler";
 
@@ -289,7 +291,7 @@ export class FloorplanCard extends LitElement {
     const lightColor = lightBadgePaint(st);
     const activeColor = cssColor(item.activeColor) ?? lightColor;
     const rippleColor =
-      item.rippleColor ?? stateColor ?? item.activeColor ?? lightColor ?? "var(--primary-color, #03a9f4)";
+      item.rippleColor ?? stateColor ?? item.activeColor ?? lightColor ?? SKIN_ACCENT;
     // Ink that can actually be read on whatever the badge ended up painted
     // (issue #106, @MrMcFlyy): a white state colour used to take the theme's
     // white icon with it. undefined for a colour we cannot resolve — a
@@ -372,7 +374,7 @@ export class FloorplanCard extends LitElement {
         data-id=${cssIdent(t.id) ?? nothing}
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
                font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
-               color:${cssColorOr(t.color, "var(--primary-text-color)")};
+               color:${cssColorOr(t.color, SKIN_TEXT)};
                transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
       >
         ${t.text}
@@ -418,7 +420,11 @@ export class FloorplanCard extends LitElement {
         )
       : nothing;
     return html`
-      <ha-card .header=${c.title ?? nothing}>
+      <!-- The skin (issue #122) rides on the card rather than on .plan, so the
+           floor switcher and the card's own background follow it too — a Tron
+           plan floating on a white card would read as a bug. Every token the
+           card draws with is declared on :host, so this only ever overrides. -->
+      <ha-card .header=${c.title ?? nothing} style=${skinStyle(c.skin) || nothing}>
         <div
           class="stage"
           style="aspect-ratio: ${dims.w} / ${dims.h};"
@@ -437,8 +443,7 @@ export class FloorplanCard extends LitElement {
             class="plan"
             style="aspect-ratio: ${dims.w} / ${dims.h};
                    width: min(100%, calc(100cqh * ${dims.w} / ${dims.h}));
-                   background:${cssColorOr(
-                     c.background, "var(--card-background-color, #fff)")};"
+                   background:${cssColorOr(c.background, SKIN_PAPER)};"
           >
           <!-- preserveAspectRatio="none" is correct here, and it took a wrong
                fix to see why. Fitting the plan into a card that is the wrong
@@ -453,7 +458,18 @@ export class FloorplanCard extends LitElement {
                count), "meet" letterboxes the SVG away from the overlay and
                every icon drifts off the wall it was placed on, while "none"
                stretches both layers identically: distorted, but aligned. -->
-          <svg viewBox="0 0 ${dims.w} ${dims.h}" preserveAspectRatio="none">
+          <!-- Keyed on the skin (issue #122). A skin changes custom properties on
+               an ancestor, and Chromium does not repaint an SVG element whose
+               colour comes from a var() inside a presentation attribute or an
+               inline style unless something else about it changes — Lit writes
+               the same attribute string either way, so switching skins left
+               every door, window and room fill painted in the previous skin's
+               colours while the computed values were already correct. Keying
+               rebuilds the subtree instead, which repaints by construction.
+               Only on a skin change; ordinary state updates are untouched. -->
+          ${keyed(
+            c.skin ?? "",
+            svg`<svg viewBox="0 0 ${dims.w} ${dims.h}" preserveAspectRatio="none">
             <g transform=${rotTransform || nothing}>
             ${active.image
               ? svg`<image href=${active.image} x="0" y="0" width=${c.width} height=${c.height}
@@ -523,11 +539,11 @@ export class FloorplanCard extends LitElement {
                 ? this.hass?.states[o.shutterEntity]
                 : undefined;
               const symbol = renderOpening(o, {
-                color: "var(--primary-text-color)",
+                color: SKIN_WALL,
                 open: amount > 0,
                 amount,
                 active: this._openingActive(o),
-                accent: o.activeColor ?? "var(--primary-color, #03a9f4)",
+                accent: o.activeColor ?? SKIN_ACCENT,
                 // External roller shutter layer (issue #74). No entity bound
                 // yet → previewed shut, like a static plan.
                 shutter: o.shutterEntity
@@ -581,7 +597,8 @@ export class FloorplanCard extends LitElement {
                 : nothing
             }
             </g>
-          </svg>
+          </svg>`
+          )}
           <div class="items">
             ${active.areas?.map((a) => this._renderAreaLabel(a, c, rot))}
             ${active.texts.map((t) => this._renderText(t, c, rot))}
@@ -636,11 +653,26 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
-  static styles = css`
+  // skinTokens declares every --fp-skin-* default on :host (issue #122). It
+  // comes first so a skin's inline overrides on <ha-card> — a descendant — win
+  // by the cascade's ordinary inheritance rules rather than by !important.
+  static styles = [
+    skinTokens,
+    css`
     ha-card {
       height: 100%;
       box-sizing: border-box;
       overflow: hidden;
+      /* The skin paints the card, not just the plan: .plan is only the canvas
+         box, and on a card that isn't the canvas's shape the rest would stay
+         the Home Assistant theme's colour. Unskinned this is ha-card's own
+         default chain, so nothing changes. */
+      background: var(--fp-skin-card-bg, var(--ha-card-background, var(--card-background-color, #fff)));
+      /* The title sits on that background, and ha-card colours it from this
+         variable rather than inheriting — so a dark skin under a light Home
+         Assistant theme would print a dark title on near-black. The default is
+         ha-card's own. */
+      --ha-card-header-color: var(--fp-skin-text, var(--primary-text-color));
       /* A column, so the stage takes the height left over after the card's
          own header rather than the card's whole height. With a title set, a
          full-height stage measures past the bottom of the card by exactly the
@@ -680,9 +712,9 @@ export class FloorplanCard extends LitElement {
     }
     .floor-switcher button {
       cursor: pointer;
-      border: 1px solid var(--divider-color, #ccc);
-      background: var(--card-background-color, #fff);
-      color: var(--primary-text-color);
+      border: 1px solid var(--fp-skin-badge-border, var(--divider-color, #ccc));
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
+      color: var(--fp-skin-text, var(--primary-text-color));
       border-radius: 6px;
       padding: 4px 8px;
       font-size: 12px;
@@ -694,9 +726,9 @@ export class FloorplanCard extends LitElement {
       white-space: nowrap;
     }
     .floor-switcher button.active {
-      background: var(--primary-color, #03a9f4);
+      background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
       color: var(--text-primary-color, #fff);
-      border-color: var(--primary-color, #03a9f4);
+      border-color: var(--fp-skin-accent, var(--primary-color, #03a9f4));
     }
     svg {
       position: absolute;
@@ -706,7 +738,15 @@ export class FloorplanCard extends LitElement {
       display: block;
     }
     .wall {
-      stroke: var(--primary-text-color);
+      stroke: var(--fp-skin-wall, var(--primary-text-color));
+      /* CSS beats the presentation attribute, so the skin sets the wall's
+         weight while WALL_THICKNESS keeps owning the geometry the doorway
+         mask and the opening symbols are cut from. Capped at 10 for that
+         reason — see MAX_SKIN_WALL_WIDTH. */
+      stroke-width: var(--fp-skin-wall-width, 8);
+      /* Neon, for the skins that want it. Everyone else gets none, which
+         costs nothing. */
+      filter: var(--fp-skin-wall-filter, none);
     }
     /* Sun dimming (issue #113): decoration, never a pointer target. The
        transition matters — HA steps the sun elevation every ~30s, and without
@@ -820,14 +860,15 @@ export class FloorplanCard extends LitElement {
     .badge {
       width: 34px;
       height: 34px;
-      border-radius: 50%;
-      background: var(--card-background-color, #fff);
-      border: 1.5px solid var(--divider-color, #ccc);
+      border-radius: var(--fp-skin-badge-radius, 50%);
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
+      border: var(--fp-skin-badge-border-width, 1.5px) solid
+        var(--fp-skin-badge-border, var(--divider-color, #ccc));
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--primary-text-color);
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+      color: var(--fp-skin-text, var(--primary-text-color));
+      box-shadow: var(--fp-skin-badge-shadow, 0 1px 3px rgba(0, 0, 0, 0.2));
     }
     /* The reading standing in for the icon (issue #106). Inherits the badge's
        text color, so every rule that recolours a badge — active, --fp-state —
@@ -845,9 +886,13 @@ export class FloorplanCard extends LitElement {
      * exactly what every badge used before the option existed.
      */
     .item.on .badge {
-      background: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
-      border-color: var(--fp-active, var(--state-light-active-color, var(--state-active-color, #fdd835)));
-      color: var(--fp-ink, var(--text-primary-color, #212121));
+      background: var(--fp-active, var(--fp-skin-active, var(--state-light-active-color, var(--state-active-color, #fdd835))));
+      border-color: var(--fp-active, var(--fp-skin-active, var(--state-light-active-color, var(--state-active-color, #fdd835))));
+      /* --fp-ink is contrastText's answer for a colour we could read; when the
+         active colour came from the skin there is no per-item colour to read,
+         so the skin states its own ink. A pastel badge under a dark Home
+         Assistant theme would otherwise take that theme's near-white text. */
+      color: var(--fp-ink, var(--fp-skin-active-ink, var(--text-primary-color, #212121)));
     }
     /* A resolved state colour paints the badge whatever the on/off state —
        thresholds exist for sensors, which are never "on". Declared *after* the
@@ -897,8 +942,8 @@ export class FloorplanCard extends LitElement {
       line-height: 1;
       padding: 1px 4px;
       border-radius: 4px;
-      background: var(--card-background-color, #fff);
-      color: var(--primary-text-color);
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
+      color: var(--fp-skin-text, var(--primary-text-color));
       white-space: nowrap;
     }
     .text {
@@ -918,11 +963,11 @@ export class FloorplanCard extends LitElement {
       letter-spacing: 0.02em;
       text-transform: uppercase;
       line-height: 1;
-      color: var(--primary-text-color);
+      color: var(--fp-skin-text, var(--primary-text-color));
       opacity: 0.7;
       text-shadow:
-        0 1px 2px var(--card-background-color, #fff),
-        0 -1px 2px var(--card-background-color, #fff);
+        0 1px 2px var(--fp-skin-bg, var(--card-background-color, #fff)),
+        0 -1px 2px var(--fp-skin-bg, var(--card-background-color, #fff));
     }
     .stack {
       position: relative;
@@ -1031,7 +1076,8 @@ export class FloorplanCard extends LitElement {
         stroke-width: 14;
       }
     }
-  `;
+  `,
+  ];
 }
 
 declare global {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -727,7 +727,11 @@ export class FloorplanCard extends LitElement {
     }
     .floor-switcher button.active {
       background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
-      color: var(--text-primary-color, #fff);
+      /* Its own ink, not the badge's: this sits on --fp-skin-accent, and the
+         skin whose accent wants dark ink is not necessarily the one whose
+         active badge does. Left at the theme's text-on-primary, Pastel and
+         Tron print near-white on a pale blue and a bright cyan. */
+      color: var(--fp-skin-accent-ink, var(--text-primary-color, #fff));
       border-color: var(--fp-skin-accent, var(--primary-color, #03a9f4));
     }
     svg {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { html, nothing } from "lit";
 import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
+import { SKIN_ACCENT } from "./skins";
 import {
   FURNITURE_DEFAULT_SIZE,
   DEFAULT_GLOW_RADIUS,
@@ -1904,7 +1905,7 @@ describe("renderArea", () => {
   it("emits the vertex points and the default fill/opacity", () => {
     const markup = flattenMarkup(renderArea({ id: "a", points: square }));
     expect(markup).toContain("points=0,0 10,0 10,10 0,10");
-    expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
+    expect(markup).toContain(`fill=${SKIN_ACCENT}`);
     expect(markup).toContain("fill-opacity=0.25");
   });
 
@@ -1918,7 +1919,7 @@ describe("renderArea", () => {
     const markup = flattenMarkup(
       renderArea({ id: "a", points: square, color: "red;position:fixed;inset:0" })
     );
-    expect(markup).toContain("fill=var(--primary-color, #03a9f4)");
+    expect(markup).toContain(`fill=${SKIN_ACCENT}`);
     expect(markup).not.toContain("position:fixed");
   });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1716,7 +1716,10 @@ export interface OpeningStyle {
   amount?: number;
   /** Entity-driven "actively open" state: tints the moving parts with `accent`. */
   active?: boolean;
-  /** Accent color used while `active` (default the HA primary color). */
+  /**
+   * Accent color used while `active`. Defaults to {@link SKIN_ACCENT} — the
+   * skin's accent, falling back to the HA primary color when unskinned.
+   */
   accent?: string;
   /**
    * External roller shutter layered over the opening (issue #74): how far

--- a/src/render.ts
+++ b/src/render.ts
@@ -40,6 +40,7 @@ import {
   trackerAxisFraction,
 } from "./types";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, cssIcon } from "./css-safe";
+import { SKIN_ACCENT, SKIN_PAPER } from "./skins";
 
 export const WALL_THICKNESS = 8;
 
@@ -1644,7 +1645,7 @@ function rollCurtain(length: number, tone: string, amt: number): SVGTemplateResu
     const x = -half + (length * i) / slats;
     ticks.push(
       svg`<line x1=${x} y1=${-bandT / 2} x2=${x} y2=${bandT / 2}
-            stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
+            stroke=${SKIN_PAPER} stroke-width="0.75" />`
     );
   }
   return svg`<g class="fp-roll-curtain" style="transform:scaleY(${1 - amt});">
@@ -1679,7 +1680,7 @@ function swingShutter(
       const x = x0 + (w * i) / n;
       out.push(
         svg`<line x1=${x} y1=${-t / 2} x2=${x} y2=${t / 2}
-              stroke="var(--card-background-color, #fff)" stroke-width="0.75" />`
+              stroke=${SKIN_PAPER} stroke-width="0.75" />`
       );
     }
     return out;
@@ -1733,12 +1734,12 @@ export interface OpeningStyle {
  * can transition them smoothly between open and closed.
  */
 export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResult {
-  const { color, open = true, active = false, accent = "var(--primary-color, #03a9f4)" } = style;
+  const { color, open = true, active = false, accent = SKIN_ACCENT } = style;
   const half = o.length / 2;
   const cutH = WALL_THICKNESS + 4;
   // The moving parts take the accent color when actively open (sensor-driven).
   // Sanitised: color/accent are config-supplied and land in `style="stroke/fill:…"`.
-  const tone = cssColorOr(active ? accent : color, "var(--primary-color, #03a9f4)");
+  const tone = cssColorOr(active ? accent : color, SKIN_ACCENT);
   // Fraction open (0..1) drives partial swing/slide. Defaults to the binary
   // `open` so callers that don't pass `amount` render exactly as before.
   const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
@@ -1902,7 +1903,7 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   if (style.shutter) {
     const shutterTone = cssColorOr(
       style.shutter.active ? accent : color,
-      "var(--primary-color, #03a9f4)"
+      SKIN_ACCENT
     );
     const amt2 = Math.max(0, Math.min(1, style.shutter.amount));
     body = svg`${body}${
@@ -2121,7 +2122,7 @@ export function renderArea(a: Area, liveColor?: string): SVGTemplateResult {
   return svg`<polygon class="fp-area" data-id=${cssIdent(a.id) ?? nothing}
                        data-entity=${cssEntityId(a.entity) ?? nothing}
                        points=${pts}
-                       fill=${liveFill ? liveColor : cssColorOr(a.color, "var(--primary-color, #03a9f4)")}
+                       fill=${liveFill ? liveColor : cssColorOr(a.color, SKIN_ACCENT)}
                        fill-opacity=${cssNumber(opacity, DEFAULT_AREA_OPACITY)}
                        stroke="none"
                        stroke-width="0" />`;
@@ -2512,7 +2513,7 @@ export function renderRipple(
   return html`
     <div
       class="ripple ${active ? "active" : ""}"
-      style="width:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;height:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;--fp-ripple-color:${cssColorOr(color, "var(--primary-color, #03a9f4)")};"
+      style="width:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;height:${cssNumber(sizePx, DEFAULT_RIPPLE_SIZE)}px;--fp-ripple-color:${cssColorOr(color, SKIN_ACCENT)};"
     >
       <span class="dot"></span>
       ${Array.from(
@@ -2572,7 +2573,7 @@ export interface TrackerRenderOptions {
  * `fp-tracker-band` are provided by the host component's styles.
  */
 export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTemplateResult {
-  const color = t.color ?? "var(--primary-color, #03a9f4)";
+  const color = t.color ?? SKIN_ACCENT;
   const dotR = (t.dotSize ?? DEFAULT_TRACKER_DOT_SIZE) / 2;
   const cx = t.x + t.w / 2;
   const cy = t.y + t.h / 2;

--- a/src/skins.test.ts
+++ b/src/skins.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_SKIN_WALL_WIDTH,
   SKINS,
   SKIN_TOKENS,
+  type SkinToken,
   findSkin,
   skinStyle,
   SKIN_ACCENT,
@@ -50,6 +51,53 @@ describe("the skin registry", () => {
       expect(width).toBeLessThanOrEqual(MAX_SKIN_WALL_WIDTH);
     }
   });
+});
+
+/**
+ * The bug this guards against is quiet: a skin sets its accent and forgets the
+ * ink that sits on it, everything still renders, and the label is simply
+ * unreadable — Pastel's near-white on a pale blue measured 1.7:1. Completeness
+ * cannot catch it, because the token *is* set; only the pairing is wrong.
+ *
+ * Thresholds are WCAG AA: 3.0 for the ink pairs, which are UI labels on a
+ * coloured chip, and 4.5 for body text on the paper. Walls are deliberately
+ * exempt — Pastel's whole point is a soft 3.5:1 line, and that is a drawing,
+ * not something anyone reads.
+ */
+describe("every built-in skin is legible", () => {
+  const luminance = (hex: string): number => {
+    const channels = [1, 3, 5]
+      .map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+      .map((v) => (v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+  /** WCAG 2.x contrast ratio, 1 (identical) to 21 (black on white). */
+  const contrast = (a: string, b: string): number => {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  it("computes a ratio we can trust", () => {
+    expect(contrast("#000000", "#ffffff")).toBeCloseTo(21, 1);
+    expect(contrast("#ffffff", "#ffffff")).toBeCloseTo(1, 5);
+  });
+
+  for (const skin of SKINS.slice(1)) {
+    it(`${skin.id} reads its ink against what it sits on`, () => {
+      const v = (token: SkinToken): string => {
+        const value = skin.vars[token];
+        // These four are the pairs the ratio is computed from, so a palette
+        // that states one as a gradient or a var() chain needs this test
+        // rethought rather than silently skipped.
+        expect(value).toMatch(/^#[0-9a-f]{6}$/);
+        return value as string;
+      };
+      expect(contrast(v("--fp-skin-accent-ink"), v("--fp-skin-accent"))).toBeGreaterThanOrEqual(3);
+      expect(contrast(v("--fp-skin-active-ink"), v("--fp-skin-active"))).toBeGreaterThanOrEqual(3);
+      expect(contrast(v("--fp-skin-text"), v("--fp-skin-bg"))).toBeGreaterThanOrEqual(4.5);
+      expect(contrast(v("--fp-skin-text"), v("--fp-skin-badge-bg"))).toBeGreaterThanOrEqual(4.5);
+    });
+  }
 });
 
 describe("skinStyle", () => {

--- a/src/skins.test.ts
+++ b/src/skins.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_SKIN,
+  MAX_SKIN_WALL_WIDTH,
+  SKINS,
+  SKIN_TOKENS,
+  findSkin,
+  skinStyle,
+  SKIN_ACCENT,
+  SKIN_PAPER,
+  SKIN_TEXT,
+  SKIN_WALL,
+} from "./skins";
+
+describe("the skin registry", () => {
+  it("ships the default first, and it declares nothing", () => {
+    expect(SKINS[0].id).toBe(DEFAULT_SKIN);
+    expect(SKINS[0].vars).toEqual({});
+  });
+
+  it("has unique, lowercase ids — they are stored in saved plans", () => {
+    const ids = SKINS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z][a-z0-9-]*$/);
+  });
+
+  it("gives every skin a label and a one-line description for the dropdown", () => {
+    for (const s of SKINS) {
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(s.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * A palette that forgets a token half-inherits the Home Assistant theme, and
+   * the result is a plan that looks broken rather than skinned — dark walls on
+   * Tron's black paper, say. Completeness is the property that prevents it.
+   */
+  it("gives every non-default skin the complete token set", () => {
+    for (const s of SKINS.slice(1)) {
+      expect(Object.keys(s.vars).sort()).toEqual([...SKIN_TOKENS].sort());
+    }
+  });
+
+  it("keeps every skinned wall inside the doorway cut", () => {
+    for (const s of SKINS.slice(1)) {
+      const width = Number(s.vars["--fp-skin-wall-width"]);
+      expect(Number.isFinite(width)).toBe(true);
+      expect(width).toBeGreaterThan(0);
+      expect(width).toBeLessThanOrEqual(MAX_SKIN_WALL_WIDTH);
+    }
+  });
+});
+
+describe("skinStyle", () => {
+  it("emits nothing for the default — an unskinned plan renders as it always did", () => {
+    expect(skinStyle(DEFAULT_SKIN)).toBe("");
+    expect(skinStyle(undefined)).toBe("");
+  });
+
+  it("emits nothing for an id we don't ship, rather than a half-applied look", () => {
+    expect(skinStyle("nintendo")).toBe("");
+    expect(skinStyle("")).toBe("");
+    expect(skinStyle(42)).toBe("");
+    expect(skinStyle(null)).toBe("");
+    expect(skinStyle({ id: "tron" })).toBe("");
+  });
+
+  it("emits every declaration of the skin it names", () => {
+    const style = skinStyle("tron");
+    expect(style).toContain("--fp-skin-bg:#05080c;");
+    expect(style).toContain("--fp-skin-wall:#7de3ff;");
+    for (const token of SKIN_TOKENS) expect(style).toContain(`${token}:`);
+  });
+
+  it("finds a skin by id, and only by an exact one", () => {
+    expect(findSkin("pastel")?.label).toBe("Pastel");
+    expect(findSkin("Pastel")).toBeUndefined();
+    expect(findSkin(undefined)).toBeUndefined();
+  });
+});
+
+/**
+ * These values are library constants rather than config, so `cssColor` never
+ * sees them — but they land in the same `style="…"` attribute a config colour
+ * does, and Lit does not escape `;` or `}` there. Holding them to the same
+ * no-breakout rule means a future palette cannot quietly become the one CSS
+ * injection the sanitiser was written to prevent.
+ */
+describe("built-in skin values cannot break out of a style attribute", () => {
+  const values = SKINS.flatMap((s) => Object.values(s.vars));
+
+  it("has values to check (guards against an empty-registry pass)", () => {
+    expect(values.length).toBeGreaterThan(0);
+  });
+
+  it("contains no declaration or rule terminator", () => {
+    for (const v of values) {
+      expect(v).not.toContain(";");
+      expect(v).not.toContain("{");
+      expect(v).not.toContain("}");
+    }
+  });
+
+  it("contains no quote, escape, at-rule, comment or !important", () => {
+    for (const v of values) {
+      expect(v).not.toMatch(/["'@\\!]/);
+      expect(v).not.toContain("/*");
+      expect(v).not.toContain("*/");
+    }
+  });
+
+  it("never fetches a remote resource", () => {
+    for (const v of values) expect(v.toLowerCase()).not.toContain("url(");
+  });
+});
+
+describe("the chains interpolated from TypeScript", () => {
+  /**
+   * Each is read at a call site that may sit outside the element carrying the
+   * token defaults, so the original hard-coded value has to survive as the
+   * innermost fallback — that is what keeps an unskinned plan unchanged.
+   */
+  it("keeps the pre-skin value as the last fallback", () => {
+    expect(SKIN_PAPER).toContain("var(--card-background-color, #fff)");
+    expect(SKIN_WALL).toContain("var(--primary-text-color)");
+    expect(SKIN_TEXT).toContain("var(--primary-text-color)");
+    expect(SKIN_ACCENT).toContain("var(--primary-color, #03a9f4)");
+  });
+
+  it("reads its token first", () => {
+    expect(SKIN_PAPER.startsWith("var(--fp-skin-bg,")).toBe(true);
+    expect(SKIN_WALL.startsWith("var(--fp-skin-wall,")).toBe(true);
+    expect(SKIN_TEXT.startsWith("var(--fp-skin-text,")).toBe(true);
+    expect(SKIN_ACCENT.startsWith("var(--fp-skin-accent,")).toBe(true);
+  });
+});

--- a/src/skins.ts
+++ b/src/skins.ts
@@ -36,6 +36,7 @@ export const SKIN_TOKENS = [
   "--fp-skin-wall-width",
   "--fp-skin-wall-filter",
   "--fp-skin-accent",
+  "--fp-skin-accent-ink",
   "--fp-skin-active",
   "--fp-skin-active-ink",
   "--fp-skin-text",
@@ -92,6 +93,10 @@ export const SKINS: readonly Skin[] = [
       "--fp-skin-wall-width": "10",
       "--fp-skin-wall-filter": "none",
       "--fp-skin-accent": "#e4444c",
+      // White, not the charcoal ink: on this red it reads at 4.0 where the
+      // charcoal manages 2.8. The skin whose accent is dark enough to want
+      // dark ink is the one that would get this wrong by reusing active-ink.
+      "--fp-skin-accent-ink": "#ffffff",
       "--fp-skin-active": "#ffcb05",
       "--fp-skin-active-ink": "#3b3b3b",
       "--fp-skin-text": "#3b3b3b",
@@ -117,6 +122,7 @@ export const SKINS: readonly Skin[] = [
       "--fp-skin-wall-width": "7",
       "--fp-skin-wall-filter": "none",
       "--fp-skin-accent": "#a8c8ec",
+      "--fp-skin-accent-ink": "#4a4453",
       "--fp-skin-active": "#ffd6a5",
       "--fp-skin-active-ink": "#4a4453",
       "--fp-skin-text": "#4a4453",
@@ -142,6 +148,7 @@ export const SKINS: readonly Skin[] = [
       "--fp-skin-wall-width": "5",
       "--fp-skin-wall-filter": "drop-shadow(0 0 4px #22d3ee)",
       "--fp-skin-accent": "#22d3ee",
+      "--fp-skin-accent-ink": "#05080c",
       "--fp-skin-active": "#ff9f1c",
       "--fp-skin-active-ink": "#05080c",
       "--fp-skin-text": "#cdf6ff",
@@ -211,6 +218,7 @@ export const skinTokens = css`
     --fp-skin-wall-width: 8;
     --fp-skin-wall-filter: none;
     --fp-skin-accent: var(--primary-color, #03a9f4);
+    --fp-skin-accent-ink: var(--text-primary-color, #fff);
     --fp-skin-active: var(--state-light-active-color, var(--state-active-color, #fdd835));
     --fp-skin-active-ink: var(--text-primary-color, #212121);
     --fp-skin-text: var(--primary-text-color);

--- a/src/skins.ts
+++ b/src/skins.ts
@@ -1,0 +1,225 @@
+/**
+ * Built-in skins (issue #122).
+ *
+ * A skin restyles a whole plan at once. Everything the card draws already reads
+ * its colour from a Home Assistant theme variable — `--primary-text-color` for
+ * the walls, `--card-background-color` for the paper and badges,
+ * `--primary-color` for the accents — which is exactly why the card looks like
+ * a Home Assistant card and nothing else. A skin is a thin layer of card-local
+ * custom properties that sits *in front of* those chains.
+ *
+ * Two consequences worth stating, because the whole design rests on them:
+ *
+ * - **The default skin declares nothing.** `skinStyle` returns `""` for it, so
+ *   an unskinned plan emits not one extra declaration and renders exactly as it
+ *   did before this file existed. Every token's default (see {@link skinTokens})
+ *   is the literal fallback chain that used to be hard-coded at the call site.
+ * - **A skin never overrides what a user set.** The per-element variables
+ *   (`--fp-active`, `--fp-state`, `--fp-ink`, `--fp-ripple-color`) and every
+ *   config colour are resolved ahead of these tokens, so a room painted green
+ *   stays green under Tron. A skin only supplies the fallbacks.
+ *
+ * Uploaded/community skins (the other half of #122) are additional entries in
+ * {@link SKINS} and need no new plumbing.
+ */
+
+import { css } from "lit";
+
+/**
+ * Every token a skin may set. Exported so the tests can assert each skin is
+ * complete — a palette that forgets `--fp-skin-text` is a plan you cannot read.
+ */
+export const SKIN_TOKENS = [
+  "--fp-skin-bg",
+  "--fp-skin-card-bg",
+  "--fp-skin-wall",
+  "--fp-skin-wall-width",
+  "--fp-skin-wall-filter",
+  "--fp-skin-accent",
+  "--fp-skin-active",
+  "--fp-skin-active-ink",
+  "--fp-skin-text",
+  "--fp-skin-badge-bg",
+  "--fp-skin-badge-border",
+  "--fp-skin-badge-border-width",
+  "--fp-skin-badge-radius",
+  "--fp-skin-badge-shadow",
+  "--fp-skin-furniture",
+  "--fp-skin-glow",
+] as const;
+
+export type SkinToken = (typeof SKIN_TOKENS)[number];
+
+export interface Skin {
+  /** Stored in the config as `skin:`. Lowercase, stable — renaming one breaks saved plans. */
+  id: string;
+  /** Shown in the editor's dropdown. */
+  label: string;
+  /** One line of "what is this for", shown as the field's helper text. */
+  description: string;
+  /** Token overrides. Empty for the default skin, which is the absence of a skin. */
+  vars: Partial<Record<SkinToken, string>>;
+}
+
+export const DEFAULT_SKIN = "default";
+
+/**
+ * The widest a skinned wall may be drawn.
+ *
+ * A doorway is a hole punched through the wall layer by an SVG mask, and that
+ * hole is `WALL_THICKNESS + 4` = 12 units tall (see `renderWallMask`). Only the
+ * *stroke* is skinnable — the geometry constants are shared with the mask and
+ * the opening symbols — so a wall wider than the hole would not be fully
+ * cleared by its own door, and every doorway would show a sliver of wall.
+ */
+export const MAX_SKIN_WALL_WIDTH = 10;
+
+export const SKINS: readonly Skin[] = [
+  {
+    id: DEFAULT_SKIN,
+    label: "Default",
+    description: "Follows your Home Assistant theme",
+    vars: {},
+  },
+  {
+    id: "odnetnin",
+    label: "Odnetnin",
+    description: "Playful and chunky — thick outlines on warm paper",
+    vars: {
+      "--fp-skin-bg": "#fffdf7",
+      "--fp-skin-card-bg": "#fffdf7",
+      "--fp-skin-wall": "#3b3b3b",
+      "--fp-skin-wall-width": "10",
+      "--fp-skin-wall-filter": "none",
+      "--fp-skin-accent": "#e4444c",
+      "--fp-skin-active": "#ffcb05",
+      "--fp-skin-active-ink": "#3b3b3b",
+      "--fp-skin-text": "#3b3b3b",
+      "--fp-skin-badge-bg": "#ffffff",
+      "--fp-skin-badge-border": "#3b3b3b",
+      "--fp-skin-badge-border-width": "2px",
+      // Rounded square rather than a circle, and a hard offset shadow instead
+      // of a blur — the two together are what read as "printed sticker".
+      "--fp-skin-badge-radius": "30%",
+      "--fp-skin-badge-shadow": "0 2px 0 #3b3b3b",
+      "--fp-skin-furniture": "#b9b3a7",
+      "--fp-skin-glow": "#ffe9a8",
+    },
+  },
+  {
+    id: "pastel",
+    label: "Pastel",
+    description: "Soft and low-contrast — muted mauve on blush",
+    vars: {
+      "--fp-skin-bg": "#fdf7f9",
+      "--fp-skin-card-bg": "#fdf7f9",
+      "--fp-skin-wall": "#8b8296",
+      "--fp-skin-wall-width": "7",
+      "--fp-skin-wall-filter": "none",
+      "--fp-skin-accent": "#a8c8ec",
+      "--fp-skin-active": "#ffd6a5",
+      "--fp-skin-active-ink": "#4a4453",
+      "--fp-skin-text": "#4a4453",
+      "--fp-skin-badge-bg": "#ffffff",
+      "--fp-skin-badge-border": "#e6dced",
+      "--fp-skin-badge-border-width": "1.5px",
+      "--fp-skin-badge-radius": "50%",
+      "--fp-skin-badge-shadow": "0 1px 4px rgba(120, 100, 130, 0.18)",
+      "--fp-skin-furniture": "#d8cfe0",
+      "--fp-skin-glow": "#ffe8d6",
+    },
+  },
+  {
+    id: "tron",
+    label: "Tron",
+    description: "Neon lines on near-black — thin walls that glow",
+    vars: {
+      "--fp-skin-bg": "#05080c",
+      "--fp-skin-card-bg": "#05080c",
+      "--fp-skin-wall": "#7de3ff",
+      // Thin, because a neon line is the light rather than the mass. The glow
+      // does the work the width would have done.
+      "--fp-skin-wall-width": "5",
+      "--fp-skin-wall-filter": "drop-shadow(0 0 4px #22d3ee)",
+      "--fp-skin-accent": "#22d3ee",
+      "--fp-skin-active": "#ff9f1c",
+      "--fp-skin-active-ink": "#05080c",
+      "--fp-skin-text": "#cdf6ff",
+      "--fp-skin-badge-bg": "#0b1220",
+      "--fp-skin-badge-border": "#22d3ee",
+      "--fp-skin-badge-border-width": "1.5px",
+      "--fp-skin-badge-radius": "50%",
+      "--fp-skin-badge-shadow": "0 0 8px rgba(34, 211, 238, 0.5)",
+      "--fp-skin-furniture": "#1e4b57",
+      "--fp-skin-glow": "#7de3ff",
+    },
+  },
+];
+
+/**
+ * The chains that get interpolated into SVG attributes and inline styles from
+ * TypeScript, rather than written in a stylesheet.
+ *
+ * Each is `var(<token>, <what the call site used to hard-code>)`, so every one
+ * still resolves on its own even where the token defaults below are out of
+ * scope — and an unskinned plan emits the same colour it always did, one
+ * `var()` deeper.
+ */
+export const SKIN_PAPER = "var(--fp-skin-bg, var(--card-background-color, #fff))";
+export const SKIN_WALL = "var(--fp-skin-wall, var(--primary-text-color))";
+export const SKIN_TEXT = "var(--fp-skin-text, var(--primary-text-color))";
+export const SKIN_ACCENT = "var(--fp-skin-accent, var(--primary-color, #03a9f4))";
+
+/** The skin with this id, or `undefined` — including for the default. */
+export function findSkin(id: unknown): Skin | undefined {
+  if (typeof id !== "string") return undefined;
+  return SKINS.find((s) => s.id === id);
+}
+
+/**
+ * The `style` attribute text that applies a skin, or `""` when there is nothing
+ * to apply.
+ *
+ * Returning `""` for both the default *and* an unrecognised id is deliberate:
+ * a hand-written `skin: nintendo` renders as today rather than as a half-styled
+ * plan built from whichever tokens happened to match.
+ *
+ * The values are library constants, not config, so there is nothing to
+ * sanitise here — but they still land in a `style="…"` attribute, and
+ * `skins.test.ts` holds them to the same no-breakout rule `cssColor` enforces
+ * for user input.
+ */
+export function skinStyle(id: unknown): string {
+  const skin = findSkin(id);
+  if (!skin) return "";
+  return Object.entries(skin.vars)
+    .map(([k, v]) => `${k}:${v};`)
+    .join("");
+}
+
+/**
+ * Default values for every token, to be included in the `static styles` of both
+ * the card and the editor. Each one is the exact fallback chain that used to be
+ * written at the call site, so an unskinned plan is unchanged and every
+ * `var(--fp-skin-…)` read still works standalone.
+ */
+export const skinTokens = css`
+  :host {
+    --fp-skin-bg: var(--card-background-color, #fff);
+    --fp-skin-card-bg: var(--ha-card-background, var(--card-background-color, #fff));
+    --fp-skin-wall: var(--primary-text-color);
+    --fp-skin-wall-width: 8;
+    --fp-skin-wall-filter: none;
+    --fp-skin-accent: var(--primary-color, #03a9f4);
+    --fp-skin-active: var(--state-light-active-color, var(--state-active-color, #fdd835));
+    --fp-skin-active-ink: var(--text-primary-color, #212121);
+    --fp-skin-text: var(--primary-text-color);
+    --fp-skin-badge-bg: var(--card-background-color, #fff);
+    --fp-skin-badge-border: var(--divider-color, #ccc);
+    --fp-skin-badge-border-width: 1.5px;
+    --fp-skin-badge-radius: 50%;
+    --fp-skin-badge-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    --fp-skin-furniture: #9e9e9e;
+    --fp-skin-glow: #ffd9a0;
+  }
+`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -634,8 +634,12 @@ export const DEFAULT_AREA_BORDER_WIDTH = 3;
 
 /** Radius of a light's cast pool, in canvas units (issue #6). */
 export const DEFAULT_GLOW_RADIUS = 140;
-/** Warm white, for a light that cannot report a color of its own. */
-export const DEFAULT_GLOW_COLOR = "#ffd9a0";
+/**
+ * Warm white, for a light that cannot report a color of its own — as the skin's
+ * token (issue #122) so Tron's pools read cyan rather than tungsten, with the
+ * original hex as the fallback so an unskinned plan is unchanged.
+ */
+export const DEFAULT_GLOW_COLOR = "var(--fp-skin-glow, #ffd9a0)";
 /**
  * Opacity band a light's `brightness` maps into at the center of its pool.
  *
@@ -687,7 +691,8 @@ export const DEFAULT_TRACKER_DOT_SIZE = 14;
 export const DEFAULT_ITEM_SIZE = 34;
 export const DEFAULT_TEXT_SIZE = 16;
 export const DEFAULT_RIPPLE_SIZE = 80;
-export const FURNITURE_COLOR = "#9e9e9e";
+/** Neutral gray, so furniture reads differently from the walls. Skinnable (#122). */
+export const FURNITURE_COLOR = "var(--fp-skin-furniture, #9e9e9e)";
 
 /** Default width/height per furniture type, in virtual units. */
 export const FURNITURE_DEFAULT_SIZE: Record<FurnitureType, { w: number; h: number }> = {
@@ -803,7 +808,18 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * 0/90/180/270 are normalized (see normalizePlanRotation).
    */
   rotation?: number;
-  /** Canvas background color (CSS / hex). Falls back to the card background. */
+  /**
+   * Built-in skin id (issue #122), e.g. `odnetnin`, `pastel`, `tron`. Restyles
+   * the whole plan at once — paper, walls, badges, accents — by supplying the
+   * fallbacks every element already reads.
+   *
+   * Unset (or an id we don't ship) means the default look, which follows the
+   * Home Assistant theme exactly as it always has. A skin only ever supplies
+   * fallbacks, so any colour set on an element itself still wins. See
+   * `src/skins.ts`.
+   */
+  skin?: string;
+  /** Canvas background color (CSS / hex). Falls back to the skin's paper, then the card background. */
   background?: string;
   /**
    * Follow the real sun (issue #113): dim the plan through dusk and brighten


### PR DESCRIPTION
Closes #122 — the built-in half of it. Uploaded community skins are additional entries in the same registry and need no new plumbing, which is why the token set below is documented as a supported surface rather than kept private.

## What this adds

One line of config restyles the whole plan:

```yaml
type: custom:easy-floorplan-card
skin: tron
```

| Skin | What it looks like |
| --- | --- |
| `default` | Follows your Home Assistant theme, exactly as the card always has. What you get with no `skin` set. |
| `odnetnin` | Playful and chunky: thick charcoal outlines on warm cream paper, rounded-square badges with a hard printed-sticker shadow, red accent, bright yellow for anything on. |
| `pastel` | Soft and low-contrast: muted mauve walls on blush paper, peach for active devices. |
| `tron` | Neon on near-black: thin cyan walls that glow, amber for active devices. Light pools read best here — a lit room genuinely lights up. |

Pick one in the editor under **Project → Skin**, above the Background colour it interacts with. Choosing Default writes no `skin` key at all.

## How it works

Everything the card draws already read its colour from a Home Assistant theme variable — `--primary-text-color` for the walls, `--card-background-color` for the paper and badges, `--primary-color` for the accents. A skin is a thin layer of card-local custom properties sitting in front of those chains.

That has two consequences the whole design rests on:

- **The default skin declares nothing.** Every token's default is the literal chain that used to be hard-coded at the call site, so an unskinned plan renders unchanged — verified against a dark theme too (walls `#e1e1e1`, badge `#1c1c1c`, wall width 8, filter none).
- **A skin never overrides what you set.** It only supplies fallbacks, so a room with its own `color`, a device with its own `activeColor` and a `background` on the plan all still win. You can switch skins freely without losing colours you chose by hand.

The editor canvas is skinned too, so it stays WYSIWYG. The editor's own chrome — toolbar, panels, forms — deliberately is not; that is what keeps the canvas reading as the plan rather than as more editor.

Named `skin` rather than `theme` because Home Assistant already means something specific by `theme:` on a card, and the two would be confused in every sentence of the docs.

## Notes for review

**A repaint bug worth knowing about.** Switching skins left every door, window and room fill painted in the *previous* skin's colours. The computed values were already correct — Chromium does not repaint an SVG element whose colour comes from a `var()` inside a presentation attribute or an inline style unless something else about it changes, and Lit writes the same attribute string either way. Both SVGs are now wrapped in Lit's `keyed()` on the skin id, so a skin change rebuilds the subtree and repaints by construction. Ordinary state updates are untouched.

**`--fp-skin-active-ink`** exists because `contrastText` only ever sees a colour some *element* set. A pastel active badge under a dark theme would otherwise take that theme's near-white text and swallow its own icon. `--ha-card-header-color` is set for the same reason: `ha-card` colours its title from that variable rather than inheriting, so a dark skin under a light theme printed a dark title on near-black.

**Wall width is capped at 10.** A doorway is a 12-unit gap cut through the wall layer by a mask that shares `WALL_THICKNESS` with the opening symbols, so a wider wall would not be fully cleared by its own door. Only the stroke is skinnable; the geometry constants stay put. `skins.test.ts` enforces the cap.

## Verification

`npm run typecheck`, `npm test` (675 pass, 18 new) and `npm run build` are clean.

In the dev harness I confirmed, for each skin, that the card and the editor canvas change together; that the dropdown round-trips (`skin: odnetnin` out, key dropped on Default); that `var()` resolves in `stop-color` so the light pools take the skin's glow; that `background` and per-element colours survive every skin; and that the default still tracks a dark Home Assistant theme in both directions.

New tests cover the registry's completeness (a palette that forgets a token half-inherits the HA theme and looks broken rather than skinned), the unknown-id fallback, the wall-width cap, and — mirroring `css-safe.adversarial.test.ts` — that no built-in value could break out of the `style` attribute it lands in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
