### PR TITLE
feat(opening): reach the shutter behind the window, and show that it is there

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ distorted anyway.
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
 | `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
 | `sliderStyle` | `single` \| `bypass` \| `biparting` | With `motion: slide`: one panel (default), two stacking, or two centre-parting. |
+| `showShutterIcon` | boolean                 | Draw that icon (default `true` whenever both are bound). Editor: **Shutter icon**. Turning it off changes nothing about the gestures — for a plan where every window has a shutter and the icons start to shout. |
+| `shutterIcon` | string                      | Override the icon's glyph. Left unset it follows the shutter entity, whose default comes in an open/closed pair; an override is one glyph for both states, and colour still reports the state. |
 | `tapTarget`   | `opening` \| `shutter`      | With both entities bound, which one a tap acts on (default `opening`); the other moves to press-and-hold. Editor: **Tap opens**. Pointing it at the shutter opens the shutter's dialog — it does not drive the motor; set `tap_action: toggle` for that. |
 | `tap_action`  | ActionConfig                | Standard Lovelace action, acting on whichever entity `tapTarget` leads with (or on `shutterEntity` when it is the only one bound). By default an open/close `cover` toggles and everything else opens more-info. An action's own `entity` picks which of the two it acts on. |
 | `hold_action` / `double_tap_action` | ActionConfig | With both entities bound, hold opens the shutter's more-info by default — a tap is never retargeted at the shutter motor. Double-tap does nothing unless configured. |

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ distorted anyway.
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves: hinged (default), sliding panels, or a roll-up curtain (garage / roller shutter). |
 | `sash`        | `single` \| `double`        | Swing windows only: one full-width sash, or the classic two. Default `double`. |
-| `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. |
+| `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. Tapping the opening opens this entity's more-info dialog. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |

--- a/README.md
+++ b/README.md
@@ -368,8 +368,11 @@ distorted anyway.
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves: hinged (default), sliding panels, or a roll-up curtain (garage / roller shutter). |
 | `sash`        | `single` \| `double`        | Swing windows only: one full-width sash, or the classic two. Default `double`. |
-| `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. Tapping the opening opens this entity's more-info dialog. |
+| `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |
+| `shutterInvert` | boolean                   | Flip the shutter's open/closed reading — a reed contact on hinged panels often reads `on` when they are shut. Separate from `invert`. |
+| `shutterActiveColor` | string               | Shutter color while open. Falls back to `activeColor`, then the accent. |
+| `shutterFlipV` | boolean                    | Hang hinged panels on the sash's own side of the wall instead of the far side. Ignored by the roll curtain. |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |
@@ -379,6 +382,9 @@ distorted anyway.
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
 | `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
 | `sliderStyle` | `single` \| `bypass` \| `biparting` | With `motion: slide`: one panel (default), two stacking, or two centre-parting. |
+| `tapTarget`   | `opening` \| `shutter`      | With both entities bound, which one a tap acts on (default `opening`); the other moves to press-and-hold. Editor: **Tap opens**. Pointing it at the shutter opens the shutter's dialog — it does not drive the motor; set `tap_action: toggle` for that. |
+| `tap_action`  | ActionConfig                | Standard Lovelace action, acting on whichever entity `tapTarget` leads with (or on `shutterEntity` when it is the only one bound). By default an open/close `cover` toggles and everything else opens more-info. An action's own `entity` picks which of the two it acts on. |
+| `hold_action` / `double_tap_action` | ActionConfig | With both entities bound, hold opens the shutter's more-info by default — a tap is never retargeted at the shutter motor. Double-tap does nothing unless configured. |
 
 ### Item (device)
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -800,6 +800,179 @@ describe("openingForm — sash and shutter (issues #73 / #74)", () => {
   });
 });
 
