### PR TITLE
Sliders: a sensor per panel, and a biparting door that stacks instead of pocketing (closes #145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,16 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   tracks the position live. Everything else uses the on/off behavior above.
 - **Motion** — **swing** (default), **slide**, or **roll** (a slatted curtain that thins
   onto its track). Sliding openings take a **Style**: *single* (one panel into the wall),
-  *bypass* (two panels on parallel tracks), or *biparting* (two panels parting at the
-  middle). **Slide** sets the direction.
+  *bypass* (two panels on parallel tracks), *biparting (into the walls)* (two panels
+  parting at the middle, each recessing into its own wall — a pocket door), or
+  *biparting (over fixed panels)* (the same two panels stacking over a fixed panel at
+  each jamb — the usual patio / bay slider, where nothing leaves the opening and the
+  middle half is as clear as it gets). **Slide** sets the direction; a biparting slider
+  parts both ways, so it has none.
+- **One sensor per panel** — a biparting slider with a contact on each leaf takes a
+  **Second panel** entity, and then each panel opens and accents on its own state: left
+  open and right shut draws exactly that. Leave it empty and both panels follow the first
+  entity, as they always have. **Invert** covers both, and a tap still acts on the first.
 - **Orientation** — **Hinge** (left / right) and **Opens** (this side / other side) face a
   swing door any of four ways; they're pure mirrors (`flipH` / `flipV`), so the animation
   follows.
@@ -203,6 +211,9 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
 openings:
   # sliding window, patio-door style, driven by a cover
   - { id: patio, type: window, motion: slide, sliderStyle: biparting, x: 640, y: 500, length: 160, angle: 0, entity: cover.patio_door }
+  # a two-panel patio slider with a contact on each leaf: the panels stack over
+  # the fixed side panels, and each one follows its own sensor
+  - { id: bay, type: window, motion: slide, sliderStyle: biparting-bypass, x: 300, y: 500, length: 200, angle: 0, entity: binary_sensor.sliding_door_left, secondaryEntity: binary_sensor.sliding_door_right }
   # a swing door hinged on the right, opening into the other room
   - { id: hall, type: door, x: 300, y: 100, length: 80, angle: 0, flipH: true, flipV: true }
 ```
@@ -378,16 +389,17 @@ distorted anyway.
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |
 | `entity`      | string                      | Contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
+| `secondaryEntity` | string                  | Biparting sliders: a second contact / `cover` for the other panel, so each leaf moves on its own state. Unset = both follow `entity`. |
 | `invert`      | boolean                     | Flip the open/closed interpretation.                   |
 | `activeColor` | string                      | Leaf/arc color while actively open (default primary).  |
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
 | `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
-| `sliderStyle` | `single` \| `bypass` \| `biparting` | With `motion: slide`: one panel (default), two stacking, or two centre-parting. |
 | `showShutterIcon` | boolean                 | Draw that icon (default `true` whenever both are bound). Editor: **Shutter icon**. Turning it off changes nothing about the gestures — for a plan where every window has a shutter and the icons start to shout. |
 | `shutterIcon` | string                      | Override the icon's glyph. Left unset it follows the shutter entity, whose default comes in an open/closed pair; an override is one glyph for both states, and colour still reports the state. |
 | `tapTarget`   | `opening` \| `shutter`      | With both entities bound, which one a tap acts on (default `opening`); the other moves to press-and-hold. Editor: **Tap opens**. Pointing it at the shutter opens the shutter's dialog — it does not drive the motor; set `tap_action: toggle` for that. |
 | `tap_action`  | ActionConfig                | Standard Lovelace action, acting on whichever entity `tapTarget` leads with (or on `shutterEntity` when it is the only one bound). By default an open/close `cover` toggles and everything else opens more-info. An action's own `entity` picks which of the two it acts on. |
 | `hold_action` / `double_tap_action` | ActionConfig | With both entities bound, hold opens the shutter's more-info by default — a tap is never retargeted at the shutter motor. Double-tap does nothing unless configured. |
+| `sliderStyle` | `single` \| `bypass` \| `biparting` \| `biparting-bypass` | With `motion: slide`: one panel (default), two stacking, two centre-parting into the walls, or two centre-parting over a fixed panel at each jamb. |
 
 ### Item (device)
 

--- a/README.md
+++ b/README.md
@@ -493,6 +493,12 @@ with nothing to configure. Windows behave the same way, so an open one spills li
 outside. A cover reporting a partial position opens a proportional gap, and at night the
 clearing a lit room holds against the dark reaches through the same doorways its pool does.
 
+A two-panel slider counts **both** its leaves, so a door with a sensor on each opens a gap
+when either one does. How wide follows what the style actually draws: `biparting` sends its
+leaves into the walls and can clear the whole opening, while `biparting-bypass` and
+`converging` keep theirs inside the frame and so clear at most half of it however wide open
+they are.
+
 Pools are drawn above room fills but below furniture and walls, so light reads as cast onto
 the floor. Furniture under a lit lamp picks up about half the cast, enough to read as lit
 without turning into the color of the light. Pools never intercept clicks.

--- a/README.md
+++ b/README.md
@@ -182,14 +182,22 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
 - **Partial** — a `cover` reporting `current_position` (0–100) is drawn partly open and
   tracks the position live. Everything else uses the on/off behavior above.
 - **Motion** — **swing** (default), **slide**, or **roll** (a slatted curtain that thins
-  onto its track). Sliding openings take a **Style**: *single* (one panel into the wall),
-  *bypass* (two panels on parallel tracks), *biparting (into the walls)* (two panels
-  parting at the middle, each recessing into its own wall — a pocket door), or
-  *biparting (over fixed panels)* (the same two panels stacking over a fixed panel at
-  each jamb — the usual patio / bay slider, where nothing leaves the opening and the
-  middle half is as clear as it gets). **Slide** sets the direction; a biparting slider
-  parts both ways, so it has none.
-- **One sensor per panel** — a biparting slider with a contact on each leaf takes a
+  onto its track). Sliding openings take a **Style**, and which one you want comes down to
+  where the panels go and what is left clear:
+
+  | Style | Panels | Where they go | What clears |
+  | --- | --- | --- | --- |
+  | *single* | one moving | into the wall | the whole opening |
+  | *bypass* | one moving, one fixed | behind the fixed one | half |
+  | *biparting (into the walls)* | two moving | each recesses into its own wall — a pocket door | the whole opening |
+  | *biparting (over fixed panels)* | two moving, two fixed | out onto a fixed panel at each jamb | the middle half |
+  | *converging* | two moving | toward each other, stacking in the middle | a quarter at each jamb |
+
+  The last two are both patio sliders and they are mirror images: pick *biparting (over
+  fixed panels)* if the outer quarters of your door are fixed glass, and *converging* if
+  every leaf slides. **Slide** sets the direction; a style that moves both panels has
+  none.
+- **One sensor per panel** — a two-panel slider with a contact on each leaf takes a
   **Second panel** entity, and then each panel opens and accents on its own state: left
   open and right shut draws exactly that. Leave it empty and both panels follow the first
   entity, as they always have. **Invert** covers both, and a tap still acts on the first.
@@ -214,6 +222,8 @@ openings:
   # a two-panel patio slider with a contact on each leaf: the panels stack over
   # the fixed side panels, and each one follows its own sensor
   - { id: bay, type: window, motion: slide, sliderStyle: biparting-bypass, x: 300, y: 500, length: 200, angle: 0, entity: binary_sensor.sliding_door_left, secondaryEntity: binary_sensor.sliding_door_right }
