### PR TITLE
Devices: answer the press, and stop pretending the inert ones are buttons (closes #134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,29 @@ then pick the entity in the **Element** section below the canvas.
 Bind an entity and the element stops being a drawing: openings move with their real
 state, rooms and furniture recolor, markers glide, icons spin.
 
+#### Press feedback
+
+A tap used to change nothing on screen until the entity itself came back — which on a
+cover, or a bulb on a slow bridge, is long enough to wonder whether it registered at all.
+Devices now answer the press immediately. Set **Press effect** under **Project**:
+
+| Effect | What it does |
+| ------ | ------------ |
+| **Press in** (default) | The device dips to 92% and springs back — fast in, slow out, so even a quick tap is visible. |
+| **Ink ripple** | A circle spreads and fades from the point you touched. |
+| **Flash** | A halo of the skin's accent color, with no movement at all. |
+| **None** | Nothing, as before. |
+
+It is one setting for the whole plan rather than per device: it is how the dashboard
+feels, and a plan where half the devices answered differently would read as broken.
+
+**Only devices that do something respond.** A device with no entity bound, or with
+`tap_action: none` and nothing on hold or double-tap, gets neither the effect nor the hand
+cursor — feedback promising an action that never arrives is worse than none.
+
+With the OS *reduce motion* preference set, all three fall back to the flash halo with no
+transition: the affordance stays, the movement goes.
+
 #### Doors & windows
 
 Drop a **door** or **window** from the toolbar and it snaps onto the nearest wall. Left
@@ -284,6 +307,7 @@ The editor writes this config for you; manual editing is optional.
 | `sunBrightnessMin` | number | `0.45` | Brightness once the sun is fully down, 0–1. |
 | `sunBrightnessMax` | number | `1` | Brightness in full daylight, 0–1. |
 | `skin`       | string   | `default`          | Built-in look for the whole plan: `default`, `odnetnin`, `pastel` or `tron`. See [Skins](#skins). |
+| `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |

--- a/README.md
+++ b/README.md
@@ -158,8 +158,11 @@ It is one setting for the whole plan rather than per device: it is how the dashb
 feels, and a plan where half the devices answered differently would read as broken.
 
 **Only devices that do something respond.** A device with no entity bound, or with
-`tap_action: none` and nothing on hold or double-tap, gets neither the effect nor the hand
-cursor — feedback promising an action that never arrives is worse than none.
+`tap_action: none` and nothing on hold or double-tap, isn't treated as a button at all: no
+press effect, no hand cursor, no tab stop, and no `button` role for a screen reader to
+announce. Feedback promising an action that never arrives is worse than none — and an
+inert device that answers the keyboard with silence is the same promise, made where it is
+hardest to check.
 
 With the OS *reduce motion* preference set, all three fall back to the flash halo with no
 transition: the affordance stays, the movement goes.

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -3,6 +3,7 @@ import {
   defaultItemAction,
   hasAction,
   actionForGesture,
+  itemIsInteractive,
   serviceFromAction,
   executeAction,
 } from "./actions";
@@ -138,5 +139,61 @@ describe("executeAction", () => {
     executeAction(n, hass, { entity: "light.a" }, { action: "none" });
     expect(hass.calls.length).toBe(0);
     expect(n.events.length).toBe(0);
+  });
+});
+
+// Issue #134: press feedback and the pointer cursor are gated on this, so a
+// device that answers to nothing neither animates nor looks pressable.
+describe("itemIsInteractive", () => {
+  it("a bound device in a toggling domain is interactive", () => {
+    expect(itemIsInteractive({ entity: "light.a" })).toBe(true);
+    expect(itemIsInteractive({ entity: "switch.a" })).toBe(true);
+  });
+
+  it("a bound device in any other domain still opens more-info", () => {
+    expect(itemIsInteractive({ entity: "sensor.a" })).toBe(true);
+    expect(itemIsInteractive({ entity: "cover.a" })).toBe(true);
+  });
+
+  it("no entity bound: nothing to toggle and nothing to show (issue #39)", () => {
+    // The default action resolves to more-info, which executeAction drops for
+    // want of an entity id — hasAction alone would call this interactive.
+    expect(hasAction(defaultItemAction(undefined))).toBe(true);
+    expect(itemIsInteractive({})).toBe(false);
+    expect(itemIsInteractive({ entity: "" })).toBe(false);
+  });
+
+  it("tap_action: none is only inert when the other gestures are too", () => {
+    const off = { entity: "light.a", tap_action: { action: "none" } } as const;
+    expect(itemIsInteractive(off)).toBe(false);
+    // A hold that does something still makes the device worth pressing.
+    expect(itemIsInteractive({ ...off, hold_action: { action: "toggle" } })).toBe(true);
+    expect(itemIsInteractive({ ...off, double_tap_action: { action: "more-info" } })).toBe(true);
+  });
+
+  it("checks each action's own requirement, not just that it is configured", () => {
+    const base = { entity: "" };
+    // Configured but unusable — every one of these passes hasAction.
+    expect(itemIsInteractive({ ...base, tap_action: { action: "navigate" } })).toBe(false);
+    expect(itemIsInteractive({ ...base, tap_action: { action: "url" } })).toBe(false);
+    expect(itemIsInteractive({ ...base, tap_action: { action: "call-service" } })).toBe(false);
+    expect(itemIsInteractive({ ...base, tap_action: { action: "perform-action" } })).toBe(false);
+    expect(itemIsInteractive({ ...base, tap_action: { action: "toggle" } })).toBe(false);
+    // …and the usable forms of the same.
+    expect(
+      itemIsInteractive({ ...base, tap_action: { action: "navigate", navigation_path: "/x" } })
+    ).toBe(true);
+    expect(itemIsInteractive({ ...base, tap_action: { action: "url", url_path: "https://x" } })).toBe(
+      true
+    );
+    expect(
+      itemIsInteractive({ ...base, tap_action: { action: "call-service", service: "light.turn_on" } })
+    ).toBe(true);
+    // more-info can name its own entity, so it does not need the device's.
+    expect(
+      itemIsInteractive({ ...base, tap_action: { action: "more-info", entity: "sensor.b" } })
+    ).toBe(true);
+    // fire-dom-event always dispatches; whether anyone listens is not ours.
+    expect(itemIsInteractive({ ...base, tap_action: { action: "fire-dom-event" } })).toBe(true);
   });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -32,6 +32,59 @@ export function actionForGesture(
   return gesture === "hold" ? item.hold_action : item.double_tap_action;
 }
 
+/**
+ * Whether a gesture would actually do anything — the same guards
+ * {@link executeAction} applies before it acts, asked ahead of time.
+ *
+ * `hasAction` only says a config exists and isn't "none". That is not the same
+ * question: a `toggle` with no entity, a `navigate` with no path and a
+ * `call-service` with no service all pass it and then do nothing.
+ */
+function gestureDoesSomething(
+  item: { entity?: string },
+  config: ActionConfig | undefined
+): boolean {
+  if (!config || config.action === "none") return false;
+  switch (config.action) {
+    case "toggle":
+      return !!item.entity;
+    case "more-info":
+      return !!(config.entity ?? item.entity);
+    case "navigate":
+      return !!config.navigation_path;
+    case "url":
+      return !!config.url_path;
+    case "perform-action":
+    case "call-service":
+      return serviceFromAction(config) !== null;
+    case "fire-dom-event":
+      // Always dispatches; whether anything listens is not ours to know.
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Whether pressing this device does anything at all (issue #134) — any of its
+ * three gestures.
+ *
+ * Drives both the press effect and the pointer cursor. A device with no entity
+ * bound (issue #39: hardware that exists physically but not in HA) and one set
+ * to `tap_action: none` both look pressable today and answer to nothing;
+ * animating them would turn a small lie into a louder one.
+ */
+export function itemIsInteractive(item: {
+  entity?: string;
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
+}): boolean {
+  return (["tap", "hold", "double_tap"] as const).some((g) =>
+    gestureDoesSomething(item, actionForGesture(item, g))
+  );
+}
+
 export interface ServiceCall {
   domain: string;
   service: string;

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -11,6 +11,7 @@ import {
   wallForm,
   projectForm,
   projectRotationForm,
+  projectPressForm,
   projectSkinForm,
   projectSunForm,
   floorImageForm,
@@ -19,7 +20,7 @@ import {
 } from "./editor-forms";
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
-import { DEFAULT_GLOW_RADIUS } from "./types";
+import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
 import { DEFAULT_SKIN, SKINS } from "./skins";
 
 const fields: FormField[] = [
@@ -630,6 +631,33 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(form.data.skin).toBe(DEFAULT_SKIN);
     expect(form.toPatch({ skin: DEFAULT_SKIN })).toEqual({ skin: undefined });
     expect(form.toPatch({ skin: "tron" })).toEqual({ skin: "tron" });
+  });
+
+  it("press effect offers all four and keeps the default out of the YAML (#134)", () => {
+    const base = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    const form = projectPressForm(base);
+    expect(form.fields.map((x) => x.name)).toEqual(["pressEffect"]);
+    const options = (form.fields[0].selector.select as { options: { value: string; label: string }[] })
+      .options;
+    expect(options.map((o) => o.value)).toEqual(["scale", "ripple", "flash", "none"]);
+    // A device already has its own "Ripple" toggle (the presence ring), so
+    // this one is named apart from it.
+    expect(options.find((o) => o.value === "ripple")!.label).toBe("Ink ripple");
+    expect(form.data.pressEffect).toBe(DEFAULT_PRESS_EFFECT);
+    expect(form.toPatch({ pressEffect: DEFAULT_PRESS_EFFECT })).toEqual({ pressEffect: undefined });
+    expect(form.toPatch({ pressEffect: "ripple" })).toEqual({ pressEffect: "ripple" });
+    // "None" is a choice, not an absence — it has to be written down.
+    expect(form.toPatch({ pressEffect: "none" })).toEqual({ pressEffect: "none" });
+  });
+
+  it("press effect reads a junk value back as the default it renders as (#134)", () => {
+    const form = projectPressForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      pressEffect: "sparkle",
+    } as never);
+    expect(form.data.pressEffect).toBe(DEFAULT_PRESS_EFFECT);
   });
 
   it("skin reads back a skin we don't ship as the default, matching what it renders as", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_TRACKER_DOT_SIZE,
   DEFAULT_SUN_MIN,
   DEFAULT_SUN_MAX,
+  DEFAULT_PRESS_EFFECT,
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
@@ -36,6 +37,7 @@ import {
   isPresenceEntity,
   normalizePlanRotation,
   openingMotion,
+  pressEffectOf,
   sliderStyleOf,
   shutterStyleOf,
   windowSash,
@@ -865,6 +867,39 @@ export function projectForm(c: FloorplanCardConfig): FormSpec {
     ],
     data: { title: c.title ?? "", width: c.width, height: c.height, grid: c.grid ?? DEFAULT_GRID },
     toPatch: identity,
+  };
+}
+
+/**
+ * How a device answers a press (issue #134). Its own one-field form for the
+ * same reason the skin has one — the editor places it in the Project section,
+ * and it belongs to the plan rather than to any element.
+ *
+ * "Ink ripple" rather than plain "Ripple": a device already has a **Ripple**
+ * toggle of its own, the presence ring, and two controls in one editor sharing
+ * a name would be a genuinely confusing pair.
+ */
+export function projectPressForm(c: FloorplanCardConfig): FormSpec {
+  return {
+    fields: [
+      {
+        name: "pressEffect",
+        label: "Press effect",
+        helper: "Feedback when a device is pressed. Only devices that do something respond",
+        selector: dropdown(
+          opt("scale", "Press in"),
+          opt("ripple", "Ink ripple"),
+          opt("flash", "Flash"),
+          opt("none", "None")
+        ),
+      },
+    ],
+    data: { pressEffect: pressEffectOf(c) },
+    // The default stays out of the YAML, as the skin's does.
+    toPatch: (p) =>
+      "pressEffect" in p && p.pressEffect === DEFAULT_PRESS_EFFECT
+        ? { ...p, pressEffect: undefined }
+        : p,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -122,6 +122,7 @@ import {
   openingForm,
   projectForm,
   projectRotationForm,
+  projectPressForm,
   projectSkinForm,
   projectSunForm,
   textForm,
@@ -3637,6 +3638,9 @@ export class FloorplanCardEditor extends LitElement {
           this._patchConfig(patch as Partial<FloorplanCardConfig>)
         )}
         ${this._renderForm(projectSunForm(this._config), (patch) =>
+          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        )}
+        ${this._renderForm(projectPressForm(this._config), (patch) =>
           this._patchConfig(patch as Partial<FloorplanCardConfig>)
         )}
       </div>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -343,9 +343,16 @@ export class FloorplanCard extends LitElement {
     // of transformed — badges and labels stay upright at any rotation.
     const p = rotatePlanPoint(item.x, item.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
-    // Only a device that answers gets press feedback or a pointer cursor
-    // (issue #134). An unbound device and `tap_action: none` both look
-    // pressable today and do nothing.
+    // Only a device that answers is a button (issue #134) — the press effect,
+    // the pointer cursor, the `button` role, the tab stop and the gesture
+    // listeners all hang off this one fact.
+    //
+    // The semantics matter more than the cursor did. An inert device was
+    // announced as "button" to a screen reader, sat in the tab order, and
+    // replied to Enter with nothing: the same lie, told louder, to the people
+    // least able to check it against what the plan looks like. Its label text
+    // stays in the DOM either way, so nothing becomes unreadable — only the
+    // false affordance goes.
     const interactive = itemIsInteractive(item);
     return html`
       <div
@@ -361,13 +368,16 @@ export class FloorplanCard extends LitElement {
           ? `--fp-active:${activeColor};`
           : ""}${badgeInk ? `--fp-ink:${badgeInk};` : ""}"
         title=${this._label(item)}
-        role="button"
-        tabindex="0"
+        role=${interactive ? "button" : nothing}
+        tabindex=${interactive ? "0" : nothing}
         @action=${(ev: CustomEvent<{ action: "tap" | "hold" | "double_tap" }>) =>
           this._handleItemAction(ev, item)}
         .actionHandler=${actionHandler({
           hasHold: hasAction(item.hold_action),
           hasDoubleClick: hasAction(item.double_tap_action),
+          // Unbinds the gesture listeners outright, so keyboard activation
+          // cannot reach an action that would do nothing.
+          disabled: !interactive,
         })}
         @pointerdown=${interactive && pressEffectOf(c) === "ripple"
           ? (ev: PointerEvent) => this._startInk(ev)

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -12,6 +12,9 @@ import {
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_SUN_MIN,
   DEFAULT_SUN_MAX,
+  PRESS_SCALE,
+  PRESS_IN_MS,
+  PRESS_OUT_MS,
   getFloors,
   trackerPresenceDetected,
 } from "./types";
@@ -48,6 +51,7 @@ import {
   badgeContentOf,
   badgeValue,
   badgeValueSize,
+  pressEffectOf,
   itemHiddenWhenInactive,
   itemLabelSize,
   hassRenderInputsChanged,
@@ -63,7 +67,7 @@ import {
 } from "./render";
 import type { Opening } from "./types";
 import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
-import { actionForGesture, executeAction, hasAction } from "./actions";
+import { actionForGesture, executeAction, hasAction, itemIsInteractive } from "./actions";
 import { actionHandler } from "./action-handler";
 
 /**
@@ -263,6 +267,30 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
+  /**
+   * Start the ink ripple at the point that was actually touched (issue #134).
+   *
+   * The position cannot come from CSS — only the event knows where the finger
+   * landed — so it is handed over as two custom properties and the animation
+   * itself stays in the stylesheet.
+   *
+   * Restarting needs the reflow: re-adding a class whose animation is still
+   * running is a no-op, so a quick second tap would draw nothing at all.
+   * Listeners are passive and only write style, so the gesture detection in
+   * `actionHandler` is untouched.
+   */
+  private _startInk(ev: PointerEvent): void {
+    const item = ev.currentTarget as HTMLElement | null;
+    const ink = item?.querySelector<HTMLElement>(".press-ink");
+    if (!ink) return;
+    const box = item!.getBoundingClientRect();
+    ink.style.setProperty("--fp-ink-x", `${ev.clientX - box.left}px`);
+    ink.style.setProperty("--fp-ink-y", `${ev.clientY - box.top}px`);
+    ink.classList.remove("inking");
+    void ink.offsetWidth;
+    ink.classList.add("inking");
+  }
+
   private _renderItem(item: FloorItem, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
     const on = this._isOn(item);
     // Name/state composition lives in itemBadgeLabel, including #39's
@@ -315,9 +343,15 @@ export class FloorplanCard extends LitElement {
     // of transformed — badges and labels stay upright at any rotation.
     const p = rotatePlanPoint(item.x, item.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
+    // Only a device that answers gets press feedback or a pointer cursor
+    // (issue #134). An unbound device and `tap_action: none` both look
+    // pressable today and do nothing.
+    const interactive = itemIsInteractive(item);
     return html`
       <div
-        class="item fp-item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""}"
+        class="item fp-item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""} ${interactive
+          ? "interactive"
+          : ""}"
         data-id=${cssIdent(item.id) ?? nothing}
         data-entity=${cssEntityId(item.entity) ?? nothing}
         data-kind=${cssIdent(item.kind) ?? nothing}
@@ -335,8 +369,14 @@ export class FloorplanCard extends LitElement {
           hasHold: hasAction(item.hold_action),
           hasDoubleClick: hasAction(item.double_tap_action),
         })}
+        @pointerdown=${interactive && pressEffectOf(c) === "ripple"
+          ? (ev: PointerEvent) => this._startInk(ev)
+          : nothing}
       >
         ${visual}
+        ${interactive && pressEffectOf(c) === "ripple"
+          ? html`<span class="press-ink" aria-hidden="true"></span>`
+          : nothing}
         ${labelText
           ? html`<span
               class="label ${visual === nothing ? "inflow" : ""}"
@@ -426,7 +466,7 @@ export class FloorplanCard extends LitElement {
            card draws with is declared on :host, so this only ever overrides. -->
       <ha-card .header=${c.title ?? nothing} style=${skinStyle(c.skin) || nothing}>
         <div
-          class="stage"
+          class="stage press-${pressEffectOf(c)}"
           style="aspect-ratio: ${dims.w} / ${dims.h};"
         >
           <!-- The plan box: exactly the canvas ratio, fitted inside whatever
@@ -835,10 +875,102 @@ export class FloorplanCard extends LitElement {
       position: absolute;
       transform: translate(-50%, -50%);
       pointer-events: auto;
-      cursor: pointer;
+      /* Not a hand: a device with nothing bound, or tap_action set to none,
+         is not a button (issue #134). Only .interactive gets the pointer. */
+      cursor: default;
       display: flex;
       flex-direction: column;
       align-items: center;
+    }
+    .item.interactive {
+      cursor: pointer;
+      /* Stops the long-press magnifier / text selection on touch from firing
+         over a device you are only trying to press. */
+      -webkit-tap-highlight-color: transparent;
+      -webkit-touch-callout: none;
+      user-select: none;
+    }
+
+    /* ---- Press feedback (issue #134) -------------------------------------
+       Chosen plan-wide; the stage carries press-scale / press-ripple /
+       press-flash / press-none and each rule below is scoped to its own.
+       Only .interactive devices respond, so nothing animates that would not
+       then do something. */
+
+    /* Scale: the transform has to repeat the translate, since .item is
+       centred on its own anchor and a bare scale() would drop that and jump
+       the device down-right by half its size. */
+    .press-scale .item.interactive {
+      transition: transform ${PRESS_OUT_MS}ms cubic-bezier(0.2, 0.8, 0.3, 1);
+    }
+    .press-scale .item.interactive:active {
+      transform: translate(-50%, -50%) scale(${PRESS_SCALE});
+      transition-duration: ${PRESS_IN_MS}ms;
+    }
+
+    /* Flash: drop-shadow rather than a box-shadow or a background, so the halo
+       follows whatever the device actually draws — the badge's circle, a bare
+       ripple ring, the label — instead of a rectangle around it. */
+    .press-flash .item.interactive {
+      transition: filter ${PRESS_OUT_MS}ms ease-out;
+    }
+    .press-flash .item.interactive:active {
+      filter: drop-shadow(0 0 5px var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      transition-duration: ${PRESS_IN_MS}ms;
+    }
+
+    /* Ink: a circle spreading from the touch point. Positioned by
+       _startInk, which is the only thing that knows where the finger landed. */
+    .press-ink {
+      position: absolute;
+      left: var(--fp-ink-x, 50%);
+      top: var(--fp-ink-y, 50%);
+      width: 0;
+      height: 0;
+      border-radius: 50%;
+      /* Decoration: it must never swallow the tap it is reporting. */
+      pointer-events: none;
+      opacity: 0;
+      background: currentColor;
+    }
+    .press-ink.inking {
+      animation: fp-press-ink 520ms ease-out;
+    }
+    @keyframes fp-press-ink {
+      from {
+        width: 0;
+        height: 0;
+        margin: 0;
+        opacity: 0.32;
+      }
+      to {
+        width: 120px;
+        height: 120px;
+        margin: -60px 0 0 -60px;
+        opacity: 0;
+      }
+    }
+
+    /* Reduced motion keeps the feedback and drops the movement: the halo, with
+       no transition. Removing the effect outright would answer an
+       accessibility preference by taking the affordance away. */
+    @media (prefers-reduced-motion: reduce) {
+      .press-scale .item.interactive,
+      .press-flash .item.interactive,
+      .press-ripple .item.interactive {
+        transition: none;
+      }
+      .press-scale .item.interactive:active {
+        transform: translate(-50%, -50%);
+      }
+      .press-scale .item.interactive:active,
+      .press-ripple .item.interactive:active,
+      .press-flash .item.interactive:active {
+        filter: drop-shadow(0 0 5px var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      }
+      .press-ink.inking {
+        animation: none;
+      }
     }
     /*
      * The item's x/y anchors its icon, not its icon-plus-label. Were the label

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -9,6 +9,7 @@ import {
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
   GLOW_MIN_RADIUS,
+  DEFAULT_PRESS_EFFECT,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   SUN_ELEVATION_NIGHT,
@@ -57,6 +58,7 @@ import {
   resolveItemIcon,
   matchStateRule,
   badgeContentOf,
+  pressEffectOf,
   badgeValue,
   badgeReading,
   badgeValueSize,
@@ -1542,6 +1544,29 @@ describe("resolveStateColor (issue #68)", () => {
       expect(matchStateRule(undefined, 1)).toBeUndefined();
       expect(matchStateRule([], 1)).toBeUndefined();
     });
+  });
+});
+
+describe("pressEffectOf (#134)", () => {
+  it("defaults to the scale dip when nothing is configured", () => {
+    expect(pressEffectOf({})).toBe(DEFAULT_PRESS_EFFECT);
+    expect(pressEffectOf({})).toBe("scale");
+  });
+
+  it("passes every effect the card has a rule for", () => {
+    for (const e of ["scale", "ripple", "flash", "none"] as const) {
+      expect(pressEffectOf({ pressEffect: e })).toBe(e);
+    }
+  });
+
+  it("falls back to the default rather than to nothing on a junk value", () => {
+    // The value becomes a class name. Left unchecked, a typo would emit
+    // `press-typo`, match no rule, and look exactly like "feature missing".
+    expect(pressEffectOf({ pressEffect: "dip" as never })).toBe("scale");
+    expect(pressEffectOf({ pressEffect: "" as never })).toBe("scale");
+    expect(pressEffectOf({ pressEffect: 42 as never })).toBe("scale");
+    // …but an explicit "none" is a real choice and must survive.
+    expect(pressEffectOf({ pressEffect: "none" })).toBe("none");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -9,6 +9,7 @@ import type {
   StateColorRule,
   BadgeContent,
   BadgeEntity,
+  PressEffect,
   Furniture,
   Tracker,
   Area,
@@ -34,6 +35,7 @@ import {
   GLOW_MIN_OPACITY,
   GLOW_MAX_OPACITY,
   GLOW_MIN_RADIUS,
+  DEFAULT_PRESS_EFFECT,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   getFloors,
@@ -1154,6 +1156,21 @@ export function badgeContentOf(item: {
   if (item.badgeContent === "icon" || item.badgeContent === "value" || item.badgeContent === "none")
     return item.badgeContent;
   return item.showIcon === false ? "none" : "icon";
+}
+
+/**
+ * Which press effect a plan uses (issue #134), resolving anything unrecognised
+ * to the default rather than to nothing.
+ *
+ * The value becomes a class name, so an unchecked string would land as
+ * `press-whatever`, match no rule, and silently mean "no feedback" — a
+ * hand-edited typo would look like the feature was never implemented.
+ */
+export function pressEffectOf(c: { pressEffect?: PressEffect }): PressEffect {
+  const v = c.pressEffect;
+  return v === "scale" || v === "ripple" || v === "flash" || v === "none"
+    ? v
+    : DEFAULT_PRESS_EFFECT;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -629,6 +629,35 @@ export const SUN_ELEVATION_DAY = 6;
 export const DEFAULT_SUN_MIN = 0.45;
 export const DEFAULT_SUN_MAX = 1;
 
+/**
+ * How a device answers a press (issue #134):
+ *
+ * - `scale` — dips to {@link PRESS_SCALE} and springs back, the feedback HA's
+ *   own Tile card and every touch OS uses.
+ * - `ripple` — an ink circle spreads from the point you touched.
+ * - `flash` — a halo of the skin's accent, with no movement at all.
+ * - `none` — the pre-#134 behaviour, nothing.
+ */
+export type PressEffect = "scale" | "ripple" | "flash" | "none";
+
+/** On by default: the issue asked for feedback, so "no feedback" is the opt-out. */
+export const DEFAULT_PRESS_EFFECT: PressEffect = "scale";
+
+/**
+ * How far a pressed device shrinks. Deep enough to read at a 34px badge,
+ * shallow enough not to look like the icon is falling over.
+ */
+export const PRESS_SCALE = 0.92;
+
+/**
+ * Press feedback timing. The release is deliberately far slower than the
+ * press: a tap can be over in 30ms, and with a symmetric transition it would
+ * finish before a screen ever painted it. Dipping instantly and easing back
+ * out makes even the quickest tap visible.
+ */
+export const PRESS_IN_MS = 80;
+export const PRESS_OUT_MS = 260;
+
 export const DEFAULT_AREA_OPACITY = 0.25;
 export const DEFAULT_AREA_BORDER_WIDTH = 3;
 
@@ -841,6 +870,20 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   sunBrightnessMin?: number;
   /** Plan brightness in full daylight, 0-1. Default {@link DEFAULT_SUN_MAX}. */
   sunBrightnessMax?: number;
+  /**
+   * What a device does when you press it (issue #134). Tapping used to change
+   * nothing on screen until the entity itself came back — which on a cover or
+   * a slow bulb is long enough to wonder whether the tap registered at all.
+   *
+   * Plan-wide rather than per-device: it is a property of how the dashboard
+   * feels, not of any one lamp, and a plan where half the devices answer
+   * differently would read as broken. Default {@link DEFAULT_PRESS_EFFECT}.
+   *
+   * Applies only to devices that actually *do* something — see
+   * {@link itemIsInteractive}. Feedback promising an action that never comes is
+   * worse than none.
+   */
+  pressEffect?: PressEffect;
   /**
    * Multi-floor data. When present and non-empty this is the source of truth.
    * When absent, the legacy flat arrays below describe a single implicit floor


### PR DESCRIPTION
Closes #134.

A tap changed nothing on screen until the entity itself came back. On a cover, or a bulb behind a slow bridge, that is long enough to wonder whether it registered — so you tap again.

## Three effects, one setting

Under **Project → Press effect**:

| Effect | What it does |
| --- | --- |
| **Press in** (default) | Dips to 92% and springs back |
| **Ink ripple** | A circle spreading from the point you touched |
| **Flash** | A halo of the skin's accent, no movement at all |
| **None** | As before |

Plan-wide rather than per-device: it is how the dashboard *feels*, and a plan where half the devices answered differently would read as broken.

Named **Ink ripple**, not "Ripple" — a device already has a **Ripple** toggle of its own (the presence ring), and two controls sharing a name in one editor would be a genuinely confusing pair.

## Three things worth calling out

**The timings are asymmetric on purpose** — 80ms in, 260ms out. A tap can be over in 30ms; a symmetric transition would finish before a frame ever painted it. Dipping instantly and easing back out is what makes even the quickest tap visible.

**The scale rule repeats the translate.** `.item` is centred on its own anchor, so a bare `scale()` would drop that and jump the device down-right by half its size. Measured: 8% shrink, **zero** centre drift on both axes.

**Flash uses `drop-shadow`, not `box-shadow`**, so the halo follows what the device actually draws — the badge's circle, a bare ripple ring, the label — instead of boxing a rectangle around it. It reads the skin's accent token, so Tron glows cyan.

The ink is the only part needing script: nothing but the event knows where the finger landed, so the position goes to CSS as two custom properties and the animation stays in the stylesheet. Restarting needs a forced reflow — re-adding a class whose animation is still running is a no-op, so a quick second tap would otherwise draw nothing.

## Inert devices, and a small lie retired

`hasAction` was not the right question. A `toggle` with no entity, a `navigate` with no path and a `call-service` with no service all pass it and then do nothing. `itemIsInteractive` asks each action for its own requirement, across all three gestures — so a device whose tap is `none` but whose **hold** toggles still reads as pressable.

Those devices now get neither the effect nor the hand cursor. That also retires something the card already got wrong: an unbound device (#39's "dumb smoke detector") has shown `cursor: pointer` since it existed.

```
light.kitchen                  -> dips, cursor: pointer
sensor.temp                    -> dips (more-info), cursor: pointer
no entity bound                -> nothing, cursor: default
tap_action: none               -> nothing, cursor: default
tap none + hold toggle         -> dips, cursor: pointer
```

## Reduced motion

All three fall back to the flash halo with no transition. Removing the effect outright would answer an accessibility preference by taking the affordance away.

## Verification

`:active` is UA-driven and cannot be held from script, so the rules were read back off the **CSSOM** rather than assumed — selectors, declarations, keyframes and the `prefers-reduced-motion` block all confirmed as emitted.

- Ink: lands at exactly the press point, interpolates 0→120px staying centred (`margin-left` tracks −width/2) while fading 0.32→0.
- Scale: 8% shrink, 0px centre drift, exact restore.
- Flash: accent token resolves to the skin's colour; halo follows the badge circle (screenshotted).
- Gating: inert devices carry no ink element, no `interactive` class, and `cursor: default`.
- `tsc`, **689 tests**, `npm run build` green; duplication sweep clean.
- 10 of the new tests fail against `main`.

One harness note: the Browser pane tab runs backgrounded, which pauses CSS animations and transitions — the ink was measured by driving the Web Animations clock directly rather than by waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)