+describe("openingForm — shutter invert and side (issue #74 follow-up)", () => {
+  const win = { id: "w1", type: "window", x: 0, y: 0, length: 90, angle: 0 } as Opening;
+  const hinged = { ...win, shutterEntity: "binary_sensor.persiana" } as Opening;
+  const roller = { ...win, shutterEntity: "cover.tapparella" } as Opening;
+  const names = (o: Opening) => openingForm(o).fields.map((f) => f.name);
+
+  it("offers Invert shutter only once a shutter is bound", () => {
+    expect(names(win)).not.toContain("shutterInvert");
+    expect(names(hinged)).toContain("shutterInvert");
+    expect(names(roller)).toContain("shutterInvert");
+  });
+
+  it("keeps it separate from the opening's own Invert", () => {
+    // A reed contact on the shutter and the window's own sensor routinely
+    // disagree about which way round `on` means open.
+    const both = { ...hinged, entity: "binary_sensor.win" } as Opening;
+    expect(names(both)).toContain("invert");
+    expect(names(both)).toContain("shutterInvert");
+    expect(openingForm({ ...both, shutterInvert: true, invert: false } as Opening).data)
+      .toMatchObject({ shutterInvert: true, invert: false });
+  });
+
+  it("asks which side only for hinged panels", () => {
+    // The roll curtain is symmetric about the wall line, so the answer would
+    // change nothing on screen.
+    expect(names(hinged)).toContain("shutterSide");
+    expect(names(roller)).not.toContain("shutterSide");
+    // …and it follows the explicit style, not just the entity's domain.
+    expect(names({ ...roller, shutterStyle: "swing" } as Opening)).toContain("shutterSide");
+    expect(names({ ...hinged, shutterStyle: "roll" } as Opening)).not.toContain("shutterSide");
+  });
+
+  it("reads the side back off shutterFlipV", () => {
+    expect(openingForm(hinged).data.shutterSide).toBe("far");
+    expect(openingForm({ ...hinged, shutterFlipV: true } as Opening).data.shutterSide).toBe("near");
+  });
+
+  it("patches the side and the invert back into config keys", () => {
+    const { toPatch } = openingForm(hinged);
+    expect(toPatch({ shutterSide: "near" })).toEqual({ shutterFlipV: true });
+    // "far" is the default, so it stays out of the YAML.
+    expect(toPatch({ shutterSide: "far" })).toEqual({ shutterFlipV: undefined });
+    expect(toPatch({ shutterInvert: true })).toEqual({ shutterInvert: true });
+    expect(toPatch({ shutterInvert: false })).toEqual({ shutterInvert: undefined });
+  });
+
+  it("clearing the shutter clears everything that only meant something with it", () => {
+    const decorated = {
+      ...hinged,
+      shutterStyle: "swing",
+      shutterFlipV: true,
+      shutterInvert: true,
+      shutterActiveColor: "#ff0000",
+    } as Opening;
+    // Left behind, a stale invert or side would silently reapply to whatever
+    // shutter is bound next.
+    expect(openingForm(decorated).toPatch({ shutterEntity: undefined })).toEqual({
+      shutterEntity: undefined,
+      shutterStyle: undefined,
+      shutterFlipV: undefined,
+      shutterInvert: undefined,
+      shutterActiveColor: undefined,
+    });
+  });
+
+  it("binding a different shutter keeps its settings", () => {
+    expect(openingForm(hinged).toPatch({ shutterEntity: "cover.other" })).toEqual({
+      shutterEntity: "cover.other",
+    });
+  });
+});
+
+describe("openingForm — actions (issue #74 follow-up)", () => {
+  const win = { id: "w1", type: "window", x: 0, y: 0, length: 90, angle: 0 } as Opening;
+  const names = (o: Opening) => openingForm(o).fields.map((f) => f.name);
+  const gestures = ["tap_action", "hold_action", "double_tap_action"];
+  /** A cover that can open and close; everything else reports no features. */
+  const toggleable = (id: string) => (id.startsWith("cover.") ? 3 : 0);
+  const defaultOf = (o: Opening, name: string, featuresOf?: (id: string) => number) =>
+    (openingForm(o, featuresOf).fields.find((f) => f.name === name)!.selector as {
+      ui_action: { default_action: string };
+    }).ui_action.default_action;
+
+  it("offers no actions until there is something to act on", () => {
+    for (const g of gestures) expect(names(win)).not.toContain(g);
+  });
+
+  it("offers all three once either entity is bound", () => {
+    for (const g of gestures) {
+      expect(names({ ...win, entity: "binary_sensor.win" } as Opening)).toContain(g);
+      // A shutter-only opening is pressable too, so it gets them as well.
+      expect(names({ ...win, shutterEntity: "cover.tapparella" } as Opening)).toContain(g);
+    }
+  });
+
+  it("the tap default names what the card would actually do", () => {
+    const cover = { ...win, entity: "cover.win" } as Opening;
+    expect(defaultOf(cover, "tap_action", toggleable)).toBe("toggle");
+    // Without a features lookup the form can only say "no features", and a
+    // cover it cannot open reads more-info — same as the card would do.
+    expect(defaultOf(cover, "tap_action")).toBe("more-info");
+    expect(defaultOf({ ...win, entity: "binary_sensor.win" } as Opening, "tap_action", toggleable))
+      .toBe("more-info");
+    // A shutter-only opening taps its shutter, since nothing else is bound.
+    expect(
+      defaultOf({ ...win, shutterEntity: "cover.tapparella" } as Opening, "tap_action", toggleable)
+    ).toBe("toggle");
+  });
+
+  it("hold defaults to more-info only when there is a shutter to reach", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    expect(defaultOf(both, "hold_action", toggleable)).toBe("more-info");
+    expect(defaultOf({ ...win, entity: "binary_sensor.win" } as Opening, "hold_action")).toBe("none");
+    expect(defaultOf({ ...win, shutterEntity: "cover.s" } as Opening, "hold_action")).toBe("none");
+  });
+
+  it("offers the tap target only with two entities to choose between", () => {
+    expect(names({ ...win, entity: "binary_sensor.win" } as Opening)).not.toContain("tapTarget");
+    expect(names({ ...win, shutterEntity: "cover.s" } as Opening)).not.toContain("tapTarget");
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    expect(names(both)).toContain("tapTarget");
+    expect(openingForm(both).data.tapTarget).toBe("opening");
+    expect(openingForm({ ...both, tapTarget: "shutter" } as Opening).data.tapTarget).toBe("shutter");
+  });
+
+  it("names the opening's own half after what it is", () => {
+    const label = (o: Opening) =>
+      (openingForm(o).fields.find((f) => f.name === "tapTarget")!.selector as {
+        select: { options: { value: string; label: string }[] };
+      }).select.options[0].label;
+    const bound = { entity: "binary_sensor.x", shutterEntity: "cover.s" };
+    expect(label({ ...win, ...bound } as Opening)).toBe("The window");
+    expect(label({ ...win, ...bound, type: "door" } as Opening)).toBe("The door");
+  });
+
+  it("the tap default follows the chosen target", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    expect(defaultOf(both, "tap_action", toggleable)).toBe("more-info");
+    // Pointing it at an open/close cover still reads more-info: the choice
+    // opens the shutter's dialog rather than driving the motor.
+    expect(defaultOf({ ...both, tapTarget: "shutter" } as Opening, "tap_action", toggleable)).toBe(
+      "more-info"
+    );
+  });
+
+  it("keeps the default out of the YAML and drops it with the shutter", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    const { toPatch } = openingForm(both);
+    expect(toPatch({ tapTarget: "shutter" })).toEqual({ tapTarget: "shutter" });
+    expect(toPatch({ tapTarget: "opening" })).toEqual({ tapTarget: undefined });
+    // Unbinding the shutter leaves nothing to lead with.
+    expect(
+      openingForm({ ...both, tapTarget: "shutter" } as Opening).toPatch({ shutterEntity: undefined })
+        .tapTarget
+    ).toBeUndefined();
+  });
+
+  it("double-tap always defaults to nothing", () => {
+    const both = { ...win, entity: "cover.win", shutterEntity: "cover.s" } as Opening;
+    expect(defaultOf(both, "double_tap_action", toggleable)).toBe("none");
+  });
+
+  it("round-trips the configured actions untouched", () => {
+    const tap = { action: "toggle", entity: "cover.s" };
+    const o = { ...win, entity: "binary_sensor.win", tap_action: tap } as Opening;
+    expect(openingForm(o).data.tap_action).toBe(tap);
+    expect(openingForm(o).data.hold_action).toBeUndefined();
+    expect(openingForm(o).toPatch({ tap_action: tap })).toEqual({ tap_action: tap });
+    // A configured tap replaces the default the field would otherwise name.
+    expect(defaultOf(o, "tap_action", toggleable)).toBe("toggle");
+  });
+});
+
 describe("area scoping never traps you (issue reported on #83)", () => {
   const item = { id: "i", entity: "", kind: "light", x: 0, y: 0 } as FloorItem;
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -916,6 +916,43 @@ describe("openingForm — actions (issue #74 follow-up)", () => {
     expect(defaultOf({ ...win, shutterEntity: "cover.s" } as Opening, "hold_action")).toBe("none");
   });
 
+  it("offers the icon switch only with two entities, and the glyph only while it is on", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    expect(names({ ...win, shutterEntity: "cover.s" } as Opening)).not.toContain("showShutterIcon");
+    expect(names(both)).toContain("showShutterIcon");
+    expect(names(both)).toContain("shutterIcon");
+    // Nothing drawn, nothing to restyle.
+    expect(names({ ...both, showShutterIcon: false } as Opening)).not.toContain("shutterIcon");
+    expect(names({ ...both, showShutterIcon: false } as Opening)).toContain("showShutterIcon");
+  });
+
+  it("reads the switch back as on unless it was turned off", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    expect(openingForm(both).data.showShutterIcon).toBe(true);
+    expect(openingForm({ ...both, showShutterIcon: false } as Opening).data.showShutterIcon).toBe(
+      false
+    );
+    expect(openingForm(both).data.shutterIcon).toBe("");
+    expect(openingForm({ ...both, shutterIcon: "mdi:mine" } as Opening).data.shutterIcon).toBe(
+      "mdi:mine"
+    );
+  });
+
+  it("writes down only the off switch, and drops both with the shutter", () => {
+    const both = { ...win, entity: "binary_sensor.win", shutterEntity: "cover.s" } as Opening;
+    const { toPatch } = openingForm(both);
+    expect(toPatch({ showShutterIcon: false })).toEqual({ showShutterIcon: false });
+    expect(toPatch({ showShutterIcon: true })).toEqual({ showShutterIcon: undefined });
+    expect(toPatch({ shutterIcon: "mdi:mine" })).toEqual({ shutterIcon: "mdi:mine" });
+    const cleared = openingForm({
+      ...both,
+      showShutterIcon: false,
+      shutterIcon: "mdi:mine",
+    } as Opening).toPatch({ shutterEntity: undefined });
+    expect(cleared.showShutterIcon).toBeUndefined();
+    expect(cleared.shutterIcon).toBeUndefined();
+  });
+
   it("offers the tap target only with two entities to choose between", () => {
     expect(names({ ...win, entity: "binary_sensor.win" } as Opening)).not.toContain("tapTarget");
     expect(names({ ...win, shutterEntity: "cover.s" } as Opening)).not.toContain("tapTarget");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -39,6 +39,7 @@ import {
   isPresenceEntity,
   normalizeOverlayScale,
   normalizePlanRotation,
+  openingActionForGesture,
   openingMotion,
   pressEffectOf,
   sliderStyleOf,
@@ -197,7 +198,14 @@ export const FURNITURE_LABELS: Record<FurnitureType, string> = {
   airHandler: "air handler",
 };
 
-export function openingForm(o: Opening): FormSpec {
+/**
+ * `featuresOf` reads an entity's `supported_features`, the one hass-derived
+ * fact this form needs: it decides whether a tap on a `cover` toggles it or
+ * opens more-info, so it is what lets the Tap field name the default the card
+ * would *actually* take rather than a guess. Defaults to "no features", which
+ * is what a form rendered without hass can honestly say.
+ */
+export function openingForm(o: Opening, featuresOf: (entityId: string) => number = () => 0): FormSpec {
   const motion = openingMotion(o);
   const style = sliderStyleOf(o);
   const fields: FormField[] = [
@@ -276,9 +284,73 @@ export function openingForm(o: Opening): FormSpec {
       helper: "Hinged panels fold back against the wall; roll-up slats disappear upward",
       selector: dropdown(opt("swing", "Hinged (louvered panels)"), opt("roll", "Roll-up (slats)")),
     });
+    // Which face of the wall hinged panels hang on. Only asked for hinged
+    // shutters: the roll curtain is drawn symmetrically about the wall line,
+    // so the answer would change nothing on screen.
+    if (shutterStyleOf(o) === "swing") {
+      fields.push({
+        name: "shutterSide",
+        label: "Shutter side",
+        helper: "Which side of the wall the panels hang on",
+        selector: dropdown(opt("far", "Away from the sash"), opt("near", "Same side as the sash")),
+      });
+    }
+    // Its own switch, not the opening's: a reed contact on a hinged shutter
+    // routinely reads `on` when the panels are shut, while the window behind
+    // it reads the other way round.
+    fields.push({ name: "shutterInvert", label: "Invert shutter", selector: { boolean: {} } });
   }
   if (o.entity) fields.push({ name: "invert", label: "Invert", selector: { boolean: {} } });
   fields.push(angleField());
+  // With both bound, which one a press leads with. Only a real question when
+  // there are two entities to choose between — and the reason it exists: the
+  // shutter used to be reachable by hold alone, which is not discoverable and
+  // is awkward on a wall tablet.
+  if (o.entity && o.shutterEntity) {
+    fields.push({
+      name: "tapTarget",
+      label: "Tap opens",
+      helper: "The other one moves to press-and-hold. Opens the dialog; use Tap action below to move the shutter itself",
+      selector: dropdown(
+        opt("opening", o.type === "door" ? "The door" : "The window"),
+        opt("shutter", "The shutter")
+      ),
+    });
+  }
+  // Actions, once there is anything to act on. The tap default names what the
+  // card would do untouched — toggle for an open/close cover, more-info
+  // otherwise — so the field never claims a default the card doesn't take.
+  if (o.entity || o.shutterEntity) {
+    fields.push(
+      {
+        name: "tap_action",
+        label: "Tap action",
+        selector: {
+          ui_action: {
+            default_action:
+              openingActionForGesture(o, "tap", featuresOf)?.config.action ?? "none",
+          },
+        },
+      },
+      {
+        name: "hold_action",
+        label: "Hold action",
+        // With both bound, holding reaches whichever entity the tap does not.
+        // With only one, there is nothing left for hold to open.
+        helper: o.entity && o.shutterEntity ? "Opens the entity the tap doesn't" : undefined,
+        selector: {
+          ui_action: {
+            default_action: o.entity && o.shutterEntity ? "more-info" : "none",
+          },
+        },
+      },
+      {
+        name: "double_tap_action",
+        label: "Double-tap action",
+        selector: { ui_action: { default_action: "none" } },
+      }
+    );
+  }
   return {
     fields,
     data: {
@@ -293,13 +365,37 @@ export function openingForm(o: Opening): FormSpec {
       entity: o.entity ?? "",
       shutterEntity: o.shutterEntity ?? "",
       shutterStyle: shutterStyleOf(o),
+      shutterSide: o.shutterFlipV ? "near" : "far",
+      shutterInvert: o.shutterInvert ?? false,
+      tapTarget: o.tapTarget ?? "opening",
       invert: o.invert ?? false,
       angle: o.angle,
+      tap_action: o.tap_action,
+      hold_action: o.hold_action,
+      double_tap_action: o.double_tap_action,
     },
     toPatch(patch) {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(patch)) {
-        if (k === "motion") {
+        if (k === "shutterEntity") {
+          out.shutterEntity = v;
+          // Everything that only means something *with* a shutter goes with
+          // it. Left behind, a stale invert or side would silently reapply to
+          // whatever shutter is bound next.
+          if (!v) {
+            out.shutterStyle = undefined;
+            out.shutterFlipV = undefined;
+            out.shutterInvert = undefined;
+            out.shutterActiveColor = undefined;
+            // Nothing left to lead with, so the choice goes too — otherwise it
+            // would silently point the tap at the next shutter bound here.
+            out.tapTarget = undefined;
+          }
+        } else if (k === "shutterSide") out.shutterFlipV = v === "near" || undefined;
+        else if (k === "shutterInvert") out.shutterInvert = v || undefined;
+        // The opening is the default, so it stays out of the YAML.
+        else if (k === "tapTarget") out.tapTarget = v === "shutter" ? "shutter" : undefined;
+        else if (k === "motion") {
           out.motion = v === "slide" || v === "roll" ? v : undefined;
           // sliderStyle only applies while sliding — drop it when switching away.
           if (v !== "slide") out.sliderStyle = undefined;

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -307,6 +307,25 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
   // shutter used to be reachable by hold alone, which is not discoverable and
   // is awkward on a wall tablet.
   if (o.entity && o.shutterEntity) {
+    // The badge that makes the second entity visible. On by default; the
+    // switch is for a plan where every window has one and they start to shout.
+    fields.push({
+      name: "showShutterIcon",
+      label: "Shutter icon",
+      helper: "Shows the shutter's state beside the opening, and opens it when tapped",
+      selector: { boolean: {} },
+    });
+    // Only worth asking once the badge is actually drawn. Left empty the badge
+    // follows the entity, whose default glyph changes with the state — an
+    // override is one glyph for both, which is why it is not the default.
+    if (o.showShutterIcon ?? true) {
+      fields.push({
+        name: "shutterIcon",
+        label: "Icon",
+        helper: "Overrides the shutter entity's own icon, which changes with its state",
+        selector: { icon: {} },
+      });
+    }
     fields.push({
       name: "tapTarget",
       label: "Tap opens",
@@ -367,6 +386,8 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       shutterStyle: shutterStyleOf(o),
       shutterSide: o.shutterFlipV ? "near" : "far",
       shutterInvert: o.shutterInvert ?? false,
+      showShutterIcon: o.showShutterIcon ?? true,
+      shutterIcon: o.shutterIcon ?? "",
       tapTarget: o.tapTarget ?? "opening",
       invert: o.invert ?? false,
       angle: o.angle,
@@ -390,11 +411,16 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             // Nothing left to lead with, so the choice goes too — otherwise it
             // would silently point the tap at the next shutter bound here.
             out.tapTarget = undefined;
+            // Same for the badge and its glyph: there is nothing to badge.
+            out.showShutterIcon = undefined;
+            out.shutterIcon = undefined;
           }
         } else if (k === "shutterSide") out.shutterFlipV = v === "near" || undefined;
         else if (k === "shutterInvert") out.shutterInvert = v || undefined;
         // The opening is the default, so it stays out of the YAML.
         else if (k === "tapTarget") out.tapTarget = v === "shutter" ? "shutter" : undefined;
+        // Shown is the default: only "off" is worth writing down.
+        else if (k === "showShutterIcon") out.showShutterIcon = v ? undefined : false;
         else if (k === "motion") {
           out.motion = v === "slide" || v === "roll" ? v : undefined;
           // sliderStyle only applies while sliding — drop it when switching away.

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -65,6 +65,8 @@ import {
   shutterActive,
   shutterMarkIcon,
   shutterMarkPoint,
+  shutterMarkNormal,
+  SHUTTER_MARK_PIXEL_OFFSET,
   hasShutterMark,
   openingFromDeviceClass,
   renderRipple,
@@ -3525,12 +3527,19 @@ export class FloorplanCardEditor extends LitElement {
     const id = o.shutterEntity!;
     const st = this.hass?.states[id];
     const open = shutterAmount(st, o.shutterInvert) > 0;
-    const icon = shutterMarkIcon(st, id, open, this.hass?.entities?.[id]?.icon);
+    const icon = shutterMarkIcon(o, st, open, this.hass?.entities?.[id]?.icon);
     const accent = cssColor(o.shutterActiveColor ?? o.activeColor) ?? SKIN_ACCENT;
     const at = shutterMarkPoint(o);
+    // Same two-part offset as the card (canvas units + screen pixels), so the
+    // preview shows where the badge will actually sit. The editor never
+    // rotates the plan, hence no rotation argument.
+    const n = shutterMarkNormal(o);
     return html`<div
       class="shutter-mark ${shutterActive(st, o.shutterInvert) ? "on" : "off"}"
-      style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;--fp-active:${accent};"
+      style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;
+             transform:translate(-50%,-50%) translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
+               n.y * SHUTTER_MARK_PIXEL_OFFSET
+             }px);--fp-active:${accent};"
       title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open the shutter`}
     >
       <ha-icon icon=${icon}></ha-icon>
@@ -4703,7 +4712,7 @@ export class FloorplanCardEditor extends LitElement {
        none — the opening underneath stays clickable for selection and drag. */
     .shutter-mark {
       position: absolute;
-      transform: translate(-50%, -50%);
+      /* transform is set inline: the pixel push along the wall normal. */
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -61,6 +61,11 @@ import {
   openingDefaultOpen,
   openingMotion,
   shutterStyleOf,
+  shutterAmount,
+  shutterActive,
+  shutterMarkIcon,
+  shutterMarkPoint,
+  hasShutterMark,
   openingFromDeviceClass,
   renderRipple,
   renderFurniture,
@@ -1867,6 +1872,16 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * An entity's `supported_features` bitmask, or 0 when it isn't in `hass`.
+   * Handed to {@link openingForm} so its Tap field can name the default the
+   * live card would take — which for a `cover` depends on whether it can
+   * actually open and close.
+   */
+  private _supportedFeatures(id: string): number {
+    return (this.hass?.states[id]?.attributes?.supported_features as number) ?? 0;
+  }
+
+  /**
    * The glyph a device shows when no state rule names one — what a rule's
    * empty icon box falls back to. Resolved exactly as the card resolves it,
    * with the rules removed so a currently-matching rule cannot report itself
@@ -2917,6 +2932,9 @@ export class FloorplanCardEditor extends LitElement {
             )}
             <div class="items">
               ${floor.texts.map((t) => this._renderTextOverlay(t, c))}
+              ${floor.openings
+                .filter((o) => hasShutterMark(o))
+                .map((o) => this._renderShutterMarkOverlay(o, c))}
               ${floor.items.map((it) => this._renderItemOverlay(it, c))}
             </div>
           </div>
@@ -3346,7 +3364,9 @@ export class FloorplanCardEditor extends LitElement {
           amount: openingMotion(o) !== "swing" ? 0.55 : undefined,
           // Shutter previewed half-rolled so the layer is visible while
           // configuring, whatever the live state.
-          shutter: o.shutterEntity ? { amount: 0.55, style: shutterStyleOf(o) } : undefined,
+          shutter: o.shutterEntity
+            ? { amount: 0.55, style: shutterStyleOf(o), flip: o.shutterFlipV }
+            : undefined,
         })}
       </g>`;
   }
@@ -3490,6 +3510,31 @@ export class FloorplanCardEditor extends LitElement {
             : svg`<circle cx=${p.x} cy=${p.y} r="5" class="area-draft-point" />`
         )}
       </g>`;
+  }
+
+  /**
+   * The card's shutter badge, previewed (issue #74 follow-up) — an opening
+   * with both entities bound shows the shutter's own icon beside it, and the
+   * editor is where you find out whether it lands somewhere sensible.
+   *
+   * Inert here: the canvas selects and drags openings by clicking them, and a
+   * badge that swallowed those clicks would make the opening under it awkward
+   * to grab. On the card it is a control; here it is a picture of one.
+   */
+  private _renderShutterMarkOverlay(o: Opening, c: FloorplanCardConfig): TemplateResult {
+    const id = o.shutterEntity!;
+    const st = this.hass?.states[id];
+    const open = shutterAmount(st, o.shutterInvert) > 0;
+    const icon = shutterMarkIcon(st, id, open, this.hass?.entities?.[id]?.icon);
+    const accent = cssColor(o.shutterActiveColor ?? o.activeColor) ?? SKIN_ACCENT;
+    const at = shutterMarkPoint(o);
+    return html`<div
+      class="shutter-mark ${shutterActive(st, o.shutterInvert) ? "on" : "off"}"
+      style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;--fp-active:${accent};"
+      title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open the shutter`}
+    >
+      <ha-icon icon=${icon}></ha-icon>
+    </div>`;
   }
 
   private _renderItemOverlay(it: FloorItem, c: FloorplanCardConfig): TemplateResult {
@@ -3696,7 +3741,7 @@ export class FloorplanCardEditor extends LitElement {
       const o = this._floor().openings.find((x) => x.id === sel.id);
       if (!o) return html`${nothing}`;
       return html`
-        ${this._renderForm(openingForm(o), (patch, live) => {
+        ${this._renderForm(openingForm(o, (id) => this._supportedFeatures(id)), (patch, live) => {
           if ("entity" in patch) {
             // Infer type/motion from the entity's HA device_class (e.g. a
             // `cover` with device_class `window` → a window; a `garage`
@@ -3718,6 +3763,22 @@ export class FloorplanCardEditor extends LitElement {
               placeholder: "(primary)",
               onLive: (activeColor) => this._updateOpeningLive(o.id, { activeColor }),
               onCommit: (activeColor) => this._updateOpening(o.id, { activeColor }),
+            })
+          : nothing}
+        ${o.shutterEntity
+          ? // The shutter's own accent, so an open shutter over a shut window
+            // can read as a separate thing from the sash it covers. Falls back
+            // to the opening's active color, hence the placeholder.
+            this._renderColorRow({
+              label: "Shutter color",
+              title: "Shutter color while it is open",
+              value: o.shutterActiveColor,
+              swatch: o.activeColor ?? "#03a9f4",
+              placeholder: o.activeColor ? "(active color)" : "(primary)",
+              onLive: (shutterActiveColor) =>
+                this._updateOpeningLive(o.id, { shutterActiveColor }),
+              onCommit: (shutterActiveColor) =>
+                this._updateOpening(o.id, { shutterActiveColor }),
             })
           : nothing}
       `;
@@ -4637,6 +4698,31 @@ export class FloorplanCardEditor extends LitElement {
       position: absolute;
       inset: 0;
       pointer-events: none;
+    }
+    /* Preview of the card's shutter badge. Inherits .items' pointer-events:
+       none — the opening underneath stays clickable for selection and drag. */
+    .shutter-mark {
+      position: absolute;
+      transform: translate(-50%, -50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: var(--fp-skin-paper, var(--card-background-color, #fff));
+      border: 1px solid var(--fp-skin-wall, var(--primary-text-color, #212121));
+      color: var(--fp-skin-wall, var(--primary-text-color, #212121));
+      opacity: 0.75;
+    }
+    .shutter-mark.on {
+      color: var(--fp-active, var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      border-color: var(--fp-active, var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      opacity: 1;
+    }
+    .shutter-mark ha-icon {
+      --mdc-icon-size: 15px;
+      display: flex;
     }
     .edit-item {
       position: absolute;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -67,6 +67,7 @@ import {
   shutterMarkPoint,
   shutterMarkNormal,
   SHUTTER_MARK_PIXEL_OFFSET,
+  SHUTTER_MARK_SIZE,
   hasShutterMark,
   openingFromDeviceClass,
   renderRipple,
@@ -3533,10 +3534,14 @@ export class FloorplanCardEditor extends LitElement {
     // Same two-part offset as the card (canvas units + screen pixels), so the
     // preview shows where the badge will actually sit. The editor never
     // rotates the plan, hence no rotation argument.
+    // Always the fixed-pixel form here: the editor canvas is zoomed by the
+    // user rather than sized by the card, so `overlayScale: plan` has no
+    // meaning on it — the badges it draws for devices are fixed too.
     const n = shutterMarkNormal(o);
     return html`<div
       class="shutter-mark ${shutterActive(st, o.shutterInvert) ? "on" : "off"}"
       style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;
+             width:${SHUTTER_MARK_SIZE}px;height:${SHUTTER_MARK_SIZE}px;
              transform:translate(-50%,-50%) translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
                n.y * SHUTTER_MARK_PIXEL_OFFSET
              }px);--fp-active:${accent};"
@@ -4712,12 +4717,10 @@ export class FloorplanCardEditor extends LitElement {
        none — the opening underneath stays clickable for selection and drag. */
     .shutter-mark {
       position: absolute;
-      /* transform is set inline: the pixel push along the wall normal. */
+      /* transform and size are set inline, matching the card. */
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 22px;
-      height: 22px;
       border-radius: 50%;
       background: var(--fp-skin-paper, var(--card-background-color, #fff));
       border: 1px solid var(--fp-skin-wall, var(--primary-text-color, #212121));

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -42,6 +42,8 @@ import {
   shutterActive,
   shutterMarkPoint,
   shutterMarkIcon,
+  shutterMarkNormal,
+  SHUTTER_MARK_PIXEL_OFFSET,
   hasShutterMark,
   entityStateText,
   renderRipple,
@@ -285,18 +287,25 @@ export class FloorplanCard extends LitElement {
     const st = this.hass?.states[id];
     const open = shutterAmount(st, o.shutterInvert) > 0;
     const active = shutterActive(st, o.shutterInvert);
-    const icon = shutterMarkIcon(st, id, open, this.hass?.entities?.[id]?.icon);
+    const icon = shutterMarkIcon(o, st, open, this.hass?.entities?.[id]?.icon);
     const accent = cssColor(o.shutterActiveColor ?? o.activeColor) ?? SKIN_ACCENT;
     const at = shutterMarkPoint(o);
     const p = rotatePlanPoint(at.x, at.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
+    // Pushed clear of the opening in screen pixels as well as canvas units, so
+    // the tap target underneath stays reachable however the plan is scaled.
+    const n = shutterMarkNormal(o, rot);
+    const push = `translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
+      n.y * SHUTTER_MARK_PIXEL_OFFSET
+    }px)`;
     const name =
       (this.hass?.states[id]?.attributes?.friendly_name as string | undefined) ?? id;
     return html`
       <div
         class="shutter-mark ${active ? "on" : "off"}"
         data-entity=${cssEntityId(id) ?? nothing}
-        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;--fp-active:${accent};"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
+               transform:translate(-50%,-50%) ${push};--fp-active:${accent};"
         title="${name} · ${entityStateText(this.hass, id)}"
         role="button"
         tabindex="0"
@@ -1066,7 +1075,7 @@ export class FloorplanCard extends LitElement {
        pointer-events:none, so it takes its own back. */
     .shutter-mark {
       position: absolute;
-      transform: translate(-50%, -50%);
+      /* transform is set inline: the pixel push along the wall normal. */
       pointer-events: auto;
       cursor: pointer;
       display: flex;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -44,6 +44,8 @@ import {
   shutterMarkIcon,
   shutterMarkNormal,
   SHUTTER_MARK_PIXEL_OFFSET,
+  SHUTTER_MARK_SIZE,
+  SHUTTER_MARK_ICON_SIZE,
   hasShutterMark,
   entityStateText,
   renderRipple,
@@ -271,18 +273,27 @@ export class FloorplanCard extends LitElement {
    * The shutter badge (issue #74 follow-up): the shutter entity's own icon,
    * beside an opening that binds both a window/door and a shutter.
    *
-   * HTML rather than SVG, like the device badges and for the same two
-   * reasons: it holds a real `ha-icon`, and it is sized in screen pixels, so
-   * it stays legible on a plan whose canvas units are whatever the author
-   * chose. The glyph carries the open/closed reading on its own — HA's shutter
-   * icons come in pairs — and the accent says the same thing again in colour.
+   * HTML rather than SVG, like the device badges: it holds a real `ha-icon`.
+   * And like them it follows `overlayScale` (#148) — fixed pixels by default,
+   * so it stays legible whatever canvas units the author chose, or canvas
+   * units under `plan`, so it shrinks with the drawing instead of towering
+   * over a scaled-down one. Both offsets follow the same choice, or the badge
+   * would drift off the opening at one scale and sit on it at another.
+   *
+   * The glyph carries the open/closed reading on its own — HA's shutter icons
+   * come in pairs — and the accent says the same thing again in colour.
    *
    * Tapping it opens the shutter, whatever the opening's own tap does. That is
    * the point of drawing it: the entity the opening symbol does not lead with
    * gets a control of its own, instead of living behind a press-and-hold
    * nobody can see.
    */
-  private _renderShutterMark(o: Opening, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
+  private _renderShutterMark(
+    o: Opening,
+    c: FloorplanCardConfig,
+    rot: PlanRotation,
+    scale: OverlayScale
+  ): TemplateResult {
     const id = o.shutterEntity!;
     const st = this.hass?.states[id];
     const open = shutterAmount(st, o.shutterInvert) > 0;
@@ -292,12 +303,14 @@ export class FloorplanCard extends LitElement {
     const at = shutterMarkPoint(o);
     const p = rotatePlanPoint(at.x, at.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
-    // Pushed clear of the opening in screen pixels as well as canvas units, so
-    // the tap target underneath stays reachable however the plan is scaled.
+    // Pushed clear of the opening by the badge's own size as well as by the
+    // canvas offset, so the tap target underneath stays reachable. In the
+    // badge's own unit: fixed pixels never shrink with the plan, and would
+    // otherwise cover the opening on a large canvas in a narrow card.
     const n = shutterMarkNormal(o, rot);
-    const push = `translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
-      n.y * SHUTTER_MARK_PIXEL_OFFSET
-    }px)`;
+    const step = overlayLength(SHUTTER_MARK_PIXEL_OFFSET, scale);
+    const push = `translate(calc(${n.x} * ${step}), calc(${n.y} * ${step}))`;
+    const box = overlayLength(SHUTTER_MARK_SIZE, scale);
     const name =
       (this.hass?.states[id]?.attributes?.friendly_name as string | undefined) ?? id;
     return html`
@@ -305,6 +318,7 @@ export class FloorplanCard extends LitElement {
         class="shutter-mark ${active ? "on" : "off"}"
         data-entity=${cssEntityId(id) ?? nothing}
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
+               width:${box};height:${box};
                transform:translate(-50%,-50%) ${push};--fp-active:${accent};"
         title="${name} · ${entityStateText(this.hass, id)}"
         role="button"
@@ -314,7 +328,10 @@ export class FloorplanCard extends LitElement {
         }}
         .actionHandler=${actionHandler({})}
       >
-        <ha-icon icon=${icon}></ha-icon>
+        <ha-icon
+          icon=${icon}
+          style="--mdc-icon-size:${overlayLength(SHUTTER_MARK_ICON_SIZE, scale)};"
+        ></ha-icon>
       </div>
     `;
   }
@@ -812,7 +829,7 @@ export class FloorplanCard extends LitElement {
               // nodes rather than morph one floor's badges into another's.
               active.openings.filter((o) => hasShutterMark(o)),
               (o, i) => `${o.id || i}-shutter`,
-              (o) => this._renderShutterMark(o, c, rot)
+              (o) => this._renderShutterMark(o, c, rot, scale)
             )}
             ${repeat(
               // No entity filter: devices that exist physically but have no HA
@@ -1081,8 +1098,7 @@ export class FloorplanCard extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 22px;
-      height: 22px;
+      /* width/height are inline: they follow overlayScale (#148). */
       border-radius: 50%;
       background: var(--fp-skin-paper, var(--card-background-color, #fff));
       border: 1px solid var(--fp-skin-wall, var(--primary-text-color, #212121));
@@ -1101,7 +1117,7 @@ export class FloorplanCard extends LitElement {
       opacity: 1;
     }
     .shutter-mark ha-icon {
-      --mdc-icon-size: 15px;
+      /* --mdc-icon-size is inline, for the same reason. */
       display: flex;
     }
     .fp-slide-panel {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -232,24 +232,43 @@ export class FloorplanCard extends LitElement {
     executeAction(this, this.hass, item, actionForGesture(item, ev.detail.action));
   }
 
+  /** Open Home Assistant's more-info dialog for an entity. */
+  private _openMoreInfo(entityId: string): void {
+    this.dispatchEvent(
+      new CustomEvent("hass-more-info", {
+        detail: { entityId },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
   /**
-   * Tapping an entity-bound opening: toggle a controllable `cover`, otherwise
-   * open the entity's more-info dialog (read-only `binary_sensor`s and
-   * position-only covers). See {@link openingClickAction}.
+   * Tapping an entity-bound opening. A bound `shutterEntity` wins the tap and
+   * opens its more-info dialog, where a position-aware `cover` exposes its
+   * slider. Otherwise a controllable `cover` toggles and everything else opens
+   * its own dialog. See {@link openingClickAction}.
    */
   private _onOpeningClick(o: Opening): void {
-    if (!this.hass || !o.entity) return;
+    if (!this.hass) return;
+    // An opening can carry two entities: "entity" is the sash's own
+    // contact or cover, "shutterEntity" the external roller shutter drawn
+    // over it (#74). The shutter is the layer a user can actually move, so
+    // it wins the tap and opens its more-info dialog - that is where a
+    // position-aware cover offers its slider. The sash keeps reporting
+    // itself through the swinging leaf on the plan, so nothing is lost.
+    // Openings carrying only a shutter used to be inert: the old
+    // "!o.entity" guard returned before anything could happen.
+    if (o.shutterEntity) {
+      this._openMoreInfo(o.shutterEntity);
+      return;
+    }
+    if (!o.entity) return;
     const features = (this.hass.states[o.entity]?.attributes?.supported_features as number) ?? 0;
     if (openingClickAction(o.entity, features) === "cover-toggle") {
       this.hass.callService("cover", "toggle", { entity_id: o.entity });
     } else {
-      this.dispatchEvent(
-        new CustomEvent("hass-more-info", {
-          detail: { entityId: o.entity },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this._openMoreInfo(o.entity);
     }
   }
 

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -35,10 +35,15 @@ import {
   sunBrightness,
   resolveOpeningAmount,
   openingIsActive,
-  openingClickAction,
+  openingActionForGesture,
+  openingIsPressable,
   shutterAmount,
   shutterStyleOf,
   shutterActive,
+  shutterMarkPoint,
+  shutterMarkIcon,
+  hasShutterMark,
+  entityStateText,
   renderRipple,
   renderFurniture,
   furnitureColor,
@@ -232,44 +237,77 @@ export class FloorplanCard extends LitElement {
     executeAction(this, this.hass, item, actionForGesture(item, ev.detail.action));
   }
 
-  /** Open Home Assistant's more-info dialog for an entity. */
-  private _openMoreInfo(entityId: string): void {
-    this.dispatchEvent(
-      new CustomEvent("hass-more-info", {
-        detail: { entityId },
-        bubbles: true,
-        composed: true,
-      })
-    );
+  /**
+   * An entity's `supported_features` bitmask, or 0 when it isn't in `hass`.
+   * An arrow property so it can be handed to the pure resolvers in `render.ts`
+   * without a `.bind(this)` at every call site.
+   */
+  private _featuresOf = (id: string): number =>
+    (this.hass?.states[id]?.attributes?.supported_features as number) ?? 0;
+
+  /** What a gesture on this opening would do, if anything. */
+  private _openingPress(o: Opening, gesture: "tap" | "hold" | "double_tap") {
+    return openingActionForGesture(o, gesture, this._featuresOf);
   }
 
   /**
-   * Tapping an entity-bound opening. A bound `shutterEntity` wins the tap and
-   * opens its more-info dialog, where a position-aware `cover` exposes its
-   * slider. Otherwise a controllable `cover` toggles and everything else opens
-   * its own dialog. See {@link openingClickAction}.
+   * Pressing an opening (issue #74 follow-up). Which entity answers — the
+   * window/door or its shutter — is {@link openingActionForGesture}'s call;
+   * from here it is the same Lovelace dispatch every device uses.
    */
-  private _onOpeningClick(o: Opening): void {
+  private _onOpeningAction(
+    ev: CustomEvent<{ action: "tap" | "hold" | "double_tap" }>,
+    o: Opening
+  ): void {
     if (!this.hass) return;
-    // An opening can carry two entities: "entity" is the sash's own
-    // contact or cover, "shutterEntity" the external roller shutter drawn
-    // over it (#74). The shutter is the layer a user can actually move, so
-    // it wins the tap and opens its more-info dialog - that is where a
-    // position-aware cover offers its slider. The sash keeps reporting
-    // itself through the swinging leaf on the plan, so nothing is lost.
-    // Openings carrying only a shutter used to be inert: the old
-    // "!o.entity" guard returned before anything could happen.
-    if (o.shutterEntity) {
-      this._openMoreInfo(o.shutterEntity);
-      return;
-    }
-    if (!o.entity) return;
-    const features = (this.hass.states[o.entity]?.attributes?.supported_features as number) ?? 0;
-    if (openingClickAction(o.entity, features) === "cover-toggle") {
-      this.hass.callService("cover", "toggle", { entity_id: o.entity });
-    } else {
-      this._openMoreInfo(o.entity);
-    }
+    const press = this._openingPress(o, ev.detail.action);
+    if (!press) return;
+    executeAction(this, this.hass, { entity: press.entity }, press.config);
+  }
+
+  /**
+   * The shutter badge (issue #74 follow-up): the shutter entity's own icon,
+   * beside an opening that binds both a window/door and a shutter.
+   *
+   * HTML rather than SVG, like the device badges and for the same two
+   * reasons: it holds a real `ha-icon`, and it is sized in screen pixels, so
+   * it stays legible on a plan whose canvas units are whatever the author
+   * chose. The glyph carries the open/closed reading on its own — HA's shutter
+   * icons come in pairs — and the accent says the same thing again in colour.
+   *
+   * Tapping it opens the shutter, whatever the opening's own tap does. That is
+   * the point of drawing it: the entity the opening symbol does not lead with
+   * gets a control of its own, instead of living behind a press-and-hold
+   * nobody can see.
+   */
+  private _renderShutterMark(o: Opening, c: FloorplanCardConfig, rot: PlanRotation): TemplateResult {
+    const id = o.shutterEntity!;
+    const st = this.hass?.states[id];
+    const open = shutterAmount(st, o.shutterInvert) > 0;
+    const active = shutterActive(st, o.shutterInvert);
+    const icon = shutterMarkIcon(st, id, open, this.hass?.entities?.[id]?.icon);
+    const accent = cssColor(o.shutterActiveColor ?? o.activeColor) ?? SKIN_ACCENT;
+    const at = shutterMarkPoint(o);
+    const p = rotatePlanPoint(at.x, at.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
+    const name =
+      (this.hass?.states[id]?.attributes?.friendly_name as string | undefined) ?? id;
+    return html`
+      <div
+        class="shutter-mark ${active ? "on" : "off"}"
+        data-entity=${cssEntityId(id) ?? nothing}
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;--fp-active:${accent};"
+        title="${name} · ${entityStateText(this.hass, id)}"
+        role="button"
+        tabindex="0"
+        @action=${() => {
+          if (this.hass) executeAction(this, this.hass, { entity: id }, { action: "more-info" });
+        }}
+        .actionHandler=${actionHandler({})}
+      >
+        <ha-icon icon=${icon}></ha-icon>
+      </div>
+    `;
   }
 
   private _renderBadge(item: FloorItem, scale: OverlayScale): TemplateResult {
@@ -690,19 +728,35 @@ export class FloorplanCard extends LitElement {
                 // yet → previewed shut, like a static plan.
                 shutter: o.shutterEntity
                   ? {
-                      amount: shutterAmount(shutterState),
-                      active: shutterActive(shutterState),
+                      amount: shutterAmount(shutterState, o.shutterInvert),
+                      active: shutterActive(shutterState, o.shutterInvert),
                       style: shutterStyleOf(o),
+                      // The shutter's own accent, falling back to the
+                      // opening's and then to the skin's.
+                      accent: o.shutterActiveColor ?? o.activeColor ?? SKIN_ACCENT,
+                      flip: o.shutterFlipV,
                     }
                   : undefined,
               });
-              if (!o.entity) return symbol;
-              // Entity-bound openings are tappable — a transparent rect over the
-              // opening's wall gap gives a reliable hit target beyond the thin
-              // leaf/panel strokes.
+              // Only an opening that answers gets a hit target — the same test
+              // devices get (issue #134), so an unbound opening is not a button
+              // that does nothing. A shutter-only opening does answer, which is
+              // why this is no longer `if (!o.entity)`.
+              if (!openingIsPressable(o, this._featuresOf)) return symbol;
+              // A transparent rect over the opening's wall gap gives a reliable
+              // hit target beyond the thin leaf/panel strokes.
               const half = o.length / 2;
               const cutH = WALL_THICKNESS + 4;
-              return svg`<g class="fp-opening" @click=${() => this._onOpeningClick(o)}>
+              return svg`<g class="fp-opening" role="button" tabindex="0"
+                    @action=${(ev: CustomEvent<{ action: "tap" | "hold" | "double_tap" }>) =>
+                      this._onOpeningAction(ev, o)}
+                    .actionHandler=${actionHandler({
+                      // Only wait out the hold/double-tap timers when a gesture
+                      // actually resolves: otherwise every tap on a plain
+                      // contact sensor would sit for 500ms before answering.
+                      hasHold: hasAction(this._openingPress(o, "hold")?.config),
+                      hasDoubleClick: hasAction(this._openingPress(o, "double_tap")?.config),
+                    })}>
                   ${symbol}
                   <rect class="fp-opening-hit" x=${o.x - half} y=${o.y - cutH / 2}
                         width=${o.length} height=${cutH}
@@ -744,6 +798,13 @@ export class FloorplanCard extends LitElement {
           <div class="items">
             ${active.areas?.map((a) => this._renderAreaLabel(a, c, rot, scale))}
             ${active.texts.map((t) => this._renderText(t, c, rot, scale))}
+            ${repeat(
+              // Keyed like the openings above: a floor switch must build fresh
+              // nodes rather than morph one floor's badges into another's.
+              active.openings.filter((o) => hasShutterMark(o)),
+              (o, i) => `${o.id || i}-shutter`,
+              (o) => this._renderShutterMark(o, c, rot)
+            )}
             ${repeat(
               // No entity filter: devices that exist physically but have no HA
               // entity still deserve their badge (issue #39). Keyed by id so a
@@ -998,6 +1059,41 @@ export class FloorplanCard extends LitElement {
     .fp-opening-hit {
       fill: transparent;
       pointer-events: all;
+    }
+    /* Shutter badge (issue #74 follow-up): screen-sized, so it stays legible
+       whatever canvas units the plan is drawn in — the same reason device
+       badges are sized in pixels. Sits in the .items overlay, which is
+       pointer-events:none, so it takes its own back. */
+    .shutter-mark {
+      position: absolute;
+      transform: translate(-50%, -50%);
+      pointer-events: auto;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: var(--fp-skin-paper, var(--card-background-color, #fff));
+      border: 1px solid var(--fp-skin-wall, var(--primary-text-color, #212121));
+      color: var(--fp-skin-wall, var(--primary-text-color, #212121));
+      opacity: 0.75;
+      transition: color 0.3s ease, opacity 0.3s ease, border-color 0.3s ease;
+      -webkit-tap-highlight-color: transparent;
+      -webkit-touch-callout: none;
+      user-select: none;
+    }
+    /* Open: the accent, said twice — the glyph is already the "open" half of
+       HA's icon pair, and the colour repeats it for a glance across the room. */
+    .shutter-mark.on {
+      color: var(--fp-active, var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      border-color: var(--fp-active, var(--fp-skin-accent, var(--primary-color, #03a9f4)));
+      opacity: 1;
+    }
+    .shutter-mark ha-icon {
+      --mdc-icon-size: 15px;
+      display: flex;
     }
     .fp-slide-panel {
       transform-box: fill-box;

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -211,3 +211,104 @@ describe("renderOpening — hinged external shutter (issue #74)", () => {
     expect(s).toContain("rotate(0deg)");
   });
 });
+
+describe("renderOpening — which side the shutter hangs on (issue #74 follow-up)", () => {
+  const win = { type: "window" } as Partial<Opening>;
+  // cutH/2 + t/2 = (8 + 4)/2 + 3/2
+  const OFFSET = 7.5;
+
+  it("hangs the panels on the far side of the wall by default", () => {
+    const s = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing" } });
+    expect(s).toContain(`translate(-45 ${OFFSET})`);
+    expect(s).toContain(`translate(45 ${OFFSET})`);
+  });
+
+  it("flip moves them to the sash's own side, offset and all", () => {
+    const s = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing", flip: true } });
+    expect(s).toContain(`translate(-45 ${-OFFSET})`);
+    expect(s).toContain(`translate(45 ${-OFFSET})`);
+    expect(s).not.toContain(`translate(-45 ${OFFSET})`);
+  });
+
+  it("flipped panels still fold away from the wall, not through it", () => {
+    // Same two angles either way — what changes is which panel takes which,
+    // so that both still swing outward from their own jamb.
+    const far = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing" } });
+    expect(far).toMatch(/translate\(-45 7\.5\)[\s\S]*?fp-door-leaf" style="transform:rotate\(45deg\)/);
+    expect(far).toMatch(/translate\(45 7\.5\)[\s\S]*?fp-leaf-r" style="transform:rotate\(-45deg\)/);
+    const near = svgOf(win, { open: false, shutter: { amount: 0.5, style: "swing", flip: true } });
+    expect(near).toMatch(/translate\(-45 -7\.5\)[\s\S]*?fp-door-leaf" style="transform:rotate\(-45deg\)/);
+    expect(near).toMatch(/translate\(45 -7\.5\)[\s\S]*?fp-leaf-r" style="transform:rotate\(45deg\)/);
+  });
+
+  it("shut is shut on either side — the panels still cover the opening", () => {
+    const near = svgOf(win, { open: false, shutter: { amount: 0, style: "swing", flip: true } });
+    expect(near).toContain("rotate(0deg)");
+    expect(near).toContain(`translate(-45 ${-OFFSET})`);
+  });
+
+  it("the roll curtain ignores the side — it is symmetric about the wall line", () => {
+    const plain = svgOf(win, { open: false, shutter: { amount: 0.4, style: "roll" } });
+    const flipped = svgOf(win, { open: false, shutter: { amount: 0.4, style: "roll", flip: true } });
+    expect(flipped).toBe(plain);
+  });
+});
+
+describe("renderOpening — the symbol stays a symbol (issue #74 follow-up)", () => {
+  const bound = { entity: "binary_sensor.win", shutterEntity: "cover.tapparella" };
+
+  it("draws no badge of its own for the second entity", () => {
+    // The shutter badge is HTML in the overlay, not SVG: it carries a real
+    // ha-icon and is sized in screen pixels. See shutterMarkPoint / the card.
+    const s = svgOf({ type: "window", ...bound }, { shutter: { amount: 0.5 } });
+    expect(s).not.toContain("<circle");
+    expect(s).not.toContain("<title>");
+    // …and binding the second entity adds nothing to the symbol: the shutter
+    // is drawn from `style.shutter`, which the host resolves either way.
+    expect(s).toBe(
+      svgOf({ type: "window", entity: "binary_sensor.win" }, { shutter: { amount: 0.5 } })
+    );
+  });
+});
+
+describe("renderOpening — the shutter's own accent (issue #74 follow-up)", () => {
+  const win = { type: "window" } as Partial<Opening>;
+
+  it("an open shutter wears its own accent, not the opening's", () => {
+    const s = svgOf(win, {
+      open: true,
+      active: true,
+      accent: "#ff0000",
+      shutter: { amount: 0.5, active: true, accent: "#00ff00" },
+    });
+    expect(s).toContain("#00ff00"); // the curtain
+    expect(s).toContain("#ff0000"); // the sash it covers, unchanged
+  });
+
+  it("falls back to the opening's accent when it has none of its own", () => {
+    const s = svgOf(win, {
+      open: false,
+      accent: "#ff0000",
+      shutter: { amount: 0.5, active: true },
+    });
+    expect(s).toContain("#ff0000");
+    expect(s).not.toContain("#00ff00");
+  });
+
+  it("an accent it isn't wearing yet paints nothing — a shut shutter is base colour", () => {
+    const s = svgOf(win, {
+      open: false,
+      shutter: { amount: 0, active: false, accent: "#00ff00", style: "swing" },
+    });
+    expect(s).not.toContain("#00ff00");
+    expect(s).toContain("#000"); // the base colour passed as `color`
+  });
+
+  it("applies to the hinged panels as well as the roll curtain", () => {
+    const swing = svgOf(win, {
+      open: false,
+      shutter: { amount: 0.5, active: true, accent: "#00ff00", style: "swing" },
+    });
+    expect(swing).toContain("fill:#00ff00");
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -35,6 +35,12 @@ import {
   DEAD_SPACE_HATCH_OPACITY,
   shutterActive,
   openingClickAction,
+  openingActionForGesture,
+  openingIsPressable,
+  hasShutterMark,
+  shutterMarkPoint,
+  shutterMarkIcon,
+  SHUTTER_MARK_OFFSET,
   resolveOpeningOpen,
   resolveOpeningAmount,
   kindFromEntity,
@@ -2014,6 +2020,335 @@ describe("shutterAmount / shutterActive (issue #74)", () => {
     expect(shutterActive(st("open", 40))).toBe(true);
     expect(shutterActive(st("closing", 0))).toBe(true);
     expect(shutterActive(st("closed", 0))).toBe(false);
+  });
+});
+
+describe("shutterAmount / shutterActive — inverted shutters (issue #74 follow-up)", () => {
+  const st = (state: string, pos?: number) =>
+    ({ state, attributes: pos === undefined ? {} : { current_position: pos } });
+
+  it("inverts the position, not just the state", () => {
+    expect(shutterAmount(st("open", 100), true)).toBe(0);
+    expect(shutterAmount(st("closed", 0), true)).toBe(1);
+    expect(shutterAmount(st("open", 30), true)).toBeCloseTo(0.7);
+  });
+
+  it("inverts the open-ish states of a plain contact", () => {
+    // A reed contact on a hinged shutter reads `on` while the panels are shut.
+    expect(shutterAmount(st("on"), true)).toBe(0);
+    expect(shutterAmount(st("off"), true)).toBe(1);
+    expect(shutterAmount(st("open"), true)).toBe(0);
+    expect(shutterAmount(st("closed"), true)).toBe(1);
+  });
+
+  it("an outage still fails closed — invert must never flip it open", () => {
+    // The whole point of checking the outage first: 1 - 0 would read as a
+    // wide-open shutter drawn from a reading we do not have.
+    expect(shutterAmount(st("unavailable"), true)).toBe(0);
+    expect(shutterAmount(st("unknown"), true)).toBe(0);
+    expect(shutterAmount(st("unavailable", 100), true)).toBe(0);
+    expect(shutterAmount(undefined, true)).toBe(0);
+    expect(shutterActive(st("unavailable"), true)).toBe(false);
+    expect(shutterActive(st("unknown", 0), true)).toBe(false);
+    expect(shutterActive(undefined, true)).toBe(false);
+  });
+
+  it("active follows the inverted reading", () => {
+    expect(shutterActive(st("on"), true)).toBe(false); // inverted: shut
+    expect(shutterActive(st("off"), true)).toBe(true); // inverted: open
+    expect(shutterActive(st("open", 100), true)).toBe(false);
+  });
+
+  it("transit is active either way round", () => {
+    // Something is moving out there whichever end the contact calls "open".
+    for (const invert of [false, true]) {
+      expect(shutterActive(st("opening", 0), invert)).toBe(true);
+      expect(shutterActive(st("closing", 100), invert)).toBe(true);
+    }
+  });
+
+  it("without the flag nothing changes (default is uninverted)", () => {
+    expect(shutterAmount(st("open", 30))).toBeCloseTo(0.3);
+    expect(shutterAmount(st("on"))).toBe(1);
+    expect(shutterActive(st("closed", 0))).toBe(false);
+  });
+});
+
+describe("openingActionForGesture (issue #74 follow-up)", () => {
+  const o = (extra: Partial<Opening> = {}) =>
+    ({ id: "o", type: "window", x: 0, y: 0, length: 90, angle: 0, ...extra }) as Opening;
+  /** A cover that can open and close; everything else reports no features. */
+  const toggleable = (id: string) => (id.startsWith("cover.") ? 3 : 0);
+  const none = () => 0;
+
+  it("tap opens more-info on the window itself", () => {
+    expect(openingActionForGesture(o({ entity: "binary_sensor.win" }), "tap", none)).toEqual({
+      entity: "binary_sensor.win",
+      config: { action: "more-info" },
+    });
+  });
+
+  it("tap toggles a cover that can open and close, and only that", () => {
+    expect(openingActionForGesture(o({ entity: "cover.win" }), "tap", toggleable)).toEqual({
+      entity: "cover.win",
+      config: { action: "toggle" },
+    });
+    // Position-only cover: no open/close bits, so more-info rather than a
+    // toggle the hardware could not honour.
+    expect(openingActionForGesture(o({ entity: "cover.win" }), "tap", () => 4)?.config).toEqual({
+      action: "more-info",
+    });
+  });
+
+  it("a shutter-only opening is driven by its shutter as the primary", () => {
+    const shutterOnly = o({ shutterEntity: "cover.tapparella" });
+    expect(openingActionForGesture(shutterOnly, "tap", toggleable)).toEqual({
+      entity: "cover.tapparella",
+      config: { action: "toggle" },
+    });
+    // Nothing is left over to be a secondary, so hold has nothing to open.
+    expect(openingActionForGesture(shutterOnly, "hold", toggleable)).toBeUndefined();
+  });
+
+  it("with both bound, the tap stays on the window and hold reaches the shutter", () => {
+    const both = o({ entity: "binary_sensor.win", shutterEntity: "cover.tapparella" });
+    // The shutter is real hardware that takes seconds to travel: a tap must
+    // never be silently retargeted at it (the lesson of issue #47).
+    expect(openingActionForGesture(both, "tap", toggleable)).toEqual({
+      entity: "binary_sensor.win",
+      config: { action: "more-info" },
+    });
+    expect(openingActionForGesture(both, "hold", toggleable)).toEqual({
+      entity: "cover.tapparella",
+      config: { action: "more-info" },
+    });
+  });
+
+  it("tapTarget: shutter swaps which entity leads", () => {
+    const both = o({
+      entity: "binary_sensor.win",
+      shutterEntity: "cover.tapparella",
+      tapTarget: "shutter",
+    });
+    // The tap opens the shutter's dialog — it does NOT drive the motor, even
+    // though the cover could be toggled. Choosing which entity answers is not
+    // choosing to move hardware on a tap (issue #47).
+    expect(openingActionForGesture(both, "tap", toggleable)).toEqual({
+      entity: "cover.tapparella",
+      config: { action: "more-info" },
+    });
+    // …and hold picks up whichever one the tap left alone.
+    expect(openingActionForGesture(both, "hold", toggleable)).toEqual({
+      entity: "binary_sensor.win",
+      config: { action: "more-info" },
+    });
+  });
+
+  it("tapTarget is ignored unless there are two entities to choose between", () => {
+    // Shutter-only: it is already the primary, and stays a plain cover tap.
+    expect(
+      openingActionForGesture(
+        o({ shutterEntity: "cover.tapparella", tapTarget: "shutter" }),
+        "tap",
+        toggleable
+      )
+    ).toEqual({ entity: "cover.tapparella", config: { action: "toggle" } });
+    // Window-only: nothing to swap to, so the choice cannot strand the press.
+    expect(
+      openingActionForGesture(o({ entity: "cover.win", tapTarget: "shutter" }), "tap", toggleable)
+    ).toEqual({ entity: "cover.win", config: { action: "toggle" } });
+  });
+
+  it("a configured tap_action still wins, and lands on the chosen entity", () => {
+    const both = o({
+      entity: "binary_sensor.win",
+      shutterEntity: "cover.tapparella",
+      tapTarget: "shutter",
+      tap_action: { action: "toggle" },
+    });
+    // Asking for a toggle *and* pointing the tap at the shutter is how you
+    // move the shutter with one press — both halves stated explicitly.
+    expect(openingActionForGesture(both, "tap", toggleable)).toEqual({
+      entity: "cover.tapparella",
+      config: { action: "toggle" },
+    });
+  });
+
+  it("tapTarget: opening is the default, spelled out", () => {
+    const both = { entity: "binary_sensor.win", shutterEntity: "cover.tapparella" };
+    expect(openingActionForGesture(o({ ...both, tapTarget: "opening" }), "tap", toggleable)).toEqual(
+      openingActionForGesture(o(both), "tap", toggleable)
+    );
+    expect(openingActionForGesture(o({ ...both, tapTarget: "opening" }), "hold", toggleable)).toEqual(
+      { entity: "cover.tapparella", config: { action: "more-info" } }
+    );
+  });
+
+  it("double-tap does nothing by default", () => {
+    const both = o({ entity: "binary_sensor.win", shutterEntity: "cover.tapparella" });
+    expect(openingActionForGesture(both, "double_tap", toggleable)).toBeUndefined();
+    expect(openingActionForGesture(o({ entity: "cover.win" }), "double_tap", toggleable))
+      .toBeUndefined();
+  });
+
+  it("an opening with nothing bound resolves no gesture at all", () => {
+    for (const g of ["tap", "hold", "double_tap"] as const) {
+      expect(openingActionForGesture(o(), g, toggleable)).toBeUndefined();
+    }
+  });
+
+  it("a configured action wins over the default, on the primary", () => {
+    const cfg = { action: "toggle" };
+    const both = o({
+      entity: "binary_sensor.win",
+      shutterEntity: "cover.tapparella",
+      tap_action: cfg,
+    });
+    expect(openingActionForGesture(both, "tap", toggleable)).toEqual({
+      entity: "binary_sensor.win",
+      config: cfg,
+    });
+  });
+
+  it("a configured action's own entity picks which of the two it acts on", () => {
+    const both = o({
+      entity: "binary_sensor.win",
+      shutterEntity: "cover.tapparella",
+      tap_action: { action: "toggle", entity: "cover.tapparella" },
+      hold_action: { action: "more-info", entity: "binary_sensor.win" },
+    });
+    expect(openingActionForGesture(both, "tap", toggleable)?.entity).toBe("cover.tapparella");
+    // Naming the shutter on the tap is a decision, so it overrides the rule
+    // that the default tap never moves it.
+    expect(openingActionForGesture(both, "hold", toggleable)?.entity).toBe("binary_sensor.win");
+  });
+
+  it("a configured action survives even with no entity to act on", () => {
+    // navigate/url need none, and dropping them would silently kill the press.
+    const nav = { action: "navigate", navigation_path: "/lovelace/0" };
+    const press = openingActionForGesture(o({ tap_action: nav }), "tap", none);
+    expect(press).toEqual({ entity: undefined, config: nav });
+  });
+
+  it("an explicit none is honoured rather than falling back to the default", () => {
+    const off = o({ entity: "cover.win", tap_action: { action: "none" } });
+    expect(openingActionForGesture(off, "tap", toggleable)?.config).toEqual({ action: "none" });
+  });
+});
+
+describe("the shutter badge (issue #74 follow-up)", () => {
+  const win = (extra: Partial<Opening> = {}) =>
+    ({ id: "o", type: "window", x: 500, y: 100, length: 90, angle: 0, ...extra }) as Opening;
+
+  it("is earned only by an opening with both entities bound", () => {
+    expect(hasShutterMark(win())).toBe(false);
+    expect(hasShutterMark(win({ entity: "binary_sensor.win" }))).toBe(false);
+    // A shutter alone has no second entity to reveal — the symbol is it.
+    expect(hasShutterMark(win({ shutterEntity: "cover.t" }))).toBe(false);
+    expect(hasShutterMark(win({ entity: "binary_sensor.win", shutterEntity: "cover.t" }))).toBe(
+      true
+    );
+  });
+
+  it("sits off the wall on the shutter's side, along the opening's normal", () => {
+    // Horizontal wall: straight out in +y, the side the shutter is drawn on.
+    expect(shutterMarkPoint(win())).toEqual({ x: 500, y: 100 + SHUTTER_MARK_OFFSET });
+    // flipV moves the shutter to the other face; the badge follows it.
+    expect(shutterMarkPoint(win({ flipV: true }))).toEqual({
+      x: 500,
+      y: 100 - SHUTTER_MARK_OFFSET,
+    });
+  });
+
+  it("follows the wall's rotation", () => {
+    // A wall running north-south (angle -90): the normal points along -x.
+    const west = shutterMarkPoint(win({ x: 172, y: 269.5, angle: -90 }));
+    expect(west.x).toBeCloseTo(172 + SHUTTER_MARK_OFFSET);
+    expect(west.y).toBeCloseTo(269.5);
+    const east = shutterMarkPoint(win({ x: 172, y: 269.5, angle: -90, flipV: true }));
+    expect(east.x).toBeCloseTo(172 - SHUTTER_MARK_OFFSET);
+    expect(east.y).toBeCloseTo(269.5);
+    // 180° puts it back on the other side of a horizontal wall.
+    expect(shutterMarkPoint(win({ angle: 180 })).y).toBeCloseTo(100 - SHUTTER_MARK_OFFSET);
+  });
+
+  it("takes a custom distance, so callers can nudge it off a crowded wall", () => {
+    expect(shutterMarkPoint(win(), 40)).toEqual({ x: 500, y: 140 });
+  });
+
+  it("shows the entity's own icon, registry override first", () => {
+    const st = { state: "open", attributes: { icon: "mdi:from-state", device_class: "shutter" } };
+    expect(shutterMarkIcon(st, "cover.s", true, "mdi:from-registry")).toBe("mdi:from-registry");
+    expect(shutterMarkIcon(st, "cover.s", true)).toBe("mdi:from-state");
+  });
+
+  it("falls back to HA's own device-class pair, which is state-aware", () => {
+    const st = (state: string) => ({ state, attributes: { device_class: "shutter" } });
+    expect(shutterMarkIcon(st("open"), "cover.s", true)).toBe("mdi:window-shutter-open");
+    expect(shutterMarkIcon(st("closed"), "cover.s", false)).toBe("mdi:window-shutter");
+  });
+
+  it("still says shutter when the entity declares no class at all", () => {
+    // An unclassed cover, or a bare contact — neither has a pair of its own,
+    // and an empty icon box would say less than a wrong-but-readable one.
+    expect(shutterMarkIcon({ state: "on", attributes: {} }, "cover.s", true)).toBe(
+      "mdi:window-shutter-open"
+    );
+    expect(shutterMarkIcon(undefined, "cover.s", false)).toBe("mdi:window-shutter");
+    expect(shutterMarkIcon(undefined, "binary_sensor.s", true)).toBe("mdi:window-shutter-open");
+  });
+
+  it("refuses an icon string that isn't one (issue #64/#106)", () => {
+    const nasty = { state: "open", attributes: { icon: "mdi:x;background:url(//evil)" } };
+    expect(shutterMarkIcon(nasty, "cover.s", true, "mdi:y;}")).toBe("mdi:window-shutter-open");
+  });
+
+  it("the open half follows the *inverted* reading, not the raw state", () => {
+    // shutterAmount has already applied shutterInvert by the time the card
+    // asks for the glyph, so a reversed contact gets the right one.
+    const contact = { state: "on", attributes: {} };
+    const open = shutterAmount(contact, true) > 0;
+    expect(open).toBe(false);
+    expect(shutterMarkIcon(contact, "binary_sensor.s", open)).toBe("mdi:window-shutter");
+  });
+});
+
+describe("openingIsPressable (issue #74 follow-up)", () => {
+  const o = (extra: Partial<Opening> = {}) =>
+    ({ id: "o", type: "window", x: 0, y: 0, length: 90, angle: 0, ...extra }) as Opening;
+  const none = () => 0;
+
+  it("an unbound opening is not a button", () => {
+    expect(openingIsPressable(o(), none)).toBe(false);
+  });
+
+  it("either entity alone makes it pressable", () => {
+    expect(openingIsPressable(o({ entity: "binary_sensor.win" }), none)).toBe(true);
+    // The gap this closes: a shutter-only opening answered to nothing before.
+    expect(openingIsPressable(o({ shutterEntity: "cover.tapparella" }), none)).toBe(true);
+  });
+
+  it("tap_action: none leaves nothing pressable — unless another gesture does", () => {
+    expect(openingIsPressable(o({ entity: "cover.win", tap_action: { action: "none" } }), none))
+      .toBe(false);
+    // Hold still resolves (both entities bound), so it is a button again.
+    expect(
+      openingIsPressable(
+        o({ entity: "cover.win", shutterEntity: "cover.s", tap_action: { action: "none" } }),
+        none
+      )
+    ).toBe(true);
+    // …or because a gesture was configured by hand.
+    expect(
+      openingIsPressable(
+        o({
+          entity: "cover.win",
+          tap_action: { action: "none" },
+          double_tap_action: { action: "more-info" },
+        }),
+        none
+      )
+    ).toBe(true);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -40,7 +40,9 @@ import {
   hasShutterMark,
   shutterMarkPoint,
   shutterMarkIcon,
+  shutterMarkNormal,
   SHUTTER_MARK_OFFSET,
+  SHUTTER_MARK_PIXEL_OFFSET,
   resolveOpeningOpen,
   resolveOpeningAmount,
   kindFromEntity,
@@ -2240,14 +2242,25 @@ describe("the shutter badge (issue #74 follow-up)", () => {
   const win = (extra: Partial<Opening> = {}) =>
     ({ id: "o", type: "window", x: 500, y: 100, length: 90, angle: 0, ...extra }) as Opening;
 
+  const both = { entity: "binary_sensor.win", shutterEntity: "cover.t" };
+
   it("is earned only by an opening with both entities bound", () => {
     expect(hasShutterMark(win())).toBe(false);
     expect(hasShutterMark(win({ entity: "binary_sensor.win" }))).toBe(false);
     // A shutter alone has no second entity to reveal — the symbol is it.
     expect(hasShutterMark(win({ shutterEntity: "cover.t" }))).toBe(false);
-    expect(hasShutterMark(win({ entity: "binary_sensor.win", shutterEntity: "cover.t" }))).toBe(
-      true
-    );
+    expect(hasShutterMark(win(both))).toBe(true);
+  });
+
+  it("can be switched off, and off is the only value worth storing", () => {
+    expect(hasShutterMark(win({ ...both, showShutterIcon: false }))).toBe(false);
+    // Absent means shown: a discoverability aid nobody switches on helps nobody.
+    expect(hasShutterMark(win({ ...both, showShutterIcon: undefined }))).toBe(true);
+    expect(hasShutterMark(win({ ...both, showShutterIcon: true }))).toBe(true);
+    // Switching it off says nothing about the gestures.
+    expect(
+      openingActionForGesture(win({ ...both, showShutterIcon: false }), "hold", () => 0)?.entity
+    ).toBe("cover.t");
   });
 
   it("sits off the wall on the shutter's side, along the opening's normal", () => {
@@ -2276,31 +2289,48 @@ describe("the shutter badge (issue #74 follow-up)", () => {
     expect(shutterMarkPoint(win(), 40)).toEqual({ x: 500, y: 140 });
   });
 
-  it("shows the entity's own icon, registry override first", () => {
+  it("shows the entity's own icon: config override, then registry, then state", () => {
+    const o = { shutterEntity: "cover.s" };
     const st = { state: "open", attributes: { icon: "mdi:from-state", device_class: "shutter" } };
-    expect(shutterMarkIcon(st, "cover.s", true, "mdi:from-registry")).toBe("mdi:from-registry");
-    expect(shutterMarkIcon(st, "cover.s", true)).toBe("mdi:from-state");
+    expect(shutterMarkIcon({ ...o, shutterIcon: "mdi:mine" }, st, true, "mdi:from-registry")).toBe(
+      "mdi:mine"
+    );
+    expect(shutterMarkIcon(o, st, true, "mdi:from-registry")).toBe("mdi:from-registry");
+    expect(shutterMarkIcon(o, st, true)).toBe("mdi:from-state");
+  });
+
+  it("an override is one glyph for both states, by definition", () => {
+    const o = { shutterEntity: "cover.s", shutterIcon: "mdi:mine" };
+    const st = (state: string) => ({ state, attributes: { device_class: "shutter" } });
+    expect(shutterMarkIcon(o, st("open"), true)).toBe("mdi:mine");
+    expect(shutterMarkIcon(o, st("closed"), false)).toBe("mdi:mine");
   });
 
   it("falls back to HA's own device-class pair, which is state-aware", () => {
+    const o = { shutterEntity: "cover.s" };
     const st = (state: string) => ({ state, attributes: { device_class: "shutter" } });
-    expect(shutterMarkIcon(st("open"), "cover.s", true)).toBe("mdi:window-shutter-open");
-    expect(shutterMarkIcon(st("closed"), "cover.s", false)).toBe("mdi:window-shutter");
+    expect(shutterMarkIcon(o, st("open"), true)).toBe("mdi:window-shutter-open");
+    expect(shutterMarkIcon(o, st("closed"), false)).toBe("mdi:window-shutter");
   });
 
   it("still says shutter when the entity declares no class at all", () => {
     // An unclassed cover, or a bare contact — neither has a pair of its own,
     // and an empty icon box would say less than a wrong-but-readable one.
-    expect(shutterMarkIcon({ state: "on", attributes: {} }, "cover.s", true)).toBe(
+    expect(shutterMarkIcon({ shutterEntity: "cover.s" }, { state: "on", attributes: {} }, true)).toBe(
       "mdi:window-shutter-open"
     );
-    expect(shutterMarkIcon(undefined, "cover.s", false)).toBe("mdi:window-shutter");
-    expect(shutterMarkIcon(undefined, "binary_sensor.s", true)).toBe("mdi:window-shutter-open");
+    expect(shutterMarkIcon({ shutterEntity: "cover.s" }, undefined, false)).toBe(
+      "mdi:window-shutter"
+    );
+    expect(shutterMarkIcon({ shutterEntity: "binary_sensor.s" }, undefined, true)).toBe(
+      "mdi:window-shutter-open"
+    );
   });
 
-  it("refuses an icon string that isn't one (issue #64/#106)", () => {
+  it("refuses an icon string that isn't one (issue #64/#106), at every level", () => {
     const nasty = { state: "open", attributes: { icon: "mdi:x;background:url(//evil)" } };
-    expect(shutterMarkIcon(nasty, "cover.s", true, "mdi:y;}")).toBe("mdi:window-shutter-open");
+    const o = { shutterEntity: "cover.s", shutterIcon: "mdi:evil;}" };
+    expect(shutterMarkIcon(o, nasty, true, "mdi:y;}")).toBe("mdi:window-shutter-open");
   });
 
   it("the open half follows the *inverted* reading, not the raw state", () => {
@@ -2309,7 +2339,42 @@ describe("the shutter badge (issue #74 follow-up)", () => {
     const contact = { state: "on", attributes: {} };
     const open = shutterAmount(contact, true) > 0;
     expect(open).toBe(false);
-    expect(shutterMarkIcon(contact, "binary_sensor.s", open)).toBe("mdi:window-shutter");
+    expect(shutterMarkIcon({ shutterEntity: "binary_sensor.s" }, contact, open)).toBe(
+      "mdi:window-shutter"
+    );
+  });
+
+  it("is pushed off the opening in screen pixels too, along the wall's normal", () => {
+    // The canvas offset scales with the plan; the badge does not. Without the
+    // pixel half, a large canvas in a narrow card pulls the badge onto the
+    // opening it describes — and that opening is a tap target.
+    expect(SHUTTER_MARK_PIXEL_OFFSET).toBeGreaterThan(11); // the badge's own radius
+    expect(shutterMarkNormal(win())).toEqual({ x: -0, y: 1 });
+    expect(shutterMarkNormal(win({ flipV: true }))).toEqual({ x: 0, y: -1 });
+  });
+
+  it("turns that push with the wall and with the plan's display rotation", () => {
+    const west = shutterMarkNormal(win({ angle: -90 }));
+    expect(west.x).toBeCloseTo(1);
+    expect(west.y).toBeCloseTo(0);
+    // The badge lives in the HTML overlay, which does not rotate with the SVG,
+    // so a rotated plan (issue #33) has to turn the vector itself.
+    const rotated = shutterMarkNormal(win(), 90);
+    expect(rotated.x).toBeCloseTo(-1);
+    expect(rotated.y).toBeCloseTo(0);
+    expect(shutterMarkNormal(win(), 180).y).toBeCloseTo(-1);
+    expect(shutterMarkNormal(win(), 270).x).toBeCloseTo(1);
+  });
+
+  it("the normal always points where the badge's anchor already went", () => {
+    // Same direction as shutterMarkPoint's own offset, or the two halves of
+    // the offset would fight each other.
+    for (const o of [win(), win({ flipV: true }), win({ angle: -90 }), win({ angle: 37 })]) {
+      const at = shutterMarkPoint(o);
+      const n = shutterMarkNormal(o);
+      expect(Math.sign(at.x - o.x) || 0).toBe(Math.sign(Number(n.x.toFixed(6))) || 0);
+      expect(Math.sign(at.y - o.y) || 0).toBe(Math.sign(Number(n.y.toFixed(6))) || 0);
+    }
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -43,6 +43,8 @@ import {
   shutterMarkNormal,
   SHUTTER_MARK_OFFSET,
   SHUTTER_MARK_PIXEL_OFFSET,
+  SHUTTER_MARK_SIZE,
+  SHUTTER_MARK_ICON_SIZE,
   resolveOpeningOpen,
   resolveOpeningAmount,
   kindFromEntity,
@@ -2348,7 +2350,10 @@ describe("the shutter badge (issue #74 follow-up)", () => {
     // The canvas offset scales with the plan; the badge does not. Without the
     // pixel half, a large canvas in a narrow card pulls the badge onto the
     // opening it describes — and that opening is a tap target.
-    expect(SHUTTER_MARK_PIXEL_OFFSET).toBeGreaterThan(11); // the badge's own radius
+    // Sized against the badge's own radius, so the circle clears the opening
+    // whichever unit `overlayScale` (#148) puts them both in.
+    expect(SHUTTER_MARK_PIXEL_OFFSET).toBeGreaterThan(SHUTTER_MARK_SIZE / 2);
+    expect(SHUTTER_MARK_ICON_SIZE).toBeLessThan(SHUTTER_MARK_SIZE);
     expect(shutterMarkNormal(win())).toEqual({ x: -0, y: 1 });
     expect(shutterMarkNormal(win({ flipV: true }))).toEqual({ x: 0, y: -1 });
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -19,6 +19,7 @@ import type {
   HassEntity,
   FloorItem,
   OverlayScale,
+  ActionConfig,
 } from "./types";
 import {
   FURNITURE_COLOR,
@@ -44,6 +45,7 @@ import {
   trackerAxisFraction,
 } from "./types";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, cssIcon } from "./css-safe";
+import { hasAction } from "./actions";
 import { SKIN_ACCENT, SKIN_PAPER, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 // The same tolerance #141 uses to decide an opening sits on a wall, so "this
 // door is in this wall" means one thing across the card.
@@ -1682,27 +1684,37 @@ export function shutterStyleOf(o: Pick<Opening, "shutterEntity" | "shutterStyle"
 
 export function shutterAmount(
   state: { state: string; attributes?: Record<string, unknown> } | undefined,
+  invert = false,
 ): number {
+  // The outage check comes first, before `invert` can touch anything: a
+  // dropout must fail closed, and inverting one would turn "we don't know"
+  // into a shutter drawn wide open (see {@link isSensorOutage}).
   if (!state || isSensorOutage(state.state)) return 0;
   const pos = state.attributes?.current_position;
   if (typeof pos === "number" && Number.isFinite(pos)) {
-    return Math.max(0, Math.min(1, pos / 100));
+    const frac = Math.max(0, Math.min(1, pos / 100));
+    return invert ? 1 - frac : frac;
   }
-  return state.state === "open" || state.state === "opening" || state.state === "closing" ||
-    state.state === "on"
-    ? 1
-    : 0;
+  const open =
+    state.state === "open" || state.state === "opening" || state.state === "closing" ||
+    state.state === "on";
+  return (invert ? !open : open) ? 1 : 0;
 }
 
 /**
  * Whether the shutter layer wears the accent — drawn (partly) open or still in
  * transit, matching {@link openingIsActive}'s "active = open" semantics.
+ *
+ * `invert` flips the reading, not the motion: a cover reporting `opening` or
+ * `closing` is active either way round, because something is moving out there
+ * whichever end of the travel the contact calls "open".
  */
 export function shutterActive(
   state: { state: string; attributes?: Record<string, unknown> } | undefined,
+  invert = false,
 ): boolean {
   if (!state || isSensorOutage(state.state)) return false;
-  return shutterAmount(state) > 0 || state.state === "opening" || state.state === "closing";
+  return shutterAmount(state, invert) > 0 || state.state === "opening" || state.state === "closing";
 }
 
 /** HA `cover` / `binary_sensor` device classes that read as a window (glass). */
@@ -1750,6 +1762,95 @@ export function openingClickAction(
   return domain === "cover" && (supportedFeatures & COVER_OPEN_CLOSE) !== 0
     ? "cover-toggle"
     : "more-info";
+}
+
+/** An opening's two bindable entities, and the actions it may carry. */
+type PressableOpening = Pick<
+  Opening,
+  "entity" | "shutterEntity" | "tapTarget" | "tap_action" | "hold_action" | "double_tap_action"
+>;
+
+/** What a gesture on an opening resolves to: an action, and what it acts on. */
+export interface OpeningPress {
+  /** The entity the action targets. Absent for an action that needs none (navigate, url). */
+  entity?: string;
+  config: ActionConfig;
+}
+
+/**
+ * Which action a gesture on an opening performs, and on **which** of its two
+ * entities (issue #74 follow-up). An opening can bind the window/door itself
+ * and its external shutter; only the first was ever reachable.
+ *
+ * The rule that shapes the rest: a tap is never *silently* retargeted at the
+ * shutter motor. Tapping is the gesture people make by accident, the shutter
+ * is real hardware that takes seconds to travel, and moving it because the
+ * plan quietly decided the shutter was the more interesting entity is exactly
+ * the accidental-hardware-move that issue #47 took out of the device defaults.
+ * So by default the tap stays on the opening and the shutter is reached by
+ * holding — until {@link Opening.tapTarget} says otherwise, which is a
+ * decision rather than an accident.
+ *
+ * - A configured `*_action` always wins. Its own `entity` picks which of the
+ *   two it acts on; without one it acts on the primary.
+ * - **primary** is the opening's `entity`, falling back to the shutter, so a
+ *   shutter-only opening is pressable at all. `tapTarget: "shutter"` swaps the
+ *   two over, but only when both are bound.
+ * - **secondary** is whichever one the primary is not, and only exists when
+ *   both are bound — otherwise it would be the same entity under another name.
+ * - Tap defaults to toggling an open/close-capable `cover`, else more-info
+ *   ({@link openingClickAction}); hold defaults to more-info on the secondary;
+ *   double-tap defaults to nothing.
+ */
+export function openingActionForGesture(
+  o: PressableOpening,
+  gesture: "tap" | "hold" | "double_tap",
+  featuresOf: (entityId: string) => number,
+): OpeningPress | undefined {
+  const opening = o.entity || undefined;
+  const shutter = o.shutterEntity || undefined;
+  // Only a genuine choice: with one entity bound there is nothing to swap.
+  const leadsWithShutter = !!(opening && shutter && o.tapTarget === "shutter");
+  const primary = leadsWithShutter ? shutter : (opening ?? shutter);
+  const secondary = opening && shutter ? (leadsWithShutter ? opening : shutter) : undefined;
+  const configured =
+    gesture === "tap" ? o.tap_action : gesture === "hold" ? o.hold_action : o.double_tap_action;
+  if (configured) return { entity: configured.entity ?? primary, config: configured };
+  if (gesture === "tap") {
+    if (!primary) return undefined;
+    return {
+      entity: primary,
+      config: {
+        action:
+          // Pointing the tap at the shutter opens its dialog; it does not
+          // drive the motor. Choosing *which* entity answers is not the same
+          // as choosing to move hardware on a tap, and that second decision
+          // stays where it is explicit — `tap_action: toggle` (issue #47).
+          !leadsWithShutter &&
+          openingClickAction(primary, featuresOf(primary)) === "cover-toggle"
+            ? "toggle"
+            : "more-info",
+      },
+    };
+  }
+  // Hold reaches whichever entity the tap left alone.
+  if (gesture === "hold" && secondary) return { entity: secondary, config: { action: "more-info" } };
+  return undefined;
+}
+
+/**
+ * Whether pressing an opening does anything at all — the mirror of
+ * {@link itemIsInteractive}, and used for the same things: the hit target, the
+ * `button` role and the tab stop. An opening with nothing bound draws no
+ * affordance it cannot honour, and a shutter-only opening finally gets one.
+ */
+export function openingIsPressable(
+  o: PressableOpening,
+  featuresOf: (entityId: string) => number,
+): boolean {
+  return (["tap", "hold", "double_tap"] as const).some((g) =>
+    hasAction(openingActionForGesture(o, g, featuresOf)?.config),
+  );
 }
 
 /**
@@ -1863,17 +1964,23 @@ function rollCurtain(length: number, tone: string, amt: number): SVGTemplateResu
  * drawn just **outside** the wall band so they never collide with the
  * window's own casement sashes (which swing to the near side), rotating
  * outward as they open. Closed, they cover the opening.
+ *
+ * `side` picks which face of the wall they hang on: `1` (default) is the far
+ * side from the sashes, `-1` the sash's own side, for a window whose outside
+ * is the near side of the wall. It flips both the offset and the fold
+ * direction, so the panels still swing *away* from the wall either way.
  */
 function swingShutter(
   length: number,
   cutH: number,
   tone: string,
-  amt: number
+  amt: number,
+  side: 1 | -1 = 1
 ): SVGTemplateResult {
   const half = length / 2;
   const t = 3;
-  // Sit the panels beyond the wall band, on the far side from the sashes.
-  const y0 = cutH / 2 + t / 2;
+  // Sit the panels beyond the wall band, clear of the sashes on their side.
+  const y0 = side * (cutH / 2 + t / 2);
   /** Slat ticks across a panel whose rect starts at `x0` and runs `w` wide. */
   const louvers = (x0: number, w: number): SVGTemplateResult[] => {
     const out: SVGTemplateResult[] = [];
@@ -1891,17 +1998,87 @@ function swingShutter(
   // panels animate with the rest of the plan for free.
   return svg`
       <g transform="translate(${-half} ${y0})">
-        <g class="fp-door-leaf" style="transform:rotate(${90 * amt}deg);">
+        <g class="fp-door-leaf" style="transform:rotate(${side * 90 * amt}deg);">
           <rect x="0" y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
           ${louvers(0, half)}
         </g>
       </g>
       <g transform="translate(${half} ${y0})">
-        <g class="fp-leaf-r" style="transform:rotate(${-90 * amt}deg);">
+        <g class="fp-leaf-r" style="transform:rotate(${-side * 90 * amt}deg);">
           <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
           ${louvers(-half, half)}
         </g>
       </g>`;
+}
+
+/**
+ * How far off the wall centre line the shutter badge sits, in canvas units.
+ * Clear of the wall band, the hinged panels (which reach ~9) and the roll
+ * curtain, so it never lands on the thing it is describing.
+ */
+export const SHUTTER_MARK_OFFSET = 22;
+
+/**
+ * Where an opening's shutter badge sits, in plan coordinates (issue #74
+ * follow-up).
+ *
+ * The badge is HTML, not SVG — it holds a real `ha-icon` and has to stay
+ * upright and screen-sized — so the position is worked out here rather than
+ * falling out of the symbol's own transform. It follows the shutter to the
+ * outside of the wall: the offset is taken along the opening's normal and
+ * mirrored by `flipV`, which is what moves the drawn shutter too.
+ */
+export function shutterMarkPoint(
+  o: Pick<Opening, "x" | "y" | "angle" | "flipV">,
+  offset: number = SHUTTER_MARK_OFFSET,
+): { x: number; y: number } {
+  const dy = (o.flipV ? -1 : 1) * offset;
+  const rad = (o.angle * Math.PI) / 180;
+  return { x: o.x - Math.sin(rad) * dy, y: o.y + Math.cos(rad) * dy };
+}
+
+/**
+ * Whether an opening earns a shutter badge: both entities bound (issue #74
+ * follow-up).
+ *
+ * The badge exists because the second entity is otherwise invisible — the plan
+ * draws the shutter, but nothing says the symbol answers to two different
+ * things, so press-and-hold is a gesture you would have to already know about
+ * to find. With one entity bound there is no second thing to reveal.
+ */
+export function hasShutterMark(o: Pick<Opening, "entity" | "shutterEntity">): boolean {
+  return !!(o.entity && o.shutterEntity);
+}
+
+/** Last-resort shutter glyphs, for an entity with no device class of its own. */
+const SHUTTER_FALLBACK_ICON = { on: "mdi:window-shutter-open", off: "mdi:window-shutter" };
+
+/**
+ * The glyph for an opening's shutter badge — the shutter entity's **own**
+ * icon, resolved exactly as Home Assistant resolves it, so the badge shows
+ * whatever that entity shows everywhere else in HA: the registry override
+ * first, then the icon on the state, then the domain/device-class default.
+ *
+ * State-aware at every level: HA's own defaults are pairs (a `shutter` cover
+ * reads `window-shutter-open` while open), so the glyph itself carries the
+ * open/closed reading rather than only its colour. `open` is the already
+ * inverted reading from {@link shutterAmount}, so a reed contact wired the
+ * other way round still picks the right half of the pair.
+ */
+export function shutterMarkIcon(
+  st: { state: string; attributes?: Record<string, unknown> } | undefined,
+  entityId: string,
+  open: boolean,
+  registryIcon?: string,
+): string {
+  const registry = cssIcon(registryIcon);
+  if (registry) return registry;
+  const attr = cssIcon(st?.attributes?.icon);
+  if (attr) return attr;
+  return (
+    entityDefaultIcon(entityId, st?.attributes?.device_class as string | undefined, open) ??
+    (open ? SHUTTER_FALLBACK_ICON.on : SHUTTER_FALLBACK_ICON.off)
+  );
 }
 
 /** Style options for {@link renderOpening}. */
@@ -1927,8 +2104,19 @@ export interface OpeningStyle {
    * External roller shutter layered over the opening (issue #74): how far
    * open (0..1, see {@link shutterAmount}) and whether it wears the accent.
    * Rendered as the roll curtain on top of the sash.
+   *
+   * `accent` is the shutter's own — it may read differently from the sash it
+   * covers — and falls back to the opening's. `flip` hangs hinged panels on
+   * the sash's own side of the wall; the roll curtain ignores it, being drawn
+   * symmetrically about the wall line.
    */
-  shutter?: { amount: number; active?: boolean; style?: "roll" | "swing" };
+  shutter?: {
+    amount: number;
+    active?: boolean;
+    style?: "roll" | "swing";
+    accent?: string;
+    flip?: boolean;
+  };
 }
 
 /**
@@ -2107,13 +2295,13 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   // active/accent state is independent of the window's.
   if (style.shutter) {
     const shutterTone = cssColorOr(
-      style.shutter.active ? accent : color,
+      style.shutter.active ? (style.shutter.accent ?? accent) : color,
       SKIN_ACCENT
     );
     const amt2 = Math.max(0, Math.min(1, style.shutter.amount));
     body = svg`${body}${
       style.shutter.style === "swing"
-        ? swingShutter(o.length, cutH, shutterTone, amt2)
+        ? swingShutter(o.length, cutH, shutterTone, amt2, style.shutter.flip ? -1 : 1)
         : rollCurtain(o.length, shutterTone, amt2)
     }`;
   }

--- a/src/render.ts
+++ b/src/render.ts
@@ -2019,6 +2019,42 @@ function swingShutter(
 export const SHUTTER_MARK_OFFSET = 22;
 
 /**
+ * A second offset for the badge, in **screen pixels**, applied on top of
+ * {@link SHUTTER_MARK_OFFSET}.
+ *
+ * Two offsets because two things have to be cleared, and they are measured in
+ * different units. The wall and the shutter panels are canvas units and shrink
+ * with the plan; the badge is a fixed 22px and does not. With only the canvas
+ * offset, a plan drawn on a large canvas in a narrow card pulls the badge so
+ * close that its own circle covers the opening underneath — and the opening is
+ * a tap target, so it stops being comfortably hittable.
+ *
+ * Sized against the badge's own radius (11px) plus air, so the opening stays
+ * clear at any scale.
+ */
+export const SHUTTER_MARK_PIXEL_OFFSET = 14;
+
+/**
+ * The direction the shutter badge is pushed, as a unit vector in **screen**
+ * space — the opening's normal, mirrored by `flipV` like the drawn shutter,
+ * then turned by the plan's own display rotation (issue #33), since the badge
+ * lives in the HTML overlay and does not rotate with the SVG.
+ */
+export function shutterMarkNormal(
+  o: Pick<Opening, "angle" | "flipV">,
+  rot: PlanRotation = 0,
+): { x: number; y: number } {
+  const s = o.flipV ? -1 : 1;
+  const rad = (o.angle * Math.PI) / 180;
+  const n = { x: -Math.sin(rad) * s, y: Math.cos(rad) * s };
+  // The linear half of rotatePlanPoint: (x,y) → (−y,x) at 90°, and so on.
+  if (rot === 90) return { x: -n.y, y: n.x };
+  if (rot === 180) return { x: -n.x, y: -n.y };
+  if (rot === 270) return { x: n.y, y: -n.x };
+  return n;
+}
+
+/**
  * Where an opening's shutter badge sits, in plan coordinates (issue #74
  * follow-up).
  *
@@ -2038,16 +2074,22 @@ export function shutterMarkPoint(
 }
 
 /**
- * Whether an opening earns a shutter badge: both entities bound (issue #74
- * follow-up).
+ * Whether an opening earns a shutter badge: both entities bound, and not
+ * switched off (issue #74 follow-up).
  *
  * The badge exists because the second entity is otherwise invisible — the plan
  * draws the shutter, but nothing says the symbol answers to two different
  * things, so press-and-hold is a gesture you would have to already know about
  * to find. With one entity bound there is no second thing to reveal.
+ *
+ * On by default, because a discoverability aid nobody switches on helps
+ * nobody. Off is for the plan where every window has a shutter and the icons
+ * become the loudest thing on it; the gestures keep working either way.
  */
-export function hasShutterMark(o: Pick<Opening, "entity" | "shutterEntity">): boolean {
-  return !!(o.entity && o.shutterEntity);
+export function hasShutterMark(
+  o: Pick<Opening, "entity" | "shutterEntity" | "showShutterIcon">,
+): boolean {
+  return !!(o.entity && o.shutterEntity) && (o.showShutterIcon ?? true);
 }
 
 /** Last-resort shutter glyphs, for an entity with no device class of its own. */
@@ -2066,11 +2108,16 @@ const SHUTTER_FALLBACK_ICON = { on: "mdi:window-shutter-open", off: "mdi:window-
  * other way round still picks the right half of the pair.
  */
 export function shutterMarkIcon(
+  o: Pick<Opening, "shutterEntity" | "shutterIcon">,
   st: { state: string; attributes?: Record<string, unknown> } | undefined,
-  entityId: string,
   open: boolean,
   registryIcon?: string,
 ): string {
+  const entityId = o.shutterEntity ?? "";
+  // The author's own choice first, as it is for a device (issue #106) — the
+  // one candidate that is a decision rather than a default.
+  const configured = cssIcon(o.shutterIcon);
+  if (configured) return configured;
   const registry = cssIcon(registryIcon);
   if (registry) return registry;
   const attr = cssIcon(st?.attributes?.icon);

--- a/src/render.ts
+++ b/src/render.ts
@@ -2035,6 +2035,16 @@ export const SHUTTER_MARK_OFFSET = 22;
 export const SHUTTER_MARK_PIXEL_OFFSET = 14;
 
 /**
+ * The badge's own size, and its glyph's. In the same unit as
+ * {@link SHUTTER_MARK_PIXEL_OFFSET} — screen pixels by default, canvas units
+ * under `overlayScale: plan` (#148), which is why the offset above is sized
+ * against it: both have to answer to the same choice or the badge lands on the
+ * opening at one scale and floats away at another.
+ */
+export const SHUTTER_MARK_SIZE = 22;
+export const SHUTTER_MARK_ICON_SIZE = 15;
+
+/**
  * The direction the shutter badge is pushed, as a unit vector in **screen**
  * space — the opening's normal, mirrored by `flipV` like the drawn shutter,
  * then turned by the plan's own display rotation (issue #33), since the badge

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,56 @@ export interface Opening {
    */
   shutterStyle?: "roll" | "swing";
   /**
+   * Flip the open/closed interpretation of {@link shutterEntity}, exactly as
+   * {@link invert} does for `entity`. Not the same switch: a reed contact on a
+   * hinged shutter commonly reports `on` when the panels are **shut** (the
+   * magnet only meets its contact when they are folded together), while the
+   * window behind it reports the other way round. One flag could not describe
+   * both.
+   */
+  shutterInvert?: boolean;
+  /**
+   * Colour of the shutter while it is (partly) open. Falls back to
+   * {@link activeColor}, then the skin accent — so a plan that only wants one
+   * accent still sets one, and a plan that wants the shutter to read
+   * separately from the sash it covers can say so.
+   */
+  shutterActiveColor?: string;
+  /**
+   * Hinged shutters only: put the panels on the sash's **own** side of the
+   * wall instead of the far side (the default). Shutters live outside, and
+   * which side of a wall "outside" is depends on the room — a window drawn
+   * with `flipV` opens the other way, and its shutters follow it.
+   *
+   * Ignored by the roll curtain, which is drawn symmetrically about the wall
+   * line and so looks identical either way.
+   */
+  shutterFlipV?: boolean;
+  /**
+   * With both entities bound, which one the gestures lead with — the
+   * window/door itself (the default), or the shutter. The other one moves to
+   * hold. Meaningless with only one bound, since there is nothing to choose
+   * between.
+   *
+   * The default is the opening because a tap is the gesture people make by
+   * accident and the shutter is real hardware that takes seconds to travel
+   * (issue #47). Naming the shutter here is the opposite of an accident, so
+   * the choice is honoured — it opens the shutter's dialog rather than driving
+   * the motor. Moving it on a tap is a further step, and stays with
+   * {@link tap_action}.
+   */
+  tapTarget?: OpeningTapTarget;
+  /**
+   * Lovelace actions for the opening (issue #74 follow-up). Same shape as
+   * {@link FloorItem.tap_action}; an action's own `entity` picks which of
+   * `entity` / `shutterEntity` it acts on. Defaults: tap opens/toggles the
+   * primary entity, hold shows more-info for the shutter when both are bound,
+   * double-tap does nothing. See {@link openingActionForGesture}.
+   */
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
+  /**
    * Sliding openings only (`motion: "slide"`): how the panels are arranged.
    * - `single` (default) — one panel slides aside into the wall.
    * - `bypass` — two panels on parallel tracks; one slides behind the other
@@ -136,6 +186,14 @@ export interface Opening {
    */
   sliderStyle?: "single" | "bypass" | "biparting";
 }
+
+/**
+ * Which of an opening's two entities its gestures lead with — see
+ * {@link Opening.tapTarget}. Named by role rather than by entity id, like
+ * {@link BadgeEntity}, so renaming an entity in Home Assistant cannot orphan
+ * the choice.
+ */
+export type OpeningTapTarget = "opening" | "shutter";
 
 export type ItemKind =
   | "light"

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,22 @@ export interface Opening {
    */
   tapTarget?: OpeningTapTarget;
   /**
+   * Draw the shutter's icon beside the opening (default true, whenever both
+   * entities are bound). It is what makes the second entity visible at all —
+   * and a control of its own, since tapping it opens the shutter — but on a
+   * dense plan, or one where every window has a shutter, it is a lot of
+   * icons. Turning it off leaves the gestures untouched.
+   */
+  showShutterIcon?: boolean;
+  /**
+   * Override that icon. Absent, it is the shutter entity's own — the registry
+   * override, then the icon on the state, then Home Assistant's
+   * domain/device-class default, which is a **pair**, so the glyph itself
+   * carries open/closed. An override is a single glyph and gives that up;
+   * colour still reports the state.
+   */
+  shutterIcon?: string;
+  /**
    * Lovelace actions for the opening (issue #74 follow-up). Same shape as
    * {@link FloorItem.tap_action}; an action's own `entity` picks which of
    * `entity` / `shutterEntity` it acts on. Defaults: tap opens/toggles the


### PR DESCRIPTION
### Problem

An opening can bind two entities: `entity` for the sash and `shutterEntity` for the external roller shutter (#74). Both are drawn (`shutterAmount` / `shutterActive` / `shutterStyleOf`) and both are watched in `collectWatchedEntities`, but only `entity` was ever read for a press. Three things followed.

**The shutter was unreachable.** With both bound, the tap always targeted `entity`. Where that is a read-only contact `binary_sensor`, `openingClickAction()` returns `more-info` and the contact's dialog opens — the shutter drawn right there on the plan could be neither inspected nor moved.

**Shutter-only openings were inert.** An opening carrying only a `shutterEntity` never reacted at all: the `!o.entity` guard returned before anything could happen.

**Nothing said there were two entities.** Even once the shutter is reachable, the symbol still looks like a single thing, so whichever gesture reaches the second entity is something you would have to already know about to find.

### Change

**One resolver for every gesture.** `openingActionForGesture(o, gesture, featuresOf)` returns the action *and* the entity it acts on:

| gesture | default |
| --- | --- |
| tap | the opening — `toggle` for an open/close `cover`, else `more-info` |
| hold | `more-info` on the shutter — whichever entity the tap did not take |
| double tap | nothing |

A configured `tap_action` / `hold_action` / `double_tap_action` always wins, and its own `entity` field picks which of the two it acts on. `openingIsPressable` mirrors `itemIsInteractive` from #134 and gates the hit target, so a **shutter-only opening becomes pressable** while an opening with nothing bound stops claiming to be a button. Hold and double-tap timers are armed only when those gestures actually resolve, so an ordinary contact sensor still answers a tap immediately.

**Why the tap does not simply default to the shutter.** That was this PR's first proposal, and it is the one thing #47 argues against: a tap is the gesture people make by accident, and a shutter is real hardware that takes seconds to travel. Retargeting every tap at the shutter motor by default reintroduces exactly the accidental-hardware-move that #47 took out of the device defaults. The shutter is reached three other ways instead — all of them explicit:

- **press and hold** (the default once both entities are bound),
- **`tapTarget: shutter`** per opening, shown in the editor as **Tap opens**. Pointing the tap at the shutter opens its *dialog* rather than driving the motor; moving it is a further, separate decision that stays with `tap_action: toggle`,
- **the shutter's own icon**, below.

**The second entity is now visible.** An opening binding both draws the shutter entity's own icon beside it, and tapping that icon opens the shutter whatever the opening itself does. The glyph is resolved exactly as HA resolves it — registry override, then the icon on the state, then the domain/device-class default — and those defaults come in pairs, so a `shutter` cover reads `window-shutter-open` while open and `window-shutter` while shut. The accent repeats the same reading in colour. It is HTML in the overlay rather than SVG, for the two reasons the device badges are: it holds a real `ha-icon`, and it is sized in screen pixels, so it stays legible on a canvas of any scale.

**The shutter gets a reading and a look of its own.** `shutterInvert` (a reed contact on hinged shutters commonly reads `on` when the panels are *shut*, while the window behind it reads the other way round), `shutterActiveColor`, and `shutterFlipV` for hanging hinged panels on the sash's own side of the wall. Invert applies to the position *and* to the open-ish state, but the outage check comes first: an `unavailable` shutter must never invert into a wide-open one. Transit (`opening` / `closing`) stays active either way round.

**Editor.** Shutter invert / side / colour rows, the three gesture fields, and **Tap opens**. The gesture fields' defaults name what the card would *actually* do — the tap field reads `toggle` only for a cover that can open and close — so no field advertises a default the card does not take. The shutter badge is previewed on the canvas, inert there so it cannot swallow a selection click.

### The open question, answered

> Should long-press on an opening surface the other entity, the sash contact?

Yes — that is now the default whenever both entities are bound, and it works in both directions: hold always reaches whichever entity the tap did not.

### Notes

**Backwards compatible.** Every new key is optional, and a plan binding only `entity` renders and behaves exactly as before. Nothing needs to change in existing YAML.

**Now verified.** The earlier "could not run this locally" caveat no longer applies: `npx tsc --noEmit` is clean and `npx vitest run` passes **797 tests across 10 files**, 59 of them new — invert and sensor-outage behaviour, the full gesture-resolution table, the badge's position and icon resolution, the shutter side and accent in `renderOpening`, and the new form fields with patch round-tripping.

**About this branch's history.** The first two commits are superseded by the third: `_onOpeningClick` and its `_openMoreInfo` helper are gone, replaced by the gesture path above, and the README line they added is rewritten. The net diff against `main` is the final state.

**New config keys.** `tapTarget`, `shutterInvert`, `shutterActiveColor`, `shutterFlipV`, `tap_action`, `hold_action`, `double_tap_action` — all documented in the README's Opening table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