+  # the same door with no fixed glass: both leaves slide and stack in the middle
+  - { id: terrace, type: window, motion: slide, sliderStyle: converging, x: 300, y: 700, length: 200, angle: 0, entity: binary_sensor.terrace_left, secondaryEntity: binary_sensor.terrace_right }
   # a swing door hinged on the right, opening into the other room
   - { id: hall, type: door, x: 300, y: 100, length: 80, angle: 0, flipH: true, flipV: true }
 ```
@@ -389,7 +399,7 @@ distorted anyway.
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |
 | `entity`      | string                      | Contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
-| `secondaryEntity` | string                  | Biparting sliders: a second contact / `cover` for the other panel, so each leaf moves on its own state. Unset = both follow `entity`. |
+| `secondaryEntity` | string                  | Two-panel sliders (`biparting`, `biparting-bypass`, `converging`): a second contact / `cover` for the other panel, so each leaf moves on its own state. Unset = both follow `entity`. |
 | `invert`      | boolean                     | Flip the open/closed interpretation.                   |
 | `activeColor` | string                      | Leaf/arc color while actively open (default primary).  |
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
@@ -399,7 +409,7 @@ distorted anyway.
 | `tapTarget`   | `opening` \| `shutter`      | With both entities bound, which one a tap acts on (default `opening`); the other moves to press-and-hold. Editor: **Tap opens**. Pointing it at the shutter opens the shutter's dialog — it does not drive the motor; set `tap_action: toggle` for that. |
 | `tap_action`  | ActionConfig                | Standard Lovelace action, acting on whichever entity `tapTarget` leads with (or on `shutterEntity` when it is the only one bound). By default an open/close `cover` toggles and everything else opens more-info. An action's own `entity` picks which of the two it acts on. |
 | `hold_action` / `double_tap_action` | ActionConfig | With both entities bound, hold opens the shutter's more-info by default — a tap is never retargeted at the shutter motor. Double-tap does nothing unless configured. |
-| `sliderStyle` | `single` \| `bypass` \| `biparting` \| `biparting-bypass` | With `motion: slide`: one panel (default), two stacking, two centre-parting into the walls, or two centre-parting over a fixed panel at each jamb. |
+| `sliderStyle` | `single` \| `bypass` \| `biparting` \| `biparting-bypass` \| `converging` | With `motion: slide`: one panel (default), two stacking, two centre-parting into the walls, two centre-parting over a fixed panel at each jamb, or two running together to stack in the middle. |
 
 ### Item (device)
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -171,6 +171,69 @@ describe("openingForm", () => {
   });
 });
 
+describe("openingForm — biparting sliders (issue #145)", () => {
+  const slider = (extra: Partial<Opening> = {}) =>
+    ({ ...door, motion: "slide", ...extra }) as Opening;
+  const names = (o: Opening) => openingForm(o).fields.map((x) => x.name);
+
+  it("offers both biparting styles", () => {
+    const styleField = openingForm(slider()).fields.find((x) => x.name === "style")!;
+    const opts = (styleField.selector as { select: { options: { value: string }[] } }).select
+      .options.map((o) => o.value);
+    expect(opts).toEqual(["single", "bypass", "biparting", "biparting-bypass"]);
+  });
+
+  it("hides the slide direction for both of them — they part both ways", () => {
+    expect(names(slider({ sliderStyle: "biparting-bypass" }))).not.toContain("slide");
+    expect(names(slider({ sliderStyle: "bypass" }))).toContain("slide");
+  });
+
+  it("offers a second panel entity only on a bound biparting slider", () => {
+    // Nothing to bind without a first entity, or with only one moving panel.
+    expect(names(slider({ sliderStyle: "biparting" }))).not.toContain("secondaryEntity");
+    expect(names(slider({ sliderStyle: "bypass", entity: "binary_sensor.a" })))
+      .not.toContain("secondaryEntity");
+    expect(names({ ...door, entity: "binary_sensor.a" } as Opening))
+      .not.toContain("secondaryEntity");
+    for (const sliderStyle of ["biparting", "biparting-bypass"] as const) {
+      const bound = openingForm(slider({ sliderStyle, entity: "binary_sensor.a" }));
+      expect(bound.fields.map((x) => x.name)).toContain("secondaryEntity");
+      const field = bound.fields.find((x) => x.name === "secondaryEntity")!;
+      // Same pickers as the first panel: a contact or a cover per leaf.
+      expect(field.selector).toEqual({
+        entity: { filter: [{ domain: ["binary_sensor", "cover"] }] },
+      });
+    }
+  });
+
+  it("carries the bound second entity in data", () => {
+    const d = openingForm(
+      slider({ sliderStyle: "biparting", entity: "binary_sensor.a", secondaryEntity: "binary_sensor.b" })
+    ).data;
+    expect(d.secondaryEntity).toBe("binary_sensor.b");
+    expect(openingForm(slider({ sliderStyle: "biparting" })).data.secondaryEntity).toBe("");
+  });
+
+  it("drops the second entity when the opening stops having two panels", () => {
+    const form = openingForm(
+      slider({ sliderStyle: "biparting", entity: "binary_sensor.a", secondaryEntity: "binary_sensor.b" })
+    );
+    // Leaving biparting, or leaving sliding altogether, strips the now-dead
+    // binding — the same rule that already drops sliderStyle.
+    expect(form.toPatch({ style: "single" }).secondaryEntity).toBeUndefined();
+    expect(form.toPatch({ style: "bypass" }).secondaryEntity).toBeUndefined();
+    expect(form.toPatch({ motion: "swing" }).secondaryEntity).toBeUndefined();
+    expect(form.toPatch({ motion: "roll" }).secondaryEntity).toBeUndefined();
+    // Switching between the two biparting styles keeps it: both have two panels.
+    expect(form.toPatch({ style: "biparting-bypass" })).toEqual({
+      sliderStyle: "biparting-bypass",
+    });
+    expect(form.toPatch({ secondaryEntity: "binary_sensor.c" })).toEqual({
+      secondaryEntity: "binary_sensor.c",
+    });
+  });
+});
+
 describe("itemForm", () => {
   const item = { id: "i", entity: "light.a", kind: "light", x: 0, y: 0 } as FloorItem;
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -171,31 +171,35 @@ describe("openingForm", () => {
   });
 });
 
-describe("openingForm — biparting sliders (issue #145)", () => {
+describe("openingForm — two-panel sliders (issue #145)", () => {
   const slider = (extra: Partial<Opening> = {}) =>
     ({ ...door, motion: "slide", ...extra }) as Opening;
   const names = (o: Opening) => openingForm(o).fields.map((x) => x.name);
+  // Every style with a second moving panel for `secondaryEntity` to drive.
+  const TWO_PANEL = ["biparting", "biparting-bypass", "converging"] as const;
 
-  it("offers both biparting styles", () => {
+  it("offers every slider style", () => {
     const styleField = openingForm(slider()).fields.find((x) => x.name === "style")!;
     const opts = (styleField.selector as { select: { options: { value: string }[] } }).select
       .options.map((o) => o.value);
-    expect(opts).toEqual(["single", "bypass", "biparting", "biparting-bypass"]);
+    expect(opts).toEqual(["single", "bypass", "biparting", "biparting-bypass", "converging"]);
   });
 
-  it("hides the slide direction for both of them — they part both ways", () => {
-    expect(names(slider({ sliderStyle: "biparting-bypass" }))).not.toContain("slide");
+  it("hides the slide direction for each of them — both panels move", () => {
+    for (const sliderStyle of TWO_PANEL) {
+      expect(names(slider({ sliderStyle }))).not.toContain("slide");
+    }
     expect(names(slider({ sliderStyle: "bypass" }))).toContain("slide");
   });
 
-  it("offers a second panel entity only on a bound biparting slider", () => {
+  it("offers a second panel entity only on a bound two-panel slider", () => {
     // Nothing to bind without a first entity, or with only one moving panel.
     expect(names(slider({ sliderStyle: "biparting" }))).not.toContain("secondaryEntity");
     expect(names(slider({ sliderStyle: "bypass", entity: "binary_sensor.a" })))
       .not.toContain("secondaryEntity");
     expect(names({ ...door, entity: "binary_sensor.a" } as Opening))
       .not.toContain("secondaryEntity");
-    for (const sliderStyle of ["biparting", "biparting-bypass"] as const) {
+    for (const sliderStyle of TWO_PANEL) {
       const bound = openingForm(slider({ sliderStyle, entity: "binary_sensor.a" }));
       expect(bound.fields.map((x) => x.name)).toContain("secondaryEntity");
       const field = bound.fields.find((x) => x.name === "secondaryEntity")!;
@@ -224,10 +228,10 @@ describe("openingForm — biparting sliders (issue #145)", () => {
     expect(form.toPatch({ style: "bypass" }).secondaryEntity).toBeUndefined();
     expect(form.toPatch({ motion: "swing" }).secondaryEntity).toBeUndefined();
     expect(form.toPatch({ motion: "roll" }).secondaryEntity).toBeUndefined();
-    // Switching between the two biparting styles keeps it: both have two panels.
-    expect(form.toPatch({ style: "biparting-bypass" })).toEqual({
-      sliderStyle: "biparting-bypass",
-    });
+    // Switching between two-panel styles keeps it: they all have a second leaf.
+    for (const sliderStyle of TWO_PANEL) {
+      expect(form.toPatch({ style: sliderStyle })).toEqual({ sliderStyle });
+    }
     expect(form.toPatch({ secondaryEntity: "binary_sensor.c" })).toEqual({
       secondaryEntity: "binary_sensor.c",
     });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -14,6 +14,7 @@ import type {
   FloorplanCardConfig,
   Furniture,
   Opening,
+  SliderStyle,
   Tracker,
   Wall,
 } from "./types";
@@ -48,6 +49,7 @@ import {
   openingActionForGesture,
   openingMotion,
   openingHasTwoPanels,
+  sliderStyleHasTwoPanels,
   pressEffectOf,
   sliderStyleOf,
   shutterStyleOf,
@@ -213,7 +215,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
     });
   }
   if (motion === "slide") {
-    // A biparting slider parts both ways at once, so there is no direction to
+    // A two-panel slider moves both ways at once, so there is no direction to
     // pick — `flipH` only swaps which panel each sensor drives (issue #145).
     if (!twoPanels) {
       fields.push({
@@ -229,7 +231,8 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         opt("single", "Single"),
         opt("bypass", "Bypass (stack)"),
         opt("biparting", "Biparting (into the walls)"),
-        opt("biparting-bypass", "Biparting (over fixed panels)")
+        opt("biparting-bypass", "Biparting (over fixed panels)"),
+        opt("converging", "Converging (both panels stack in the middle)")
       ),
     });
   }
@@ -241,7 +244,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       : "Type and motion follow the entity's device class",
     selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
   });
-  // One sensor per leaf (issue #145). Only the biparting styles have a second
+  // One sensor per leaf (issue #145). Only a two-panel style has a second
   // moving panel to drive, and only once the first is bound — a slider whose
   // *second* panel alone has a sensor would be more confusing than useful.
   if (twoPanels && o.entity) {
@@ -419,8 +422,9 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         else if (k === "opens") out.flipV = v === "other" || undefined;
         else if (k === "style") {
           out.sliderStyle = v === "single" ? undefined : v;
-          // Only a biparting slider has a second moving panel to bind.
-          if (v !== "biparting" && v !== "biparting-bypass") out.secondaryEntity = undefined;
+          // Only a two-panel style has a second moving panel to bind. Asked of
+          // the style itself, so a style added later can't be forgotten here.
+          if (!sliderStyleHasTwoPanels(v as SliderStyle)) out.secondaryEntity = undefined;
         }
         else if (k === "invert") out.invert = v || undefined;
         else out[k] = v;

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -47,6 +47,7 @@ import {
   normalizePlanRotation,
   openingActionForGesture,
   openingMotion,
+  openingHasTwoPanels,
   pressEffectOf,
   sliderStyleOf,
   shutterStyleOf,
@@ -174,6 +175,7 @@ export function furnitureLabel(type: string, catalog: SymbolCatalog = BUILTIN_SY
 export function openingForm(o: Opening, featuresOf: (entityId: string) => number = () => 0): FormSpec {
   const motion = openingMotion(o);
   const style = sliderStyleOf(o);
+  const twoPanels = openingHasTwoPanels(o);
   const fields: FormField[] = [
     { name: "type", label: "Type", selector: dropdown(opt("door", "Door"), opt("window", "Window")) },
     {
@@ -211,7 +213,9 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
     });
   }
   if (motion === "slide") {
-    if (style !== "biparting") {
+    // A biparting slider parts both ways at once, so there is no direction to
+    // pick — `flipH` only swaps which panel each sensor drives (issue #145).
+    if (!twoPanels) {
       fields.push({
         name: "slide",
         label: "Slide",
@@ -224,16 +228,30 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       selector: dropdown(
         opt("single", "Single"),
         opt("bypass", "Bypass (stack)"),
-        opt("biparting", "Biparting (split)")
+        opt("biparting", "Biparting (into the walls)"),
+        opt("biparting-bypass", "Biparting (over fixed panels)")
       ),
     });
   }
   fields.push({
     name: "entity",
     label: "Entity",
-    helper: "Type and motion follow the entity's device class",
+    helper: twoPanels
+      ? "Drives the first panel; type and motion follow its device class"
+      : "Type and motion follow the entity's device class",
     selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
   });
+  // One sensor per leaf (issue #145). Only the biparting styles have a second
+  // moving panel to drive, and only once the first is bound — a slider whose
+  // *second* panel alone has a sensor would be more confusing than useful.
+  if (twoPanels && o.entity) {
+    fields.push({
+      name: "secondaryEntity",
+      label: "Second panel",
+      helper: "Its own sensor for the other panel — leave empty to move both together",
+      selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
+    });
+  }
   // Offered on doors too: French doors and patio doors get shutters as well.
   // A hinged shutter usually reports through a contact sensor, so binary
   // sensors belong in the picker next to covers (issue #74).
@@ -348,6 +366,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       style,
       sash: windowSash(o),
       entity: o.entity ?? "",
+      secondaryEntity: o.secondaryEntity ?? "",
       shutterEntity: o.shutterEntity ?? "",
       shutterStyle: shutterStyleOf(o),
       shutterSide: o.shutterFlipV ? "near" : "far",
@@ -389,12 +408,20 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         else if (k === "showShutterIcon") out.showShutterIcon = v ? undefined : false;
         else if (k === "motion") {
           out.motion = v === "slide" || v === "roll" ? v : undefined;
-          // sliderStyle only applies while sliding — drop it when switching away.
-          if (v !== "slide") out.sliderStyle = undefined;
+          // sliderStyle only applies while sliding — drop it when switching
+          // away, and with it the second panel's sensor (issue #145).
+          if (v !== "slide") {
+            out.sliderStyle = undefined;
+            out.secondaryEntity = undefined;
+          }
         } else if (k === "sash") out.sash = v === "single" ? "single" : undefined;
         else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
         else if (k === "opens") out.flipV = v === "other" || undefined;
-        else if (k === "style") out.sliderStyle = v === "single" ? undefined : v;
+        else if (k === "style") {
+          out.sliderStyle = v === "single" ? undefined : v;
+          // Only a biparting slider has a second moving panel to bind.
+          if (v !== "biparting" && v !== "biparting-bypass") out.secondaryEntity = undefined;
+        }
         else if (k === "invert") out.invert = v || undefined;
         else out[k] = v;
       }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -63,6 +63,9 @@ import {
   renderGlow,
   resolveOpeningAmount,
   wallsLightPassesThrough,
+  openingClearFraction,
+  openingHasTwoPanels,
+  secondPanelOf,
   renderGlowMask,
   openingDefaultOpen,
   openingMotion,
@@ -2554,9 +2557,21 @@ export class FloorplanCardEditor extends LitElement {
     // Skipped entirely on a floor with no cast light, which is most of them:
     // this sits on the path of every keystroke and drag in the editor.
     const lightWalls = floor.items.some((it) => it.glow)
-      ? wallsLightPassesThrough(floor.walls, floor.openings, (o) =>
-          resolveOpeningAmount(o, o.entity ? this.hass?.states[o.entity] : undefined)
-        )
+      ? wallsLightPassesThrough(floor.walls, floor.openings, (o) => {
+          const amt = (id?: string) =>
+            resolveOpeningAmount(o, id ? this.hass?.states[id] : undefined);
+          // Same reading as the card, second leaf included (issue #145).
+          return openingClearFraction(
+            o,
+            amt(o.entity),
+            o.secondaryEntity && openingHasTwoPanels(o)
+              ? resolveOpeningAmount(
+                  secondPanelOf(o),
+                  this.hass?.states[o.secondaryEntity]
+                )
+              : undefined
+          );
+        })
       : floor.walls;
     const floorEmpty =
       !floor.walls.length &&

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -37,6 +37,8 @@ import {
   openingIsActive,
   openingActionForGesture,
   openingIsPressable,
+  openingHasTwoPanels,
+  secondPanelOf,
   shutterAmount,
   shutterStyleOf,
   shutterActive,
@@ -244,6 +246,19 @@ export class FloorplanCard extends LitElement {
   private _openingActive(o: Opening): boolean {
     const state = o.entity ? this.hass?.states[o.entity] : undefined;
     return openingIsActive(o, state);
+  }
+
+  /**
+   * The second panel's own state for a biparting slider with a sensor on each
+   * leaf (issue #145). `undefined` — no second sensor, or a style with only one
+   * moving panel — leaves both panels on the first entity, so nothing about a
+   * single-sensor slider changes.
+   */
+  private _openingSecond(o: Opening): { amount: number; active: boolean } | undefined {
+    if (!o.secondaryEntity || !openingHasTwoPanels(o)) return undefined;
+    const panel = secondPanelOf(o);
+    const state = this.hass?.states[o.secondaryEntity];
+    return { amount: resolveOpeningAmount(panel, state), active: openingIsActive(panel, state) };
   }
 
   private _itemIcon(item: FloorItem): string {
@@ -809,6 +824,8 @@ export class FloorplanCard extends LitElement {
                 amount,
                 active: this._openingActive(o),
                 accent: o.activeColor ?? SKIN_ACCENT,
+                // Per-leaf state for a two-sensor biparting slider (issue #145).
+                second: this._openingSecond(o),
                 // External roller shutter layer (issue #74). No entity bound
                 // yet → previewed shut, like a static plan.
                 shutter: o.shutterEntity

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -65,6 +65,7 @@ import {
   renderGlowMask,
   renderSunDimMask,
   wallsLightPassesThrough,
+  openingClearFraction,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -644,7 +645,12 @@ export class FloorplanCard extends LitElement {
     // state change the card takes.
     const castsLight = c.sunDimming || active.items.some((it) => it.glow);
     const lightWalls = castsLight
-      ? wallsLightPassesThrough(active.walls, active.openings, (o) => this._openingAmount(o))
+      ? wallsLightPassesThrough(active.walls, active.openings, (o) =>
+          // Both leaves, and the travel each style actually has (issue #145):
+          // asking `entity` alone left a door whose *second* panel was open
+          // still blocking light outright.
+          openingClearFraction(o, this._openingAmount(o), this._openingSecond(o)?.amount)
+        )
       : active.walls;
     // Lit rooms hold back the night (issue #113): without this the flat dim
     // multiplies the lit-vs-unlit contrast too, and a lamp ends up *less*

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -118,35 +118,95 @@ describe("renderOpening — biparting over fixed panels", () => {
   });
 });
 
-describe("renderOpening — a biparting slider's second panel (issue #145)", () => {
-  for (const sliderStyle of ["biparting", "biparting-bypass"] as const) {
-    const travel = sliderStyle === "biparting" ? 45 : 22.5;
+// Issue #145: the two-operable-leaf slider. No fixed panels at all — both
+// leaves move, toward each other, and stack over the middle.
+describe("renderOpening — converging", () => {
+  const converging = (extra: Partial<Opening> = {}) =>
+    sliding({ sliderStyle: "converging", ...extra });
+
+  it("draws two half-width moving panels and nothing fixed", () => {
+    const closed = svgOf(converging(), { open: false });
+    // length 90 → two 45 panels, both of them on a slide group. Contrast with
+    // biparting-bypass, which splits the same opening into four quarters.
+    expect(closed.match(/width=45/g)?.length).toBe(2);
+    expect(closed.match(/fp-slide-panel/g)?.length).toBe(2);
+    expect(closed).not.toContain("width=22.5");
+    expect(closed).toContain("translateX(0px)"); // meet in the middle when shut
+  });
+
+  it("runs the panels toward each other, not apart", () => {
+    const open = svgOf(converging(), { open: true });
+    // First panel (at the −x jamb) travels +, second −: the opposite of every
+    // biparting style, and the whole point of this one.
+    expect(open).toContain("translateX(22.5px)");
+    expect(open).toContain("translateX(-22.5px)");
+  });
+
+  it("stacks over the middle half, clearing a quarter at each jamb", () => {
+    const open = svgOf(converging(), { open: true });
+    // Panel one spans −45..0 and shifts +22.5 → −22.5..22.5; panel two spans
+    // 0..45 and shifts −22.5 → the same. Both land on the middle half, so the
+    // outer quarters (−45..−22.5 and 22.5..45) are what actually clears.
+    expect(open).toContain("x=-45");
+    expect(open).toContain('x="0"');
+    expect(open).toContain("width=45");
+  });
+
+  it("keeps the panels on parallel tracks so neither blocks the other", () => {
+    const s = svgOf(converging(), { open: false });
+    expect(s).toContain("y1=1.75"); // two tracks, as in bypass
+    expect(s).toContain("y1=-1.75");
+    expect(s).toContain("y=0.5"); // first panel on the front track
+    expect(s).toContain("y=-3"); // second on the back track, clear of it
+  });
+
+  it("accents both panels when both are open — neither one is fixed", () => {
+    const open = svgOf(converging(), { open: true, active: true, accent: "#f00" });
+    expect(open.match(/fill:#f00/g)?.length).toBe(2);
+    expect(open).not.toContain("fill=#000"); // no fixed panel to keep the base color
+  });
+});
+
+describe("renderOpening — a two-panel slider's second panel (issue #145)", () => {
+  // Travel per panel, and which way the *first* one goes. The biparting styles
+  // part outward from the centre; `converging` runs the other way, so the same
+  // per-panel rules have to hold with both signs.
+  const TWO_PANEL = [
+    { sliderStyle: "biparting", travel: 45, out: -1 },
+    { sliderStyle: "biparting-bypass", travel: 22.5, out: -1 },
+    { sliderStyle: "converging", travel: 22.5, out: 1 },
+  ] as const;
+  for (const { sliderStyle, travel, out } of TWO_PANEL) {
+    // Signed travel: `first` is what panel one shows fully open, `second` its
+    // opposite number — the panels always move against each other.
+    const first = `translateX(${out * travel}px)`;
+    const second = `translateX(${-out * travel}px)`;
     describe(sliderStyle, () => {
       it("moves both panels together when no second state is given", () => {
         const open = svgOf(sliding({ sliderStyle }), { amount: 1 });
-        expect(open).toContain(`translateX(-${travel}px)`);
-        expect(open).toContain(`translateX(${travel}px)`);
+        expect(open).toContain(first);
+        expect(open).toContain(second);
       });
       it("opens one panel while the other stays shut", () => {
         const s = svgOf(sliding({ sliderStyle }), { amount: 1, second: { amount: 0 } });
-        expect(s).toContain(`translateX(-${travel}px)`); // first panel open
+        expect(s).toContain(first); // first panel open
         expect(s).toContain("translateX(0px)"); // second still closed
-        expect(s).not.toContain(`translateX(${travel}px)`);
+        expect(s).not.toContain(second);
       });
       it("opens the second panel while the first stays shut", () => {
         const s = svgOf(sliding({ sliderStyle }), { amount: 0, second: { amount: 1 } });
-        expect(s).toContain(`translateX(${travel}px)`);
+        expect(s).toContain(second);
         expect(s).toContain("translateX(0px)");
-        expect(s).not.toContain(`translateX(-${travel}px)`);
+        expect(s).not.toContain(first);
       });
       it("gives each panel its own travel for two position-aware covers", () => {
         const s = svgOf(sliding({ sliderStyle }), { amount: 0.5, second: { amount: 1 } });
-        expect(s).toContain(`translateX(-${travel / 2}px)`);
-        expect(s).toContain(`translateX(${travel}px)`);
+        expect(s).toContain(`translateX(${(out * travel) / 2}px)`);
+        expect(s).toContain(second);
       });
       it("clamps a second panel's out-of-range amount", () => {
         const s = svgOf(sliding({ sliderStyle }), { amount: 0, second: { amount: 4 } });
-        expect(s).toContain(`translateX(${travel}px)`);
+        expect(s).toContain(second);
       });
       it("accents only the panel whose own sensor reads open", () => {
         const s = svgOf(sliding({ sliderStyle }), {

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -82,6 +82,93 @@ describe("renderOpening — sliding door", () => {
   });
 });
 
+// Issue #145: a patio slider whose panels stack over fixed side panels rather
+// than recessing into the walls, and one contact sensor per moving panel.
+describe("renderOpening — biparting over fixed panels", () => {
+  const bipartingBypass = (extra: Partial<Opening> = {}) =>
+    sliding({ sliderStyle: "biparting-bypass", ...extra });
+
+  it("splits the opening into four quarter panels", () => {
+    const closed = svgOf(bipartingBypass(), { open: false });
+    // length 90 → four 22.5 panels: two fixed at the jambs, two moving.
+    expect(closed.match(/width=22\.5/g)?.length).toBe(4);
+    expect(closed.match(/fp-slide-panel/g)?.length).toBe(2);
+    expect(closed).toContain("translateX(0px)"); // meet in the middle when closed
+  });
+  it("travels a quarter of the opening, so the panels stay inside it", () => {
+    const open = svgOf(bipartingBypass(), { open: true });
+    // A quarter (22.5) each way — half of what `biparting` travels, because
+    // these park over the fixed panels instead of disappearing into the wall.
+    expect(open).toContain("translateX(-22.5px)");
+    expect(open).toContain("translateX(22.5px)");
+    expect(open).not.toContain("translateX(-45px)");
+  });
+  it("keeps both panels on parallel tracks, like a bypass slider", () => {
+    const s = svgOf(bipartingBypass(), { open: false });
+    expect(s).toContain("y1=1.75"); // two tracks drawn, as in bypass
+    expect(s).toContain("y1=-1.75");
+    expect(s).toContain("y=0.5"); // fixed panels ride the front track
+    expect(s).toContain("y=-3"); // the moving ones the back track, clear of them
+  });
+  it("never accents the fixed panels, however open the slider is", () => {
+    const open = svgOf(bipartingBypass(), { open: true, active: true, accent: "#f00" });
+    // Two moving panels take the accent; the two fixed ones keep the base color.
+    expect(open.match(/fill:#f00/g)?.length).toBe(2);
+    expect(open.match(/fill=#000/g)?.length).toBe(2);
+  });
+});
+
+describe("renderOpening — a biparting slider's second panel (issue #145)", () => {
+  for (const sliderStyle of ["biparting", "biparting-bypass"] as const) {
+    const travel = sliderStyle === "biparting" ? 45 : 22.5;
+    describe(sliderStyle, () => {
+      it("moves both panels together when no second state is given", () => {
+        const open = svgOf(sliding({ sliderStyle }), { amount: 1 });
+        expect(open).toContain(`translateX(-${travel}px)`);
+        expect(open).toContain(`translateX(${travel}px)`);
+      });
+      it("opens one panel while the other stays shut", () => {
+        const s = svgOf(sliding({ sliderStyle }), { amount: 1, second: { amount: 0 } });
+        expect(s).toContain(`translateX(-${travel}px)`); // first panel open
+        expect(s).toContain("translateX(0px)"); // second still closed
+        expect(s).not.toContain(`translateX(${travel}px)`);
+      });
+      it("opens the second panel while the first stays shut", () => {
+        const s = svgOf(sliding({ sliderStyle }), { amount: 0, second: { amount: 1 } });
+        expect(s).toContain(`translateX(${travel}px)`);
+        expect(s).toContain("translateX(0px)");
+        expect(s).not.toContain(`translateX(-${travel}px)`);
+      });
+      it("gives each panel its own travel for two position-aware covers", () => {
+        const s = svgOf(sliding({ sliderStyle }), { amount: 0.5, second: { amount: 1 } });
+        expect(s).toContain(`translateX(-${travel / 2}px)`);
+        expect(s).toContain(`translateX(${travel}px)`);
+      });
+      it("clamps a second panel's out-of-range amount", () => {
+        const s = svgOf(sliding({ sliderStyle }), { amount: 0, second: { amount: 4 } });
+        expect(s).toContain(`translateX(${travel}px)`);
+      });
+      it("accents only the panel whose own sensor reads open", () => {
+        const s = svgOf(sliding({ sliderStyle }), {
+          amount: 1,
+          active: true,
+          accent: "#f00",
+          second: { amount: 0, active: false },
+        });
+        expect(s.match(/fill:#f00/g)?.length).toBe(1); // the open panel only
+        expect(s).toContain("fill:#000"); // the shut one keeps the base color
+      });
+    });
+  }
+  it("is ignored by the styles that only move one panel", () => {
+    for (const sliderStyle of ["single", "bypass"] as const) {
+      const s = svgOf(sliding({ sliderStyle }), { amount: 1, second: { amount: 0 } });
+      const withoutSecond = svgOf(sliding({ sliderStyle }), { amount: 1 });
+      expect(s).toBe(withoutSecond);
+    }
+  });
+});
+
 describe("renderOpening — sliding window", () => {
   it("slides like a slider but with thin glass panels (thickness 1.5)", () => {
     const win = svgOf({ type: "window", motion: "slide" }, { open: true });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -101,6 +101,7 @@ import {
   editorGlowPaint,
   glowReach,
   wallsLightPassesThrough,
+  openingClearFraction,
   renderGlowMask,
   renderOpening,
   renderGlow,
@@ -3394,6 +3395,71 @@ describe("lightBadgePaint (#106)", () => {
 // Issue #143: "doors act as walls and stop the light pool, regardless of
 // open/close status". Walls and openings are stored independently, so the glow
 // sweep saw uncut walls where the plan draws a hole.
+// Issue #145 meets #143: a two-panel slider has two sensors and its leaves do
+// not travel the full width, so neither the amount nor the leaf count could be
+// read off `entity` alone.
+describe("openingClearFraction (#145 / #143)", () => {
+  const slider = (sliderStyle: string): Opening =>
+    ({ id: "o", type: "window", motion: "slide", sliderStyle, x: 300, y: 300, length: 200, angle: 0 }) as Opening;
+
+  it("counts both leaves, so the second panel alone opens a gap", () => {
+    // The bug: a door whose only open leaf was the second one blocked light
+    // outright, because the light asked `entity` and nothing else.
+    for (const s of ["biparting", "biparting-bypass", "converging"]) {
+      expect({ s, clear: openingClearFraction(slider(s), 0, 1) > 0 }).toEqual({ s, clear: true });
+    }
+  });
+
+  it("matches how far each style's leaves actually travel", () => {
+    // Measured against the drawn geometry: biparting sends its leaves into the
+    // walls, the patio styles keep theirs inside the frame at a quarter each.
+    const table = [
+      ["biparting", 1, 1, 1],
+      ["biparting", 1, 0, 0.5],
+      ["biparting-bypass", 1, 1, 0.5],
+      ["biparting-bypass", 1, 0, 0.25],
+      ["converging", 1, 1, 0.5],
+      ["converging", 1, 0, 0.25],
+    ] as Array<[string, number, number, number]>;
+    for (const [s, a1, a2, want] of table) {
+      expect({ s, a1, a2, clear: openingClearFraction(slider(s), a1, a2) }).toEqual({
+        s, a1, a2, clear: want,
+      });
+    }
+  });
+
+  it("never lets a patio slider through more light than it draws", () => {
+    // The ceiling is the point: these two keep their leaves in the frame, so
+    // reading `amount` alone would pass twice the light that is drawn.
+    for (const s of ["biparting-bypass", "converging"]) {
+      expect(openingClearFraction(slider(s), 1, 1)).toBeLessThanOrEqual(0.5);
+    }
+  });
+
+  it("leaves every other opening exactly as it was", () => {
+    const shut = 0;
+    const open = 1;
+    const half = 0.4;
+    for (const o of [
+      { id: "d", type: "door", x: 0, y: 0, length: 90, angle: 0 } as Opening,
+      { id: "r", type: "window", motion: "roll", x: 0, y: 0, length: 90, angle: 0 } as Opening,
+      slider("single"),
+      slider("bypass"),
+    ]) {
+      for (const a of [shut, half, open]) {
+        expect(openingClearFraction(o, a)).toBe(a);
+      }
+    }
+    // …including a single-sensor biparting, where the mean of one amount is itself.
+    expect(openingClearFraction(slider("biparting"), 0.6)).toBeCloseTo(0.6, 10);
+  });
+
+  it("clamps a junk reading rather than cutting a gap wider than the wall", () => {
+    expect(openingClearFraction(slider("biparting"), 5, 5)).toBe(1);
+    expect(openingClearFraction(slider("converging"), -3, -3)).toBe(0);
+  });
+});
+
 describe("wallsLightPassesThrough (#143)", () => {
   const wall = (x1: number, y1: number, x2: number, y2: number, id = "w") => ({ id, x1, y1, x2, y2 });
   // A door centred on a horizontal wall at y=100, spanning x 480..520.

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -21,6 +21,7 @@ import {
   openingMirror,
   sliderStyleOf,
   openingHasTwoPanels,
+  sliderStyleHasTwoPanels,
   secondPanelOf,
   openingFromDeviceClass,
   windowSash,
@@ -254,10 +255,12 @@ describe("sliderStyleOf", () => {
   it("is single for swinging openings regardless of sliderStyle", () => {
     expect(sliderStyleOf({ type: "door", sliderStyle: "bypass" } as Opening)).toBe("single");
   });
-  it("carries the biparting-bypass style through (issue #145)", () => {
-    expect(
-      sliderStyleOf({ type: "door", motion: "slide", sliderStyle: "biparting-bypass" } as Opening),
-    ).toBe("biparting-bypass");
+  it("carries the two-panel styles through (issue #145)", () => {
+    for (const sliderStyle of ["biparting-bypass", "converging"] as const) {
+      expect(sliderStyleOf({ type: "door", motion: "slide", sliderStyle } as Opening)).toBe(
+        sliderStyle,
+      );
+    }
   });
 });
 
@@ -265,12 +268,16 @@ describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
   const slider = (extra: Partial<Opening> = {}) =>
     ({ type: "door", motion: "slide", ...extra }) as Opening;
 
-  it("is true for exactly the two biparting styles", () => {
-    expect(openingHasTwoPanels(slider({ sliderStyle: "biparting" }))).toBe(true);
-    expect(openingHasTwoPanels(slider({ sliderStyle: "biparting-bypass" }))).toBe(true);
+  it("is true for exactly the styles that move both panels", () => {
+    for (const sliderStyle of ["biparting", "biparting-bypass", "converging"] as const) {
+      expect(openingHasTwoPanels(slider({ sliderStyle }))).toBe(true);
+      expect(sliderStyleHasTwoPanels(sliderStyle)).toBe(true);
+    }
     // bypass moves one panel past a fixed one; single moves the only panel.
     expect(openingHasTwoPanels(slider({ sliderStyle: "bypass" }))).toBe(false);
     expect(openingHasTwoPanels(slider())).toBe(false);
+    expect(sliderStyleHasTwoPanels("bypass")).toBe(false);
+    expect(sliderStyleHasTwoPanels("single")).toBe(false);
     // A swing door has leaves, but no sliding panel to bind a second sensor to.
     expect(openingHasTwoPanels({ type: "door", sliderStyle: "biparting" } as Opening)).toBe(false);
   });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -20,6 +20,8 @@ import {
   openingMotion,
   openingMirror,
   sliderStyleOf,
+  openingHasTwoPanels,
+  secondPanelOf,
   openingFromDeviceClass,
   windowSash,
   shutterAmount,
@@ -251,6 +253,63 @@ describe("sliderStyleOf", () => {
   });
   it("is single for swinging openings regardless of sliderStyle", () => {
     expect(sliderStyleOf({ type: "door", sliderStyle: "bypass" } as Opening)).toBe("single");
+  });
+  it("carries the biparting-bypass style through (issue #145)", () => {
+    expect(
+      sliderStyleOf({ type: "door", motion: "slide", sliderStyle: "biparting-bypass" } as Opening),
+    ).toBe("biparting-bypass");
+  });
+});
+
+describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
+  const slider = (extra: Partial<Opening> = {}) =>
+    ({ type: "door", motion: "slide", ...extra }) as Opening;
+
+  it("is true for exactly the two biparting styles", () => {
+    expect(openingHasTwoPanels(slider({ sliderStyle: "biparting" }))).toBe(true);
+    expect(openingHasTwoPanels(slider({ sliderStyle: "biparting-bypass" }))).toBe(true);
+    // bypass moves one panel past a fixed one; single moves the only panel.
+    expect(openingHasTwoPanels(slider({ sliderStyle: "bypass" }))).toBe(false);
+    expect(openingHasTwoPanels(slider())).toBe(false);
+    // A swing door has leaves, but no sliding panel to bind a second sensor to.
+    expect(openingHasTwoPanels({ type: "door", sliderStyle: "biparting" } as Opening)).toBe(false);
+  });
+
+  it("swaps in the second entity and keeps everything else", () => {
+    const o = slider({
+      sliderStyle: "biparting",
+      entity: "binary_sensor.left",
+      secondaryEntity: "binary_sensor.right",
+      invert: true,
+      length: 90,
+    });
+    expect(secondPanelOf(o)).toEqual({ ...o, entity: "binary_sensor.right" });
+  });
+
+  it("resolves the second panel independently, sharing invert", () => {
+    const o = slider({
+      sliderStyle: "biparting",
+      entity: "binary_sensor.left",
+      secondaryEntity: "binary_sensor.right",
+    });
+    const panel = secondPanelOf(o);
+    expect(resolveOpeningAmount(panel, { state: "on" })).toBe(1);
+    expect(resolveOpeningAmount(panel, { state: "off" })).toBe(0);
+    expect(openingIsActive(panel, { state: "on" })).toBe(true);
+    expect(openingIsActive(panel, { state: "off" })).toBe(false);
+    // Position-aware covers drive the panel partway, and invert flips it.
+    expect(
+      resolveOpeningAmount(panel, { state: "open", attributes: { current_position: 40 } }),
+    ).toBeCloseTo(0.4);
+    expect(
+      resolveOpeningAmount(secondPanelOf({ ...o, invert: true }), {
+        state: "open",
+        attributes: { current_position: 40 },
+      }),
+    ).toBeCloseTo(0.6);
+    // An outage on one leaf fails that leaf closed, not the whole opening.
+    expect(resolveOpeningAmount(panel, { state: "unavailable" })).toBe(0);
+    expect(openingIsActive(panel, { state: "unavailable" })).toBe(false);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2525,6 +2525,66 @@ describe("collectWatchedEntities includes shutter entities (issue #74)", () => {
   });
 });
 
+/**
+ * Review on #151: the openings loop took `entity` and `shutterEntity` and not
+ * `secondaryEntity`, so a plan never re-rendered when only the *second* panel's
+ * contact moved — the headline case of #145, silently not working.
+ *
+ * The failure was worse than a frozen panel: any other watched entity moving
+ * dragged a render along with it and the panel caught up, so it looked
+ * intermittent. Both halves are asserted below, because set membership alone
+ * would not have caught it — `hassRenderInputsChanged` compares state objects
+ * by identity, which is the thing that actually decides whether a render runs.
+ */
+describe("collectWatchedEntities includes a slider's second panel (issue #145)", () => {
+  const twoPanelPlan = (secondaryEntity?: string) =>
+    ({
+      type: "t", width: 1000, height: 600,
+      floors: [{ id: "f", name: "F", walls: [], items: [], texts: [], furniture: [], trackers: [],
+        openings: [{ id: "o", type: "window", x: 0, y: 0, length: 200, angle: 0,
+          motion: "slide", sliderStyle: "converging",
+          entity: "binary_sensor.left", ...(secondaryEntity ? { secondaryEntity } : {}) }] }],
+    }) as unknown as FloorplanCardConfig;
+
+  it("watches both leaves' sensors", () => {
+    const ids = collectWatchedEntities(twoPanelPlan("binary_sensor.right"));
+    expect(ids.has("binary_sensor.left")).toBe(true);
+    expect(ids.has("binary_sensor.right")).toBe(true);
+  });
+
+  it("adds nothing when the opening has only one sensor", () => {
+    expect(collectWatchedEntities(twoPanelPlan()).size).toBe(1);
+  });
+
+  // The assertion that actually pins the bug: HA hands over a fresh state
+  // object for what changed and carries the rest across by identity, so a
+  // render only happens if the *second* sensor's id is in the watched set.
+  it("re-renders when only the second panel's sensor changes", () => {
+    const watched = collectWatchedEntities(twoPanelPlan("binary_sensor.right"));
+    const left = { state: "off" };
+    const prev = {
+      states: { "binary_sensor.left": left, "binary_sensor.right": { state: "off" } },
+    } as unknown as RenderHass;
+    const next = {
+      // Same object for the left sensor — nothing about it moved.
+      states: { "binary_sensor.left": left, "binary_sensor.right": { state: "on" } },
+    } as unknown as RenderHass;
+    expect(hassRenderInputsChanged(prev, next, watched)).toBe(true);
+  });
+
+  it("still skips a tick where neither leaf moved", () => {
+    const watched = collectWatchedEntities(twoPanelPlan("binary_sensor.right"));
+    const states = { "binary_sensor.left": { state: "off" }, "binary_sensor.right": { state: "off" } };
+    expect(
+      hassRenderInputsChanged(
+        { states } as unknown as RenderHass,
+        { states } as unknown as RenderHass,
+        watched
+      )
+    ).toBe(false);
+  });
+});
+
 describe("polygonCentroid", () => {
   it("averages the vertices", () => {
     const square = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }];

--- a/src/render.ts
+++ b/src/render.ts
@@ -10,6 +10,7 @@ import type {
   FloorplanCardConfig,
   Floor,
   Opening,
+  SliderStyle,
   ItemKind,
   IconAnimation,
   StateColorRule,
@@ -1662,20 +1663,25 @@ export function openingMirror(o: Opening): { sx: 1 | -1; sy: 1 | -1 } {
  * Resolve a sliding opening's panel arrangement. Only meaningful while sliding
  * (swinging openings always resolve to `single`), defaulting to `single`.
  */
-export function sliderStyleOf(
-  o: Opening,
-): "single" | "bypass" | "biparting" | "biparting-bypass" {
+export function sliderStyleOf(o: Opening): SliderStyle {
   return openingMotion(o) === "slide" ? (o.sliderStyle ?? "single") : "single";
 }
 
 /**
- * Whether this opening draws **two** moving panels — the two biparting styles.
- * `single` and `bypass` both move one panel (bypass's other panel is fixed), so
- * only these two have a second leaf for `secondaryEntity` to drive (issue #145).
+ * Whether a slider style draws **two** moving panels, and so has a second leaf
+ * for `secondaryEntity` to drive (issue #145). `single` and `bypass` both move
+ * one panel — bypass's other panel is fixed — so neither qualifies.
+ *
+ * Takes the style rather than the opening because the editor asks about a style
+ * the user has just picked, before it is on any opening.
  */
+export function sliderStyleHasTwoPanels(style: SliderStyle): boolean {
+  return style === "biparting" || style === "biparting-bypass" || style === "converging";
+}
+
+/** {@link sliderStyleHasTwoPanels} for an opening as configured. */
 export function openingHasTwoPanels(o: Opening): boolean {
-  const style = sliderStyleOf(o);
-  return style === "biparting" || style === "biparting-bypass";
+  return sliderStyleHasTwoPanels(sliderStyleOf(o));
 }
 
 /**
@@ -2387,6 +2393,39 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         </g>
         <g class="fp-slide-panel" style="transform:translateX(${q * amt2}px);">
           <rect x="0" y=${-off - t / 2} width=${q} height=${t} style="fill:${tone2};" />
+        </g>`;
+    } else if (sliderStyle === "converging") {
+      // Two moving panels and nothing else (issue #145) — the slider whose
+      // leaves are both operable. They ride parallel tracks, so neither blocks
+      // the other, and they travel *toward* each other until they stack over
+      // the middle half: the mirror image of `biparting-bypass`, which clears
+      // the middle and leaves the ends glazed.
+      //
+      // Travel is a quarter, not a panel's full width, and that is the whole
+      // design of this style. A leaf physically can slide its own width, right
+      // across its neighbour — but then two open leaves simply swap sides and
+      // cover the opening again, which is the one thing a floor plan must not
+      // draw. Parking each at the halfway point makes both-open the case it
+      // reads as: stacked in the middle, a quarter clear at each jamb. The
+      // price is that a single open leaf draws a quarter clear rather than the
+      // half it could reach, and that is the right way round — under-promising
+      // the gap you can walk through beats inventing one that isn't there.
+      const off = 1.75; // half the gap between the two tracks, as in bypass
+      const q = half / 2; // each panel parks over the middle half
+      body = svg`
+        ${jambs}
+        <!-- tracks -->
+        <line x1=${-half} y1=${-off} x2=${half} y2=${-off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <line x1=${-half} y1=${off} x2=${half} y2=${off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <!-- both panels move, so both take the accent on their own state:
+             front track travels right, back track left, and they meet. -->
+        <g class="fp-slide-panel" style="transform:translateX(${q * amt}px);">
+          <rect x=${-half} y=${off - t / 2} width=${half} height=${t} style="fill:${tone};" />
+        </g>
+        <g class="fp-slide-panel" style="transform:translateX(${-q * amt2}px);">
+          <rect x="0" y=${-off - t / 2} width=${half} height=${t} style="fill:${tone2};" />
         </g>`;
     } else {
       // Single panel: fills the opening closed, slides fully aside when open.

--- a/src/render.ts
+++ b/src/render.ts
@@ -522,6 +522,52 @@ function clipWallToBox(
  * circle with no clip at all.
  */
 /**
+ * How much of an opening's width is actually clear, 0–1 — what {@link
+ * wallsLightPassesThrough} cuts out of the wall for light to pass through.
+ *
+ * Not simply the leaf's `amount`, for two reasons that both arrived with the
+ * two-panel sliders (issue #145):
+ *
+ * **Both panels count.** A door with a sensor per leaf and only its *second*
+ * panel open was drawing that panel open while still blocking light outright,
+ * because the light asked `entity` and nothing else.
+ *
+ * **Travel is not the same as clearance.** `biparting` sends each leaf out into
+ * a wall, so two open leaves clear the whole opening. The patio styles keep
+ * their leaves inside it — each travels a quarter — so even wide open they
+ * clear only half. Reading `amount` alone would have `converging` letting
+ * through twice the light it draws.
+ *
+ *  | style                    | both open | one open |
+ *  | ------------------------ | --------- | -------- |
+ *  | `biparting`              | all of it | half     |
+ *  | `biparting-bypass`       | half      | a quarter|
+ *  | `converging`             | half      | a quarter|
+ *
+ * Every other opening keeps `amount` untouched, so a swing door, a roll-up and
+ * a single-panel slider all behave exactly as they did — as does a
+ * single-sensor `biparting`, where both leaves share one amount and the mean
+ * of it is itself.
+ */
+export function openingClearFraction(o: Opening, amount: number, secondAmount?: number): number {
+  const a1 = Math.max(0, Math.min(1, amount));
+  const a2 = Math.max(0, Math.min(1, secondAmount ?? amount));
+  switch (sliderStyleOf(o)) {
+    case "biparting":
+      // Each leaf recesses into its own wall, so between them they can clear
+      // the opening completely.
+      return (a1 + a2) / 2;
+    case "biparting-bypass":
+    case "converging":
+      // Each leaf is a quarter wide and travels a quarter, and stays in the
+      // frame — so the pair tops out at half the opening however wide open.
+      return (a1 + a2) / 4;
+    default:
+      return a1;
+  }
+}
+
+/**
  * The walls as **light** meets them (issue #143): the plan's walls with a gap
  * cut wherever an opening is currently open.
  *
@@ -539,9 +585,19 @@ function clipWallToBox(
  * A window behaves the same way: shut it blocks, open it spills light outside,
  * which is what an open window does.
  *
- * The gap is `length * amount`, centred. A half-open slider really clears one
- * side rather than the middle, but the pool is a soft radial wash and centring
- * keeps this to one interval per opening instead of a handed special case.
+ * The caller supplies how much of each opening is clear — see
+ * {@link openingClearFraction}, which is where a two-panel slider's two
+ * sensors are reconciled into one number.
+ *
+ * The gap is `length * fraction`, **centred**, and that is an approximation
+ * worth naming. A half-open slider really clears one side rather than the
+ * middle; `converging` is the sharpest case, since its two leaves stack in the
+ * centre and what actually clears is a quarter at each jamb — so the gap is
+ * the right *size* and the wrong *place*. The amount of light through the wall
+ * is right, where it lands is approximate, and the pool is a soft radial wash
+ * that hides most of the difference. Fixing it properly means letting one
+ * opening contribute several intervals rather than one, which is a change to
+ * this function's contract rather than to its arithmetic.
  */
 export function wallsLightPassesThrough(
   walls: readonly Wall[],

--- a/src/render.ts
+++ b/src/render.ts
@@ -1662,8 +1662,32 @@ export function openingMirror(o: Opening): { sx: 1 | -1; sy: 1 | -1 } {
  * Resolve a sliding opening's panel arrangement. Only meaningful while sliding
  * (swinging openings always resolve to `single`), defaulting to `single`.
  */
-export function sliderStyleOf(o: Opening): "single" | "bypass" | "biparting" {
+export function sliderStyleOf(
+  o: Opening,
+): "single" | "bypass" | "biparting" | "biparting-bypass" {
   return openingMotion(o) === "slide" ? (o.sliderStyle ?? "single") : "single";
+}
+
+/**
+ * Whether this opening draws **two** moving panels — the two biparting styles.
+ * `single` and `bypass` both move one panel (bypass's other panel is fixed), so
+ * only these two have a second leaf for `secondaryEntity` to drive (issue #145).
+ */
+export function openingHasTwoPanels(o: Opening): boolean {
+  const style = sliderStyleOf(o);
+  return style === "biparting" || style === "biparting-bypass";
+}
+
+/**
+ * The second moving panel as an opening in its own right, so it can go through
+ * {@link resolveOpeningAmount} / {@link openingIsActive} unchanged rather than
+ * threading a "which panel" argument down the whole resolver chain (issue #145).
+ * Shares the geometry and `invert`; only the bound entity differs. Callers must
+ * check {@link openingHasTwoPanels} and a set `secondaryEntity` first — with no
+ * entity this resolves to the type default, not to the first panel's state.
+ */
+export function secondPanelOf(o: Opening): Opening {
+  return { ...o, entity: o.secondaryEntity };
 }
 
 /**
@@ -2184,6 +2208,13 @@ export interface OpeningStyle {
     accent?: string;
     flip?: boolean;
   };
+  /**
+   * The second moving panel of a biparting slider (issue #145), when it has a
+   * sensor of its own. Omitted — the only case before that issue — leaves both
+   * panels sharing `amount` and `active`, so a single-entity slider parts
+   * symmetrically exactly as it always has. Ignored by every other style.
+   */
+  second?: { amount: number; active?: boolean };
 }
 
 /**
@@ -2286,6 +2317,15 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
               stroke=${color} stroke-width="2" />`;
     const sliderStyle = sliderStyleOf(o);
+    // The second moving panel of a biparting slider (issue #145). With a sensor
+    // of its own it opens and accents independently; without one it mirrors the
+    // first panel, which is what a single-entity slider has always drawn.
+    const amt2 = style.second
+      ? Math.max(0, Math.min(1, style.second.amount))
+      : amt;
+    const tone2 = style.second
+      ? cssColorOr(style.second.active ? accent : color, SKIN_ACCENT)
+      : tone;
     if (sliderStyle === "bypass") {
       // Double bypass: two half-width panels on parallel tracks. The moving
       // (back) panel slides left to stack behind the fixed (front) panel.
@@ -2307,17 +2347,46 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     } else if (sliderStyle === "biparting") {
       // Biparting: two half-width panels meet at the centre and part, each
       // recessing into the wall on its own side (left panel → left, right → right).
-      const shift = half * amt;
       body = svg`
         ${jambs}
         <!-- track -->
         <line x1=${-half} y1="0" x2=${half} y2="0"
               stroke=${color} stroke-width="0.75" opacity="0.6" />
-        <g class="fp-slide-panel" style="transform:translateX(${-shift}px);">
+        <g class="fp-slide-panel" style="transform:translateX(${-half * amt}px);">
           <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
         </g>
-        <g class="fp-slide-panel" style="transform:translateX(${shift}px);">
-          <rect x="0" y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+        <g class="fp-slide-panel" style="transform:translateX(${half * amt2}px);">
+          <rect x="0" y=${-t / 2} width=${half} height=${t} style="fill:${tone2};" />
+        </g>`;
+    } else if (sliderStyle === "biparting-bypass") {
+      // Biparting over fixed panels (issue #145) — the patio / bay slider. The
+      // opening divides into four: a fixed panel at each jamb on the front
+      // track, and two moving panels on the back track that meet in the middle
+      // and part until each sits over the fixed panel on its side. Nothing
+      // recesses into the wall, so travel is a quarter of the opening rather
+      // than half, and even wide open the outer quarters stay glazed — which is
+      // the whole difference from `biparting` and the reason it can't be faked
+      // by clamping that one's travel.
+      const off = 1.75; // half the gap between the two tracks, as in bypass
+      const q = half / 2; // one panel: the opening splits into four
+      body = svg`
+        ${jambs}
+        <!-- tracks -->
+        <line x1=${-half} y1=${-off} x2=${half} y2=${-off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <line x1=${-half} y1=${off} x2=${half} y2=${off}
+              stroke=${color} stroke-width="0.75" opacity="0.6" />
+        <!-- fixed panels: outer quarters, front track. Never accented, even
+             wide open — the accent marks what has moved, and lighting these
+             would accent exactly the half that is still glazed shut. -->
+        <rect x=${-half} y=${off - t / 2} width=${q} height=${t} fill=${color} />
+        <rect x=${half - q} y=${off - t / 2} width=${q} height=${t} fill=${color} />
+        <!-- moving panels: inner quarters, back track -->
+        <g class="fp-slide-panel" style="transform:translateX(${-q * amt}px);">
+          <rect x=${-q} y=${-off - t / 2} width=${q} height=${t} style="fill:${tone};" />
+        </g>
+        <g class="fp-slide-panel" style="transform:translateX(${q * amt2}px);">
+          <rect x="0" y=${-off - t / 2} width=${q} height=${t} style="fill:${tone2};" />
         </g>`;
     } else {
       // Single panel: fills the opening closed, slides fully aside when open.

--- a/src/render.ts
+++ b/src/render.ts
@@ -114,6 +114,11 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     for (const o of f.openings) {
       if (o.entity) ids.add(o.entity);
       if (o.shutterEntity) ids.add(o.shutterEntity);
+      // The second panel of a two-panel slider (issue #145). Exactly the trap
+      // named above, and the worst version of it: the panel is not frozen, it
+      // catches up whenever some *other* watched entity moves, so it reads as
+      // intermittent rather than broken.
+      if (o.secondaryEntity) ids.add(o.secondaryEntity);
     }
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,15 @@ export interface Opening {
    * drawn open (swing symbol) and windows closed, matching a static floor plan.
    */
   entity?: string;
+  /**
+   * Biparting sliders only: a second contact / `cover` driving the **other**
+   * moving panel (issue #145), for a two-panel door with a sensor on each leaf.
+   * `entity` keeps the first panel — the one at the −x jamb in the opening's own
+   * frame, so `flipH` swaps which panel each sensor draws, exactly as it mirrors
+   * everything else. Unset (the default) leaves both panels on `entity`, which
+   * is what a single-sensor slider has always drawn. `invert` covers both.
+   */
+  secondaryEntity?: string;
   /** Flip the open/closed interpretation of `entity` (for inverted sensors). */
   invert?: boolean;
   /** Color of the leaf/sash and swing arc while actively open. Falls back to the primary color. */
@@ -197,10 +206,14 @@ export interface Opening {
    * - `bypass` — two panels on parallel tracks; one slides behind the other
    *   (patio-door style).
    * - `biparting` — two panels meet in the middle and part, each recessing into
-   *   the wall on its own side.
+   *   the wall on its own side (a pocket door / galandage).
+   * - `biparting-bypass` — the same two panels, but they stack over a fixed
+   *   panel at each jamb instead of vanishing into the wall (issue #145), so
+   *   nothing leaves the opening and at most its middle half ever clears. The
+   *   common patio / bay slider.
    * Ignored for swinging openings.
    */
-  sliderStyle?: "single" | "bypass" | "biparting";
+  sliderStyle?: "single" | "bypass" | "biparting" | "biparting-bypass";
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,14 @@ export interface Wall {
 export type OpeningType = "door" | "window";
 
 /**
+ * How a sliding opening's panels are arranged. Named as a type rather than
+ * inlined on {@link Opening.sliderStyle} so the render and the editor agree on
+ * the set — three of these carry a second moving panel and the list had started
+ * being retyped by hand (issue #145). See that field for what each one draws.
+ */
+export type SliderStyle = "single" | "bypass" | "biparting" | "biparting-bypass" | "converging";
+
+/**
  * A door or window. Positioned by its center point and rotation so it can be
  * dropped onto (and aligned with) a wall, but it is stored independently.
  */
@@ -85,7 +93,7 @@ export interface Opening {
    */
   entity?: string;
   /**
-   * Biparting sliders only: a second contact / `cover` driving the **other**
+   * Two-panel sliders only: a second contact / `cover` driving the **other**
    * moving panel (issue #145), for a two-panel door with a sensor on each leaf.
    * `entity` keeps the first panel — the one at the −x jamb in the opening's own
    * frame, so `flipH` swaps which panel each sensor draws, exactly as it mirrors
@@ -211,9 +219,14 @@ export interface Opening {
    *   panel at each jamb instead of vanishing into the wall (issue #145), so
    *   nothing leaves the opening and at most its middle half ever clears. The
    *   common patio / bay slider.
+   * - `converging` — two moving panels and nothing else (issue #145): they
+   *   travel *toward* each other and stack in the middle, clearing a quarter of
+   *   the opening at each jamb. The two-operable-leaf slider, and the mirror
+   *   image of `biparting-bypass` — where that one clears the middle, this
+   *   clears the ends.
    * Ignored for swinging openings.
    */
-  sliderStyle?: "single" | "bypass" | "biparting" | "biparting-bypass";
+  sliderStyle?: SliderStyle;
 }
 
 /**


### PR DESCRIPTION
### The problem

@lepiaf56 has a two-panel patio slider with an independent contact on each leaf, and the card can say neither thing.

**One state for two panels.** A sliding opening carries one `entity`, and `biparting` draws both panels from it. Left open and right shut — the everyday case on a patio door you only ever open one side of — can only be drawn as both open or both shut.

**And it draws the wrong door.** `biparting` recesses each panel into the wall on its own side. That is a pocket door (*galandage*). The common patio slider has fixed panels at the jambs and the moving ones ride in front of them: nothing disappears into a wall, and even wide open the outer quarters stay glazed.

### The change

**`secondaryEntity`** binds the other panel — the field name an item already uses for its second reading:

```yaml
- id: bay
  type: window
  motion: slide
  sliderStyle: biparting-bypass
  entity: binary_sensor.sliding_door_left
  secondaryEntity: binary_sensor.sliding_door_right
```

Each panel then resolves its own amount, its own accent and its own outage. Unset, both panels stay on `entity` and every slider that exists today draws exactly as it did.

The plumbing is deliberately thin. `secondPanelOf()` hands the second panel to `resolveOpeningAmount` / `openingIsActive` as an opening in its own right, rather than threading a "which panel" argument down the resolver chain — so the second leaf inherits the rules the first one already had, including failing closed on `unavailable`. Per leaf, so one dropped sensor no longer shuts the whole opening. `invert` and the tap target stay shared: it is one opening.

**`sliderStyle: biparting-bypass`** draws the patio door. The opening splits into four — two fixed panels at the jambs on the front track, two moving ones on the back track — and the moving pair parts until each sits over the fixed panel on its side.

Travel is therefore a **quarter** of the opening rather than half, and the clear span tops out at the middle half however wide open the door is. That is the whole difference from `biparting`, and the reason it can't be had by clamping that one's travel: the outer quarters stay glazed, and on a plan that is the part you can't walk through.

**`sliderStyle: converging`** draws the same door without the fixed glass, after @lepiaf56 [clarified](https://github.com/nicosandller/easy-floorplan/pull/151#issuecomment-5251263471) that theirs has none: two leaves, both operable, overlapping each other rather than a fixed panel.

That is the **mirror image** of `biparting-bypass`, not a variant of it. The panels run *toward* each other and stack over the middle half, so what clears is a quarter at each jamb — where `biparting-bypass` keeps the outer quarters glazed and clears the middle. Neither can be had by clamping the other, so it joins it rather than replacing it; which one you want depends on whether your outer quarters are fixed glass.

Travel is a quarter here too, and that is the whole design of the style. A leaf can physically slide its own width, straight across its neighbour on the other track — but then two open leaves swap sides and cover the opening again, which is the one thing a plan must not draw. Parking each at the halfway point makes both-open read the way the door looks. The price: a single open leaf draws a quarter clear rather than the half it could reach. Under-promising the gap you can walk through beats inventing one that isn't there.

`secondaryEntity` needed nothing new for it — the second panel goes through `secondPanelOf` exactly as the biparting styles do. The style *list* was the fragile part: it was being retyped by hand in the editor's `toPatch`, so that check now asks `sliderStyleHasTwoPanels`, and `SliderStyle` is a named type rather than an inline union in three places.

Two smaller decisions, both commented:

- **The fixed panels are never accented, even wide open.** `bypass` does accent its fixed panel today and this deliberately doesn't follow it — the accent marks what has *moved*, and lighting these would accent exactly the half that is still shut. I left `bypass` alone rather than change a card that already exists.
- **Every two-panel style hides the slide-direction field.** A door that moves both leaves at once has no direction; `flipH` only swaps which panel each sensor drives. Switching a slider to a one-panel style drops `secondaryEntity`, the same way leaving `slide` already drops `sliderStyle`.

`biparting` is untouched and stays the default for anyone who really does have a pocket door, so no existing card changes on upgrade.

### Editor

**Style** gains *Biparting (over fixed panels)* and *Converging (both panels stack in the middle)* beside a relabelled *Biparting (into the walls)*. **Second panel** appears only on a two-panel slider that already has its first entity bound — a slider whose *second* panel alone had a sensor would be more confusing than useful — and takes the same contact/cover picker as the first.

### Verified

Unit tests can't see this, so it was measured on the built card in a browser, reading laid-out geometry back in canvas units. Opening spans **200–400**:

| | panel one | panel two | what clears |
| --- | --- | --- | --- |
| `converging`, both shut | 200–300 | 300–400 | nothing — it fills the opening |
| `converging`, both open | 250–350 | 250–350 | 200–250 and 350–400 |
| `converging`, left contact only | 250–350 | 300–400 | 200–250 |
| `biparting-bypass`, both open | 200–250 | 350–400 | 250–350 |
| `biparting`, both open | 100–200 | 400–500 | the whole opening |

`converging`'s two leaves land exactly on each other over the middle half, and the two patio styles come out as exact mirrors — which is the claim worth checking, since it is why both exist. Nothing crosses a jamb except `biparting`, which is supposed to. This also confirms `translateX(Npx)` on the SVG group still resolves in user units at the new quarter travel. Computed fills confirm only the leaves that moved wear the accent, and that `converging` has no fixed rect to leave unaccented.

949 tests pass (+41 across the three two-panel styles: per-panel travel in both directions, clamping, per-panel accent, the second state being ignored by the one-panel styles, and the form's field visibility and patches). README carries a table of all five styles, since which one you want is now a real choice.

Rebased onto current `main` after the review, which had moved six commits — including the shutter work in #153 and per-wall thickness in #157, both of which touch openings. The geometry above was re-measured afterwards and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


