### PR TITLE
Areas: tap a room to zoom in on it

### DIFF
--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -79,6 +79,8 @@ import {
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
+  areaZoomTransform,
+  IDENTITY_ZOOM,
   type PlanRotation,
 } from "./render";
 import { deadSpacesCached } from "./dead-space";
@@ -113,6 +115,8 @@ export class FloorplanCard extends LitElement {
   @state() private _config?: FloorplanCardConfig;
   /** View-state: which floor is shown. Never persisted to config. */
   @state() private _activeFloorId?: string;
+  /** View-state: which area (if any) the plan is zoomed in to. Never persisted. */
+  @state() private _zoomedAreaId?: string;
   private readonly _wallMaskId = `fp-wall-mask-${FloorplanCard._nextWallMaskId++}`;
   /** Prefix for this card's glow gradient ids, unique per instance (issue #6). */
   private readonly _glowIdBase = `fp-glow-${FloorplanCard._nextGlowId++}`;
@@ -251,6 +255,11 @@ export class FloorplanCard extends LitElement {
         })
       );
     }
+  }
+
+  /** Tapping a room zooms the plan in to it; tapping the same room again zooms back out. */
+  private _onAreaClick(a: Area): void {
+    this._zoomedAreaId = this._zoomedAreaId === a.id ? undefined : a.id;
   }
 
   private _renderBadge(item: FloorItem, scale: OverlayScale): TemplateResult {
@@ -465,7 +474,7 @@ export class FloorplanCard extends LitElement {
         style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
                font-size:${overlayLength(cssNumber(t.size, DEFAULT_TEXT_SIZE), scale)};
                color:${cssColorOr(t.color, SKIN_TEXT)};
-               transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
+               transform:translate(-50%,-50%) scale(var(--fp-inv-zoom,1)) rotate(${cssNumber(t.angle, 0)}deg);"
       >
         ${t.text}
       </div>
@@ -530,6 +539,12 @@ export class FloorplanCard extends LitElement {
           lightWalls
         )
       : nothing;
+    // Zoom-to-room (tap an area). Both the SVG and the HTML overlay live
+    // inside one transformed wrapper below, so the two layers — positioned
+    // completely differently (a group transform vs. per-point left/top%) —
+    // reframe identically instead of drifting apart under zoom.
+    const zoomedArea = active.areas?.find((a) => a.id === this._zoomedAreaId);
+    const zoom = zoomedArea ? areaZoomTransform(zoomedArea.points, c.width, c.height, rot) : IDENTITY_ZOOM;
     return html`
       <!-- The skin (issue #122) rides on the card rather than on .plan, so the
            floor switcher and the card's own background follow it too — a Tron
@@ -570,6 +585,15 @@ export class FloorplanCard extends LitElement {
                count), "meet" letterboxes the SVG away from the overlay and
                every icon drifts off the wall it was placed on, while "none"
                stretches both layers identically: distorted, but aligned. -->
+          <!-- Zoom-to-room (tap an area). One wrapper around both the SVG and
+               the HTML overlay so a CSS transform here reframes both layers
+               identically — see areaZoomTransform. Wraps the keyed() skin
+               block below rather than sitting inside it, so a skin change
+               (which rebuilds that subtree) never disturbs this transform. -->
+          <div
+            class="plan-zoom"
+            style="transform: translate(${zoom.txPercent}%, ${zoom.tyPercent}%) scale(${zoom.scale});"
+          >
           <!-- Keyed on the skin (issue #122). A skin changes custom properties on
                an ancestor, and Chromium does not repaint an SVG element whose
                colour comes from a var() inside a presentation attribute or an
@@ -588,8 +612,11 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio=${imageFitRatio(active.imageFit)}
                           opacity=${active.imageOpacity ?? 1} />`
               : nothing}
-            ${active.areas?.map((a) =>
-              renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))
+            ${active.areas?.map(
+              (a) =>
+                svg`<g class="area-tap-target" @click=${() => this._onAreaClick(a)}>
+                  ${renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))}
+                </g>`
             )}
             <!-- Dead spaces (issue #88): the regions the walls seal off that no
                  door or window reaches, hatched. Above the room fills, so a
@@ -722,7 +749,7 @@ export class FloorplanCard extends LitElement {
             </g>
           </svg>`
           )}
-          <div class="items">
+          <div class="items" style="--fp-inv-zoom:${1 / zoom.scale};">
             ${active.areas?.map((a) => this._renderAreaLabel(a, c, rot, scale))}
             ${active.texts.map((t) => this._renderText(t, c, rot, scale))}
             ${repeat(
@@ -743,6 +770,16 @@ export class FloorplanCard extends LitElement {
             )}
           </div>
           </div>
+          ${zoom.scale > 1
+            ? html`<button
+                class="zoom-out"
+                title="Zoom out"
+                aria-label="Zoom out"
+                @click=${() => (this._zoomedAreaId = undefined)}
+              >
+                <ha-icon icon="mdi:magnify-minus-outline"></ha-icon>
+              </button>`
+            : nothing}
           ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
         </div>
       </ha-card>
@@ -766,6 +803,8 @@ export class FloorplanCard extends LitElement {
                 this._activeFloorId = f.id;
                 // Remember it for the next element the editor preview builds.
                 lastViewedFloor.set(floorMemoryKey(floors), f.id);
+                // A room on the floor just left is meaningless on the new one.
+                this._zoomedAreaId = undefined;
               }}
             >
               ${f.short || f.name}
@@ -897,6 +936,40 @@ export class FloorplanCard extends LitElement {
       color: var(--fp-skin-accent-ink, var(--text-primary-color, #fff));
       border-color: var(--fp-skin-accent, var(--primary-color, #03a9f4));
     }
+    /* Zoom-to-room (tap an area). One wrapper around both the SVG and the
+       HTML overlay so a transform here reframes both layers identically —
+       transform-origin:0 0 matches the translate-percent math in
+       areaZoomTransform(). Setting a transform (even the identity) makes this
+       div establish the containing block for its absolutely-positioned
+       svg/.items children, so it needs the same inset:0 they'd otherwise use. */
+    .plan-zoom {
+      position: absolute;
+      inset: 0;
+      transform-origin: 0 0;
+      transition: transform 0.4s ease;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .plan-zoom {
+        transition: none;
+      }
+    }
+    .zoom-out {
+      position: absolute;
+      top: 8px;
+      left: 8px;
+      z-index: 1;
+      cursor: pointer;
+      border: 1px solid var(--divider-color, #ccc);
+      background: var(--card-background-color, #fff);
+      color: var(--primary-text-color);
+      border-radius: 6px;
+      padding: 4px;
+      line-height: 0;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+    .area-tap-target {
+      cursor: pointer;
+    }
     svg {
       position: absolute;
       inset: 0;
@@ -1003,7 +1076,15 @@ export class FloorplanCard extends LitElement {
     }
     .item {
       position: absolute;
-      transform: translate(-50%, -50%);
+      /* Counter-scaled against the zoom-to-room transform (--fp-inv-zoom,
+         set on .items) so a badge stays a constant, legible screen size
+         instead of ballooning with the room it's tapped into. Same duration
+         and easing as .plan-zoom's own transition, so the zoom and its
+         counter-scale animate in lockstep — without this the custom property
+         changes in a single frame while the plan takes 0.4s to catch up, and
+         every badge is briefly the wrong size mid-transition. */
+      transform: translate(-50%, -50%) scale(var(--fp-inv-zoom, 1));
+      transition: transform 0.4s ease;
       pointer-events: auto;
       /* Not a hand: a device with nothing bound, or tap_action set to none,
          is not a button (issue #134). Only .interactive gets the pointer. */
@@ -1029,12 +1110,16 @@ export class FloorplanCard extends LitElement {
 
     /* Scale: the transform has to repeat the translate, since .item is
        centred on its own anchor and a bare scale() would drop that and jump
-       the device down-right by half its size. */
+       the device down-right by half its size. Also has to repeat the
+       zoom-to-room counter-scale (--fp-inv-zoom) and multiply rather than
+       replace it — restating scale(${PRESS_SCALE}) alone would drop the
+       counter-scale along with the translate, and a badge held down at 4x
+       zoom would balloon to roughly 4x its resting size instead of shrinking. */
     .press-scale .item.interactive {
       transition: transform ${PRESS_OUT_MS}ms cubic-bezier(0.2, 0.8, 0.3, 1);
     }
     .press-scale .item.interactive:active {
-      transform: translate(-50%, -50%) scale(${PRESS_SCALE});
+      transform: translate(-50%, -50%) scale(calc(var(--fp-inv-zoom, 1) * ${PRESS_SCALE}));
       transition-duration: ${PRESS_IN_MS}ms;
     }
 
@@ -1091,7 +1176,7 @@ export class FloorplanCard extends LitElement {
         transition: none;
       }
       .press-scale .item.interactive:active {
-        transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%) scale(var(--fp-inv-zoom, 1));
       }
       .press-scale .item.interactive:active,
       .press-ripple .item.interactive:active,
@@ -1218,12 +1303,17 @@ export class FloorplanCard extends LitElement {
       white-space: nowrap;
       font-weight: 500;
       line-height: 1;
+      /* Keeps its own counter-scale (inline, see _renderText) in step with
+         .plan-zoom's transition — same reasoning as .item's transform. */
+      transition: transform 0.4s ease;
     }
     .area-label {
       position: absolute;
       pointer-events: none;
       white-space: nowrap;
-      transform: translate(-50%, -50%);
+      transform: translate(-50%, -50%) scale(var(--fp-inv-zoom, 1));
+      /* Same lockstep-with-.plan-zoom reasoning as .item and .text above. */
+      transition: transform 0.4s ease;
       font-weight: 600;
       /* The default size stays a normal rule so card-mod can still override it
          — room names had no config option before overlayScale landed, and this

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -81,6 +81,8 @@ import {
   rotatePlanPoint,
   planRotationTransform,
   polygonCentroid,
+  areaZoomTransform,
+  IDENTITY_ZOOM,
   renderArea,
   renderAreaBorder,
   WALL_THICKNESS,
@@ -2039,6 +2041,77 @@ describe("polygonCentroid", () => {
 
   it("returns the origin for an empty polygon", () => {
     expect(polygonCentroid([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("areaZoomTransform", () => {
+  it("returns the identity transform for an empty polygon", () => {
+    expect(areaZoomTransform([], 100, 100, 0)).toEqual(IDENTITY_ZOOM);
+  });
+
+  it("centers a small room and scales it up, capped at maxScale", () => {
+    // A 10x10 room centered in a 100x100 canvas — the padded bbox is small,
+    // so scale would blow past maxScale without the cap. Centered (not near
+    // an edge) so the pan clamp below doesn't interfere with this assertion.
+    const room = [{ x: 45, y: 45 }, { x: 55, y: 45 }, { x: 55, y: 55 }, { x: 45, y: 55 }];
+    const t = areaZoomTransform(room, 100, 100, 0, 0.15, 4);
+    expect(t.scale).toBe(4);
+    // Room center (50,50) as a fraction of the canvas is (0.5, 0.5); at 4x
+    // that must land back on the wrapper's own center (50%) — i.e. no pan.
+    expect(t.txPercent).toBeCloseTo(50 - 4 * 0.5 * 100);
+    expect(t.tyPercent).toBeCloseTo(50 - 4 * 0.5 * 100);
+  });
+
+  it("never zooms out past 1x for a room bigger than the canvas", () => {
+    const room = [{ x: -50, y: -50 }, { x: 500, y: -50 }, { x: 500, y: 500 }, { x: -50, y: 500 }];
+    const t = areaZoomTransform(room, 100, 100, 0);
+    expect(t.scale).toBe(1);
+  });
+
+  it("accounts for whole-plan rotation the same way rotatePlanPoint does", () => {
+    // A 100x50 canvas rotated 90°: the displayed frame is 50x100. A room
+    // spanning the full un-rotated width should end up spanning the
+    // *displayed* height once rotated, not overflow it.
+    const room = [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 100, y: 10 }, { x: 0, y: 10 }];
+    const t = areaZoomTransform(room, 100, 50, 90);
+    // The rotated bbox should exactly fill the 50-wide, 100-tall displayed
+    // canvas along its constraining axis, so scale caps at 1 (room already
+    // spans the full displayed height).
+    expect(t.scale).toBe(1);
+  });
+
+  it("clamps the pan so a room near a corner never uncovers the plan", () => {
+    // A 10x10 room in the corner of a 980x700 canvas at 4x scale, mirroring
+    // the reviewer's reproduction (canvas 980x700, area (40,40)-(140,110)).
+    const room = [{ x: 40, y: 40 }, { x: 140, y: 40 }, { x: 140, y: 110 }, { x: 40, y: 110 }];
+    const t = areaZoomTransform(room, 980, 700, 0);
+    // Uncentered pan would be positive (panning the plan's top-left corner
+    // into view, uncovering blank space beyond it) — clamped to exactly 0.
+    expect(t.txPercent).toBe(0);
+    expect(t.tyPercent).toBe(0);
+  });
+
+  it("clamps the pan to 0 when scale floors to 1 (room too big to zoom into)", () => {
+    // A room taller than the canvas: scale floors to 1, and without the
+    // clamp the pan would still shift the plan sideways for no zoom at all.
+    const room = [{ x: 40, y: 40 }, { x: 400, y: 40 }, { x: 400, y: 660 }, { x: 40, y: 660 }];
+    const t = areaZoomTransform(room, 980, 700, 0);
+    expect(t.scale).toBe(1);
+    expect(t.txPercent).toBe(0);
+    expect(t.tyPercent).toBe(0);
+  });
+
+  it("returns the identity transform for a non-finite input instead of emitting NaN", () => {
+    // A single hand-edited non-numeric coordinate must never reach the style
+    // sink — NaN there would invalidate --fp-inv-zoom and, through it, every
+    // device badge's transform on the plan.
+    const room = [
+      { x: Number.NaN, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    expect(areaZoomTransform(room, 100, 100, 0)).toEqual(IDENTITY_ZOOM);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -2305,6 +2305,81 @@ export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: n
   return { x: sum.x / points.length, y: sum.y / points.length };
 }
 
+/** Neutral (unzoomed) result of {@link areaZoomTransform} — identity view. */
+export const IDENTITY_ZOOM: AreaZoomTransform = { scale: 1, txPercent: 0, tyPercent: 0 };
+
+export interface AreaZoomTransform {
+  /** Uniform scale applied to the whole plan. */
+  scale: number;
+  /** Translation as a percentage of the transformed element's own box (so it
+   *  is resolution-independent — see the CSS `translate()` percentage rule). */
+  txPercent: number;
+  tyPercent: number;
+}
+
+/**
+ * A CSS `translate(%) scale()` pair that frames an area's bounding box inside
+ * the `w`×`h` canvas ("zoom in to an area on tap"). Applied with
+ * `transform-origin: 0 0` to a wrapper around both the SVG and the HTML
+ * overlay, so both layers — which are positioned in two different ways —
+ * reframe identically instead of drifting apart.
+ *
+ * Uses `rotatePlanPoint` on the area's own points rather than the raw
+ * `points` array so this lines up with a rotated plan (issue #33): the
+ * overlay already remaps every point through the same function, and the SVG
+ * layer carries the matching group transform.
+ *
+ * `padFrac` pads the bounding box (as a fraction of its own larger
+ * dimension) so the zoomed room isn't cropped edge-to-edge; `maxScale`
+ * caps how far a small room can zoom in. Never zooms *out* past 1x — an
+ * area bigger than the canvas simply fills it edge-to-edge.
+ *
+ * The pan is clamped so the plan's own edge never moves inside the visible
+ * box — centering a room near a corner would otherwise pan the wrapper past
+ * the canvas and show bare card background where the plan should be. At
+ * `scale === 1` the clamp range collapses to exactly `[0, 0]`, so a room too
+ * big to zoom into (taller or wider than the canvas) reports no pan either —
+ * without this, tapping such a room would slide the plan sideways for no
+ * zoom at all.
+ */
+export function areaZoomTransform(
+  points: readonly AreaPoint[],
+  w: number,
+  h: number,
+  rot: PlanRotation,
+  padFrac = 0.15,
+  maxScale = 4
+): AreaZoomTransform {
+  if (!points.length) return IDENTITY_ZOOM;
+  const rotated = points.map((p) => rotatePlanPoint(p.x, p.y, w, h, rot));
+  const d = rotatedCanvasSize(w, h, rot);
+  const xs = rotated.map((p) => p.x);
+  const ys = rotated.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const pad = Math.max(maxX - minX, maxY - minY) * padFrac;
+  const bw = Math.max(maxX - minX + pad * 2, 1);
+  const bh = Math.max(maxY - minY + pad * 2, 1);
+  const scale = Math.max(1, Math.min(maxScale, Math.min(d.w / bw, d.h / bh)));
+  // A non-finite input (NaN/Infinity coordinates from a hand-edited config)
+  // must never reach the style sink: --fp-inv-zoom:NaN invalidates the whole
+  // custom property, and .item's transform is built from it, so every device
+  // badge on the plan would lose its centering along with the scale.
+  if (!Number.isFinite(scale)) return IDENTITY_ZOOM;
+  const cxFrac = (minX + maxX) / 2 / d.w;
+  const cyFrac = (minY + maxY) / 2 / d.h;
+  // Range collapses to [0, 0] at scale === 1, so an unzoomable room (bigger
+  // than the canvas along its binding axis) reports no pan.
+  const clamp = (t: number) => Math.min(0, Math.max(100 * (1 - scale), t));
+  return {
+    scale,
+    txPercent: clamp(50 - scale * cxFrac * 100),
+    tyPercent: clamp(50 - scale * cyFrac * 100),
+  };
+}
+
 /**
  * Diagonal hatching, at 45°, spaced in canvas units so it keeps the same weight
  * on the plan whatever size the card is drawn at.


### PR DESCRIPTION
## Summary
- Tapping an area's fill on the live card zooms the plan in to that room; tapping it again (or a zoom-out button that appears top-left) returns to the full view. Switching floors resets the zoom.
- The zoom is one shared CSS transform around both the SVG and the HTML overlay, framed on the tapped area's bounding box (padded so the room isn't cropped edge-to-edge, capped at 4x, never zooming out past 1x) — computed with the same `rotatePlanPoint` math the overlay already uses so it stays correct on a rotated plan.
- Device badges, text, and area-name labels counter-scale against the zoom (via an inherited `--fp-inv-zoom` custom property) so they stay a constant, legible screen size instead of growing along with the zoomed room.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (adds `areaZoomTransform` coverage: identity/empty polygon, scale cap, floor-at-1x for an oversized room, and rotation handling)
- [x] `npm run build`
- [x] Manually verified against a real Home Assistant instance: tapping a room zooms in, the zoom-out button returns to the full view, and device badges hold their size while the room scales

🤖 Generated with [Claude Code](https://claude.com/claude-code)