### PR TITLE
Walls: per-wall adjustable thickness

### DIFF
--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -22,7 +22,7 @@ import {
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
-import { DEFAULT_SKIN, SKINS } from "./skins";
+import { DEFAULT_SKIN, SKINS, MAX_SKIN_WALL_WIDTH } from "./skins";
 
 const fields: FormField[] = [
   { name: "name", label: "Name", selector: { text: {} } },
@@ -604,6 +604,25 @@ describe("wallForm / projectForm / floorImageForm", () => {
   it("wall exposes rounded coordinates", () => {
     const d = wallForm({ id: "w", x1: 1.4, y1: 2.6, x2: 3, y2: 4 }).data;
     expect(d).toMatchObject({ x1: 1, y1: 3, x2: 3, y2: 4 });
+  });
+
+  it("wall defaults thickness to WALL_THICKNESS and strips it back out at the default", () => {
+    const form = wallForm({ id: "w", x1: 0, y1: 0, x2: 1, y2: 1 });
+    expect(form.data.thickness).toBe(8);
+    expect(form.toPatch({ thickness: 8 })).toEqual({ thickness: undefined });
+    expect(form.toPatch({ thickness: 5 })).toEqual({ thickness: 5 });
+  });
+
+  it("wall reflects a custom thickness in its data", () => {
+    const d = wallForm({ id: "w", x1: 0, y1: 0, x2: 1, y2: 1, thickness: 10 }).data;
+    expect(d.thickness).toBe(10);
+  });
+
+  it("wall's thickness slider is capped at MAX_SKIN_WALL_WIDTH", () => {
+    const field = wallForm({ id: "w", x1: 0, y1: 0, x2: 1, y2: 1 }).fields.find(
+      (f) => f.name === "thickness"
+    )!;
+    expect((field.selector.number as { max: number }).max).toBe(MAX_SKIN_WALL_WIDTH);
   });
 
   it("project fields are required numbers with min 1", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -33,6 +33,7 @@ import {
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
+  WALL_THICKNESS,
   badgeContentOf,
   domainIconAnimation,
   isPresenceEntity,
@@ -45,7 +46,7 @@ import {
   windowSash,
 } from "./render";
 import { defaultItemAction } from "./actions";
-import { DEFAULT_SKIN, SKINS, findSkin } from "./skins";
+import { DEFAULT_SKIN, SKINS, findSkin, MAX_SKIN_WALL_WIDTH } from "./skins";
 
 /** One ha-form schema item, extended with our label/helper (read by computeLabel). */
 export interface FormField {
@@ -861,9 +862,33 @@ export function wallForm(w: Wall): FormSpec {
     selector: { number: { mode: "box" } },
   });
   return {
-    fields: [coord("x1", "Start X"), coord("y1", "Start Y"), coord("x2", "End X"), coord("y2", "End Y")],
-    data: { x1: Math.round(w.x1), y1: Math.round(w.y1), x2: Math.round(w.x2), y2: Math.round(w.y2) },
-    toPatch: identity,
+    fields: [
+      coord("x1", "Start X"),
+      coord("y1", "Start Y"),
+      coord("x2", "End X"),
+      coord("y2", "End Y"),
+      {
+        name: "thickness",
+        label: "Thickness",
+        // Capped at MAX_SKIN_WALL_WIDTH, not a rounder number: past that a
+        // wall stops being fully cleared by its own door or window (the
+        // doorway mask's cut is sized off the shared WALL_THICKNESS
+        // constant, not per-wall — see render.ts's wallThickness).
+        selector: {
+          number: { min: 2, max: MAX_SKIN_WALL_WIDTH, step: 1, mode: "slider", unit_of_measurement: "px" },
+        },
+      },
+    ],
+    data: {
+      x1: Math.round(w.x1),
+      y1: Math.round(w.y1),
+      x2: Math.round(w.x2),
+      y2: Math.round(w.y2),
+      thickness: w.thickness ?? WALL_THICKNESS,
+    },
+    // Keep the default out of the YAML so untouched walls stay terse.
+    toPatch: (p) =>
+      "thickness" in p && p.thickness === WALL_THICKNESS ? { ...p, thickness: undefined } : p,
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -89,6 +89,7 @@ import {
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
+  wallStrokeStyle,
 } from "./render";
 import { deadSpacesCached } from "./dead-space";
 import { cssColor, cssColorOr, cssNumber, contrastText } from "./css-safe";
@@ -3316,7 +3317,7 @@ export class FloorplanCardEditor extends LitElement {
         <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
               class="wall ${selected ? "selected" : ""}"
               mask=${`url(#${this._wallMaskId})`}
-              stroke-width=${WALL_THICKNESS} stroke-linecap="round" />
+              style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />
         ${
           selected
             ? svg`

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -67,6 +67,7 @@ import {
   itemHiddenWhenInactive,
   itemLabelSize,
   areaLabelFontSize,
+  wallStrokeStyle,
   normalizeOverlayScale,
   overlayLength,
   hassRenderInputsChanged,
@@ -628,7 +629,7 @@ export class FloorplanCard extends LitElement {
                 (w) => svg`
                 <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
                       class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
-                      stroke-width=${WALL_THICKNESS} stroke-linecap="round" />`
+                      style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />`
               )}
             </g>
             <!-- Room outlines, above the walls they trace. An area polygon runs

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { html, nothing } from "lit";
 import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
-import { SKIN_ACCENT, SKIN_WALL } from "./skins";
+import { SKIN_ACCENT, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 import {
   FURNITURE_DEFAULT_SIZE,
   DEFAULT_GLOW_RADIUS,
@@ -57,6 +57,8 @@ import {
   itemLabelSize,
   areaLabelSize,
   areaLabelFontSize,
+  wallThickness,
+  wallStrokeStyle,
   normalizeOverlayScale,
   overlayLength,
   hassRenderInputsChanged,
@@ -808,6 +810,41 @@ describe("overlay scaling", () => {
     expect(overlayLength(areaLabelSize("14;}body{display:none"), "plan")).toBe(
       "calc(14 * var(--fp-u, 1px))"
     );
+  });
+});
+
+describe("wallThickness — clamped to the skin-safe range at the sink", () => {
+  it("defaults to WALL_THICKNESS when unset", () => {
+    expect(wallThickness(undefined)).toBe(8);
+  });
+
+  it("passes a value inside the range through unchanged", () => {
+    expect(wallThickness(5)).toBe(5);
+  });
+
+  it("floors at 2", () => {
+    expect(wallThickness(0)).toBe(2);
+    expect(wallThickness(-5)).toBe(2);
+  });
+
+  it("caps at MAX_SKIN_WALL_WIDTH — past this the doorway mask stops fully clearing the wall", () => {
+    expect(wallThickness(30)).toBe(MAX_SKIN_WALL_WIDTH);
+    expect(wallThickness(24)).toBe(MAX_SKIN_WALL_WIDTH);
+  });
+
+  it("neutralizes a style-injection payload before it reaches the style sink", () => {
+    expect(wallThickness("5px;color:red")).toBe(8);
+  });
+});
+
+describe("wallStrokeStyle — leaves the skin's stroke-width alone when it can", () => {
+  it("emits nothing for an untouched wall, so the skin's --fp-skin-wall-width wins", () => {
+    expect(wallStrokeStyle(undefined)).toBe("");
+  });
+
+  it("emits a clamped stroke-width once the wall asks for one", () => {
+    expect(wallStrokeStyle(5)).toBe("stroke-width:5;");
+    expect(wallStrokeStyle(30)).toBe(`stroke-width:${MAX_SKIN_WALL_WIDTH};`);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -44,7 +44,7 @@ import {
   trackerAxisFraction,
 } from "./types";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, cssIcon } from "./css-safe";
-import { SKIN_ACCENT, SKIN_PAPER, SKIN_WALL } from "./skins";
+import { SKIN_ACCENT, SKIN_PAPER, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 // The same tolerance #141 uses to decide an opening sits on a wall, so "this
 // door is in this wall" means one thing across the card.
 import { OPENING_ON_WALL_EPS } from "./dead-space";
@@ -924,6 +924,34 @@ export function itemLabelSize(v: unknown): number {
 /** Clamp a config area `labelSize` to the same 8–40 range item labels use. */
 export function areaLabelSize(v: unknown): number {
   return Math.min(40, Math.max(8, cssNumber(v, DEFAULT_AREA_LABEL_SIZE)));
+}
+
+/**
+ * Clamp a config wall `thickness` to the skin-safe range at the render sink:
+ * at least 2 units, and never past {@link MAX_SKIN_WALL_WIDTH} — the same
+ * ceiling a skin's `--fp-skin-wall-width` observes, and for the same reason
+ * (see that constant's comment): a wall wider than the doorway mask's cut
+ * would not be fully cleared by its own door or window. The editor's slider
+ * already stays inside this range; this guards a hand-edited or imported
+ * config that doesn't. Falls back to {@link WALL_THICKNESS} for anything
+ * unset or unreadable, via `cssNumber`'s shared style-sink guard.
+ */
+export function wallThickness(v: unknown): number {
+  return Math.min(MAX_SKIN_WALL_WIDTH, Math.max(2, cssNumber(v, WALL_THICKNESS)));
+}
+
+/**
+ * The `stroke-width` declaration for a wall, or `""` to leave it to the
+ * skin. A skin sets `--fp-skin-wall-width` on `.wall` (issue #122), and a
+ * CSS declaration always beats an SVG presentation attribute — so writing
+ * `stroke-width=` directly on the element, the pre-skins approach, has no
+ * effect any more. Same fix {@link areaLabelFontSize} used for `.area-label`:
+ * write the value inline only when it says something the skin doesn't, so an
+ * untouched wall keeps following the skin and an explicit thickness
+ * overrides it.
+ */
+export function wallStrokeStyle(thickness: unknown): string {
+  return thickness === undefined ? "" : `stroke-width:${wallThickness(thickness)};`;
 }
 
 // ---- overlay scaling --------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,15 @@ export interface Wall {
   y1: number;
   x2: number;
   y2: number;
+  /**
+   * Stroke width in virtual units. Defaults to {@link WALL_THICKNESS}
+   * (render.ts) when unset, and clamped there (`wallThickness`) to at most
+   * `MAX_SKIN_WALL_WIDTH` (skins.ts): the doorway mask that cuts this wall's
+   * own doors and windows is sized off the shared `WALL_THICKNESS` constant,
+   * not per-wall, so a wall drawn wider than that ceiling would not be fully
+   * cleared by its own opening. Raise the ceiling only alongside that mask.
+   */
+  thickness?: number;
 }
 
 export type OpeningType = "door" | "window";


### PR DESCRIPTION
## Summary
- Adds an optional `thickness` field to `Wall` (defaulting to the plan-wide `WALL_THICKNESS`) so individual walls can be drawn thicker or thinner than the rest of the plan.
- Adds a Thickness slider to the wall property panel in the editor.
- Applies in both the editor canvas and the live card.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [ ] Visual check in `npm run serve`: draw/select a wall, adjust its Thickness slider, confirm it renders thicker/thinner in both the editor canvas and the live-preview pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)