### PR TITLE
Skins: put a palette above the card, not on it, so card-mod can still reach it (closes #155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,9 @@ so the canvas reads as the plan, and a **background image** still covers the ski
 ### Rolling your own
 
 A skin is a set of CSS custom properties, so [card-mod](#styling-hooks-card-mod) can set
-the same ones for the same result:
+the same ones for the same result — including on top of a skin, to change one thing about
+it rather than replace it. A skinned card also carries its id as `data-skin` on the card
+element, so a rule can apply to one skin only:
 
 ```yaml
 type: custom:easy-floorplan-card
@@ -746,6 +748,11 @@ card_mod:
       --fp-skin-accent: #f2aa4c;
     }
 ```
+
+Values are plain CSS, so quoting them breaks the declaration rather than setting it:
+`--fp-skin-wall-width: 5` works, `--fp-skin-wall-width: "5"` draws hairline walls. The
+`var()` default can't catch that — a fallback only applies to a property that is *unset*,
+never to one set to something invalid.
 
 | Token | Default | Paints |
 | --- | --- | --- |

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -70,7 +70,15 @@ import {
 } from "./render";
 import { deadSpacesCached } from "./dead-space";
 import type { Opening } from "./types";
-import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
+import {
+  skinAttribute,
+  skinPalettes,
+  skinTokens,
+  SKIN_ACCENT,
+  SKIN_PAPER,
+  SKIN_TEXT,
+  SKIN_WALL,
+} from "./skins";
 import { actionForGesture, executeAction, hasAction, itemIsInteractive } from "./actions";
 import { actionHandler } from "./action-handler";
 
@@ -154,6 +162,20 @@ export class FloorplanCard extends LitElement {
     const prev = changed.get("hass") as HomeAssistant | undefined;
     if (!prev || !this.hass) return true;
     return hassRenderInputsChanged(prev, this.hass, this._watchedEntities);
+  }
+
+  /**
+   * Carry the skin as an attribute on the host, where `skinPalettes` picks it
+   * up (issue #155). It has to be the host and not the template, because the
+   * point is to sit *above* the `<ha-card>` a card-mod rule targets — see
+   * skins.ts. Only ever a `findSkin` match, so an unrecognised `skin:` puts no
+   * attribute on the element at all.
+   */
+  protected willUpdate(changed: PropertyValues): void {
+    if (!changed.has("_config")) return;
+    const skin = skinAttribute(this._config?.skin);
+    if (skin) this.setAttribute("data-skin", skin);
+    else this.removeAttribute("data-skin");
   }
 
   public getCardSize(): number {
@@ -496,7 +518,9 @@ export class FloorplanCard extends LitElement {
            floor switcher and the card's own background follow it too — a Tron
            plan floating on a white card would read as a bug. Every token the
            card draws with is declared on :host, so this only ever overrides. -->
-      <ha-card .header=${c.title ?? nothing} style=${skinStyle(c.skin) || nothing}>
+      <!-- No skin style here: the palette comes from data-skin on the host, so
+           a card-mod rule on this element still wins (issue #155). -->
+      <ha-card .header=${c.title ?? nothing}>
         <div
           class="stage press-${pressEffectOf(c)}"
           style="aspect-ratio: ${dims.w} / ${dims.h};"
@@ -736,11 +760,14 @@ export class FloorplanCard extends LitElement {
     `;
   }
 
-  // skinTokens declares every --fp-skin-* default on :host (issue #122). It
-  // comes first so a skin's inline overrides on <ha-card> — a descendant — win
-  // by the cascade's ordinary inheritance rules rather than by !important.
+  // skinTokens declares every --fp-skin-* default on :host (issue #122), and
+  // skinPalettes the chosen skin's values on the same element (issue #155).
+  // Both sit above <ha-card>, so a card-mod rule on that element beats them by
+  // ordinary inheritance rather than needing !important. Palettes come second:
+  // same specificity as the defaults, so tree order is what picks the skin.
   static styles = [
     skinTokens,
+    skinPalettes,
     css`
     ha-card {
       height: 100%;

--- a/src/skins.test.ts
+++ b/src/skins.test.ts
@@ -7,6 +7,8 @@ import {
   type SkinToken,
   findSkin,
   skinStyle,
+  skinAttribute,
+  skinPalettes,
   SKIN_ACCENT,
   SKIN_PAPER,
   SKIN_TEXT,
@@ -125,6 +127,57 @@ describe("skinStyle", () => {
     expect(findSkin("pastel")?.label).toBe("Pastel");
     expect(findSkin("Pastel")).toBeUndefined();
     expect(findSkin(undefined)).toBeUndefined();
+  });
+});
+
+/**
+ * Issue #155: a skin used to ride an inline `style` on the same `<ha-card>` the
+ * README tells people to card-mod, and inline beats a plain rule — so choosing
+ * a skin silently killed every documented `--fp-skin-*` override. The palette
+ * now lands on `:host`, above that element, where a card-mod rule beats it by
+ * inheritance instead.
+ */
+describe("skinAttribute / skinPalettes (issue #155)", () => {
+  const palettes = skinPalettes.cssText;
+
+  it("names a real skin, and nothing else", () => {
+    expect(skinAttribute("tron")).toBe("tron");
+    expect(skinAttribute("pastel")).toBe("pastel");
+    // No attribute for the default, an id we don't ship, or a non-string —
+    // the same rule skinStyle applies, so an unknown skin renders unskinned.
+    expect(skinAttribute(DEFAULT_SKIN)).toBeUndefined();
+    expect(skinAttribute("nintendo")).toBeUndefined();
+    expect(skinAttribute(undefined)).toBeUndefined();
+    expect(skinAttribute(42)).toBeUndefined();
+  });
+
+  it("carries a host rule per non-default skin, and none for the default", () => {
+    for (const s of SKINS.slice(1)) {
+      expect(palettes).toContain(`:host([data-skin="${s.id}"])`);
+    }
+    expect(palettes).not.toContain(`[data-skin="${DEFAULT_SKIN}"]`);
+  });
+
+  it("declares each skin's complete token set, same as the inline style did", () => {
+    for (const s of SKINS.slice(1)) {
+      const block = palettes.split(`:host([data-skin="${s.id}"]){`)[1].split("}")[0];
+      for (const token of SKIN_TOKENS) {
+        expect(block).toContain(`${token}:${s.vars[token as SkinToken]};`);
+      }
+    }
+  });
+
+  // The selector interpolates the id, so a future skin called `a"],*` would be
+  // a stylesheet-wide rule rather than one skin's. The registry's id shape test
+  // is what prevents it; this asserts the two stay tied together.
+  it("interpolates only ids that cannot escape the selector", () => {
+    for (const s of SKINS) expect(s.id).toMatch(/^[a-z][a-z0-9-]*$/);
+  });
+
+  it("puts the palette on the host, never on the card-mod target", () => {
+    // The whole fix in one assertion: nothing here may select `ha-card`, or a
+    // card-mod rule on that element would be back to losing the cascade.
+    expect(palettes).not.toContain("ha-card");
   });
 });
 

--- a/src/skins.ts
+++ b/src/skins.ts
@@ -23,7 +23,7 @@
  * {@link SKINS} and need no new plumbing.
  */
 
-import { css } from "lit";
+import { css, unsafeCSS } from "lit";
 
 /**
  * Every token a skin may set. Exported so the tests can assert each skin is
@@ -195,6 +195,10 @@ export function findSkin(id: unknown): Skin | undefined {
  * sanitise here — but they still land in a `style="…"` attribute, and
  * `skins.test.ts` holds them to the same no-breakout rule `cssColor` enforces
  * for user input.
+ *
+ * The **card** no longer uses this — see {@link skinPalettes} for why an inline
+ * style was the wrong place for a skin. The editor still does: nothing
+ * card-mods the editor, and its canvas already carries an inline style.
  */
 export function skinStyle(id: unknown): string {
   const skin = findSkin(id);
@@ -203,6 +207,44 @@ export function skinStyle(id: unknown): string {
     .map(([k, v]) => `${k}:${v};`)
     .join("");
 }
+
+/** The `data-skin` a card should carry, or `undefined` for no attribute. */
+export function skinAttribute(id: unknown): string | undefined {
+  const skin = findSkin(id);
+  return skin && skin.id !== DEFAULT_SKIN ? skin.id : undefined;
+}
+
+/**
+ * Every non-default palette, as a rule per skin on `:host` (issue #155).
+ *
+ * A skin used to be an inline `style` on the card's `<ha-card>` — the same
+ * element the README tells people to card-mod. An inline style beats any
+ * non-`!important` rule, so picking a skin silently killed every documented
+ * `--fp-skin-*` override, all sixteen of them. Only the default skin escaped,
+ * and only because it writes no inline style at all.
+ *
+ * Declared on `:host` the tokens sit *above* `ha-card` rather than on it, so a
+ * card-mod rule wins by inheritance instead of losing the cascade — which is
+ * exactly why overrides already worked on an unskinned plan. It also puts a
+ * palette where {@link skinTokens} already puts the defaults.
+ *
+ * Built by hand rather than through `css` because the selector is per-skin.
+ * Nothing here is user input — ids and values are module constants, the card
+ * only ever emits an id {@link findSkin} matched, and `skins.test.ts` holds
+ * both to the same no-breakout rule user colours go through.
+ */
+export const skinPalettes = unsafeCSS(
+  SKINS.filter((s) => s.id !== DEFAULT_SKIN)
+    .map(
+      (s) =>
+        `:host([data-skin="${s.id}"]){` +
+        Object.entries(s.vars)
+          .map(([k, v]) => `${k}:${v};`)
+          .join("") +
+        `}`
+    )
+    .join("\n")
+);
 
 /**
  * Default values for every token, to be included in the `static styles` of both


### PR DESCRIPTION
### The problem

The README documents card-mod on `ha-card` as the way to restyle a plan without writing a skin:

```yaml
card_mod:
  style: |
    ha-card {
      --fp-skin-wall: #f2aa4c;
    }
```

That works on an unskinned card and does nothing at all on a skinned one — because a skin was applied as an inline `style` on that same `ha-card`, and an inline style beats any non-`!important` rule. Every one of the seventeen tokens, on `odnetnin`, `pastel` and `tron`. The default skin escaped only because `skinStyle` returns `""` for it, so nothing inline was written — which is precisely why the bug reads as "card-mod works" right up until someone picks a skin.

It surfaced in #147, where the reporter's own problem turned out to be a quoted value (`"5"` is a CSS string, not a length, so `stroke-width` went invalid and fell back to a hairline `1`). They'd have hit this next.

### The change

Declare the palettes on `:host` instead, keyed off a `data-skin` attribute the card sets from a `findSkin` match:

```css
:host([data-skin="tron"]) { --fp-skin-wall: #7de3ff; /* … */ }
```

`:host` is strictly above `ha-card`, so a card-mod declaration on that element wins by **inheritance** rather than having to win the cascade — the same reason overrides already worked on an unskinned plan. It also puts a palette where `skinTokens` already puts the defaults, so the two live together instead of at opposite ends of the render.

Three things worth stating, all commented:

- **The attribute is only ever a `findSkin` match**, so a hand-written `skin: nintendo` still puts nothing on the element and renders unskinned, exactly as before. The selector interpolates the id, so a test ties the palette to the registry's existing id-shape rule — a future skin called `a"],*` would otherwise be a stylesheet-wide rule.
- **`skinStyle` stays, for the editor.** Its canvas paints from an inline style it already builds, and nothing card-mods the editor. Noted at both ends so the two don't drift.
- **A card-mod rule against `:host` rather than `ha-card` still loses**, before and after. Lit puts `static styles` in `adoptedStyleSheets`, which the cascade orders *after* an injected `<style>`, so an equal-specificity rule loses on tree order. `ha-card` is the documented idiom and it's the one worth making work.

### Verified

Unit tests can't see this, so it was measured on built cards in a browser, injecting into the card's shadow root the way card-mod does. Computed `stroke-width` on `.wall`:

| card-mod rule | default | tron, before | tron, after |
| --- | --- | --- | --- |
| *(none)* | 8px | 5px | 5px |
| `ha-card { --fp-skin-wall-width: 3 }` | 3px | **5px — ignored** | **3px** |
| `ha-card { --fp-skin-wall-width: 3 !important }` | 3px | 3px | 3px |

The regression check mattered more than the fix, since this moves every skinned card's styling. Rendered output compared before and after across **unset / `default` / `odnetnin` / `pastel` / `tron` / an unknown id** — wall stroke, width and filter, plan paper, badge background and border:

```
identical across every skin
```

Including `tron`'s `drop-shadow` filter surviving the move, and the unknown id still falling back to unskinned.

743 tests pass (+5: the attribute's match rules, a host rule per non-default skin with its complete token set, the id-shape tie, and an assertion that nothing in the palettes selects `ha-card` — the whole fix in one line).

README gains the `data-skin` hook and the quoting trap from #147.

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

