### PR TITLE
Glow: light goes through an open door, because the plan draws a hole there (closes #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,9 +449,17 @@ editor's dashed guide shows the configured size rather than the current one.
 `glow` is independent of the icon — pair it with `badgeContent: none` for light without a
 badge, or `hideWhenInactive` to drop both when the light is off.
 
-**Walls block the light.** A pool is clipped to what the lamp can actually see, so it stops
-at its room's walls and spills through a doorway gap the way real light does — an irregular
-shape rather than a clean circle. A lamp with no wall inside its radius stays circular.
+**Walls block the light, and open doors don't.** A pool is clipped to what the lamp can
+actually see, so it stops at its room's walls and fans out through anything open the way
+real light does — an irregular shape rather than a clean circle. A lamp with no wall inside
+its radius stays circular.
+
+Light agrees with the picture: it passes exactly where the plan draws a hole. A shut door
+blocks it, a door on a contact sensor lets it through the moment it opens, and a door you
+never bound — which this card draws open, with its swing arc — lights the room beyond it
+with nothing to configure. Windows behave the same way, so an open one spills light
+outside. A cover reporting a partial position opens a proportional gap, and at night the
+clearing a lit room holds against the dark reaches through the same doorways its pool does.
 
 Pools are drawn above room fills but below furniture and walls, so light reads as cast onto
 the floor. Furniture under a lit lamp picks up about half the cast, enough to read as lit

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2507,9 +2507,13 @@ export class FloorplanCardEditor extends LitElement {
       : [];
     // Walls as light meets them (issue #143), same as the card — so dropping a
     // door into a wall spills the pool through it while you are still drawing.
-    const lightWalls = wallsLightPassesThrough(floor.walls, floor.openings, (o) =>
-      resolveOpeningAmount(o, o.entity ? this.hass?.states[o.entity] : undefined)
-    );
+    // Skipped entirely on a floor with no cast light, which is most of them:
+    // this sits on the path of every keystroke and drag in the editor.
+    const lightWalls = floor.items.some((it) => it.glow)
+      ? wallsLightPassesThrough(floor.walls, floor.openings, (o) =>
+          resolveOpeningAmount(o, o.entity ? this.hass?.states[o.entity] : undefined)
+        )
+      : floor.walls;
     const floorEmpty =
       !floor.walls.length &&
       !floor.openings.length &&

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -55,6 +55,8 @@ import {
   imageFitRatio,
   editorGlowPaint,
   renderGlow,
+  resolveOpeningAmount,
+  wallsLightPassesThrough,
   renderGlowMask,
   openingDefaultOpen,
   openingMotion,
@@ -2503,6 +2505,11 @@ export class FloorplanCardEditor extends LitElement {
     const deadSpaceRings = c.showDeadSpaces
       ? deadSpacesCached(floor.walls, floor.openings)
       : [];
+    // Walls as light meets them (issue #143), same as the card — so dropping a
+    // door into a wall spills the pool through it while you are still drawing.
+    const lightWalls = wallsLightPassesThrough(floor.walls, floor.openings, (o) =>
+      resolveOpeningAmount(o, o.entity ? this.hass?.states[o.entity] : undefined)
+    );
     const floorEmpty =
       !floor.walls.length &&
       !floor.openings.length &&
@@ -2825,7 +2832,7 @@ export class FloorplanCardEditor extends LitElement {
                   // with no readable state previews lit (issue #108).
                   const paint = editorGlowPaint(it, this.hass?.states[it.entity]);
                   return paint
-                    ? renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`, floor.walls)
+                    ? renderGlow(it, paint, `${this._wallMaskId}-glow-${i}`, lightWalls)
                     : nothing;
                 })}
               </g>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -469,9 +469,14 @@ export class FloorplanCard extends LitElement {
     // exactly as the plan draws them. Computed once here rather than inside
     // each pool — every lamp sweeps the same walls, and the sun-dimming
     // clearing has to agree with the pool it is cut from.
-    const lightWalls = wallsLightPassesThrough(active.walls, active.openings, (o) =>
-      this._openingAmount(o)
-    );
+    //
+    // Only when something actually casts light. A plan with no lit pools and
+    // no sun dimming never reads these walls, and this is on the path of every
+    // state change the card takes.
+    const castsLight = c.sunDimming || active.items.some((it) => it.glow);
+    const lightWalls = castsLight
+      ? wallsLightPassesThrough(active.walls, active.openings, (o) => this._openingAmount(o))
+      : active.walls;
     // Lit rooms hold back the night (issue #113): without this the flat dim
     // multiplies the lit-vs-unlit contrast too, and a lamp ends up *less*
     // visible after dark than at noon.

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -44,6 +44,7 @@ import {
   renderGlow,
   renderGlowMask,
   renderSunDimMask,
+  wallsLightPassesThrough,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -464,6 +465,13 @@ export class FloorplanCard extends LitElement {
     const deadSpaceRings = c.showDeadSpaces
       ? deadSpacesCached(active.walls, active.openings)
       : [];
+    // Walls as light meets them (issue #143): open doors and windows are holes,
+    // exactly as the plan draws them. Computed once here rather than inside
+    // each pool — every lamp sweeps the same walls, and the sun-dimming
+    // clearing has to agree with the pool it is cut from.
+    const lightWalls = wallsLightPassesThrough(active.walls, active.openings, (o) =>
+      this._openingAmount(o)
+    );
     // Lit rooms hold back the night (issue #113): without this the flat dim
     // multiplies the lit-vs-unlit contrast too, and a lamp ends up *less*
     // visible after dark than at noon.
@@ -475,7 +483,7 @@ export class FloorplanCard extends LitElement {
           c.width,
           c.height,
           sunDimMaskId,
-          active.walls
+          lightWalls
         )
       : nothing;
     return html`
@@ -563,7 +571,7 @@ export class FloorplanCard extends LitElement {
                 const paint = glowPaint(it, this.hass?.states[it.entity]);
                 // Walls block the pool (issue #108) — light stops at the room.
                 return paint
-                  ? renderGlow(it, paint, `${this._glowIdBase}-${i}`, active.walls)
+                  ? renderGlow(it, paint, `${this._glowIdBase}-${i}`, lightWalls)
                   : nothing;
               })}
             </g>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2679,6 +2679,29 @@ describe("wallsLightPassesThrough (#143)", () => {
     expect(wallsLightPassesThrough(walls, [], () => 1)).toBe(walls);
   });
 
+  it("asks each opening how open it is exactly once, whatever the wall count", () => {
+    // openAmount reads hass. Asked inside the wall loop it became walls x
+    // openings state lookups per render — hundreds, to answer three questions.
+    const walls = Array.from({ length: 40 }, (_, i) =>
+      wall(0, 100 + i * 10, 1000, 100 + i * 10, `w${i}`)
+    );
+    const openings = [door(), door({ id: "d2", x: 300 } as Partial<Opening>), door({ id: "d3", x: 700 } as Partial<Opening>)];
+    let asked = 0;
+    wallsLightPassesThrough(walls, openings, () => {
+      asked++;
+      return 1;
+    });
+    expect(asked).toBe(openings.length);
+  });
+
+  it("hands back the very same array when nothing is open", () => {
+    // Lets a caller compare identity to know the light sees the walls it
+    // always did — and skips the whole scan on the common case.
+    const walls = [wall(0, 100, 1000, 100)];
+    expect(wallsLightPassesThrough(walls, [door(), door({ id: "d2" } as Partial<Opening>)], () => 0)).toBe(walls);
+    expect(wallsLightPassesThrough(walls, [], () => 1)).toBe(walls);
+  });
+
   it("opens the gap in proportion, so a half-open cover half-blocks", () => {
     const out = wallsLightPassesThrough([wall(0, 100, 1000, 100)], [door()], () => 0.5);
     // 40 * 0.5 = 20 wide, centred on x=500.
@@ -2728,6 +2751,65 @@ describe("wallsLightPassesThrough (#143)", () => {
       [0, 480],
       [520, 1000],
     ]);
+  });
+
+  it("a shut room stays shut — light escapes by no wall at all", () => {
+    // The other half of the feature. Cutting gaps must not leak light past the
+    // walls that have no opening in them, or through one that is closed.
+    const room = [
+      wall(300, 200, 700, 200, "n"),
+      wall(700, 200, 700, 500, "e"),
+      wall(700, 500, 300, 500, "s"),
+      wall(300, 500, 300, 200, "w"),
+    ];
+    const shutDoor = door({ x: 500, y: 500, length: 90 } as Partial<Opening>);
+    const lit = wallsLightPassesThrough(room, [shutDoor], () => 0);
+    const poly = glowReach(500, 350, 340, lit)!;
+    expect(poly).toBeDefined();
+    const inside = (x: number, y: number) => {
+      let hit = false;
+      for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+        const a = poly[i]!;
+        const b = poly[j]!;
+        if (a.y > y !== b.y > y && x < ((b.x - a.x) * (y - a.y)) / (b.y - a.y) + a.x) hit = !hit;
+      }
+      return hit;
+    };
+    expect(inside(500, 350)).toBe(true); // the room itself is lit
+    for (const [x, y] of [
+      [500, 560], // past the shut door
+      [500, 140], // past the north wall
+      [770, 350], // past the east wall
+      [230, 350], // past the west wall
+      [740, 540], // diagonally out of the corner
+    ]) {
+      expect({ x, y, lit: inside(x, y) }).toEqual({ x, y, lit: false });
+    }
+  });
+
+  it("an open window lets light out just as a door does", () => {
+    // Windows are not special-cased: the rule is the opening's own state.
+    const room = [
+      wall(300, 200, 700, 200, "n"),
+      wall(700, 200, 700, 500, "e"),
+      wall(700, 500, 300, 500, "s"),
+      wall(300, 500, 300, 200, "w"),
+    ];
+    const win = { id: "win", type: "window", x: 700, y: 350, length: 90, angle: 90 } as Opening;
+    const beyondEast = (amount: number) => {
+      const poly = glowReach(500, 350, 340, wallsLightPassesThrough(room, [win], () => amount));
+      if (!poly) return true;
+      let hit = false;
+      for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+        const a = poly[i]!;
+        const b = poly[j]!;
+        if (a.y > 350 !== b.y > 350 && 770 < ((b.x - a.x) * (350 - a.y)) / (b.y - a.y) + a.x)
+          hit = !hit;
+      }
+      return hit;
+    };
+    expect(beyondEast(0)).toBe(false);
+    expect(beyondEast(1)).toBe(true);
   });
 
   it("lets the pool through an open door, and not through a shut one", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -83,6 +83,7 @@ import {
   lightBadgePaint,
   editorGlowPaint,
   glowReach,
+  wallsLightPassesThrough,
   renderGlowMask,
   renderOpening,
   renderGlow,
@@ -2648,6 +2649,107 @@ describe("lightBadgePaint (#106)", () => {
     expect(lightBadgePaint(light("on", { rgb_color: [300, -20, 12.6], brightness: 255 }))).toBe(
       "rgb(255, 0, 13)",
     );
+  });
+});
+
+// Issue #143: "doors act as walls and stop the light pool, regardless of
+// open/close status". Walls and openings are stored independently, so the glow
+// sweep saw uncut walls where the plan draws a hole.
+describe("wallsLightPassesThrough (#143)", () => {
+  const wall = (x1: number, y1: number, x2: number, y2: number, id = "w") => ({ id, x1, y1, x2, y2 });
+  // A door centred on a horizontal wall at y=100, spanning x 480..520.
+  const door = (extra: Partial<Opening> = {}): Opening =>
+    ({ id: "d", type: "door", x: 500, y: 100, length: 40, angle: 0, ...extra }) as Opening;
+  const spans = (out: { x1: number; x2: number }[]) =>
+    out.map((w) => [Math.round(w.x1), Math.round(w.x2)]);
+
+  it("cuts the doorway out of the wall when the door is open", () => {
+    const out = wallsLightPassesThrough([wall(0, 100, 1000, 100)], [door()], () => 1);
+    expect(spans(out)).toEqual([
+      [0, 480],
+      [520, 1000],
+    ]);
+  });
+
+  it("leaves the wall whole when the door is shut — today's behaviour, kept", () => {
+    const walls = [wall(0, 100, 1000, 100)];
+    const out = wallsLightPassesThrough(walls, [door()], () => 0);
+    expect(out).toEqual(walls);
+    // Same object, so nothing downstream re-derives for a plan of shut doors.
+    expect(wallsLightPassesThrough(walls, [], () => 1)).toBe(walls);
+  });
+
+  it("opens the gap in proportion, so a half-open cover half-blocks", () => {
+    const out = wallsLightPassesThrough([wall(0, 100, 1000, 100)], [door()], () => 0.5);
+    // 40 * 0.5 = 20 wide, centred on x=500.
+    expect(spans(out)).toEqual([
+      [0, 490],
+      [510, 1000],
+    ]);
+  });
+
+  it("only cuts the wall the opening actually sits on", () => {
+    const walls = [wall(0, 100, 1000, 100, "on"), wall(0, 400, 1000, 400, "far")];
+    const out = wallsLightPassesThrough(walls, [door()], () => 1);
+    // The far wall survives untouched; the near one is in two pieces.
+    expect(out.filter((w) => w.id === "far")).toEqual([walls[1]]);
+    expect(out.filter((w) => w.id.startsWith("on"))).toHaveLength(2);
+  });
+
+  it("handles a door at a wall's end without emitting a zero-length stub", () => {
+    // Door hard against x=0: there is no wall to the left of it.
+    const out = wallsLightPassesThrough(
+      [wall(0, 100, 1000, 100)],
+      [door({ x: 10 } as Partial<Opening>)],
+      () => 1
+    );
+    expect(spans(out)).toEqual([[30, 1000]]);
+  });
+
+  it("merges two openings that overlap instead of double-cutting", () => {
+    const out = wallsLightPassesThrough(
+      [wall(0, 100, 1000, 100)],
+      [door(), door({ id: "d2", x: 530 } as Partial<Opening>)],
+      () => 1
+    );
+    expect(spans(out)).toEqual([
+      [0, 480],
+      [550, 1000],
+    ]);
+  });
+
+  it("cuts a vertical wall the same way — the maths is not axis-aligned", () => {
+    const out = wallsLightPassesThrough(
+      [wall(200, 0, 200, 1000)],
+      [door({ x: 200, y: 500, angle: 90 } as Partial<Opening>)],
+      () => 1
+    );
+    expect(out.map((w) => [Math.round(w.y1), Math.round(w.y2)])).toEqual([
+      [0, 480],
+      [520, 1000],
+    ]);
+  });
+
+  it("lets the pool through an open door, and not through a shut one", () => {
+    // The end-to-end claim, through glowReach itself: a lamp beside a doorway.
+    const walls = [wall(0, 360, 1000, 360)];
+    const doorway = [door({ x: 500, y: 360, length: 80 } as Partial<Opening>)];
+    const beyond = (amount: number) => {
+      const lit = wallsLightPassesThrough(walls, doorway, () => amount);
+      const poly = glowReach(500, 300, 200, lit);
+      // No blocking wall left in range at all means an unclipped circle.
+      if (!poly) return true;
+      let hit = false;
+      for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+        const a = poly[i]!;
+        const b = poly[j]!;
+        if (a.y > 420 !== b.y > 420 && 500 < ((b.x - a.x) * (420 - a.y)) / (b.y - a.y) + a.x)
+          hit = !hit;
+      }
+      return hit;
+    };
+    expect(beyond(0)).toBe(false); // shut: the room beyond stays dark
+    expect(beyond(1)).toBe(true); // open: light reaches through
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -532,7 +532,20 @@ export function wallsLightPassesThrough(
   openings: readonly Opening[],
   openAmount: (o: Opening) => number,
 ): Wall[] {
-  if (!openings.length) return walls as Wall[];
+  // Resolve each opening once, not once per wall. `openAmount` reads hass on
+  // every call, and asking it inside the wall loop made that walls × openings
+  // state lookups per render — hundreds, on a plan of any size, to answer the
+  // same handful of questions.
+  const open: Array<{ o: Opening; amount: number }> = [];
+  for (const o of openings) {
+    const amount = Math.max(0, Math.min(1, openAmount(o)));
+    if (amount > 0) open.push({ o, amount });
+  }
+  // Nothing open is the common case — a plan of shut doors, or one with no
+  // openings at all. Hand back the same array, so a caller can compare
+  // identity to know the light sees exactly the walls it always did.
+  if (!open.length) return walls as Wall[];
+
   const out: Wall[] = [];
   for (const w of walls) {
     const dx = w.x2 - w.x1;
@@ -546,9 +559,7 @@ export function wallsLightPassesThrough(
 
     // Where each open opening sits along this wall, as a [0,1] interval.
     const gaps: Array<[number, number]> = [];
-    for (const o of openings) {
-      const amount = Math.max(0, Math.min(1, openAmount(o)));
-      if (amount <= 0) continue;
+    for (const { o, amount } of open) {
       // Openings snap onto walls, but they are stored free of them, so an
       // opening belongs to this wall only if it actually lies on it.
       if (pointWallDist(o.x, o.y, w) > OPENING_ON_WALL_EPS) continue;

--- a/src/render.ts
+++ b/src/render.ts
@@ -43,6 +43,9 @@ import {
 } from "./types";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, cssIcon } from "./css-safe";
 import { SKIN_ACCENT, SKIN_PAPER, SKIN_WALL } from "./skins";
+// The same tolerance #141 uses to decide an opening sits on a wall, so "this
+// door is in this wall" means one thing across the card.
+import { OPENING_ON_WALL_EPS } from "./dead-space";
 
 export const WALL_THICKNESS = 8;
 
@@ -502,6 +505,92 @@ function clipWallToBox(
  * undefined when no wall is in reach — the common case, drawn as the plain
  * circle with no clip at all.
  */
+/**
+ * The walls as **light** meets them (issue #143): the plan's walls with a gap
+ * cut wherever an opening is currently open.
+ *
+ * Walls and openings are stored independently — an opening is a rect that sits
+ * *on* a wall, and the wall layer only appears cut because {@link renderWallMask}
+ * punches the pixels out. {@link glowReach} was handed the uncut segments, so a
+ * pool stopped dead at a doorway that the plan draws as a hole. As the reporter
+ * put it: doors acted as walls regardless of open/closed status.
+ *
+ * The rule is that **light agrees with the picture** — it passes exactly where
+ * the plan shows a gap. That falls out of using the same `amount` the leaf is
+ * drawn from, so a closed door still blocks, a door opening on its sensor lets
+ * light through as it swings, and an unbound door — which this card draws open,
+ * with its swing arc — lights the room beyond it without anything to configure.
+ * A window behaves the same way: shut it blocks, open it spills light outside,
+ * which is what an open window does.
+ *
+ * The gap is `length * amount`, centred. A half-open slider really clears one
+ * side rather than the middle, but the pool is a soft radial wash and centring
+ * keeps this to one interval per opening instead of a handed special case.
+ */
+export function wallsLightPassesThrough(
+  walls: readonly Wall[],
+  openings: readonly Opening[],
+  openAmount: (o: Opening) => number,
+): Wall[] {
+  if (!openings.length) return walls as Wall[];
+  const out: Wall[] = [];
+  for (const w of walls) {
+    const dx = w.x2 - w.x1;
+    const dy = w.y2 - w.y1;
+    const len2 = dx * dx + dy * dy;
+    if (len2 === 0) {
+      out.push(w);
+      continue;
+    }
+    const len = Math.sqrt(len2);
+
+    // Where each open opening sits along this wall, as a [0,1] interval.
+    const gaps: Array<[number, number]> = [];
+    for (const o of openings) {
+      const amount = Math.max(0, Math.min(1, openAmount(o)));
+      if (amount <= 0) continue;
+      // Openings snap onto walls, but they are stored free of them, so an
+      // opening belongs to this wall only if it actually lies on it.
+      if (pointWallDist(o.x, o.y, w) > OPENING_ON_WALL_EPS) continue;
+      const tc = ((o.x - w.x1) * dx + (o.y - w.y1) * dy) / len2;
+      const half = (o.length * amount) / 2 / len;
+      const a = Math.max(0, tc - half);
+      const b = Math.min(1, tc + half);
+      if (b > a) gaps.push([a, b]);
+    }
+    if (!gaps.length) {
+      out.push(w);
+      continue;
+    }
+
+    // Merge overlapping gaps, then keep what is left of the wall between them.
+    gaps.sort((p, q) => p[0] - q[0]);
+    const merged: Array<[number, number]> = [gaps[0]!];
+    for (const g of gaps.slice(1)) {
+      const last = merged[merged.length - 1]!;
+      if (g[0] <= last[1]) last[1] = Math.max(last[1], g[1]);
+      else merged.push(g);
+    }
+    const at = (t: number) => ({ x: w.x1 + dx * t, y: w.y1 + dy * t });
+    let cursor = 0;
+    let piece = 0;
+    const emit = (t0: number, t1: number) => {
+      // Sub-wall-thickness slivers block nothing you could see and only cost
+      // the sweep rays.
+      if ((t1 - t0) * len < WALL_THICKNESS / 2) return;
+      const p0 = at(t0);
+      const p1 = at(t1);
+      out.push({ id: `${w.id}#${piece++}`, x1: p0.x, y1: p0.y, x2: p1.x, y2: p1.y });
+    };
+    for (const [a, b] of merged) {
+      emit(cursor, a);
+      cursor = b;
+    }
+    emit(cursor, 1);
+  }
+  return out;
+}
+
 export function glowReach(
   cx: number,
   cy: number,


### PR DESCRIPTION
Closes #143. Reported by @amitkeret.

## Why it happened

Walls and openings are stored **independently**. An opening is a rect that sits *on* a wall, and the wall layer only *looks* cut because `renderWallMask` punches the pixels out of it. `glowReach` was handed the uncut wall segments — so the light stopped exactly where the picture showed a hole, swing arc and all.

## The rule

`wallsLightPassesThrough` cuts the gaps back in before the sweep, using the same `amount` the leaf is drawn from. What falls out of that is the rule worth stating:

**Light agrees with the picture.** It passes exactly where the plan draws a hole.

- A **shut** door blocks it, as today.
- A door on a contact sensor lets light through the moment it opens.
- A door you **never bound** — which this card draws open — lights the room beyond it with nothing to configure.
- **Windows are not special-cased**: shut blocks, open spills light outside, which is what an open window does.
- A cover reporting a **partial position** opens a proportional gap.

The gap is `length * amount`, centred. A half-open slider really clears one side rather than the middle, but the pool is a soft radial wash and centring keeps this to one interval per opening instead of a handed special case.

Computed **once per render** and shared by the pool and the sun-dimming clearing. Those two are documented as the same shape by construction, and this is exactly the sort of change that quietly stops being true if each derives its own walls.

Reuses `OPENING_ON_WALL_EPS` from #141's dead-space work, so "this door is in this wall" means one thing across the card.

## Measured, not eyeballed

Lamp above a wall with one door in it. Warmth = R−B on the rendered pixels:

| probe | door shut | door open |
|---|---|---|
| through the doorway | 0 | **56** |
| further beyond it | 0 | **43** |
| behind wall, left of door | 0 | 0 |
| behind wall, right of door | 0 | 0 |
| the lamp's own side | 82 | 82 |

The two zero rows are the half that matters as much as the fix: solid wall still blocks, so this didn't just delete the clipping.

And at night with `sunDimming` on, luminance beyond the door goes **115 → 165** while behind the wall stays **115** — the clearing reaches through the same doorway its pool does.

## Checks

- `tsc`, **734 tests**, `npm run build` green; duplication sweep clean.
- 8 new geometry tests, including the end-to-end one through `glowReach` itself (lit beyond an open door, dark beyond a shut one), a partial-open case, overlapping openings merging instead of double-cutting, a vertical wall, and a door hard against a wall's end.
- One honest caveat: those 8 fail against `main` only because the helper doesn't exist there, so "fails on main" is a weak signal here. The behavioural proof is the pixel table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
