### PR TITLE
Furniture: a symbol is data, so anyone can draw one (closes #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ screen size.
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
 - **Animated doors & windows** — bind a contact `binary_sensor` or `cover` and openings swing, slide or roll with their real state, partial positions included.
-- **Furniture** — 26 gray line-art diagrams (table, sofa, bed, stove, stairs, tv…), each bindable to an entity.
+- (${\color{red}NEW!}$) **Furniture** — 26 gray line-art diagrams (table, sofa, bed, stove, stairs, tv…), each bindable to an entity, in a searchable picker. Every one is a plain JSON file of numbers you can copy: draw your own in the editor's paste box, use it straight away, and open a PR when it's good. No SVG, so nothing you paste can run anything.
 - **Areas** — trace room polygons that color live from an entity, and link them to Home Assistant areas to scope entity pickers and bulk-add devices.
 - **Live position trackers** — map one or two distance sensors (mmWave / radar) onto a marker that moves across the plan in real time.
 - (${\color{red}NEW!}$) **Dead spaces** — hatch the spaces your walls seal off that no door or window reaches: a service shaft, the void behind a boxed-in stairwell. Nothing to draw — the regions come from the walls and openings themselves, so cutting a doorway into one stops it being dead the moment you place the door.
@@ -324,6 +324,7 @@ The editor writes this config for you; manual editing is optional.
 | `furniture`  | Furniture[]| `[]`             | Gray furniture/fixture diagrams.             |
 | `trackers`   | Tracker[]| `[]`               | Live position trackers (see [Tracker](#tracker)).    |
 | `areas`      | Area[]   | `[]`               | Named room polygons (see [Area](#area)).          |
+| `symbols`    | map      | —                  | Furniture symbols this plan defines for itself, merged over the shipped library. See [Drawing your own](#drawing-your-own). |
 
 When `floors` is present each floor carries its own `walls`, `openings`, `items`, `texts`,
 `furniture`, `trackers` and `areas`. The top-level arrays describe a single implicit floor
@@ -475,11 +476,15 @@ without turning into the color of the light. Pools never intercept clicks.
 
 `{ id, type, x, y, w, h, angle?, hand?, color?, entity?, activeColor?, stateColor? }`
 
-`type` is one of `table`, `roundTable`, `desk`, `chair`, `sofa`, `sectional`, `bed`,
-`wardrobe`, `rug`, `plant`, `fridge`, `stove`, `sink`, `dishwasher`, `washer`, `dryer`,
-`toilet`, `bathtub`, `vanity`, `stairs`, `tv`, `piano`, `fishTank`, `hotTub`,
-`waterHeater`, `airHandler`. `color` defaults to gray so furniture reads differently from
-walls; `hand` (`left` / `right`) picks which end an L-shaped `sectional`'s chaise sits on.
+`type` names a **symbol** — one of the ~26 the card ships with (`table`, `sofa`, `bed`,
+`fridge`, `stairs`, …; the full set is [`furniture/`](furniture/), a file each), or one you
+supply yourself. `color` defaults to gray so furniture reads differently from walls; `hand`
+(`left` / `right`) mirrors the symbol, and picks which end an L-shaped `sectional`'s chaise
+sits on. A `type` nothing answers to draws a plain box, so a missing symbol is a visible
+placeholder rather than a hole in the plan.
+
+The editor's **+ Add** picker draws every symbol at its real size and is searchable — type
+`couch` and you get the sofa and the sectional.
 
 Bind an **entity** and `stateColor` / `activeColor` recolor the whole diagram — a plant
 goes red when its soil sensor says it needs watering, a cabinet highlights while its
@@ -490,6 +495,41 @@ contact sensor is open.
   entity: sensor.ficus_soil_moisture,
   stateColor: [ { above: 80, color: green }, { above: 65, color: yellow }, { color: red } ] }
 ```
+
+#### Drawing your own
+
+The library will never have every piece of furniture — someone always has a wardrobe with
+seven doors. So a symbol is **data**, not code: a list of primitives with numeric attributes
+only, which the card assembles into SVG itself. Nothing you paste is ever parsed as markup.
+
+Define one in a top-level `symbols:` block and use it like any other type:
+
+```yaml
+symbols:
+  wardrobe7:
+    name: wardrobe (7 doors)
+    category: bedroom
+    keywords: [closet, fitted]
+    size: { w: 420, h: 55 }
+    parts:
+      - { rect: [0, 0, 100, 100], rx: 7.3 }
+      - { repeat: 6, step: [14.29, 0], part: { line: [14.29, 0, 14.29, 100], role: line } }
+      - { repeat: 7, step: [14.29, 0], part: { line: [11.4, 40, 11.4, 60], role: line } }
+
+furniture:
+  - { id: w1, type: wardrobe7, x: 300, y: 90, w: 420, h: 55 }
+```
+
+Coordinates are a fraction of the piece's box (`0`–`100` across and down); stroke widths are
+canvas units and don't scale. A part picks a **role** (`body`, `line`, `thin`, `detail`,
+`hint`, `solid`) rather than a colour, so your symbol inherits skins and entity recoloring
+for free. `repeat` stamps one part along a step vector.
+
+You don't have to hand-write it: **Project → Custom symbols** in the editor takes pasted JSON,
+validates it, and drops it into `symbols:` — it then shows up in the picker beside the
+built-ins. If it turns out to be generally useful, the same JSON is what you contribute to
+[`furniture/`](furniture/). The full format is in
+[`furniture/README.md`](furniture/README.md).
 
 ### Tracker
 
@@ -937,6 +977,10 @@ drives them on `requestAnimationFrame`.
 
 The harness lives entirely under `dev/` and is not in the production build. Flip
 `START_WITH_DEMO` in `dev/dev.ts` to start with a sample room instead of a blank floor.
+
+`/dev/symbols.html` on the same server draws every symbol in [`furniture/`](furniture/) on
+one page — the contact sheet to check a new one against. It reads the directory, so a file
+you add appears with no other edit.
 
 ## License
 

--- a/dev/symbols.ts
+++ b/dev/symbols.ts
@@ -1,6 +1,6 @@
 import "../src/index";
 import type { FloorplanCardConfig } from "../src/types";
-import { FURNITURE_DEFAULT_SIZE } from "../src/types";
+import { BUILTIN_SYMBOLS } from "../src/symbols";
 
 if (!customElements.get("ha-card")) {
   class C extends HTMLElement {
@@ -16,10 +16,12 @@ if (!customElements.get("ha-card")) {
 }
 if (!customElements.get("ha-icon")) customElements.define("ha-icon", class extends HTMLElement {} as any);
 
-const TYPES = Object.keys(FURNITURE_DEFAULT_SIZE) as Array<keyof typeof FURNITURE_DEFAULT_SIZE>;
+// Straight off the bundled catalogue, so a symbol dropped into furniture/ shows
+// up here with no other edit — this page is the contact sheet you check it on.
+const TYPES = Object.keys(BUILTIN_SYMBOLS);
 const COLS = 6, CELL = 260;
 const furniture = TYPES.map((t, i) => {
-  const { w, h } = FURNITURE_DEFAULT_SIZE[t];
+  const { w, h } = BUILTIN_SYMBOLS[t]!.size;
   return { id: t, type: t, x: (i % COLS) * CELL + CELL / 2, y: Math.floor(i / COLS) * CELL + CELL / 2, w, h };
 });
 // both hands of the sectional, side by side

--- a/furniture/README.md
+++ b/furniture/README.md
@@ -1,0 +1,108 @@
+# Furniture symbols
+
+Every glyph the card draws lives in this directory, one JSON file per symbol. Adding a new
+one is adding a file — no code, no build step, no entry in a list somewhere else.
+
+**A symbol is geometry, not markup.** It is a list of primitives with numeric attributes,
+and the card builds the SVG elements itself. Nothing here is ever parsed as markup, which
+is why you can paste a stranger's symbol into your dashboard without reading it first:
+there is no `<script>`, no `on*` handler, no `javascript:` href, and no colour to smuggle a
+`url()` into. That is also the constraint you have to draw within.
+
+## The shape of a file
+
+```jsonc
+{
+  "id": "sofa",                      // must match the filename
+  "name": "sofa",                    // what the picker shows
+  "category": "living",              // living | bedroom | kitchen | bath | utility | other
+  "keywords": ["couch", "settee"],   // search only — "couch" should find this
+  "size": { "w": 170, "h": 72 },     // default size when someone places it
+  "viewBox": [0, 0, 100, 100],       // optional; this is the default
+  "footprint": "rect",               // optional; "ellipse" for a round-bodied piece
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 5.555556, "role": "body" },
+    { "line": [0, 30, 100, 30] },
+    { "line": [12, 30, 12, 100] },
+    { "line": [88, 30, 88, 100] }
+  ]
+}
+```
+
+## Coordinates
+
+Draw inside the viewBox, origin top-left. The card maps that box onto whatever `w × h` the
+user gave the piece, and centres it:
+
+- **x** is a fraction of the width — `50` is the middle, `0` and `100` are the edges.
+- **y** is a fraction of the height, the same way.
+- **Lengths** (`r` on a circle, `rx` on a rect) scale by the **smaller** side, so a circle
+  stays a circle on a piece that is not square.
+- An **ellipse**'s `rx` and `ry` each follow their own axis, because you named both.
+- **Stroke widths are canvas units** and never scale. A 2-unit line is 2 units on a chair
+  and on a sectional; line art that thickened with the furniture would read as a different
+  drawing at every size.
+
+Coordinates outside the viewBox are fine and are not clipped — that is how `tv.json` draws
+its stand below the box, at `y = 200`.
+
+`"space": "square"` on a part lays it out in the centred square of side `min(w, h)` instead
+of the full box. Reach for it when a group of parts has to stay concentric with a circle:
+`hotTub.json` puts its jets in square space so they sit on the water rather than spreading
+out with the shell.
+
+## Primitives
+
+| part | draws |
+|---|---|
+| `{ "line": [x1, y1, x2, y2] }` | a line |
+| `{ "rect": [x, y, w, h], "rx": 4 }` | a rectangle, optionally rounded |
+| `{ "circle": [cx, cy, r] }` | a circle — stays round at any aspect |
+| `{ "ellipse": [cx, cy, rx, ry] }` | an ellipse, stretching with the box |
+| `{ "polygon": [[x, y], …] }` | a closed shape |
+| `{ "polyline": [[x, y], …] }` | an open run of segments |
+| `{ "path": [["M", x, y], ["L", x, y], ["Q", …], ["C", …], ["Z"]] }` | a path |
+| `{ "repeat": 6, "step": [dx, dy], "part": { … } }` | one part stamped 6 times |
+
+A `path` is a list of commands, not a `d` string — the card has to scale x and y separately,
+so it needs them apart. Absolute `M`, `L`, `Q`, `C` and `Z` only; flatten arcs to curves.
+
+`repeat` is how a fitted wardrobe run, a flight of stairs and a piano keyboard stay short.
+Each copy is offset by `i × step`, and it holds a single part rather than a group.
+
+## Roles
+
+A part never names a colour. It picks a **role**, and the card pours in whatever colour the
+piece resolves to — the default grey, a `color:` from the config, a skin, or a live colour
+driven by a bound entity. That is what makes a contributed symbol work with all of those
+without doing anything.
+
+| role | fill | stroke width | opacity | use for |
+|---|---|---|---|---|
+| `body` | yes, at 0.12 | 2 | 1 | the carcass — the outline of the thing |
+| `line` | no | 2 | 1 | the main detail lines |
+| `thin` | no | 1.5 | 1 | secondary detail |
+| `detail` | no | 1.5 | 0.7 | quieter detail |
+| `hint` | no | 1 | 0.6 | texture — keys, jets, bubbles |
+| `solid` | yes, fully | — | 0.7 | a filled shape, e.g. a fish's tail |
+
+`rect`, `ellipse` and `polygon` default to `body`; everything else defaults to `line`. Add
+numeric `width`, `opacity`, `fillOpacity` or `dash` to override the role — see `rug.json`,
+which is a `body` at `0.08` with a dashed outline.
+
+## Drawing one
+
+1. Copy the closest existing file and change the numbers. Most glyphs are under a dozen parts.
+2. Try it without a PR: paste the JSON into **Project → Custom symbols** in the editor. It
+   lands in your card's `symbols:` block and shows up in the picker beside the built-ins.
+3. When it looks right, drop it here as `<id>.json` and open a pull request.
+
+`npm run serve`, then `/dev/symbols.html`, draws every symbol in this directory on one page —
+add a file and it appears. Check it there at its default size *and* stretched: a glyph can be
+right by the numbers and wrong on screen.
+
+## What gets merged
+
+Symbols that a lot of people would place. A fitted wardrobe, a kitchen island, a treadmill —
+things a floorplan needs. Keep it to one drawing per file, readable at 40 pixels wide, in the
+same flat line-art style as the rest, and give it keywords someone would actually search for.

--- a/furniture/airHandler.json
+++ b/furniture/airHandler.json
@@ -1,0 +1,12 @@
+{
+  "id": "airHandler",
+  "name": "air handler",
+  "category": "utility",
+  "keywords": ["hvac", "ahu", "furnace", "ventilation"],
+  "size": { "w": 60, "h": 56 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 7.142857 },
+    { "line": [8, 8, 92, 92], "role": "detail", "opacity": 0.8 },
+    { "line": [8, 92, 92, 8], "role": "detail", "opacity": 0.8 }
+  ]
+}

--- a/furniture/bathtub.json
+++ b/furniture/bathtub.json
@@ -1,0 +1,12 @@
+{
+  "id": "bathtub",
+  "name": "bathtub",
+  "category": "bath",
+  "keywords": ["bath", "tub"],
+  "size": { "w": 150, "h": 76 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 5.263158 },
+    { "rect": [6, 12, 88, 76], "rx": 12, "role": "line" },
+    { "circle": [14, 50, 5.5], "role": "thin" }
+  ]
+}

--- a/furniture/bed.json
+++ b/furniture/bed.json
@@ -1,0 +1,13 @@
+{
+  "id": "bed",
+  "name": "bed",
+  "category": "bedroom",
+  "keywords": ["double", "mattress", "sleep"],
+  "size": { "w": 150, "h": 200 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 2.666667 },
+    { "line": [0, 26, 100, 26], "role": "line" },
+    { "rect": [10, 6, 34, 14], "rx": 2, "role": "thin" },
+    { "rect": [56, 6, 34, 14], "rx": 2, "role": "thin" }
+  ]
+}

--- a/furniture/chair.json
+++ b/furniture/chair.json
@@ -1,0 +1,11 @@
+{
+  "id": "chair",
+  "name": "chair",
+  "category": "living",
+  "keywords": ["seat"],
+  "size": { "w": 44, "h": 44 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 9.090909 },
+    { "line": [0, 22, 100, 22], "role": "line" }
+  ]
+}

--- a/furniture/desk.json
+++ b/furniture/desk.json
@@ -1,0 +1,11 @@
+{
+  "id": "desk",
+  "name": "desk",
+  "category": "living",
+  "keywords": ["office", "workstation"],
+  "size": { "w": 120, "h": 60 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "line": [0, 55, 100, 55], "role": "detail" }
+  ]
+}

--- a/furniture/dishwasher.json
+++ b/furniture/dishwasher.json
@@ -1,0 +1,12 @@
+{
+  "id": "dishwasher",
+  "name": "dishwasher",
+  "category": "kitchen",
+  "keywords": ["dishes"],
+  "size": { "w": 60, "h": 60 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "rect": [10, 24, 80, 62], "rx": 5, "role": "detail", "opacity": 0.8 },
+    { "line": [6, 88, 94, 88], "role": "line" }
+  ]
+}

--- a/furniture/dryer.json
+++ b/furniture/dryer.json
@@ -1,0 +1,13 @@
+{
+  "id": "dryer",
+  "name": "dryer",
+  "category": "utility",
+  "keywords": ["tumble dryer", "laundry"],
+  "size": { "w": 60, "h": 62 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "line": [6, 18, 94, 18], "role": "detail" },
+    { "circle": [50, 56, 30], "role": "line" },
+    { "circle": [50, 56, 13.5], "role": "detail" }
+  ]
+}

--- a/furniture/fishTank.json
+++ b/furniture/fishTank.json
@@ -1,0 +1,16 @@
+{
+  "id": "fishTank",
+  "name": "fish tank",
+  "category": "living",
+  "keywords": ["aquarium", "fish", "water"],
+  "size": { "w": 100, "h": 40 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 10 },
+    { "rect": [5, 12, 90, 76], "role": "hint" },
+    { "ellipse": [32, 40, 7, 9], "role": "thin" },
+    { "path": [["M", 39, 40], ["L", 44, 32], ["L", 44, 48], ["Z"]], "role": "solid" },
+    { "ellipse": [68, 60, 7, 9], "role": "thin" },
+    { "path": [["M", 61, 60], ["L", 56, 52], ["L", 56, 68], ["Z"]], "role": "solid" },
+    { "circle": [82, 32, 4], "role": "hint" }
+  ]
+}

--- a/furniture/fridge.json
+++ b/furniture/fridge.json
@@ -1,0 +1,13 @@
+{
+  "id": "fridge",
+  "name": "fridge",
+  "category": "kitchen",
+  "keywords": ["refrigerator", "freezer"],
+  "size": { "w": 60, "h": 64 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "line": [0, 40, 100, 40], "role": "line" },
+    { "line": [84, 12, 84, 30], "role": "line" },
+    { "line": [84, 50, 84, 84], "role": "line" }
+  ]
+}

--- a/furniture/hotTub.json
+++ b/furniture/hotTub.json
@@ -1,0 +1,15 @@
+{
+  "id": "hotTub",
+  "name": "hot tub",
+  "category": "bath",
+  "keywords": ["jacuzzi", "spa", "whirlpool"],
+  "size": { "w": 120, "h": 120 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 3.333333 },
+    { "circle": [50, 50, 36], "role": "line" },
+    { "circle": [27.68, 27.68, 5], "role": "hint", "space": "square" },
+    { "circle": [72.32, 27.68, 5], "role": "hint", "space": "square" },
+    { "circle": [27.68, 72.32, 5], "role": "hint", "space": "square" },
+    { "circle": [72.32, 72.32, 5], "role": "hint", "space": "square" }
+  ]
+}

--- a/furniture/piano.json
+++ b/furniture/piano.json
@@ -1,0 +1,13 @@
+{
+  "id": "piano",
+  "name": "piano",
+  "category": "living",
+  "keywords": ["upright", "keyboard", "music"],
+  "size": { "w": 140, "h": 60 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "line": [4, 70, 96, 70], "role": "thin" },
+    { "repeat": 7, "step": [12.5, 0], "part": { "line": [12.5, 70, 12.5, 94], "role": "hint" } },
+    { "line": [4, 22, 96, 22], "role": "hint", "opacity": 0.5 }
+  ]
+}

--- a/furniture/plant.json
+++ b/furniture/plant.json
@@ -1,0 +1,14 @@
+{
+  "id": "plant",
+  "name": "plant",
+  "category": "living",
+  "keywords": ["pot", "tree", "greenery"],
+  "size": { "w": 44, "h": 44 },
+  "footprint": "ellipse",
+  "parts": [
+    { "ellipse": [50, 50, 50, 50], "role": "body" },
+    { "circle": [50, 38, 18], "role": "thin" },
+    { "circle": [34, 58, 18], "role": "thin" },
+    { "circle": [66, 58, 18], "role": "thin" }
+  ]
+}

--- a/furniture/roundTable.json
+++ b/furniture/roundTable.json
@@ -1,0 +1,11 @@
+{
+  "id": "roundTable",
+  "name": "round table",
+  "category": "living",
+  "keywords": ["dining", "circular"],
+  "size": { "w": 100, "h": 100 },
+  "footprint": "ellipse",
+  "parts": [
+    { "ellipse": [50, 50, 50, 50], "role": "body" }
+  ]
+}

--- a/furniture/rug.json
+++ b/furniture/rug.json
@@ -1,0 +1,11 @@
+{
+  "id": "rug",
+  "name": "rug",
+  "category": "living",
+  "keywords": ["carpet", "mat"],
+  "size": { "w": 180, "h": 120 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 12, "role": "body", "fillOpacity": 0.08, "dash": [8, 5] },
+    { "rect": [10, 10, 80, 80], "rx": 8, "role": "detail", "opacity": 0.6 }
+  ]
+}

--- a/furniture/sectional.json
+++ b/furniture/sectional.json
@@ -1,0 +1,13 @@
+{
+  "id": "sectional",
+  "name": "sectional (L)",
+  "category": "living",
+  "keywords": ["couch", "sofa", "corner", "chaise"],
+  "size": { "w": 230, "h": 180 },
+  "parts": [
+    { "polygon": [[0, 0], [100, 0], [100, 100], [58, 100], [58, 55], [0, 55]], "role": "body" },
+    { "line": [0, 16, 100, 16], "role": "line" },
+    { "line": [9, 16, 9, 55], "role": "line" },
+    { "line": [58, 16, 58, 100], "role": "line" }
+  ]
+}

--- a/furniture/sink.json
+++ b/furniture/sink.json
@@ -1,0 +1,12 @@
+{
+  "id": "sink",
+  "name": "sink",
+  "category": "kitchen",
+  "keywords": ["basin", "tap", "faucet"],
+  "size": { "w": 64, "h": 48 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 8.333333 },
+    { "rect": [12, 18, 76, 50], "rx": 8.333333, "role": "line" },
+    { "circle": [50, 10, 5], "role": "line" }
+  ]
+}

--- a/furniture/sofa.json
+++ b/furniture/sofa.json
@@ -1,0 +1,13 @@
+{
+  "id": "sofa",
+  "name": "sofa",
+  "category": "living",
+  "keywords": ["couch", "settee", "seat"],
+  "size": { "w": 170, "h": 72 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 5.555556 },
+    { "line": [0, 30, 100, 30], "role": "line" },
+    { "line": [12, 30, 12, 100], "role": "line" },
+    { "line": [88, 30, 88, 100], "role": "line" }
+  ]
+}

--- a/furniture/stairs.json
+++ b/furniture/stairs.json
@@ -1,0 +1,13 @@
+{
+  "id": "stairs",
+  "name": "stairs",
+  "category": "utility",
+  "keywords": ["steps", "staircase"],
+  "size": { "w": 90, "h": 170 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 4.444444 },
+    { "repeat": 6, "step": [0, 14.285714], "part": { "line": [0, 14.285714, 100, 14.285714], "role": "thin" } },
+    { "line": [50, 96.470588, 50, 3.529412], "role": "thin" },
+    { "path": [["M", 38, 16], ["L", 50, 2.352941], ["L", 62, 16]], "role": "thin" }
+  ]
+}

--- a/furniture/stove.json
+++ b/furniture/stove.json
@@ -1,0 +1,14 @@
+{
+  "id": "stove",
+  "name": "stove",
+  "category": "kitchen",
+  "keywords": ["cooker", "hob", "oven", "range"],
+  "size": { "w": 64, "h": 64 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.25 },
+    { "circle": [28, 28, 16], "role": "line" },
+    { "circle": [72, 28, 16], "role": "line" },
+    { "circle": [28, 72, 16], "role": "line" },
+    { "circle": [72, 72, 16], "role": "line" }
+  ]
+}

--- a/furniture/table.json
+++ b/furniture/table.json
@@ -1,0 +1,10 @@
+{
+  "id": "table",
+  "name": "table",
+  "category": "living",
+  "keywords": ["dining"],
+  "size": { "w": 120, "h": 80 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 5 }
+  ]
+}

--- a/furniture/toilet.json
+++ b/furniture/toilet.json
@@ -1,0 +1,12 @@
+{
+  "id": "toilet",
+  "name": "toilet",
+  "category": "bath",
+  "keywords": ["wc", "loo", "lavatory"],
+  "size": { "w": 48, "h": 68 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 8.333333 },
+    { "rect": [10, 0, 80, 22], "rx": 6.25, "role": "line" },
+    { "ellipse": [50, 68, 34, 30], "role": "line" }
+  ]
+}

--- a/furniture/tv.json
+++ b/furniture/tv.json
@@ -1,0 +1,11 @@
+{
+  "id": "tv",
+  "name": "tv",
+  "category": "living",
+  "keywords": ["television", "screen", "media"],
+  "size": { "w": 110, "h": 18 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 22.222222 },
+    { "line": [32, 100, 68, 200], "role": "line" }
+  ]
+}

--- a/furniture/vanity.json
+++ b/furniture/vanity.json
@@ -1,0 +1,12 @@
+{
+  "id": "vanity",
+  "name": "vanity",
+  "category": "bath",
+  "keywords": ["washbasin", "sink", "bathroom"],
+  "size": { "w": 110, "h": 55 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 7.272727 },
+    { "ellipse": [50, 56, 20, 26], "role": "line" },
+    { "circle": [50, 14, 5], "role": "thin" }
+  ]
+}

--- a/furniture/wardrobe.json
+++ b/furniture/wardrobe.json
@@ -1,0 +1,13 @@
+{
+  "id": "wardrobe",
+  "name": "wardrobe",
+  "category": "bedroom",
+  "keywords": ["closet", "armoire", "cupboard"],
+  "size": { "w": 120, "h": 55 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 7.272727 },
+    { "line": [50, 0, 50, 100], "role": "line" },
+    { "line": [44, 40, 44, 60], "role": "line" },
+    { "line": [56, 40, 56, 60], "role": "line" }
+  ]
+}

--- a/furniture/washer.json
+++ b/furniture/washer.json
@@ -1,0 +1,13 @@
+{
+  "id": "washer",
+  "name": "washer",
+  "category": "utility",
+  "keywords": ["washing machine", "laundry"],
+  "size": { "w": 60, "h": 62 },
+  "parts": [
+    { "rect": [0, 0, 100, 100], "rx": 6.666667 },
+    { "line": [6, 18, 94, 18], "role": "detail" },
+    { "circle": [50, 56, 30], "role": "line" },
+    { "circle": [16, 9, 4.5], "role": "thin" }
+  ]
+}

--- a/furniture/waterHeater.json
+++ b/furniture/waterHeater.json
@@ -1,0 +1,12 @@
+{
+  "id": "waterHeater",
+  "name": "water heater",
+  "category": "utility",
+  "keywords": ["boiler", "cylinder", "tank"],
+  "size": { "w": 52, "h": 52 },
+  "footprint": "ellipse",
+  "parts": [
+    { "ellipse": [50, 50, 50, 50], "role": "body" },
+    { "circle": [50, 50, 17], "role": "thin" }
+  ]
+}

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -13,11 +13,16 @@ import type {
   FloorText,
   FloorplanCardConfig,
   Furniture,
-  FurnitureType,
   Opening,
   Tracker,
   Wall,
 } from "./types";
+import {
+  BUILTIN_SYMBOLS,
+  symbolList,
+  type SymbolCatalog,
+  type SymbolDef,
+} from "./symbols";
 import {
   DEFAULT_AREA_OPACITY,
   DEFAULT_AREA_LABEL_SIZE,
@@ -138,64 +143,24 @@ const dropdown = (...options: { value: string; label: string }[]) => ({
   select: { mode: "dropdown", options },
 });
 
-export const FURNITURE_TYPES: FurnitureType[] = [
-  "table",
-  "roundTable",
-  "desk",
-  "chair",
-  "sofa",
-  "bed",
-  "wardrobe",
-  "rug",
-  "plant",
-  "fridge",
-  "stove",
-  "sink",
-  "toilet",
-  "stairs",
-  "tv",
-  "sectional",
-  "washer",
-  "dryer",
-  "dishwasher",
-  "bathtub",
-  "vanity",
-  "waterHeater",
-  "airHandler",
-  "fishTank",
-  "piano",
-  "hotTub",
-];
+/**
+ * Every symbol the picker and the type dropdown offer, grouped by room and
+ * alphabetical inside each group.
+ *
+ * Derived from the catalogue rather than hand-listed (issue #90). The two lists
+ * that used to live here — an ordering array and a label map — had to be edited
+ * for every new glyph, and only the label map was exhaustiveness-checked: a type
+ * added to the union but forgotten in the array simply never appeared in the
+ * editor, silently. A symbol now carries its own name and category.
+ */
+export function furnitureChoices(catalog: SymbolCatalog = BUILTIN_SYMBOLS): SymbolDef[] {
+  return symbolList(catalog);
+}
 
-/** User-facing labels for furniture types (the enum uses camelCase). */
-export const FURNITURE_LABELS: Record<FurnitureType, string> = {
-  table: "table",
-  roundTable: "round table",
-  desk: "desk",
-  chair: "chair",
-  sofa: "sofa",
-  bed: "bed",
-  wardrobe: "wardrobe",
-  rug: "rug",
-  plant: "plant",
-  fridge: "fridge",
-  stove: "stove",
-  sink: "sink",
-  toilet: "toilet",
-  stairs: "stairs",
-  tv: "tv",
-  sectional: "sectional (L)",
-  fishTank: "fish tank",
-  piano: "piano",
-  hotTub: "hot tub",
-  washer: "washer",
-  dryer: "dryer",
-  dishwasher: "dishwasher",
-  bathtub: "bathtub",
-  vanity: "vanity",
-  waterHeater: "water heater",
-  airHandler: "air handler",
-};
+/** A symbol's display name, falling back to its raw id for an unknown type. */
+export function furnitureLabel(type: string, catalog: SymbolCatalog = BUILTIN_SYMBOLS): string {
+  return catalog[type]?.name ?? type;
+}
 
 export function openingForm(o: Opening): FormSpec {
   const motion = openingMotion(o);
@@ -674,18 +639,24 @@ export function textForm(t: FloorText): FormSpec {
  * {@link itemForm} — a plant drawn inside the Living Room offers the Living
  * Room's sensors first.
  */
-export function furnitureForm(f: Furniture, areaScope?: AreaEntityScope): FormSpec {
+export function furnitureForm(
+  f: Furniture,
+  areaScope?: AreaEntityScope,
+  catalog: SymbolCatalog = BUILTIN_SYMBOLS
+): FormSpec {
+  const choices = furnitureChoices(catalog);
+  // A piece whose symbol this install doesn't have keeps its own id in the
+  // list, so opening the form doesn't silently retype it to whatever sorts
+  // first — the config would then be quietly rewritten on the next commit.
+  const options = choices.some((s) => s.id === f.type)
+    ? choices.map((s) => ({ value: s.id, label: s.name }))
+    : [{ value: f.type, label: `${f.type} (missing)` }, ...choices.map((s) => ({ value: s.id, label: s.name }))];
   return {
     fields: [
       {
         name: "type",
         label: "Type",
-        selector: {
-          select: {
-            mode: "dropdown",
-            options: FURNITURE_TYPES.map((t) => ({ value: t, label: FURNITURE_LABELS[t] })),
-          },
-        },
+        selector: { select: { mode: "dropdown", options } },
       },
       // L-shaped sectional only (#40): which side the chaise extends on,
       // facing the sofa from the front. Conditional, in the same shape

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -19,6 +19,7 @@ import type {
 } from "./types";
 import {
   BUILTIN_SYMBOLS,
+  findSymbol,
   symbolList,
   type SymbolCatalog,
   type SymbolDef,
@@ -159,7 +160,7 @@ export function furnitureChoices(catalog: SymbolCatalog = BUILTIN_SYMBOLS): Symb
 
 /** A symbol's display name, falling back to its raw id for an unknown type. */
 export function furnitureLabel(type: string, catalog: SymbolCatalog = BUILTIN_SYMBOLS): string {
-  return catalog[type]?.name ?? type;
+  return findSymbol(catalog, type)?.name ?? type;
 }
 
 export function openingForm(o: Opening): FormSpec {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,7 +12,6 @@ import type {
   FloorItem,
   FloorText,
   Furniture,
-  FurnitureType,
   ItemKind,
   Tracker,
   TrackerSensor,
@@ -22,6 +21,14 @@ import type {
   StateColorRule,
 } from "./types";
 import {
+  normalizeSymbol,
+  symbolCatalog,
+  symbolMatches,
+  symbolSize,
+  type SymbolCatalog,
+  type SymbolDef,
+} from "./symbols";
+import {
   DEFAULT_CUSTOM_PERCENT,
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
@@ -30,7 +37,6 @@ import {
   DEFAULT_HEIGHT,
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_TRACKER_DOT_SIZE,
-  FURNITURE_DEFAULT_SIZE,
   configsEqual,
   emptyConfig,
   getFloors,
@@ -114,8 +120,8 @@ import {
 } from "./editor-geometry";
 import type { AreaEntityScope } from "./editor-forms";
 import {
-  FURNITURE_LABELS,
-  FURNITURE_TYPES,
+  furnitureChoices,
+  furnitureLabel,
   areaForm,
   areaNameForm,
   diffFormValue,
@@ -279,6 +285,15 @@ export class FloorplanCardEditor extends LitElement {
   @state() private _floorMenuOpen = false;
   /** "+ Add" popover (device / text / furniture glyphs) visibility. */
   @state() private _addMenuOpen = false;
+  /**
+   * Search query for the furniture picker (issue #90). Lives beside
+   * `_addMenuOpen` and is cleared wherever that is, so reopening the popover
+   * always shows the whole library rather than the last thing you looked for.
+   */
+  @state() private _addQuery = "";
+  /** Paste-a-symbol box in the Project panel, and its last validation error. */
+  @state() private _symbolDraft = "";
+  @state() private _symbolError = "";
   /** Project section expanded? Collapsed by default — page settings are touched rarely. */
   @state() private _projectOpen = false;
   /**
@@ -409,6 +424,15 @@ export class FloorplanCardEditor extends LitElement {
   private _floor(): Floor {
     const floors = this._config.floors ?? [];
     return floors.find((f) => f.id === this._activeFloorId) ?? floors[0];
+  }
+
+  /**
+   * The shipped symbol library with this config's own `symbols:` merged over
+   * it (issue #90). Memoized on the config's identity inside `symbolCatalog`,
+   * so calling it per cell in the picker costs one lookup.
+   */
+  private _symbols(): SymbolCatalog {
+    return symbolCatalog(this._config.symbols);
   }
 
   /** Discrete change to the active floor's elements (snapshots for undo). */
@@ -912,6 +936,7 @@ export class FloorplanCardEditor extends LitElement {
         ev.stopPropagation();
         this._floorMenuOpen = false;
         this._addMenuOpen = false;
+        this._addQuery = "";
         return;
       }
       if (this._draft || this._draftTracker || this._draftArea || this._marquee || this._drag) {
@@ -1472,8 +1497,8 @@ export class FloorplanCardEditor extends LitElement {
     this._tool = "select";
   }
 
-  private _addFurniture(type: FurnitureType): void {
-    const size = FURNITURE_DEFAULT_SIZE[type];
+  private _addFurniture(type: string): void {
+    const size = symbolSize(type, this._symbols());
     const f: Furniture = {
       id: uid("furn"),
       type,
@@ -2296,7 +2321,7 @@ export class FloorplanCardEditor extends LitElement {
       case "furniture": {
         const fu = f.furniture.find((x) => x.id === sel.id);
         if (!fu) return "Furniture";
-        const label = FURNITURE_LABELS[fu.type];
+        const label = furnitureLabel(fu.type, this._symbols());
         return `${label.charAt(0).toUpperCase()}${label.slice(1)} · ${Math.round(fu.w)}×${Math.round(fu.h)}`;
       }
       case "area": {
@@ -2535,6 +2560,7 @@ export class FloorplanCardEditor extends LitElement {
               @click=${() => {
                 this._floorMenuOpen = false;
                 this._addMenuOpen = false;
+                this._addQuery = "";
               }}
             ></div>`
           : nothing}
@@ -2655,6 +2681,7 @@ export class FloorplanCardEditor extends LitElement {
               @click=${() => {
                 this._floorMenuOpen = !this._floorMenuOpen;
                 this._addMenuOpen = false;
+                this._addQuery = "";
               }}
             >
               <ha-icon icon="mdi:cog-outline"></ha-icon>
@@ -2828,7 +2855,10 @@ export class FloorplanCardEditor extends LitElement {
                    what you place is what you get. Previewed at full strength
                    with no hass in the editor, so the radius is adjustable
                    without having to turn the real light on. -->
-              ${renderGlowMask(floor.furniture, c.width, c.height, `${this._wallMaskId}-glowmask`)}
+              ${renderGlowMask(
+                floor.furniture, c.width, c.height,
+                `${this._wallMaskId}-glowmask`, this._symbols()
+              )}
               <g class="fp-glows"
                  mask=${floor.furniture.length ? `url(#${this._wallMaskId}-glowmask)` : nothing}>
                 ${floor.items.map((it, i) => {
@@ -3208,13 +3238,27 @@ export class FloorplanCardEditor extends LitElement {
     // Any open toolbar popover would be orphaned by the layout change.
     this._floorMenuOpen = false;
     this._addMenuOpen = false;
+    this._addQuery = "";
   }
 
-  /** The "+ Add" popover: device, text, then every furniture type as its real glyph. */
+  /**
+   * The "+ Add" popover: device, text, then every symbol as its real glyph.
+   *
+   * The grid is searchable and grouped (issue #90). It was 26 fixed cells over
+   * six rows, which was already the tallest thing in the editor; with a
+   * community library behind it the list only grows, so the query filters on id,
+   * name, category and the symbol's own keywords — "couch" finds the sofa.
+   */
   private _renderAddMenu(): TemplateResult {
     const close = () => {
       this._addMenuOpen = false;
+      this._addQuery = "";
     };
+    const catalog = this._symbols();
+    const matches = furnitureChoices(catalog).filter((s) => symbolMatches(s, this._addQuery));
+    const grouped = !this._addQuery.trim();
+    let lastCategory = "";
+
     return html`
       <div class="pop left add-pop">
         <button
@@ -3235,31 +3279,64 @@ export class FloorplanCardEditor extends LitElement {
         >
           <ha-icon icon="mdi:format-text"></ha-icon> Text
         </button>
-        <div class="add-furn-grid">
-          ${FURNITURE_TYPES.map((t) => {
-            const size = FURNITURE_DEFAULT_SIZE[t];
-            // Glyphs are drawn centered at the origin; pad the viewBox a bit
-            // (tv draws its stand below the box, plants overflow slightly).
-            const pad = Math.max(size.w, size.h) * 0.25 + 6;
-            const vb = `${-size.w / 2 - pad} ${-size.h / 2 - pad} ${size.w + pad * 2} ${size.h + pad * 2}`;
-            return html`
-              <button
-                class="furn-cell"
-                title=${FURNITURE_LABELS[t]}
-                @click=${() => {
-                  this._addFurniture(t);
-                  close();
-                }}
-              >
-                <svg viewBox=${vb}>
-                  ${renderFurniture({ id: "preview", type: t, x: 0, y: 0, w: size.w, h: size.h })}
-                </svg>
-                <span>${FURNITURE_LABELS[t]}</span>
-              </button>
-            `;
-          })}
+        <div class="furn-search">
+          <ha-icon icon="mdi:magnify"></ha-icon>
+          <input
+            type="search"
+            placeholder="Search furniture"
+            .value=${this._addQuery}
+            @input=${(e: Event) => {
+              this._addQuery = (e.target as HTMLInputElement).value;
+            }}
+            @keydown=${(e: KeyboardEvent) => {
+              // Escape clears the query first; the popover's own Escape
+              // handler closes it, so without this one key would do both.
+              if (e.key === "Escape" && this._addQuery) {
+                e.stopPropagation();
+                this._addQuery = "";
+              }
+            }}
+          />
+        </div>
+        <div class="add-furn-scroll">
+          ${matches.length
+            ? matches.map((s) => {
+                const header = grouped && s.category !== lastCategory ? s.category : "";
+                lastCategory = s.category;
+                return html`${header ? html`<div class="furn-group">${header}</div>` : nothing}
+                  ${this._renderFurnCell(s, close)}`;
+              })
+            : html`<div class="furn-empty">No symbol matches “${this._addQuery}”</div>`}
         </div>
       </div>
+    `;
+  }
+
+  /** One picker cell: the symbol drawn at its own default size, plus its name. */
+  private _renderFurnCell(s: SymbolDef, close: () => void): TemplateResult {
+    // Glyphs are drawn centered at the origin; pad the viewBox a bit
+    // (tv draws its stand below the box, plants overflow slightly).
+    const { w, h } = s.size;
+    const pad = Math.max(w, h) * 0.25 + 6;
+    const vb = `${-w / 2 - pad} ${-h / 2 - pad} ${w + pad * 2} ${h + pad * 2}`;
+    return html`
+      <button
+        class="furn-cell"
+        title=${s.name}
+        @click=${() => {
+          this._addFurniture(s.id);
+          close();
+        }}
+      >
+        <svg viewBox=${vb}>
+          ${renderFurniture(
+            { id: "preview", type: s.id, x: 0, y: 0, w, h },
+            undefined,
+            this._symbols()
+          )}
+        </svg>
+        <span>${s.name}</span>
+      </button>
     `;
   }
 
@@ -3391,7 +3468,7 @@ export class FloorplanCardEditor extends LitElement {
     return svg`
       <g class="furn-hit ${selected ? "selected" : ""}"
          @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "furniture", id: f.id })}>
-        ${renderFurniture(f)}
+        ${renderFurniture(f, undefined, this._symbols())}
         ${
           selected
             ? svg`<rect x=${f.x - f.w / 2 - 4} y=${f.y - f.h / 2 - 4}
@@ -3678,8 +3755,100 @@ export class FloorplanCardEditor extends LitElement {
         ${this._renderForm(projectDeadSpaceForm(this._config), (patch) =>
           this._patchConfig(patch as Partial<FloorplanCardConfig>)
         )}
+        ${this._renderSymbolsPanel()}
       </div>
     `;
+  }
+
+  /**
+   * Paste a furniture symbol into this plan (issue #90).
+   *
+   * The point is that you don't need a pull request to draw something the
+   * library hasn't got: paste the geometry here, it lands in the config's
+   * `symbols:` block, and it appears in the picker beside the built-ins. If it
+   * turns out to be generally useful, the same JSON is what you contribute to
+   * `furniture/`.
+   *
+   * It is validated through `normalizeSymbol` — the same function the shipped
+   * library goes through — so a malformed paste is reported here rather than
+   * becoming a broken glyph on the plan. Nothing pasted is ever parsed as
+   * markup; see `symbols.ts`.
+   */
+  private _renderSymbolsPanel(): TemplateResult {
+    const own = Object.keys(this._config.symbols ?? {});
+    return html`
+      <div class="row col symbols-panel">
+        <label>Custom symbols</label>
+        ${own.length
+          ? html`<div class="symbol-list">
+              ${own.map(
+                (id) => html`
+                  <span class="symbol-chip">
+                    ${id}
+                    <button
+                      class="chip-x"
+                      title=${`Remove ${id}`}
+                      @click=${() => this._removeSymbol(id)}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                `
+              )}
+            </div>`
+          : nothing}
+        <textarea
+          class="symbol-input"
+          rows="4"
+          spellcheck="false"
+          placeholder=${'{ "id": "my-desk", "size": { "w": 120, "h": 60 }, "parts": [ … ] }'}
+          .value=${this._symbolDraft}
+          @input=${(e: Event) => {
+            this._symbolDraft = (e.target as HTMLTextAreaElement).value;
+            this._symbolError = "";
+          }}
+        ></textarea>
+        ${this._symbolError ? html`<div class="symbol-error">${this._symbolError}</div>` : nothing}
+        <div class="symbol-actions">
+          <button ?disabled=${!this._symbolDraft.trim()} @click=${this._addSymbol}>
+            Add symbol
+          </button>
+          <a
+            href="https://github.com/nicosandller/easy-floorplan/blob/main/furniture/README.md"
+            target="_blank"
+            rel="noreferrer"
+            >How to draw one</a
+          >
+        </div>
+      </div>
+    `;
+  }
+
+  private _addSymbol = (): void => {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(this._symbolDraft);
+    } catch (err) {
+      this._symbolError = `Not valid JSON — ${(err as Error).message}`;
+      return;
+    }
+    const problems: string[] = [];
+    const def = normalizeSymbol(raw, undefined, problems);
+    if (!def) {
+      this._symbolError = problems[0] ?? "Not a usable symbol.";
+      return;
+    }
+    this._patchConfig({ symbols: { ...(this._config.symbols ?? {}), [def.id]: raw } });
+    this._symbolDraft = "";
+    this._symbolError = "";
+  };
+
+  private _removeSymbol(id: string): void {
+    const rest = { ...(this._config.symbols ?? {}) };
+    delete rest[id];
+    // Drop the key entirely when the last one goes, so removing every symbol
+    // leaves the config as it was rather than carrying an empty block forever.
+    this._patchConfig({ symbols: Object.keys(rest).length ? rest : undefined });
   }
 
   /**
@@ -3812,7 +3981,7 @@ export class FloorplanCardEditor extends LitElement {
       const f = this._floor().furniture.find((x) => x.id === sel.id);
       if (!f) return html`${nothing}`;
       return html`
-        ${this._renderForm(furnitureForm(f, this._areaEntitiesAt(f.x, f.y)), (patch, live) =>
+        ${this._renderForm(furnitureForm(f, this._areaEntitiesAt(f.x, f.y), this._symbols()), (patch, live) =>
           this._applyElementPatch("furniture", f.id, patch, live)
         )}
         ${this._renderColorRow({
@@ -4527,13 +4696,57 @@ export class FloorplanCardEditor extends LitElement {
     .add-entry:hover {
       background: var(--secondary-background-color, #f5f5f5);
     }
-    .add-furn-grid {
+    /* Search row above the grid (issue #90): the library grows with every
+       contributed symbol, so the list has to be findable, not just scrollable. */
+    .furn-search {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 8px;
+      padding: 4px 6px;
+      border: 1px solid var(--divider-color, #e0e0e0);
+      border-radius: 6px;
+    }
+    .furn-search ha-icon {
+      --mdc-icon-size: 16px;
+      color: var(--secondary-text-color);
+      flex: none;
+    }
+    .furn-search input {
+      flex: 1;
+      min-width: 0;
+      border: none;
+      outline: none;
+      background: none;
+      font: inherit;
+      font-size: 12px;
+      color: var(--primary-text-color);
+    }
+    .add-furn-scroll {
       display: grid;
       grid-template-columns: repeat(5, 1fr);
       gap: 4px;
       margin-top: 8px;
       padding-top: 8px;
       border-top: 1px solid var(--divider-color, #eee);
+      /* 26 built-ins already filled six rows; a community library is unbounded. */
+      max-height: 46vh;
+      overflow-y: auto;
+    }
+    .furn-group {
+      grid-column: 1 / -1;
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--secondary-text-color);
+      opacity: 0.8;
+      padding: 4px 2px 0;
+    }
+    .furn-empty {
+      grid-column: 1 / -1;
+      padding: 10px 2px;
+      font-size: 12px;
+      color: var(--secondary-text-color);
     }
     .furn-cell {
       display: flex;
@@ -5159,6 +5372,72 @@ export class FloorplanCardEditor extends LitElement {
     }
     .row input.num {
       flex: 0 0 64px;
+    }
+    /* Paste-a-symbol block (issue #90): a stacked row, since a JSON blob does
+       not fit the label-then-control shape the rest of the panel uses. */
+    .row.col {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .row.col > label {
+      flex: none;
+      margin-bottom: 2px;
+    }
+    .symbol-input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 6px;
+      border-radius: 4px;
+      border: 1px solid var(--divider-color, #ccc);
+      background: var(--card-background-color, #fff);
+      color: var(--primary-text-color);
+      font-family: var(--code-font-family, ui-monospace, monospace);
+      font-size: 11px;
+      resize: vertical;
+    }
+    .symbol-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+    .symbol-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 6px;
+      border-radius: 10px;
+      font-size: 11px;
+      background: var(--secondary-background-color, #f2f2f2);
+      color: var(--primary-text-color);
+    }
+    .symbol-chip button.chip-x {
+      border: none;
+      background: none;
+      padding: 0;
+      font-size: 11px;
+      line-height: 1;
+      color: var(--secondary-text-color);
+    }
+    .symbol-actions button[disabled] {
+      opacity: 0.5;
+      cursor: default;
+    }
+    .symbol-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-top: 6px;
+      font-size: 12px;
+    }
+    .symbol-actions a {
+      color: var(--secondary-text-color);
+    }
+    .symbol-error {
+      margin-top: 4px;
+      font-size: 11px;
+      color: var(--error-color, #c62828);
     }
     /* Compact inline checkbox+label used inside a .row that already has its
        primary <label> on the left (e.g. the Tracker sensor "invert" toggle). */

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -81,6 +81,7 @@ import {
   planRotationTransform,
   type PlanRotation,
 } from "./render";
+import { symbolCatalog } from "./symbols";
 import { deadSpacesCached } from "./dead-space";
 import type { Opening } from "./types";
 import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
@@ -608,7 +609,10 @@ export class FloorplanCard extends LitElement {
                  pools screen-blend with each other (two lamps brighten where
                  they meet) without screening against the plan beneath, which
                  would wash out on a light theme. -->
-            ${renderGlowMask(active.furniture, c.width, c.height, `${this._glowIdBase}-mask`)}
+            ${renderGlowMask(
+              active.furniture, c.width, c.height,
+              `${this._glowIdBase}-mask`, symbolCatalog(c.symbols)
+            )}
             <g class="fp-glows"
                mask=${active.furniture.length ? `url(#${this._glowIdBase}-mask)` : nothing}>
               ${active.items.map((it, i) => {
@@ -621,7 +625,11 @@ export class FloorplanCard extends LitElement {
               })}
             </g>
             ${active.furniture.map((f) =>
-              renderFurniture(f, furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined))
+              renderFurniture(
+                f,
+                furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined),
+                symbolCatalog(c.symbols)
+              )
             )}
             ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
             <g mask=${`url(#${this._wallMaskId})`}>

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -3,7 +3,6 @@ import { html, nothing } from "lit";
 import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
 import { SKIN_ACCENT, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 import {
-  FURNITURE_DEFAULT_SIZE,
   DEFAULT_GLOW_RADIUS,
   DEFAULT_GLOW_COLOR,
   GLOW_MIN_OPACITY,
@@ -41,9 +40,6 @@ import {
   defaultIcon,
   renderFurniture,
   furnitureColor,
-  sectionalPoints,
-  SECTIONAL_CHAISE_FRACTION,
-  SECTIONAL_SEAT_FRACTION,
   entityDefaultIcon,
   trackerSensorReading,
   openingInMotion,
@@ -96,6 +92,7 @@ import {
   renderRipple,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
+import { symbolCatalog, symbolSize } from "./symbols";
 
 /**
  * Render a Lit template to the string it would emit, for asserting on markup.
@@ -1118,64 +1115,78 @@ describe("furnitureColor (issue #82)", () => {
   });
 });
 
-describe("sectionalPoints", () => {
+describe("the sectional's L-shaped outline", () => {
   const w = 200;
   const h = 160;
+  // Fractions the sectional symbol is drawn to: the chaise's share of the
+  // width, and the main run's depth from the back.
+  const CHAISE = 0.42;
+  const SEAT = 0.55;
+
+  /** The base polygon's corners, read back out of the rendered glyph. */
+  function outline(hand?: "left" | "right"): Array<[number, number]> {
+    const markup = flattenMarkup(
+      renderFurniture({ id: "s", type: "sectional", x: 0, y: 0, w, h, hand })
+    );
+    const pts = markup.match(/<polygon[^>]*\spoints=([^\s>]+(?:\s[-\d.]+,[-\d.]+)*)/)?.[1];
+    expect(pts, "the sectional draws a polygon base").toBeTruthy();
+    return pts!
+      .trim()
+      .split(/\s+/)
+      .map((p) => p.split(",").map(Number) as [number, number]);
+  }
 
   function area(pts: Array<[number, number]>): number {
     let a = 0;
     for (let i = 0; i < pts.length; i++) {
-      const [x1, y1] = pts[i];
-      const [x2, y2] = pts[(i + 1) % pts.length];
+      const [x1, y1] = pts[i]!;
+      const [x2, y2] = pts[(i + 1) % pts.length]!;
       a += x1 * y2 - x2 * y1;
     }
     return Math.abs(a) / 2;
   }
 
   it("is an L: six corners, not a rectangle", () => {
-    expect(sectionalPoints(w, h, "right")).toHaveLength(6);
+    expect(outline("right")).toHaveLength(6);
   });
 
   it("fills the bounding box minus the notch", () => {
-    const chaise = w * SECTIONAL_CHAISE_FRACTION;
-    const seat = h * SECTIONAL_SEAT_FRACTION;
-    const expected = w * h - (w - chaise) * (h - seat);
-    expect(area(sectionalPoints(w, h, "right"))).toBeCloseTo(expected, 6);
+    const expected = w * h - (w - w * CHAISE) * (h - h * SEAT);
+    expect(area(outline("right"))).toBeCloseTo(expected, 6);
   });
 
   it("puts the chaise on the right when hand is right", () => {
-    const pts = sectionalPoints(w, h, "right");
     // the front edge (max y) should only be occupied on the right half
-    const front = pts.filter(([, y]) => y === h / 2).map(([x]) => x);
+    const front = outline("right").filter(([, y]) => y === h / 2).map(([x]) => x);
     expect(Math.min(...front)).toBeGreaterThan(0);
     expect(Math.max(...front)).toBeCloseTo(w / 2, 6);
   });
 
-  it("puts the chaise on the left when hand is left", () => {
-    const pts = sectionalPoints(w, h, "left");
-    const front = pts.filter(([, y]) => y === h / 2).map(([x]) => x);
-    expect(Math.max(...front)).toBeLessThan(0);
-    expect(Math.min(...front)).toBeCloseTo(-w / 2, 6);
-  });
-
-  it("left is right mirrored across x, not a different shape", () => {
-    const r = sectionalPoints(w, h, "right");
-    const l = sectionalPoints(w, h, "left");
-    expect(area(l)).toBeCloseTo(area(r), 6);
-    expect(l.map(([x, y]) => [-x, y])).toEqual(r);
-  });
-
   it("defaults to right-handed", () => {
-    expect(sectionalPoints(w, h)).toEqual(sectionalPoints(w, h, "right"));
+    expect(outline()).toEqual(outline("right"));
   });
 
   it("stays inside its bounding box", () => {
-    for (const hand of ["left", "right"] as const) {
-      for (const [x, y] of sectionalPoints(w, h, hand)) {
-        expect(Math.abs(x)).toBeLessThanOrEqual(w / 2 + 1e-9);
-        expect(Math.abs(y)).toBeLessThanOrEqual(h / 2 + 1e-9);
-      }
+    for (const [x, y] of outline("right")) {
+      expect(Math.abs(x)).toBeLessThanOrEqual(w / 2 + 1e-9);
+      expect(Math.abs(y)).toBeLessThanOrEqual(h / 2 + 1e-9);
     }
+  });
+
+  // The two hands were always one polygon reflected, and still are — only now
+  // the reflection is a transform on the group rather than a mapped point list,
+  // so it applies to every part of the glyph and to any other symbol too.
+  it("draws the left hand as the right one mirrored, not a second shape", () => {
+    expect(outline("left")).toEqual(outline("right"));
+    const left = flattenMarkup(
+      renderFurniture({ id: "s", type: "sectional", x: 10, y: 20, w, h, hand: "left" })
+    );
+    const right = flattenMarkup(
+      renderFurniture({ id: "s", type: "sectional", x: 10, y: 20, w, h, hand: "right" })
+    );
+    expect(left).toContain("rotate(0) scale(-1 1)");
+    expect(right).not.toContain("scale(-1 1)");
+    expect(left.replace(" scale(-1 1)", "")).toBe(right);
   });
 });
 
@@ -1189,7 +1200,7 @@ describe("every furniture type renders and has a default size", () => {
 
   it("has a default size for each", () => {
     for (const t of types) {
-      const s = FURNITURE_DEFAULT_SIZE[t];
+      const s = symbolSize(t);
       expect(s, t).toBeTruthy();
       expect(s.w, t).toBeGreaterThan(0);
       expect(s.h, t).toBeGreaterThan(0);
@@ -1198,9 +1209,19 @@ describe("every furniture type renders and has a default size", () => {
 
   it("renders each without throwing", () => {
     for (const t of types) {
-      const { w, h } = FURNITURE_DEFAULT_SIZE[t];
+      const { w, h } = symbolSize(t);
       expect(() => renderFurniture({ id: t, type: t, x: 0, y: 0, w, h }), t).not.toThrow();
     }
+  });
+
+  // The fallback the old `switch`'s `default` case gave an unrecognised type,
+  // now that a type can name a symbol this install simply doesn't have.
+  it("draws an unknown type as a plain box rather than nothing", () => {
+    const markup = flattenMarkup(
+      renderFurniture({ id: "x", type: "no-such-symbol", x: 0, y: 0, w: 100, h: 60 })
+    );
+    expect(markup).toContain("<rect");
+    expect(markup).toContain("fp-furniture-no-such-symbol");
   });
 
   it("renders a sectional of each hand", () => {
@@ -3161,6 +3182,26 @@ describe("renderGlowMask — furniture is dimmed, not blacked out (#108, #106)",
     expect(markup).toContain("<ellipse");
     // Explicit region, not the viewport default (the issue #102 lesson).
     expect(markup).toContain("width=1016");
+  });
+
+  // The footprint comes off the symbol now (issue #90), not off a hard-coded
+  // list of the three round built-ins — so a contributed round piece casts a
+  // round shadow without anyone editing this file.
+  it("takes a config symbol's own footprint, not just the built-in round ones", () => {
+    const catalog = symbolCatalog({
+      pouffe: { id: "pouffe", footprint: "ellipse", parts: [{ ellipse: [50, 50, 50, 50] }] },
+      crate: { id: "crate", parts: [{ rect: [0, 0, 100, 100] }] },
+    });
+    const round = flattenMarkup(
+      renderGlowMask([{ id: "p", type: "pouffe", x: 0, y: 0, w: 40, h: 40 }] as never,
+        100, 100, "gm", catalog)
+    );
+    const square = flattenMarkup(
+      renderGlowMask([{ id: "c", type: "crate", x: 0, y: 0, w: 40, h: 40 }] as never,
+        100, 100, "gm", catalog)
+    );
+    expect(round).toContain("<ellipse");
+    expect(square).not.toContain("<ellipse");
   });
 
   // This is the guard in *both* directions, and the reason the level is a

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,13 @@
 import { svg, html, nothing, type SVGTemplateResult, type TemplateResult } from "lit";
+import {
+  BUILTIN_SYMBOLS,
+  FALLBACK_SYMBOL,
+  renderSymbolParts,
+  type SymbolCatalog,
+} from "./symbols";
 import type {
   FloorplanCardConfig,
   Floor,
-  SectionalHand,
   Opening,
   ItemKind,
   IconAnimation,
@@ -807,6 +812,7 @@ export function renderGlowMask(
   width: number,
   height: number,
   id: string,
+  catalog: SymbolCatalog = BUILTIN_SYMBOLS,
 ): SVGTemplateResult {
   const pad = WALL_THICKNESS;
   return svg`
@@ -817,7 +823,10 @@ export function renderGlowMask(
               fill="white" />
         ${furniture.map((f) => {
           const rot = f.angle ? `rotate(${f.angle} ${f.x} ${f.y})` : undefined;
-          const roundBase = f.type === "roundTable" || f.type === "plant" || f.type === "waterHeater";
+          // The symbol says which shape its outline is, so a round-bodied piece
+          // casts a round shadow. This used to be a hard-coded list of the three
+          // round types, kept in sync by hand with the same list in the glyph.
+          const roundBase = catalog[f.type]?.footprint === "ellipse";
           // A mask's luminance is its transmission, and the region is already
           // white ("all the light"). So furniture paints *black* at the share
           // it blocks, leaving the share it lets through.
@@ -2468,298 +2477,38 @@ export function renderAreaBorder(
 }
 
 /**
- * Render a furniture/fixture diagram as line art inside its w×h box, centered at the
- * origin, then translated and rotated into place. Defaults to gray so it reads
- * differently from black walls.
- */
-/** Fraction of the bounding box the chaise occupies, and the main seat's depth. */
-export const SECTIONAL_CHAISE_FRACTION = 0.42;
-export const SECTIONAL_SEAT_FRACTION = 0.55;
-
-/**
- * The six corners of an L-shaped sectional, centred on the origin, back at -y.
+ * A furniture diagram: the symbol named by `f.type`, drawn as line art inside
+ * its w\u00d7h box, centered at the origin and then translated and rotated into
+ * place. Defaults to gray so it reads differently from black walls.
  *
- * `hand` is read facing the sofa from the front: a `right` sectional puts the
- * chaise on your right, extending toward you. Mirroring across x gives `left`,
- * so the two hands are the same polygon reflected -- not two separate shapes.
+ * Every glyph is data now (issue #90) \u2014 one JSON file per symbol under
+ * `furniture/`, plus whatever a config's own `symbols:` adds. `override` is the
+ * entity-driven color resolved by the caller (issue #82) \u2014 see
+ * {@link furnitureColor}; the editor passes nothing and keeps the static look
+ * while you are drawing.
+ *
+ * An unknown type draws the plain box with no detail, which is what the old
+ * hand-written `switch`'s `default` case did: a config naming a symbol that was
+ * never installed leaves a placeholder you can see and move, rather than an
+ * invisible hole in the plan.
  */
-export function sectionalPoints(
-  w: number,
-  h: number,
-  hand: SectionalHand = "right",
-): Array<[number, number]> {
-  const hw = w / 2;
-  const hh = h / 2;
-  const seat = h * SECTIONAL_SEAT_FRACTION;   // depth of the main run, from the back
-  const chaise = w * SECTIONAL_CHAISE_FRACTION;
-
-  //  back  ( -y )
-  //  +-----------------+
-  //  |                 |
-  //  |         +-------+   <- chaise, on the right
-  //  |         |
-  //  +---------+
-  //  front ( +y )
-  const pts: Array<[number, number]> = [
-    [-hw, -hh],
-    [hw, -hh],
-    [hw, hh],
-    [hw - chaise, hh],
-    [hw - chaise, -hh + seat],
-    [-hw, -hh + seat],
-  ];
-  return hand === "left" ? pts.map(([x, y]) => [-x, y] as [number, number]) : pts;
-}
-
-/**
- * A furniture diagram. `override` is the entity-driven color resolved by the
- * caller (issue #82) — see {@link furnitureColor}; the editor passes nothing
- * and keeps the static look while you are drawing.
- */
-export function renderFurniture(f: Furniture, override?: string): SVGTemplateResult {
+export function renderFurniture(
+  f: Furniture,
+  override?: string,
+  catalog: SymbolCatalog = BUILTIN_SYMBOLS,
+): SVGTemplateResult {
   const color = override ?? f.color ?? FURNITURE_COLOR;
-  const w = f.w;
-  const h = f.h;
-  const hw = w / 2;
-  const hh = h / 2;
+  const parts = renderSymbolParts(catalog[f.type] ?? FALLBACK_SYMBOL, f.w, f.h, color);
 
-  const roundBase =
-    f.type === "roundTable" || f.type === "plant" || f.type === "waterHeater";
-  const base = f.type === "sectional"
-    ? svg`<polygon points=${sectionalPoints(w, h, f.hand).map((p) => p.join(",")).join(" ")}
-                   fill=${color} fill-opacity="0.12" stroke=${color} stroke-width="2"
-                   stroke-linejoin="round" />`
-    : roundBase
-    ? svg`<ellipse cx="0" cy="0" rx=${hw} ry=${hh}
-                   fill=${color} fill-opacity="0.12" stroke=${color} stroke-width="2" />`
-    : f.type === "rug"
-      ? svg`<rect x=${-hw} y=${-hh} width=${w} height=${h} rx=${Math.min(w, h) * 0.12}
-                  fill=${color} fill-opacity="0.08" stroke=${color} stroke-width="2"
-                  stroke-dasharray="8 5" />`
-      : svg`<rect x=${-hw} y=${-hh} width=${w} height=${h} rx="4"
-                  fill=${color} fill-opacity="0.12" stroke=${color} stroke-width="2" />`;
+  // `hand: "left"` is the same symbol reflected, not a second drawing \u2014 which is
+  // what the L-shaped sectional's two hands always were, and it now works on any
+  // symbol. A mirror is uniform in |scale|, so strokes keep their width.
+  const mirror = f.hand === "left" ? " scale(-1 1)" : "";
 
-  let detail: SVGTemplateResult;
-  switch (f.type) {
-    case "chair":
-      detail = svg`<line x1=${-hw} y1=${-hh + h * 0.22} x2=${hw} y2=${-hh + h * 0.22}
-                         stroke=${color} stroke-width="2" />`;
-      break;
-    case "sofa":
-      detail = svg`
-        <line x1=${-hw} y1=${-hh + h * 0.3} x2=${hw} y2=${-hh + h * 0.3}
-              stroke=${color} stroke-width="2" />
-        <line x1=${-hw + w * 0.12} y1=${-hh + h * 0.3} x2=${-hw + w * 0.12} y2=${hh}
-              stroke=${color} stroke-width="2" />
-        <line x1=${hw - w * 0.12} y1=${-hh + h * 0.3} x2=${hw - w * 0.12} y2=${hh}
-              stroke=${color} stroke-width="2" />`;
-      break;
-    case "bed":
-      detail = svg`
-        <line x1=${-hw} y1=${-hh + h * 0.26} x2=${hw} y2=${-hh + h * 0.26}
-              stroke=${color} stroke-width="2" />
-        <rect x=${-hw + w * 0.1} y=${-hh + h * 0.06} width=${w * 0.34} height=${h * 0.14} rx="3"
-              fill="none" stroke=${color} stroke-width="1.5" />
-        <rect x=${hw - w * 0.44} y=${-hh + h * 0.06} width=${w * 0.34} height=${h * 0.14} rx="3"
-              fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    case "fridge":
-      detail = svg`
-        <line x1=${-hw} y1=${-hh + h * 0.4} x2=${hw} y2=${-hh + h * 0.4}
-              stroke=${color} stroke-width="2" />
-        <line x1=${hw - w * 0.16} y1=${-hh + h * 0.12} x2=${hw - w * 0.16} y2=${-hh + h * 0.3}
-              stroke=${color} stroke-width="2" />
-        <line x1=${hw - w * 0.16} y1=${-hh + h * 0.5} x2=${hw - w * 0.16} y2=${hh - h * 0.16}
-              stroke=${color} stroke-width="2" />`;
-      break;
-    case "stove": {
-      const r = Math.min(w, h) * 0.16;
-      const ox = w * 0.22;
-      const oy = h * 0.22;
-      detail = svg`
-        <circle cx=${-ox} cy=${-oy} r=${r} fill="none" stroke=${color} stroke-width="2" />
-        <circle cx=${ox} cy=${-oy} r=${r} fill="none" stroke=${color} stroke-width="2" />
-        <circle cx=${-ox} cy=${oy} r=${r} fill="none" stroke=${color} stroke-width="2" />
-        <circle cx=${ox} cy=${oy} r=${r} fill="none" stroke=${color} stroke-width="2" />`;
-      break;
-    }
-    case "sink":
-      detail = svg`
-        <rect x=${-hw + w * 0.12} y=${-hh + h * 0.18} width=${w * 0.76} height=${h * 0.5} rx="4"
-              fill="none" stroke=${color} stroke-width="2" />
-        <circle cx="0" cy=${-hh + h * 0.1} r=${Math.min(w, h) * 0.05}
-                fill="none" stroke=${color} stroke-width="2" />`;
-      break;
-    case "toilet":
-      detail = svg`
-        <rect x=${-hw + w * 0.1} y=${-hh} width=${w * 0.8} height=${h * 0.22} rx="3"
-              fill="none" stroke=${color} stroke-width="2" />
-        <ellipse cx="0" cy=${hh - h * 0.32} rx=${w * 0.34} ry=${h * 0.3}
-                 fill="none" stroke=${color} stroke-width="2" />`;
-      break;
-    case "stairs": {
-      const steps = 7;
-      const lines = [];
-      for (let i = 1; i < steps; i++) {
-        const y = -hh + (h / steps) * i;
-        lines.push(svg`<line x1=${-hw} y1=${y} x2=${hw} y2=${y} stroke=${color} stroke-width="1.5" />`);
-      }
-      detail = svg`${lines}
-        <line x1="0" y1=${hh - 6} x2="0" y2=${-hh + 6} stroke=${color} stroke-width="1.5" />
-        <path d="M ${-w * 0.12} ${-hh + h * 0.16} L 0 ${-hh + 4} L ${w * 0.12} ${-hh + h * 0.16}"
-              fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    }
-    case "tv":
-      detail = svg`<line x1=${-w * 0.18} y1=${hh} x2=${w * 0.18} y2=${hh + h}
-                         stroke=${color} stroke-width="2" />`;
-      break;
-    case "desk":
-      detail = svg`<line x1=${-hw} y1=${-hh + h * 0.55} x2=${hw} y2=${-hh + h * 0.55}
-                         stroke=${color} stroke-width="1.5" opacity="0.7" />`;
-      break;
-    case "wardrobe":
-      detail = svg`
-        <line x1="0" y1=${-hh} x2="0" y2=${hh} stroke=${color} stroke-width="2" />
-        <line x1=${-w * 0.06} y1=${-h * 0.1} x2=${-w * 0.06} y2=${h * 0.1}
-              stroke=${color} stroke-width="2" />
-        <line x1=${w * 0.06} y1=${-h * 0.1} x2=${w * 0.06} y2=${h * 0.1}
-              stroke=${color} stroke-width="2" />`;
-      break;
-    case "plant": {
-      const r = Math.min(w, h) * 0.18;
-      detail = svg`
-        <circle cx="0" cy=${-h * 0.12} r=${r} fill="none" stroke=${color} stroke-width="1.5" />
-        <circle cx=${-w * 0.16} cy=${h * 0.08} r=${r} fill="none" stroke=${color} stroke-width="1.5" />
-        <circle cx=${w * 0.16} cy=${h * 0.08} r=${r} fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    }
-    case "fishTank": {
-      // Issue #72: glass inset and two fish seen from above (lens body +
-      // tail) so it can't be mistaken for a rug, plus a rising bubble.
-      // Every measure scales with w/h like the other glyphs.
-      const fx = w * 0.18;
-      const fy = h * 0.1;
-      const bubble = Math.min(w, h) * 0.04;
-      const fish = (cx: number, cy: number, dir: number) => svg`
-        <ellipse cx=${cx} cy=${cy} rx=${w * 0.07} ry=${h * 0.09}
-                 fill="none" stroke=${color} stroke-width="1.5" />
-        <path d="M ${cx + dir * w * 0.07} ${cy} l ${dir * w * 0.05} ${-h * 0.08} l 0 ${h * 0.16} z"
-              fill=${color} opacity="0.7" />`;
-      detail = svg`
-        <rect x=${-hw + w * 0.05} y=${-hh + h * 0.12} width=${w * 0.9} height=${h * 0.76}
-              fill="none" stroke=${color} stroke-width="1" opacity="0.6" />
-        ${fish(-fx, -fy, 1)}
-        ${fish(fx, fy, -1)}
-        <circle cx=${w * 0.32} cy=${-h * 0.18} r=${bubble} fill="none" stroke=${color}
-                stroke-width="1" opacity="0.6" />`;
-      break;
-    }
-    case "piano": {
-      // Upright piano from above: body with a keyboard strip along the front
-      // edge, a few key separators, and the open lid line.
-      const stripY = hh - h * 0.3;
-      const keys: SVGTemplateResult[] = [];
-      for (let i = 1; i < 8; i++) {
-        const x = -hw + (w * i) / 8;
-        keys.push(svg`<line x1=${x} y1=${stripY} x2=${x} y2=${hh - h * 0.06}
-              stroke=${color} stroke-width="1" opacity="0.6" />`);
-      }
-      detail = svg`
-        <line x1=${-hw + w * 0.04} y1=${stripY} x2=${hw - w * 0.04} y2=${stripY}
-              stroke=${color} stroke-width="1.5" />
-        ${keys}
-        <line x1=${-hw + w * 0.04} y1=${-hh + h * 0.22} x2=${hw - w * 0.04} y2=${-hh + h * 0.22}
-              stroke=${color} stroke-width="1" opacity="0.5" />`;
-      break;
-    }
-    case "hotTub": {
-      // Square shell, round tub, jet bubbles in the corners of the water.
-      const r = Math.min(w, h) * 0.36;
-      const jr = Math.min(w, h) * 0.05;
-      const jd = r * 0.62;
-      detail = svg`
-        <circle cx="0" cy="0" r=${r} fill="none" stroke=${color} stroke-width="2" />
-        <circle cx=${-jd} cy=${-jd} r=${jr} fill="none" stroke=${color} stroke-width="1" opacity="0.6" />
-        <circle cx=${jd} cy=${-jd} r=${jr} fill="none" stroke=${color} stroke-width="1" opacity="0.6" />
-        <circle cx=${-jd} cy=${jd} r=${jr} fill="none" stroke=${color} stroke-width="1" opacity="0.6" />
-        <circle cx=${jd} cy=${jd} r=${jr} fill="none" stroke=${color} stroke-width="1" opacity="0.6" />`;
-      break;
-    }
-    case "rug":
-      detail = svg`<rect x=${-hw + w * 0.1} y=${-hh + h * 0.1} width=${w * 0.8} height=${h * 0.8}
-                         rx=${Math.min(w, h) * 0.08} fill="none" stroke=${color}
-                         stroke-width="1.5" opacity="0.6" />`;
-      break;
-    case "washer":
-    case "dryer": {
-      const r = Math.min(w, h) * 0.3;
-      detail = svg`
-        <line x1=${-hw + w * 0.06} y1=${-hh + h * 0.18} x2=${hw - w * 0.06} y2=${-hh + h * 0.18}
-              stroke=${color} stroke-width="1.5" opacity="0.7" />
-        <circle cx="0" cy=${h * 0.06} r=${r} fill="none" stroke=${color} stroke-width="2" />
-        ${f.type === "dryer"
-          ? svg`<circle cx="0" cy=${h * 0.06} r=${r * 0.45}
-                        fill="none" stroke=${color} stroke-width="1.5" opacity="0.7" />`
-          : svg`<circle cx=${-hw + w * 0.16} cy=${-hh + h * 0.09} r=${Math.min(w, h) * 0.045}
-                        fill="none" stroke=${color} stroke-width="1.5" />`}`;
-      break;
-    }
-    case "dishwasher":
-      detail = svg`
-        <rect x=${-hw + w * 0.1} y=${-hh + h * 0.24} width=${w * 0.8} height=${h * 0.62} rx="3"
-              fill="none" stroke=${color} stroke-width="1.5" opacity="0.8" />
-        <line x1=${-hw + w * 0.06} y1=${hh - h * 0.12} x2=${hw - w * 0.06} y2=${hh - h * 0.12}
-              stroke=${color} stroke-width="2" />`;
-      break;
-    case "waterHeater":
-      detail = svg`
-        <circle cx="0" cy="0" r=${Math.min(hw, hh) * 0.34}
-                fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    case "airHandler":
-      detail = svg`
-        <line x1=${-hw + w * 0.08} y1=${-hh + h * 0.08} x2=${hw - w * 0.08} y2=${hh - h * 0.08}
-              stroke=${color} stroke-width="1.5" opacity="0.8" />
-        <line x1=${-hw + w * 0.08} y1=${hh - h * 0.08} x2=${hw - w * 0.08} y2=${-hh + h * 0.08}
-              stroke=${color} stroke-width="1.5" opacity="0.8" />`;
-      break;
-    case "bathtub":
-      detail = svg`
-        <rect x=${-hw + w * 0.06} y=${-hh + h * 0.12} width=${w * 0.88} height=${h * 0.76}
-              rx=${Math.min(w, h) * 0.12} fill="none" stroke=${color} stroke-width="2" />
-        <circle cx=${-hw + w * 0.14} cy="0" r=${Math.min(w, h) * 0.055}
-                fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    case "vanity":
-      detail = svg`
-        <ellipse cx="0" cy=${h * 0.06} rx=${w * 0.2} ry=${h * 0.26}
-                 fill="none" stroke=${color} stroke-width="2" />
-        <circle cx="0" cy=${-hh + h * 0.14} r=${Math.min(w, h) * 0.05}
-                fill="none" stroke=${color} stroke-width="1.5" />`;
-      break;
-    case "sectional": {
-      const pts = sectionalPoints(w, h, f.hand);
-      const seatY = pts[4][1];               // where the chaise meets the main run
-      const backY = -hh + h * 0.16;
-      const divX = pts[3][0];                // the chaise's inner edge
-      const armX = f.hand === "left" ? hw - w * 0.09 : -hw + w * 0.09;
-      detail = svg`
-        <line x1=${-hw} y1=${backY} x2=${hw} y2=${backY} stroke=${color} stroke-width="2" />
-        <line x1=${armX} y1=${backY} x2=${armX} y2=${seatY} stroke=${color} stroke-width="2" />
-        <line x1=${divX} y1=${backY} x2=${divX} y2=${hh} stroke=${color} stroke-width="2" />`;
-      break;
-    }
-    case "table":
-    case "roundTable":
-    default:
-      detail = svg``;
-      break;
-  }
   return svg`<g class=${`fp-furniture fp-furniture-${cssIdent(f.type) ?? "unknown"}`}
                 data-id=${cssIdent(f.id) ?? nothing}
                 data-entity=${cssEntityId(f.entity) ?? nothing}
-                transform="translate(${f.x} ${f.y}) rotate(${f.angle ?? 0})">${base}${detail}</g>`;
+                transform="translate(${f.x} ${f.y}) rotate(${f.angle ?? 0})${mirror}">${parts}</g>`;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -2,6 +2,7 @@ import { svg, html, nothing, type SVGTemplateResult, type TemplateResult } from 
 import {
   BUILTIN_SYMBOLS,
   FALLBACK_SYMBOL,
+  findSymbol,
   renderSymbolParts,
   type SymbolCatalog,
 } from "./symbols";
@@ -826,7 +827,7 @@ export function renderGlowMask(
           // The symbol says which shape its outline is, so a round-bodied piece
           // casts a round shadow. This used to be a hard-coded list of the three
           // round types, kept in sync by hand with the same list in the glyph.
-          const roundBase = catalog[f.type]?.footprint === "ellipse";
+          const roundBase = findSymbol(catalog, f.type)?.footprint === "ellipse";
           // A mask's luminance is its transmission, and the region is already
           // white ("all the light"). So furniture paints *black* at the share
           // it blocks, leaving the share it lets through.
@@ -2498,7 +2499,7 @@ export function renderFurniture(
   catalog: SymbolCatalog = BUILTIN_SYMBOLS,
 ): SVGTemplateResult {
   const color = override ?? f.color ?? FURNITURE_COLOR;
-  const parts = renderSymbolParts(catalog[f.type] ?? FALLBACK_SYMBOL, f.w, f.h, color);
+  const parts = renderSymbolParts(findSymbol(catalog, f.type) ?? FALLBACK_SYMBOL, f.w, f.h, color);
 
   // `hand: "left"` is the same symbol reflected, not a second drawing \u2014 which is
   // what the L-shaped sectional's two hands always were, and it now works on any

--- a/src/symbols.test.ts
+++ b/src/symbols.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUILTIN_SYMBOLS,
+  FALLBACK_SYMBOL,
+  MAX_PARTS,
+  MAX_REPEAT,
+  MAX_STROKE_WIDTH,
+  MIN_STROKE_WIDTH,
+  SYMBOL_CATEGORIES,
+  normalizeSymbol,
+  renderSymbolParts,
+  symbolCatalog,
+  symbolList,
+  symbolMatches,
+  symbolSize,
+} from "./symbols";
+import type { FurnitureType } from "./types";
+
+/**
+ * Same strict flattener `render.test.ts` documents: Lit's `nothing`, null and
+ * booleans all render as nothing at all, and attribute values come out
+ * **unquoted** because this is the interpolated form.
+ */
+const flatten = (node: unknown): string => {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "symbol") return "";
+  if (Array.isArray(node)) return node.map(flatten).join("");
+  if (typeof node === "object" && "strings" in (node as Record<string, unknown>)) {
+    const { strings, values } = node as { strings: string[]; values: unknown[] };
+    return strings.reduce(
+      (acc, s, i) => acc + s + (i < values.length ? flatten(values[i]) : ""),
+      "",
+    );
+  }
+  return String(node);
+};
+
+const draw = (parts: unknown[], w = 100, h = 100): string => {
+  const def = normalizeSymbol({ id: "t", size: { w, h }, parts });
+  expect(def, "symbol should validate").not.toBeNull();
+  return flatten(renderSymbolParts(def!, w, h, "#111"));
+};
+
+/** All numbers in an attribute, e.g. `attr("x1", markup)`. */
+const attr = (name: string, markup: string): number[] =>
+  [...markup.matchAll(new RegExp(`\\s${name}=(-?[\\d.]+)`, "g"))].map((m) => Number(m[1]));
+
+// ---------------------------------------------------------------------------
+
+describe("the shipped furniture library", () => {
+  // The same glob the card bundles with, so this asserts on exactly what ships
+  // rather than on whatever happens to be on disk.
+  const files = Object.entries(
+    import.meta.glob("../furniture/*.json", { eager: true, import: "default" }) as Record<
+      string,
+      { id: string }
+    >
+  ).map(([path, raw]) => [path.split("/").pop()!, raw] as const);
+
+  it("ships every symbol as its own file, and every file validates", () => {
+    expect(files.length).toBeGreaterThan(0);
+    for (const [file, raw] of files) {
+      expect(normalizeSymbol(raw), file).not.toBeNull();
+    }
+  });
+
+  // The catalogue is keyed by the symbol's own `id`, but a contributor naturally
+  // looks for `sofa.json`. If the two drift, the file people edit is not the
+  // symbol they see, which is a confusing way to lose an afternoon.
+  it("names each file after the id inside it", () => {
+    for (const [file, raw] of files) expect(`${raw.id}.json`, file).toBe(file);
+  });
+
+  it("loads them all into the catalogue, with no id lost to a collision", () => {
+    expect(Object.keys(BUILTIN_SYMBOLS)).toHaveLength(files.length);
+  });
+
+  it("files every symbol under a known category", () => {
+    for (const s of Object.values(BUILTIN_SYMBOLS)) {
+      expect(SYMBOL_CATEGORIES as readonly string[], s.id).toContain(s.category);
+    }
+  });
+
+  it("gives every symbol a positive default size", () => {
+    for (const s of Object.values(BUILTIN_SYMBOLS)) {
+      expect(s.size.w, s.id).toBeGreaterThan(0);
+      expect(s.size.h, s.id).toBeGreaterThan(0);
+    }
+  });
+
+  // The union in types.ts is what a hand-written config autocompletes against
+  // and what the README documents. A member with no symbol behind it would draw
+  // the blank fallback box.
+  it("answers to every name in the FurnitureType union", () => {
+    const union: FurnitureType[] = [
+      "table", "roundTable", "desk", "chair", "sofa", "bed", "wardrobe", "rug",
+      "plant", "fridge", "stove", "sink", "toilet", "stairs", "tv",
+      "washer", "dryer", "dishwasher", "waterHeater", "airHandler", "bathtub",
+      "vanity", "sectional", "fishTank", "piano", "hotTub",
+    ];
+    for (const t of union) expect(BUILTIN_SYMBOLS[t], t).toBeTruthy();
+    expect(Object.keys(BUILTIN_SYMBOLS).sort()).toEqual([...union].sort());
+  });
+
+  it("draws every symbol without throwing, at its own size and at a squashed one", () => {
+    for (const s of Object.values(BUILTIN_SYMBOLS)) {
+      expect(() => renderSymbolParts(s, s.size.w, s.size.h, "#111"), s.id).not.toThrow();
+      expect(() => renderSymbolParts(s, 300, 20, "#111"), s.id).not.toThrow();
+    }
+  });
+
+  // No symbol names a color, which is what makes entity recoloring (#82) and
+  // skins (#122) work on a contributed glyph without it doing anything.
+  it("paints every part in the color it is handed, and no other", () => {
+    for (const s of Object.values(BUILTIN_SYMBOLS)) {
+      const markup = flatten(renderSymbolParts(s, s.size.w, s.size.h, "#abcdef"));
+      const paints = [...markup.matchAll(/\s(?:fill|stroke)="?([^\s/">]+)"?/g)].map((m) => m[1]);
+      expect(paints.length, s.id).toBeGreaterThan(0);
+      for (const p of paints) expect(["#abcdef", "none"], `${s.id}: ${p}`).toContain(p);
+    }
+  });
+});
+
+describe("mapping a symbol onto a piece's box", () => {
+  it("puts the middle of the viewBox at the origin, where the glyph is centered", () => {
+    const markup = draw([{ circle: [50, 50, 10] }], 200, 80);
+    expect(attr("cx", markup)).toEqual([0]);
+    expect(attr("cy", markup)).toEqual([0]);
+  });
+
+  it("reads a coordinate as a fraction of the box, per axis", () => {
+    // vy = 22 in a 0..100 viewBox is the glyphs' old `-h/2 + h * 0.22`.
+    const markup = draw([{ line: [0, 22, 100, 22] }], 300, 50);
+    expect(attr("y1", markup)).toEqual([-50 / 2 + 50 * 0.22]);
+    expect(attr("x1", markup)).toEqual([-150]);
+    expect(attr("x2", markup)).toEqual([150]);
+  });
+
+  // A radius has no axis to belong to. Scaling it by the smaller side is what
+  // the old glyphs did by hand (`Math.min(w, h) * k`) and is the only choice
+  // that leaves a circle circular on a piece that is not square.
+  it("keeps a circle circular when the piece is not square", () => {
+    const wide = draw([{ circle: [50, 50, 20] }], 400, 100);
+    const tall = draw([{ circle: [50, 50, 20] }], 100, 400);
+    expect(attr("r", wide)).toEqual([20]);
+    expect(attr("r", tall)).toEqual([20]);
+  });
+
+  it("lets an ellipse stretch with the box, because both its axes are named", () => {
+    const markup = draw([{ ellipse: [50, 50, 50, 50] }], 400, 100);
+    expect(attr("rx", markup)).toEqual([200]);
+    expect(attr("ry", markup)).toEqual([50]);
+  });
+
+  it("scales a corner radius like a radius, not like a width", () => {
+    const markup = draw([{ rect: [0, 0, 100, 100], rx: 10 }], 400, 100);
+    expect(attr("rx", markup)).toEqual([10]);
+  });
+
+  it("omits a zero corner radius rather than writing rx=0", () => {
+    expect(attr("rx", draw([{ rect: [0, 0, 100, 100] }]))).toEqual([]);
+  });
+
+  // Stroke widths are plan units, deliberately: line art that thickened with
+  // the furniture would make a big sofa look like a different drawing.
+  it("does not scale stroke width with the piece", () => {
+    expect(attr("stroke-width", draw([{ line: [0, 0, 100, 100] }], 40, 40))).toEqual([2]);
+    expect(attr("stroke-width", draw([{ line: [0, 0, 100, 100] }], 400, 400))).toEqual([2]);
+  });
+
+  it("does not clip a part that reaches outside the viewBox", () => {
+    // The tv's stand is drawn below its box this way.
+    const markup = draw([{ line: [50, 100, 50, 200] }], 100, 100);
+    expect(attr("y2", markup)).toEqual([150]);
+  });
+
+  it("respects a viewBox that is not the default 0 0 100 100", () => {
+    const def = normalizeSymbol({
+      id: "t", viewBox: [-10, -10, 20, 20], size: { w: 100, h: 100 },
+      parts: [{ circle: [0, 0, 10] }],
+    })!;
+    const markup = flatten(renderSymbolParts(def, 100, 100, "#111"));
+    expect(attr("cx", markup)).toEqual([0]);
+    expect(attr("r", markup)).toEqual([50]);
+  });
+
+  // `space: "square"` exists for rings of parts that have to stay concentric
+  // with a circle — the hot tub's jets sit on its water, not on its shell.
+  it("lays a square-space part out in the centered square of the box", () => {
+    // vx = 100 is the viewBox's right edge. In square space that is half of
+    // min(w, h) from the centre; in box space it is half of w.
+    const square = draw([{ circle: [100, 50, 0], space: "square" }], 400, 100);
+    expect(attr("cx", square)).toEqual([50]);
+    const box = draw([{ circle: [100, 50, 0] }], 400, 100);
+    expect(attr("cx", box)).toEqual([200]);
+  });
+});
+
+describe("primitives", () => {
+  it("draws a line, rect, circle, ellipse, polygon, polyline and path", () => {
+    const markup = draw([
+      { line: [0, 0, 10, 10] },
+      { rect: [0, 0, 10, 10] },
+      { circle: [5, 5, 2] },
+      { ellipse: [5, 5, 2, 3] },
+      { polygon: [[0, 0], [10, 0], [10, 10]] },
+      { polyline: [[0, 0], [10, 10]] },
+      { path: [["M", 0, 0], ["L", 10, 10], ["Z"]] },
+    ]);
+    for (const tag of ["line", "rect", "circle", "ellipse", "polygon", "polyline", "path"]) {
+      expect(markup, tag).toContain(`<${tag} `);
+    }
+  });
+
+  it("writes a path as absolute commands, mapping x and y separately", () => {
+    const markup = draw([{ path: [["M", 0, 0], ["L", 100, 100], ["Z"]] }], 200, 40);
+    expect(markup).toContain("d=M -100 -20 L 100 20 Z");
+  });
+
+  it("rejects a path that starts anywhere but a move", () => {
+    expect(normalizeSymbol({ id: "t", parts: [{ path: [["L", 1, 1]] }] })).toBeNull();
+  });
+
+  it("rejects a path command it cannot map, rather than passing it through", () => {
+    // Arcs carry flags that are not coordinates; the format leaves them out.
+    expect(normalizeSymbol({ id: "t", parts: [{ path: [["M", 0, 0], ["A", 1, 1, 0, 0, 1, 5, 5]] }] }))
+      .toBeNull();
+  });
+
+  it("rejects a path command with the wrong number of arguments", () => {
+    expect(normalizeSymbol({ id: "t", parts: [{ path: [["M", 0], ["L", 1, 1]] }] })).toBeNull();
+  });
+});
+
+describe("repeat", () => {
+  it("stamps one part n times along its step", () => {
+    const markup = draw([{ repeat: 4, step: [0, 25], part: { line: [0, 0, 100, 0] } }]);
+    expect(attr("y1", markup)).toEqual([-50, -25, 0, 25]);
+  });
+
+  it("offsets by i × step, so a long run does not drift on accumulated float", () => {
+    const def = normalizeSymbol({
+      id: "t", parts: [{ repeat: 8, step: [100 / 7, 0], part: { line: [0, 0, 0, 100] } }],
+    })!;
+    const markup = flatten(renderSymbolParts(def, 700, 100, "#111"));
+    const xs = attr("x1", markup);
+    expect(xs[xs.length - 1]).toBe(-350 + 700);
+  });
+
+  it("shifts a path, a polygon and a rect the same way it shifts a line", () => {
+    expect(draw([{ repeat: 2, step: [50, 0], part: { rect: [0, 0, 10, 10] } }]))
+      .toContain("<rect x=0 ");
+    expect(draw([{ repeat: 2, step: [0, 10], part: { path: [["M", 0, 0], ["L", 10, 0]] } }]))
+      .toContain("d=M -50 -40 L -40 -40");
+    expect(draw([{ repeat: 2, step: [10, 0], part: { polygon: [[0, 0], [10, 0], [0, 10]] } }]))
+      .toContain("points=-40,-50 -30,-50 -40,-40");
+  });
+
+  it("caps the count, so a config cannot ask for a million copies", () => {
+    const def = normalizeSymbol({
+      id: "t", parts: [{ repeat: 1e6, step: [1, 0], part: { line: [0, 0, 0, 10] } }],
+    })!;
+    expect(def.parts.length).toBe(MAX_REPEAT);
+  });
+
+  it("rounds a fractional count and floors it at one", () => {
+    const one = normalizeSymbol({
+      id: "t", parts: [{ repeat: 0, step: [1, 0], part: { line: [0, 0, 0, 10] } }],
+    });
+    expect(one!.parts).toHaveLength(1);
+  });
+
+  it("drops the whole repeat when its inner part is not drawable", () => {
+    expect(normalizeSymbol({ id: "t", parts: [{ repeat: 3, step: [1, 0], part: { line: [1, 2] } }] }))
+      .toBeNull();
+  });
+});
+
+describe("roles and their numeric overrides", () => {
+  it("fills a body at low opacity and strokes everything else at full color", () => {
+    const body = draw([{ rect: [0, 0, 100, 100], role: "body" }]);
+    expect(body).toContain("fill=#111");
+    expect(body).toContain("fill-opacity=0.12");
+    const line = draw([{ rect: [0, 0, 100, 100], role: "line" }]);
+    expect(line).toContain("fill=none");
+  });
+
+  it("gives the four line weights the widths the old glyphs used", () => {
+    const widths = (role: string) =>
+      attr("stroke-width", draw([{ line: [0, 0, 10, 10], role }]))[0];
+    expect(widths("line")).toBe(2);
+    expect(widths("thin")).toBe(1.5);
+    expect(widths("detail")).toBe(1.5);
+    expect(widths("hint")).toBe(1);
+  });
+
+  it("takes a numeric width and opacity over the role's defaults", () => {
+    const markup = draw([{ line: [0, 0, 10, 10], role: "hint", width: 3, opacity: 0.25 }]);
+    expect(attr("stroke-width", markup)).toEqual([3]);
+    expect(attr("opacity", markup)).toEqual([0.25]);
+  });
+
+  it("omits opacity when it is 1, rather than writing it on every part", () => {
+    expect(draw([{ line: [0, 0, 10, 10] }])).not.toMatch(/\sopacity=[\d.]/);
+  });
+
+  it("clamps a stroke width, so a symbol cannot paint over the whole plan", () => {
+    expect(attr("stroke-width", draw([{ line: [0, 0, 1, 1], width: 9999 }])))
+      .toEqual([MAX_STROKE_WIDTH]);
+    expect(attr("stroke-width", draw([{ line: [0, 0, 1, 1], width: -5 }])))
+      .toEqual([MIN_STROKE_WIDTH]);
+  });
+
+  it("clamps opacities into 0..1", () => {
+    expect(attr("opacity", draw([{ line: [0, 0, 1, 1], opacity: 40 }]))).toEqual([]);
+    expect(attr("opacity", draw([{ line: [0, 0, 1, 1], opacity: -3 }]))).toEqual([0]);
+  });
+
+  it("falls back to the role's own default when a number is not a number", () => {
+    const markup = draw([{ line: [0, 0, 10, 10], role: "detail", width: "3" }]);
+    expect(attr("stroke-width", markup)).toEqual([1.5]);
+  });
+
+  it("treats an unknown role as the primitive's default rather than dropping the part", () => {
+    expect(attr("stroke-width", draw([{ line: [0, 0, 10, 10], role: "neon" }]))).toEqual([2]);
+  });
+
+  it("carries a dash pattern through in plan units", () => {
+    expect(draw([{ rect: [0, 0, 100, 100], dash: [8, 5] }])).toContain("stroke-dasharray=8 5");
+  });
+});
+
+describe("validating an untrusted symbol", () => {
+  it("returns null instead of throwing, so a bad symbol costs one glyph", () => {
+    for (const bad of [null, undefined, 42, "sofa", [], {}, { id: "t" }, { id: "t", parts: [] }]) {
+      expect(normalizeSymbol(bad), JSON.stringify(bad) ?? "undefined").toBeNull();
+    }
+  });
+
+  it("rejects a coordinate that is not a finite number", () => {
+    for (const bad of [NaN, Infinity, -Infinity, "10", null, undefined, {}]) {
+      expect(normalizeSymbol({ id: "t", parts: [{ line: [0, 0, 10, bad] }] }), String(bad))
+        .toBeNull();
+    }
+  });
+
+  it("rejects a coordinate tuple of the wrong length", () => {
+    expect(normalizeSymbol({ id: "t", parts: [{ line: [0, 0, 10] }] })).toBeNull();
+    expect(normalizeSymbol({ id: "t", parts: [{ circle: [0, 0, 1, 1] }] })).toBeNull();
+  });
+
+  it("rejects a negative radius", () => {
+    expect(normalizeSymbol({ id: "t", parts: [{ circle: [0, 0, -5] }] })).toBeNull();
+  });
+
+  it("drops a part whose primitive it does not know, keeping the rest", () => {
+    const def = normalizeSymbol({
+      id: "t", parts: [{ line: [0, 0, 1, 1] }, { spiral: [0, 0, 5] }, { rect: [0, 0, 1, 1] }],
+    })!;
+    expect(def.parts).toHaveLength(2);
+  });
+
+  it("caps the total part count after repeats are expanded", () => {
+    const def = normalizeSymbol({
+      id: "t",
+      parts: Array.from({ length: 20 }, () => ({
+        repeat: MAX_REPEAT, step: [1, 0], part: { line: [0, 0, 0, 1] },
+      })),
+    })!;
+    expect(def.parts).toHaveLength(MAX_PARTS);
+  });
+
+  // The id becomes a CSS class on the drawn group, so it goes through the same
+  // identifier guard every other user-supplied hook does.
+  it("refuses an id that would not be safe as a class name, rather than renaming it", () => {
+    for (const bad of ['a"b', "a{b", "a b", "", "a;b", "café"]) {
+      expect(normalizeSymbol({ id: bad, parts: [{ line: [0, 0, 1, 1] }] }), bad).toBeNull();
+    }
+    expect(normalizeSymbol({ id: "my_desk-2", parts: [{ line: [0, 0, 1, 1] }] })?.id).toBe("my_desk-2");
+  });
+
+  it("falls back to the source name when the id is missing or unusable", () => {
+    const def = normalizeSymbol({ parts: [{ line: [0, 0, 1, 1] }] }, "my-desk");
+    expect(def?.id).toBe("my-desk");
+  });
+
+  it("defaults everything optional, so the smallest usable symbol is id plus one part", () => {
+    const def = normalizeSymbol({ id: "t", parts: [{ line: [0, 0, 1, 1] }] })!;
+    expect(def.name).toBe("t");
+    expect(def.category).toBe("other");
+    expect(def.keywords).toEqual([]);
+    expect(def.viewBox).toEqual([0, 0, 100, 100]);
+    expect(def.footprint).toBe("rect");
+    expect(def.size.w).toBeGreaterThan(0);
+  });
+
+  it("ignores a zero or negative viewBox rather than dividing by it", () => {
+    const def = normalizeSymbol({ id: "t", viewBox: [0, 0, 0, 100], parts: [{ line: [0, 0, 1, 1] }] })!;
+    expect(def.viewBox).toEqual([0, 0, 100, 100]);
+  });
+
+  it("ignores a zero or negative default size", () => {
+    const def = normalizeSymbol({ id: "t", size: { w: 0, h: -4 }, parts: [{ line: [0, 0, 1, 1] }] })!;
+    expect(def.size.w).toBeGreaterThan(0);
+    expect(def.size.h).toBeGreaterThan(0);
+  });
+
+  it("files an unrecognised category under other", () => {
+    const def = normalizeSymbol({ id: "t", category: "garage", parts: [{ line: [0, 0, 1, 1] }] })!;
+    expect(def.category).toBe("other");
+  });
+});
+
+describe("the catalogue", () => {
+  const custom = {
+    "my-desk": { id: "my-desk", name: "my desk", size: { w: 90, h: 50 }, parts: [{ rect: [0, 0, 100, 100] }] },
+  };
+
+  it("is the built-in library when a config defines no symbols", () => {
+    expect(symbolCatalog(undefined)).toBe(BUILTIN_SYMBOLS);
+  });
+
+  it("adds a config's own symbols to the shipped ones", () => {
+    const cat = symbolCatalog(custom);
+    expect(cat["my-desk"]?.name).toBe("my desk");
+    expect(cat.sofa).toBeTruthy();
+  });
+
+  it("lets a config override a shipped symbol under the same id", () => {
+    const cat = symbolCatalog({ sofa: { id: "sofa", name: "my sofa", parts: [{ rect: [0, 0, 1, 1] }] } });
+    expect(cat.sofa?.name).toBe("my sofa");
+    expect(BUILTIN_SYMBOLS.sofa?.name).toBe("sofa");
+  });
+
+  it("skips a symbol that fails validation instead of losing the whole block", () => {
+    const cat = symbolCatalog({ broken: { parts: "nope" }, ...custom });
+    expect(cat.broken).toBeUndefined();
+    expect(cat["my-desk"]).toBeTruthy();
+  });
+
+  it("keys a symbol by the block's own key when it carries no id", () => {
+    const cat = symbolCatalog({ shelf: { parts: [{ line: [0, 0, 1, 1] }] } });
+    expect(cat.shelf).toBeTruthy();
+  });
+
+  // Read on every render, so re-validating a paste box of JSON per frame would
+  // show up as jank on a plan with a lot of furniture.
+  it("memoizes on the config object's identity", () => {
+    expect(symbolCatalog(custom)).toBe(symbolCatalog(custom));
+    expect(symbolCatalog({ ...custom })).not.toBe(symbolCatalog(custom));
+  });
+
+  it("does not let a config symbol mutate the shipped library", () => {
+    symbolCatalog({ sofa: { id: "sofa", name: "mine", parts: [{ rect: [0, 0, 1, 1] }] } });
+    expect(BUILTIN_SYMBOLS.sofa?.name).toBe("sofa");
+  });
+});
+
+describe("the picker's view of the catalogue", () => {
+  it("orders by category, then by name inside it", () => {
+    const order = symbolList(BUILTIN_SYMBOLS).map((s) => s.category);
+    const ranks = order.map((c) => (SYMBOL_CATEGORIES as readonly string[]).indexOf(c));
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+    const living = symbolList(BUILTIN_SYMBOLS).filter((s) => s.category === "living").map((s) => s.name);
+    expect(living).toEqual([...living].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("puts an uncategorised community symbol at the end, not in the middle", () => {
+    const list = symbolList(symbolCatalog({ widget: { parts: [{ line: [0, 0, 1, 1] }] } }));
+    expect(list[list.length - 1]?.id).toBe("widget");
+  });
+
+  it("matches on id, name, category and the symbol's own keywords", () => {
+    const sofa = BUILTIN_SYMBOLS.sofa!;
+    for (const q of ["sofa", "SOFA", " sofa ", "couch", "living"]) {
+      expect(symbolMatches(sofa, q), q).toBe(true);
+    }
+    expect(symbolMatches(sofa, "toaster")).toBe(false);
+  });
+
+  it("matches everything on an empty query", () => {
+    expect(symbolMatches(BUILTIN_SYMBOLS.sofa!, "   ")).toBe(true);
+  });
+
+  it("gives a symbol's own default size, and a sane box for one it has never heard of", () => {
+    expect(symbolSize("sofa")).toEqual(BUILTIN_SYMBOLS.sofa!.size);
+    const unknown = symbolSize("no-such-symbol");
+    expect(unknown.w).toBeGreaterThan(0);
+    expect(unknown.h).toBeGreaterThan(0);
+  });
+});
+
+describe("the fallback symbol", () => {
+  it("is a plain box, so a missing symbol is visible rather than a hole", () => {
+    const markup = flatten(renderSymbolParts(FALLBACK_SYMBOL, 100, 60, "#111"));
+    expect(markup).toContain("<rect");
+    expect(markup).toContain("fill=#111");
+    expect(markup).not.toContain("<line");
+  });
+});

--- a/src/symbols.test.ts
+++ b/src/symbols.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_STROKE_WIDTH,
   MIN_STROKE_WIDTH,
   SYMBOL_CATEGORIES,
+  findSymbol,
   normalizeSymbol,
   renderSymbolParts,
   symbolCatalog,
@@ -349,8 +350,16 @@ describe("validating an untrusted symbol", () => {
     expect(normalizeSymbol({ id: "t", parts: [{ circle: [0, 0, 1, 1] }] })).toBeNull();
   });
 
-  it("rejects a negative radius", () => {
+  // SVG rejects a negative width/height outright, so the part drew nothing at
+  // all and said nothing about why — the silent failure this validator is for.
+  it("rejects a negative radius or a negative rect size", () => {
     expect(normalizeSymbol({ id: "t", parts: [{ circle: [0, 0, -5] }] })).toBeNull();
+    expect(normalizeSymbol({ id: "t", parts: [{ ellipse: [0, 0, 5, -5] }] })).toBeNull();
+    expect(normalizeSymbol({ id: "t", parts: [{ rect: [0, 0, -50, 20] }] })).toBeNull();
+    expect(normalizeSymbol({ id: "t", parts: [{ rect: [0, 0, 50, -20] }] })).toBeNull();
+    // Zero is degenerate but legal, and a repeat of collapsed parts is a valid
+    // way to build up a shape, so it is not the validator's business.
+    expect(normalizeSymbol({ id: "t", parts: [{ rect: [0, 0, 0, 0] }] })).not.toBeNull();
   });
 
   it("drops a part whose primitive it does not know, keeping the rest", () => {
@@ -408,6 +417,59 @@ describe("validating an untrusted symbol", () => {
   it("files an unrecognised category under other", () => {
     const def = normalizeSymbol({ id: "t", category: "garage", parts: [{ line: [0, 0, 1, 1] }] })!;
     expect(def.category).toBe("other");
+  });
+});
+
+/**
+ * `cssIdent` keeps letters, digits, `-` and `_` — so `__proto__`, `toString`
+ * and `constructor` are all perfectly legal symbol ids, and every table in
+ * `symbols.ts` is keyed by a string a config supplies. On plain objects that
+ * combination is a crash, not a curiosity.
+ */
+describe("ids that collide with Object.prototype", () => {
+  it("does not let a __proto__ symbol hijack the catalogue", () => {
+    // JSON.parse creates a real own `__proto__` property, unlike an object
+    // literal — so this is exactly what the paste box hands us.
+    const symbols = JSON.parse('{"__proto__":{"id":"__proto__","parts":[{"line":[0,0,1,1]}]}}');
+    const cat = symbolCatalog(symbols);
+    expect(Object.getPrototypeOf(cat)).toBeNull();
+    expect(cat.sofa?.name).toBe("sofa");
+    // Nothing leaks through a prototype into unrelated lookups.
+    expect(findSymbol(cat, "parts")).toBeUndefined();
+    expect(findSymbol(cat, "id")).toBeUndefined();
+  });
+
+  it("answers a type named after a prototype member with nothing, not a function", () => {
+    for (const t of ["toString", "valueOf", "constructor", "hasOwnProperty", "__proto__"]) {
+      expect(findSymbol(BUILTIN_SYMBOLS, t), t).toBeUndefined();
+    }
+  });
+
+  // This threw, and it took the whole card with it: `catalog["toString"]` is a
+  // truthy function, so `?? FALLBACK_SYMBOL` never fired and the renderer
+  // destructured it. Reachable from a config that defines no symbols at all.
+  it("draws the fallback box for such a type instead of throwing", () => {
+    for (const t of ["toString", "valueOf", "constructor", "__proto__"]) {
+      const markup = flatten(renderSymbolParts(
+        findSymbol(BUILTIN_SYMBOLS, t) ?? FALLBACK_SYMBOL, 60, 60, "#111"
+      ));
+      expect(markup, t).toContain("<rect");
+    }
+  });
+
+  it("does not read a role off the prototype chain", () => {
+    // `"toString" in ROLE_STYLE` was true, and the style read off it had an
+    // undefined width — a part stroked `stroke-width="undefined"`.
+    for (const role of ["toString", "constructor", "__proto__"]) {
+      expect(attr("stroke-width", draw([{ line: [0, 0, 10, 10], role }])), role).toEqual([2]);
+    }
+  });
+
+  it("does not read a path command off the prototype chain", () => {
+    for (const op of ["constructor", "toString"]) {
+      expect(normalizeSymbol({ id: "t", parts: [{ path: [["M", 0, 0], [op, 1, 1]] }] }), op)
+        .toBeNull();
+    }
   });
 });
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,553 @@
+/**
+ * Furniture symbols — the geometry format behind every glyph on the plan
+ * (issue #90).
+ *
+ * A symbol is a JSON list of primitives with **numeric attributes only**. The
+ * card builds the SVG elements itself, so nothing a user supplies is ever
+ * parsed as markup: no `<script>`, no `on*` handlers, no `javascript:` href,
+ * nothing to sanitise. The injection surface is gone by construction rather
+ * than by filtering, which is the whole reason the format is geometry and not
+ * SVG. See `furniture/README.md` for the authoring guide.
+ *
+ * Colors never appear in a symbol either. A part picks a {@link SymbolRole},
+ * and the renderer pours the piece's resolved color into it — so a community
+ * symbol inherits entity recoloring (#82) and skins (#122) for free, and
+ * cannot smuggle a `url()` into a paint attribute.
+ */
+import { nothing, svg, type SVGTemplateResult } from "lit";
+import { cssIdent } from "./css-safe";
+
+/** How a part is painted. Never a color — the renderer supplies that. */
+export type SymbolRole = "body" | "line" | "thin" | "detail" | "hint" | "solid";
+
+/**
+ * Which box a part's coordinates live in.
+ *
+ * `box` (the default) maps the viewBox onto the piece's full `w × h`, so a
+ * glyph stretches with the furniture. `square` maps it onto the centered
+ * square of side `min(w, h)`, which keeps a ring of parts concentric with a
+ * circle when the piece is not square — the hot tub's jets sit on its water
+ * circle in either mode only because of this.
+ */
+export type SymbolSpace = "box" | "square";
+
+/** Paint settings resolved from a part's role plus its numeric overrides. */
+export interface PartStyle {
+  role: SymbolRole;
+  width: number;
+  opacity: number;
+  fillOpacity: number;
+  dash?: number[];
+}
+
+export type PathCmd =
+  | ["M", number, number]
+  | ["L", number, number]
+  | ["Q", number, number, number, number]
+  | ["C", number, number, number, number, number, number]
+  | ["Z"];
+
+/** A part after validation: one primitive, all numbers finite, style resolved. */
+export type SymbolPart = { style: PartStyle; space: SymbolSpace } & (
+  | { kind: "line"; a: [number, number]; b: [number, number] }
+  | { kind: "rect"; x: number; y: number; w: number; h: number; rx: number }
+  | { kind: "circle"; cx: number; cy: number; r: number }
+  | { kind: "ellipse"; cx: number; cy: number; rx: number; ry: number }
+  | { kind: "poly"; closed: boolean; pts: Array<[number, number]> }
+  | { kind: "path"; cmds: PathCmd[] }
+);
+
+export interface SymbolDef {
+  id: string;
+  name: string;
+  category: string;
+  keywords: string[];
+  /** Default size in canvas units when the piece is first placed. */
+  size: { w: number; h: number };
+  /** Authoring box: `[x, y, w, h]`, origin top-left. */
+  viewBox: [number, number, number, number];
+  /** Shape the glow mask cuts for this piece (#106). */
+  footprint: "rect" | "ellipse";
+  parts: SymbolPart[];
+}
+
+export type SymbolCatalog = Readonly<Record<string, SymbolDef>>;
+
+/** Picker grouping. Anything else sorts into "other", after these. */
+export const SYMBOL_CATEGORIES = [
+  "living",
+  "bedroom",
+  "kitchen",
+  "bath",
+  "utility",
+  "other",
+] as const;
+
+/**
+ * Role defaults — the de-facto design system the built-in glyphs already used,
+ * read off the 26 of them: a filled carcass, then three weights of line art,
+ * then the one solid fill (the fish tank's tails).
+ */
+const ROLE_STYLE: Record<SymbolRole, Omit<PartStyle, "role">> = {
+  body: { width: 2, opacity: 1, fillOpacity: 0.12 },
+  line: { width: 2, opacity: 1, fillOpacity: 0 },
+  thin: { width: 1.5, opacity: 1, fillOpacity: 0 },
+  detail: { width: 1.5, opacity: 0.7, fillOpacity: 0 },
+  hint: { width: 1, opacity: 0.6, fillOpacity: 0 },
+  solid: { width: 0, opacity: 0.7, fillOpacity: 1 },
+};
+
+const DEFAULT_VIEW_BOX: [number, number, number, number] = [0, 0, 100, 100];
+
+/**
+ * Caps. A symbol arrives from a config file or a paste box, so every count is
+ * bounded: a `repeat` of a million would hang the render, and the failure mode
+ * we want is "your symbol was rejected", not "the dashboard froze".
+ */
+export const MAX_REPEAT = 64;
+export const MAX_PARTS = 256;
+export const MAX_PATH_CMDS = 256;
+export const MIN_STROKE_WIDTH = 0.25;
+export const MAX_STROKE_WIDTH = 8;
+
+const num = (v: unknown): number | null =>
+  typeof v === "number" && Number.isFinite(v) ? v : null;
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+/** A tuple of exactly `n` finite numbers, or null. */
+function nums(v: unknown, n: number): number[] | null {
+  if (!Array.isArray(v) || v.length !== n) return null;
+  const out: number[] = [];
+  for (const x of v) {
+    const f = num(x);
+    if (f === null) return null;
+    out.push(f);
+  }
+  return out;
+}
+
+function points(v: unknown): Array<[number, number]> | null {
+  if (!Array.isArray(v) || v.length < 2 || v.length > MAX_PARTS) return null;
+  const out: Array<[number, number]> = [];
+  for (const p of v) {
+    const xy = nums(p, 2);
+    if (!xy) return null;
+    out.push([xy[0]!, xy[1]!]);
+  }
+  return out;
+}
+
+const PATH_ARITY: Record<string, number> = { M: 2, L: 2, Q: 4, C: 6, Z: 0 };
+
+function pathCmds(v: unknown): PathCmd[] | null {
+  if (!Array.isArray(v) || !v.length || v.length > MAX_PATH_CMDS) return null;
+  const out: PathCmd[] = [];
+  for (const c of v) {
+    if (!Array.isArray(c) || typeof c[0] !== "string") return null;
+    const op = c[0].toUpperCase();
+    const arity = PATH_ARITY[op];
+    if (arity === undefined) return null;
+    const args = nums(c.slice(1), arity);
+    if (!args) return null;
+    out.push([op, ...args] as PathCmd);
+  }
+  // A path that never moves anywhere draws nothing; reject it so the author
+  // sees the mistake instead of an invisible part.
+  if (out[0]?.[0] !== "M") return null;
+  return out;
+}
+
+function styleOf(raw: Record<string, unknown>, fallback: SymbolRole): PartStyle {
+  const role: SymbolRole =
+    typeof raw.role === "string" && raw.role in ROLE_STYLE
+      ? (raw.role as SymbolRole)
+      : fallback;
+  const base = ROLE_STYLE[role];
+  const width = num(raw.width);
+  const opacity = num(raw.opacity);
+  const fillOpacity = num(raw.fillOpacity);
+  const dashRaw = Array.isArray(raw.dash) ? raw.dash.map(num) : null;
+  const dash =
+    dashRaw && dashRaw.length && dashRaw.length <= 8 && dashRaw.every((d) => d !== null)
+      ? (dashRaw as number[]).map((d) => clamp(d, 0, 100))
+      : undefined;
+  return {
+    role,
+    width:
+      width === null
+        ? base.width
+        : role === "solid"
+          ? clamp(width, 0, MAX_STROKE_WIDTH)
+          : clamp(width, MIN_STROKE_WIDTH, MAX_STROKE_WIDTH),
+    opacity: opacity === null ? base.opacity : clamp(opacity, 0, 1),
+    fillOpacity: fillOpacity === null ? base.fillOpacity : clamp(fillOpacity, 0, 1),
+    dash,
+  };
+}
+
+/** One raw part → one primitive, or null if it is not a shape we can draw. */
+function normalizePart(raw: unknown): SymbolPart | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  const space: SymbolSpace = r.space === "square" ? "square" : "box";
+
+  if ("line" in r) {
+    const v = nums(r.line, 4);
+    if (!v) return null;
+    return { kind: "line", a: [v[0]!, v[1]!], b: [v[2]!, v[3]!], space, style: styleOf(r, "line") };
+  }
+  if ("rect" in r) {
+    const v = nums(r.rect, 4);
+    if (!v) return null;
+    return {
+      kind: "rect", x: v[0]!, y: v[1]!, w: v[2]!, h: v[3]!,
+      rx: Math.max(0, num(r.rx) ?? 0), space, style: styleOf(r, "body"),
+    };
+  }
+  if ("circle" in r) {
+    const v = nums(r.circle, 3);
+    if (!v || v[2]! < 0) return null;
+    return { kind: "circle", cx: v[0]!, cy: v[1]!, r: v[2]!, space, style: styleOf(r, "line") };
+  }
+  if ("ellipse" in r) {
+    const v = nums(r.ellipse, 4);
+    if (!v || v[2]! < 0 || v[3]! < 0) return null;
+    return {
+      kind: "ellipse", cx: v[0]!, cy: v[1]!, rx: v[2]!, ry: v[3]!,
+      space, style: styleOf(r, "line"),
+    };
+  }
+  if ("polygon" in r || "polyline" in r) {
+    const closed = "polygon" in r;
+    const pts = points(closed ? r.polygon : r.polyline);
+    if (!pts) return null;
+    return { kind: "poly", closed, pts, space, style: styleOf(r, closed ? "body" : "line") };
+  }
+  if ("path" in r) {
+    const cmds = pathCmds(r.path);
+    if (!cmds) return null;
+    return { kind: "path", cmds, space, style: styleOf(r, "line") };
+  }
+  return null;
+}
+
+/** Shift a part by `(dx, dy)` in authoring units — how `repeat` is expanded. */
+function offsetPart(p: SymbolPart, dx: number, dy: number): SymbolPart {
+  switch (p.kind) {
+    case "line":
+      return { ...p, a: [p.a[0] + dx, p.a[1] + dy], b: [p.b[0] + dx, p.b[1] + dy] };
+    case "rect":
+      return { ...p, x: p.x + dx, y: p.y + dy };
+    case "circle":
+      return { ...p, cx: p.cx + dx, cy: p.cy + dy };
+    case "ellipse":
+      return { ...p, cx: p.cx + dx, cy: p.cy + dy };
+    case "poly":
+      return { ...p, pts: p.pts.map(([x, y]) => [x + dx, y + dy] as [number, number]) };
+    case "path":
+      return {
+        ...p,
+        cmds: p.cmds.map((c) => {
+          if (c[0] === "Z") return c;
+          const shifted = c.slice(1).map((n, i) => (n as number) + (i % 2 === 0 ? dx : dy));
+          return [c[0], ...shifted] as PathCmd;
+        }),
+      };
+  }
+}
+
+/**
+ * Expand `{ repeat, step, part }` into `repeat` copies of `part`, each shifted
+ * by `i × step`. This is what lets a fitted wardrobe run, a flight of stairs
+ * and a keyboard be a few lines of JSON instead of a `for` loop in the card —
+ * the thing issue #90 was actually about. It nests one part, never a group, so
+ * there is no recursion to bound.
+ *
+ * The offset is `i × step`, not an accumulating sum, so the last copy of a long
+ * run lands where the arithmetic says rather than a float epsilon away.
+ */
+function expandPart(raw: unknown): SymbolPart[] {
+  if (raw && typeof raw === "object" && "repeat" in (raw as Record<string, unknown>)) {
+    const r = raw as Record<string, unknown>;
+    const count = num(r.repeat);
+    const step = nums(r.step, 2);
+    const inner = normalizePart(r.part);
+    if (count === null || !step || !inner) return [];
+    const n = clamp(Math.round(count), 1, MAX_REPEAT);
+    return Array.from({ length: n }, (_, i) => offsetPart(inner, step[0]! * i, step[1]! * i));
+  }
+  const one = normalizePart(raw);
+  return one ? [one] : [];
+}
+
+/**
+ * Validate an untrusted symbol. Returns null rather than throwing — a bad
+ * symbol in a config should cost you that one glyph, not the whole dashboard.
+ *
+ * `fallbackId` names the source (the filename, for a bundled symbol, or the
+ * config key) so a symbol whose `id` is missing or unusable still resolves.
+ */
+export function normalizeSymbol(
+  raw: unknown,
+  fallbackId?: string,
+  problems?: string[]
+): SymbolDef | null {
+  const reject = (why: string) => {
+    problems?.push(why);
+    return null;
+  };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return reject("A symbol has to be a JSON object.");
+  }
+  const r = raw as Record<string, unknown>;
+
+  // The id becomes a CSS class (`fp-furniture-<id>`) and is what a config's
+  // `type` is looked up by. It has to survive the identifier guard **unchanged**
+  // — a sanitised id would file the symbol under a name no config could name,
+  // so it would validate and then never resolve. Rejecting says so out loud.
+  const named = typeof r.id === "string" && r.id.trim() ? r.id.trim() : fallbackId;
+  const id = cssIdent(named);
+  if (!id || id !== named) {
+    return reject('`id` is missing, or uses characters a CSS class cannot: letters, digits, "-" and "_" only.');
+  }
+
+  if (!Array.isArray(r.parts)) return reject("`parts` has to be an array of shapes.");
+  const parts: SymbolPart[] = [];
+  for (const p of r.parts) {
+    for (const part of expandPart(p)) {
+      if (parts.length >= MAX_PARTS) break;
+      parts.push(part);
+    }
+  }
+  if (!parts.length) {
+    return reject(
+      "No drawable parts. Each one needs a known shape (line, rect, circle, ellipse, polygon, polyline, path) with the right number of finite numbers."
+    );
+  }
+
+  const size = r.size && typeof r.size === "object" ? (r.size as Record<string, unknown>) : {};
+  const w = num(size.w);
+  const h = num(size.h);
+  const vb = nums(r.viewBox, 4);
+
+  return {
+    id,
+    name: typeof r.name === "string" && r.name.trim() ? r.name.trim().slice(0, 60) : id,
+    category:
+      typeof r.category === "string" && (SYMBOL_CATEGORIES as readonly string[]).includes(r.category)
+        ? r.category
+        : "other",
+    keywords:
+      Array.isArray(r.keywords)
+        ? r.keywords.filter((k): k is string => typeof k === "string").slice(0, 12)
+        : [],
+    size: { w: w && w > 0 ? w : 60, h: h && h > 0 ? h : 60 },
+    viewBox: vb && vb[2]! > 0 && vb[3]! > 0 ? (vb as [number, number, number, number]) : DEFAULT_VIEW_BOX,
+    footprint: r.footprint === "ellipse" ? "ellipse" : "rect",
+    parts,
+  };
+}
+
+/**
+ * What an unresolved `type` draws: the plain carcass, no detail. Same shape the
+ * old hand-written `switch` fell through to, so a config naming a symbol this
+ * install doesn't have leaves a visible, movable placeholder instead of a hole.
+ */
+export const FALLBACK_SYMBOL: SymbolDef = normalizeSymbol({
+  id: "unknown",
+  name: "unknown",
+  size: { w: 60, h: 60 },
+  parts: [{ rect: [0, 0, 100, 100], rx: 6.666667 }],
+})!;
+
+/**
+ * The symbols shipped with the card, one JSON file each in `furniture/`.
+ *
+ * Bundled with a glob rather than a generated index so contributing a symbol
+ * is exactly "add one file" — an index would be a second edit people forget,
+ * and the reviewer would have to notice. Every file goes through
+ * {@link normalizeSymbol}, the same validator a pasted symbol hits, so the
+ * shipped library is 26 live test cases for it.
+ */
+export const BUILTIN_SYMBOLS: SymbolCatalog = (() => {
+  const files = import.meta.glob("../furniture/*.json", { eager: true, import: "default" }) as Record<
+    string,
+    unknown
+  >;
+  const out: Record<string, SymbolDef> = {};
+  for (const [path, raw] of Object.entries(files)) {
+    const def = normalizeSymbol(raw, path.split("/").pop()?.replace(/\.json$/, ""));
+    if (def) out[def.id] = def;
+  }
+  return out;
+})();
+
+let cacheKey: unknown;
+let cacheValue: SymbolCatalog = BUILTIN_SYMBOLS;
+
+/**
+ * The built-in library with a config's own `symbols:` merged over it. Memoized
+ * on the config object's identity, because it is read on every render and
+ * re-validating a paste box's worth of JSON per frame would show.
+ */
+export function symbolCatalog(symbols?: Record<string, unknown>): SymbolCatalog {
+  if (!symbols || typeof symbols !== "object") return BUILTIN_SYMBOLS;
+  if (symbols === cacheKey) return cacheValue;
+  const out: Record<string, SymbolDef> = { ...BUILTIN_SYMBOLS };
+  for (const [key, raw] of Object.entries(symbols)) {
+    const def = normalizeSymbol(raw, key);
+    if (def) out[def.id] = def;
+  }
+  cacheKey = symbols;
+  cacheValue = out;
+  return out;
+}
+
+/** Every symbol, ordered for the picker: by category, then by name. */
+export function symbolList(catalog: SymbolCatalog): SymbolDef[] {
+  const rank = (c: string) => {
+    const i = (SYMBOL_CATEGORIES as readonly string[]).indexOf(c);
+    return i < 0 ? SYMBOL_CATEGORIES.length : i;
+  };
+  return Object.values(catalog).sort(
+    (a, b) => rank(a.category) - rank(b.category) || a.name.localeCompare(b.name)
+  );
+}
+
+/** Does this symbol match a picker search query? */
+export function symbolMatches(def: SymbolDef, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    def.id.toLowerCase().includes(q) ||
+    def.name.toLowerCase().includes(q) ||
+    def.category.includes(q) ||
+    def.keywords.some((k) => k.toLowerCase().includes(q))
+  );
+}
+
+/** Default placement size for a type, falling back to a plain 60×60 box. */
+export function symbolSize(type: string, catalog: SymbolCatalog = BUILTIN_SYMBOLS): {
+  w: number;
+  h: number;
+} {
+  return catalog[type]?.size ?? { w: 60, h: 60 };
+}
+
+/**
+ * Map authoring coordinates onto the piece's box.
+ *
+ * The glyph is drawn centered on the origin, which is the convention the card
+ * has always used — the caller translates and rotates it into place.
+ */
+interface Mapper {
+  x(v: number): number;
+  y(v: number): number;
+  /** A length that must not distort: scaled by the smaller axis. */
+  len(v: number): number;
+  sx(v: number): number;
+  sy(v: number): number;
+}
+
+function mapper(def: SymbolDef, w: number, h: number, space: SymbolSpace): Mapper {
+  const [vx, vy, vw, vh] = def.viewBox;
+  // `square` lays the part out in the centered square of side min(w, h), so a
+  // ring of jets stays concentric with a circle on a piece that is not square.
+  const bw = space === "square" ? Math.min(w, h) : w;
+  const bh = space === "square" ? Math.min(w, h) : h;
+  const kx = bw / vw;
+  const ky = bh / vh;
+  return {
+    x: (v) => (v - vx) * kx - bw / 2,
+    y: (v) => (v - vy) * ky - bh / 2,
+    len: (v) => v * Math.min(kx, ky),
+    sx: (v) => v * kx,
+    sy: (v) => v * ky,
+  };
+}
+
+const fmt = (n: number) => (Number.isFinite(n) ? n : 0);
+
+/** Paint attributes for a part, with the piece's color poured in. */
+function paint(style: PartStyle, color: string) {
+  const fill = style.fillOpacity > 0 ? color : "none";
+  const stroke = style.role === "solid" ? "none" : color;
+  return { fill, stroke, style };
+}
+
+function partTemplate(p: SymbolPart, m: Mapper, color: string): SVGTemplateResult {
+  const { fill, stroke, style } = paint(p.style, color);
+  // Omitted rather than defaulted: `opacity="1"` and `stroke-dasharray="none"`
+  // on every part would triple the markup a large plan carries for no effect.
+  const op = style.opacity < 1 ? style.opacity : nothing;
+  const dash = style.dash?.length ? style.dash.join(" ") : nothing;
+  const fillOp = style.fillOpacity > 0 && style.fillOpacity < 1 ? style.fillOpacity : nothing;
+  const sw = style.role === "solid" ? nothing : style.width;
+
+  switch (p.kind) {
+    case "line":
+      return svg`<line x1=${fmt(m.x(p.a[0]))} y1=${fmt(m.y(p.a[1]))}
+                       x2=${fmt(m.x(p.b[0]))} y2=${fmt(m.y(p.b[1]))}
+                       fill="none" stroke=${stroke} stroke-width=${sw}
+                       stroke-dasharray=${dash} opacity=${op} />`;
+    case "rect":
+      return svg`<rect x=${fmt(m.x(p.x))} y=${fmt(m.y(p.y))}
+                       width=${fmt(m.sx(p.w))} height=${fmt(m.sy(p.h))}
+                       rx=${p.rx > 0 ? fmt(m.len(p.rx)) : nothing}
+                       fill=${fill} fill-opacity=${fillOp}
+                       stroke=${stroke} stroke-width=${sw}
+                       stroke-dasharray=${dash} opacity=${op} />`;
+    case "circle":
+      return svg`<circle cx=${fmt(m.x(p.cx))} cy=${fmt(m.y(p.cy))} r=${fmt(m.len(p.r))}
+                         fill=${fill} fill-opacity=${fillOp}
+                         stroke=${stroke} stroke-width=${sw} opacity=${op} />`;
+    case "ellipse":
+      return svg`<ellipse cx=${fmt(m.x(p.cx))} cy=${fmt(m.y(p.cy))}
+                          rx=${fmt(m.sx(p.rx))} ry=${fmt(m.sy(p.ry))}
+                          fill=${fill} fill-opacity=${fillOp}
+                          stroke=${stroke} stroke-width=${sw} opacity=${op} />`;
+    case "poly": {
+      const pts = p.pts.map(([x, y]) => `${fmt(m.x(x))},${fmt(m.y(y))}`).join(" ");
+      return p.closed
+        ? svg`<polygon points=${pts}
+                       fill=${fill} fill-opacity=${fillOp}
+                       stroke=${stroke} stroke-width=${sw}
+                       stroke-linejoin="round" opacity=${op} />`
+        : svg`<polyline points=${pts} fill="none"
+                        stroke=${stroke} stroke-width=${sw}
+                        stroke-linejoin="round" opacity=${op} />`;
+    }
+    case "path": {
+      const d = p.cmds
+        .map((c) =>
+          c[0] === "Z"
+            ? "Z"
+            : `${c[0]} ${c
+                .slice(1)
+                .map((n, i) => (i % 2 === 0 ? fmt(m.x(n as number)) : fmt(m.y(n as number))))
+                .join(" ")}`
+        )
+        .join(" ");
+      return svg`<path d=${d}
+                       fill=${fill} fill-opacity=${fillOp}
+                       stroke=${stroke} stroke-width=${sw}
+                       stroke-linejoin="round" opacity=${op} />`;
+    }
+  }
+}
+
+/**
+ * A symbol's parts, drawn into a `w × h` box centered on the origin, in
+ * `color`. The caller wraps them in the positioned group.
+ */
+export function renderSymbolParts(
+  def: SymbolDef,
+  w: number,
+  h: number,
+  color: string
+): SVGTemplateResult[] {
+  const box = mapper(def, w, h, "box");
+  const square = mapper(def, w, h, "square");
+  return def.parts.map((p) => partTemplate(p, p.space === "square" ? square : box, color));
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -84,18 +84,45 @@ export const SYMBOL_CATEGORIES = [
 ] as const;
 
 /**
+ * Every lookup in this file is keyed by an untrusted string — a symbol id, a
+ * role name, a path command — and `cssIdent` happily passes `__proto__`,
+ * `toString` and `constructor`, which are all just letters and underscores.
+ *
+ * On a plain object that is a real fault, not a nicety. Reading
+ * `catalog["toString"]` returns `Object.prototype.toString`, a truthy value, so
+ * every `?? FALLBACK_SYMBOL` guard sails past it and the renderer destructures
+ * a function — which throws and takes the **whole card** down, from a config
+ * that never defined a symbol at all. Writing `out["__proto__"] = def` is worse
+ * in a quieter way: the assignment hits the inherited setter, so the symbol
+ * vanishes from `Object.keys` while every unrelated lookup starts resolving
+ * through the injected object.
+ *
+ * So every table here is null-prototype, and {@link own} is the one way any of
+ * them is read. Null-prototype construction alone would be enough today, but it
+ * is an invariant every future caller has to remember; the helper makes it hold
+ * even for a catalogue somebody hands us built the ordinary way.
+ */
+const dict = <T>(entries: Record<string, T>): Record<string, T> =>
+  Object.assign(Object.create(null) as Record<string, T>, entries);
+
+const own = <T>(table: Record<string, T>, key: unknown): T | undefined =>
+  typeof key === "string" && Object.prototype.hasOwnProperty.call(table, key)
+    ? table[key]
+    : undefined;
+
+/**
  * Role defaults — the de-facto design system the built-in glyphs already used,
  * read off the 26 of them: a filled carcass, then three weights of line art,
  * then the one solid fill (the fish tank's tails).
  */
-const ROLE_STYLE: Record<SymbolRole, Omit<PartStyle, "role">> = {
+const ROLE_STYLE = dict<Omit<PartStyle, "role">>({
   body: { width: 2, opacity: 1, fillOpacity: 0.12 },
   line: { width: 2, opacity: 1, fillOpacity: 0 },
   thin: { width: 1.5, opacity: 1, fillOpacity: 0 },
   detail: { width: 1.5, opacity: 0.7, fillOpacity: 0 },
   hint: { width: 1, opacity: 0.6, fillOpacity: 0 },
   solid: { width: 0, opacity: 0.7, fillOpacity: 1 },
-};
+});
 
 const DEFAULT_VIEW_BOX: [number, number, number, number] = [0, 0, 100, 100];
 
@@ -138,7 +165,7 @@ function points(v: unknown): Array<[number, number]> | null {
   return out;
 }
 
-const PATH_ARITY: Record<string, number> = { M: 2, L: 2, Q: 4, C: 6, Z: 0 };
+const PATH_ARITY = dict<number>({ M: 2, L: 2, Q: 4, C: 6, Z: 0 });
 
 function pathCmds(v: unknown): PathCmd[] | null {
   if (!Array.isArray(v) || !v.length || v.length > MAX_PATH_CMDS) return null;
@@ -146,7 +173,7 @@ function pathCmds(v: unknown): PathCmd[] | null {
   for (const c of v) {
     if (!Array.isArray(c) || typeof c[0] !== "string") return null;
     const op = c[0].toUpperCase();
-    const arity = PATH_ARITY[op];
+    const arity = own(PATH_ARITY, op);
     if (arity === undefined) return null;
     const args = nums(c.slice(1), arity);
     if (!args) return null;
@@ -159,11 +186,11 @@ function pathCmds(v: unknown): PathCmd[] | null {
 }
 
 function styleOf(raw: Record<string, unknown>, fallback: SymbolRole): PartStyle {
-  const role: SymbolRole =
-    typeof raw.role === "string" && raw.role in ROLE_STYLE
-      ? (raw.role as SymbolRole)
-      : fallback;
-  const base = ROLE_STYLE[role];
+  // `in` would walk the prototype chain, so `role: "toString"` passed the guard
+  // and then read a function whose `.width` is undefined — a part stroked
+  // `stroke-width="undefined"`.
+  const role: SymbolRole = own(ROLE_STYLE, raw.role) ? (raw.role as SymbolRole) : fallback;
+  const base = ROLE_STYLE[role]!;
   const width = num(raw.width);
   const opacity = num(raw.opacity);
   const fillOpacity = num(raw.fillOpacity);
@@ -199,7 +226,10 @@ function normalizePart(raw: unknown): SymbolPart | null {
   }
   if ("rect" in r) {
     const v = nums(r.rect, 4);
-    if (!v) return null;
+    // SVG rejects a negative width or height outright, so a mistyped rect drew
+    // nothing at all, with no error anywhere — exactly the silent failure this
+    // validator exists to prevent. Same rule the radii already had.
+    if (!v || v[2]! < 0 || v[3]! < 0) return null;
     return {
       kind: "rect", x: v[0]!, y: v[1]!, w: v[2]!, h: v[3]!,
       rx: Math.max(0, num(r.rx) ?? 0), space, style: styleOf(r, "body"),
@@ -375,13 +405,24 @@ export const BUILTIN_SYMBOLS: SymbolCatalog = (() => {
     string,
     unknown
   >;
-  const out: Record<string, SymbolDef> = {};
+  const out = dict<SymbolDef>({});
   for (const [path, raw] of Object.entries(files)) {
     const def = normalizeSymbol(raw, path.split("/").pop()?.replace(/\.json$/, ""));
     if (def) out[def.id] = def;
   }
   return out;
 })();
+
+/**
+ * Resolve a config-supplied `type` against a catalogue.
+ *
+ * The one way a catalogue is read. See {@link own}: a bare `catalog[type]` on a
+ * plain object answers `toString` with a function, which every `??` fallback in
+ * the renderers treats as a hit.
+ */
+export function findSymbol(catalog: SymbolCatalog, type: unknown): SymbolDef | undefined {
+  return own(catalog as Record<string, SymbolDef>, type);
+}
 
 let cacheKey: unknown;
 let cacheValue: SymbolCatalog = BUILTIN_SYMBOLS;
@@ -394,7 +435,10 @@ let cacheValue: SymbolCatalog = BUILTIN_SYMBOLS;
 export function symbolCatalog(symbols?: Record<string, unknown>): SymbolCatalog {
   if (!symbols || typeof symbols !== "object") return BUILTIN_SYMBOLS;
   if (symbols === cacheKey) return cacheValue;
-  const out: Record<string, SymbolDef> = { ...BUILTIN_SYMBOLS };
+  // Object.assign onto a null-prototype target, not a spread: `{ ...x }` would
+  // hand back an ordinary object and undo the whole point.
+  const out = dict<SymbolDef>({});
+  Object.assign(out, BUILTIN_SYMBOLS);
   for (const [key, raw] of Object.entries(symbols)) {
     const def = normalizeSymbol(raw, key);
     if (def) out[def.id] = def;
@@ -432,7 +476,7 @@ export function symbolSize(type: string, catalog: SymbolCatalog = BUILTIN_SYMBOL
   w: number;
   h: number;
 } {
-  return catalog[type]?.size ?? { w: 60, h: 60 };
+  return findSymbol(catalog, type)?.size ?? { w: 60, h: 60 };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,15 @@ export interface FloorText {
   angle?: number;
 }
 
+/**
+ * The symbols the card ships with, one JSON file each in `furniture/`.
+ *
+ * Not a closed set — {@link Furniture.type} takes any symbol id, including one
+ * a config defines in its own `symbols:` block or one contributed to
+ * `furniture/` (issue #90). This union is the shipped library, kept as a named
+ * type so the built-ins still autocomplete; `symbols.test.ts` asserts every
+ * member of it actually resolves.
+ */
 export type FurnitureType =
   | "table"
   | "roundTable"
@@ -429,14 +438,21 @@ export type FurnitureType =
 
 /**
  * Which end of an L-shaped sectional the chaise sits on, facing the sofa from
- * the front. Only meaningful for `type: "sectional"`; defaults to `"right"`.
+ * the front. Under the hood this mirrors the whole symbol across x, so it works
+ * on any glyph with a handedness; the editor only offers it on the sectional.
  */
 export type SectionalHand = "left" | "right";
 
 /** A gray furniture/fixture diagram placed on the plan. */
 export interface Furniture {
   id: string;
-  type: FurnitureType;
+  /**
+   * Which symbol to draw — a built-in {@link FurnitureType}, a symbol
+   * contributed to `furniture/`, or one this config defines in
+   * {@link FloorplanCardConfig.symbols}. An id nothing answers to draws the
+   * plain box, so a missing symbol is a visible placeholder rather than a hole.
+   */
+  type: FurnitureType | (string & {});
   /** L-shaped sectional only: which side the chaise extends on. Default `right`. */
   hand?: SectionalHand;
   x: number;
@@ -741,35 +757,12 @@ export const DEFAULT_RIPPLE_SIZE = 80;
 /** Neutral gray, so furniture reads differently from the walls. Skinnable (#122). */
 export const FURNITURE_COLOR = "var(--fp-skin-furniture, #9e9e9e)";
 
-/** Default width/height per furniture type, in virtual units. */
-export const FURNITURE_DEFAULT_SIZE: Record<FurnitureType, { w: number; h: number }> = {
-  table: { w: 120, h: 80 },
-  roundTable: { w: 100, h: 100 },
-  desk: { w: 120, h: 60 },
-  chair: { w: 44, h: 44 },
-  sofa: { w: 170, h: 72 },
-  bed: { w: 150, h: 200 },
-  wardrobe: { w: 120, h: 55 },
-  rug: { w: 180, h: 120 },
-  plant: { w: 44, h: 44 },
-  fridge: { w: 60, h: 64 },
-  stove: { w: 64, h: 64 },
-  sink: { w: 64, h: 48 },
-  toilet: { w: 48, h: 68 },
-  stairs: { w: 90, h: 170 },
-  tv: { w: 110, h: 18 },
-  washer: { w: 60, h: 62 },
-  dryer: { w: 60, h: 62 },
-  dishwasher: { w: 60, h: 60 },
-  waterHeater: { w: 52, h: 52 },
-  airHandler: { w: 60, h: 56 },
-  bathtub: { w: 150, h: 76 },
-  vanity: { w: 110, h: 55 },
-  sectional: { w: 230, h: 180 },
-  fishTank: { w: 100, h: 40 },
-  piano: { w: 140, h: 60 },
-  hotTub: { w: 120, h: 120 },
-};
+/**
+ * Default width/height per furniture type now lives with the symbol itself, in
+ * its `furniture/*.json` file — see `symbolSize` in `symbols.ts`. Kept out of
+ * here so a contributed symbol carries its own default rather than needing an
+ * entry in a table only the maintainer can edit.
+ */
 
 /**
  * A single floor/level. Each floor owns its own set of elements. The canvas
@@ -953,6 +946,18 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   furniture?: Furniture[];
   trackers?: Tracker[];
   areas?: Area[];
+  /**
+   * Symbols this plan defines for itself (issue #90), keyed by id and merged
+   * over the shipped `furniture/` library — so you can draw a piece nobody has
+   * contributed yet, use it today, and PR it later if it turns out to be
+   * generally useful.
+   *
+   * Deliberately typed loose: the values are untrusted geometry that
+   * `normalizeSymbol` validates on the way in, and a symbol that fails
+   * validation costs you that one glyph rather than the card. There is no
+   * markup here to sanitise — see `symbols.ts`.
+   */
+  symbols?: Record<string, unknown>;
 }
 
 export const DEFAULT_WIDTH = 1000;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // `import.meta.glob`, which bundles furniture/*.json into the card.
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
@gorischek has a wardrobe with seven doors, and the glyph only knew how to draw two. Every
piece of furniture was a hand-written `case` in a 240-line `switch`, so every request like
that became a maintainer task. The thread asked for a library people can extend, and
specifically for the existing glyphs as templates.

## A symbol is geometry, not markup

Accepting pasted SVG would drag in `<script>`, `on*` handlers, `<foreignObject>`,
`javascript:` and external `href`s — sanitiser-shaped work in a card that already had to
harden a style attribute (#65), where any miss is XSS on someone's dashboard.

So a symbol is a JSON list of primitives with **numeric attributes only**, and the card
builds the elements itself through lit. Nothing user-supplied is ever parsed as markup: the
injection surface is gone by construction rather than by filtering.

Colours never appear either. A part picks a **role** and the card pours in the resolved
colour — so a contributed symbol inherits entity recolouring (#82) and skins (#122) for
free, and cannot smuggle a `url()` into a paint attribute.

```jsonc
{
  "id": "sofa",
  "name": "sofa",
  "category": "living",
  "keywords": ["couch", "settee"],
  "size": { "w": 170, "h": 72 },
  "parts": [
    { "rect": [0, 0, 100, 100], "rx": 5.555556, "role": "body" },
    { "line": [0, 30, 100, 30] },
    { "line": [12, 30, 12, 100] },
    { "line": [88, 30, 88, 100] }
  ]
}
```

Coordinates are a fraction of the piece's box, per axis — exactly how the old glyphs were
written by hand. Lengths scale by the smaller side, which is what kept `Math.min(w, h) * k`
circular. Stroke widths stay canvas units, so line art doesn't thicken with the furniture.

Two additions to the shape @superflyer11 proposed, both of which turned out to be necessary
rather than nice:

- **`repeat`** — one part stamped along a step vector. This is what actually answers the
  original request: a seven-door wardrobe is three lines. It also made the stairs and the
  piano keyboard faithful instead of approximate.
- **`space: "square"`** — the hot tub's jets are positioned by `min(w, h)`, not per axis.
  Without it they spread off the water circle on a non-square tub. One glyph needed it; it
  generalises to any ring of parts that has to stay concentric with a circle.

## What moved

All 26 built-ins are now `furniture/*.json`, bundled by a glob so contributing is **one file**
with no index to forget. `renderFurniture` renders whichever symbol the `type` names —
built-in, contributed, or defined in a config's own `symbols:` block — and falls back to the
plain box for a name it doesn't have, which is what the old `default` case drew.

Three hand-maintained lists go away with the switch: the size table in `types.ts`, and the
ordering array and label map in `editor-forms.ts`. Only one of them was exhaustiveness-checked,
so a type added to the union but forgotten in the array simply never appeared in the editor.
A symbol carries its own name, size, keywords and category now. The glow mask reads
`footprint` from the symbol instead of the second copy of the round-types list.

`hand: "left"` became a mirror transform, which reproduces the sectional's two hands exactly
and now works on any symbol.

## Using it without a pull request

The picker is searchable and grouped, because a community library only grows — "couch" finds
the sofa *and* the sectional, off the symbol's own keywords.

**Project → Custom symbols** takes pasted JSON, validates it through the same function the
shipped library goes through, and drops it into `symbols:`. It appears in the picker
immediately, beside the built-ins — and the same JSON is what you later contribute to
`furniture/`. `furniture/README.md` is the authoring guide, next to the files people add.

## Verification

I dumped the rendered markup of all 26 glyphs at three sizes **before** touching the
renderer, and diffed the conversion against it element by element and attribute by attribute,
numerically.

**Every glyph is pixel-identical at its default size.** Better than I expected going in:
each symbol's corner radii are chosen to land on the old absolute value at *its own* default
rather than at one shared constant, which costs nothing and removes the whole category at
the sizes people actually draw at.

At other sizes seven numbers drift, all of them absolute constants becoming proportional:

| site | today | after |
|---|---|---|
| generic carcass, sink basin | `rx="4"` | proportional |
| bed pillows, toilet cistern, dishwasher panel | `rx="3"` | proportional |
| stairs centre line | `±(hh - 6)` | proportional |
| stairs arrow apex | `-hh + 4` | proportional |

Corner rounding and one arrowhead. Nothing moves on a plan drawn at default sizes.

824 tests (63 new, covering the format, the validator and the catalogue), typecheck and build
all pass. The existing furniture assertions were left alone and still pass — the fish-tank
bubble radius under non-uniform scale, the colour override reaching base *and* detail, the
CSS hooks, the glow-mask transmission.

Beyond the unit tests I checked every glyph on `/dev/symbols.html`, since a glyph can be
right by the numbers and wrong on screen, and drove the editor in a browser: a seven-door
wardrobe pasted into the box draws its six seams and seven handles, places at its own
420×55, is found by searching "closet", and renders in the live card under the skin variable.
Bad pastes report a specific reason — I made `normalizeSymbol` name the failure after seeing
three distinct errors collapse into one generic message.

Bundle: +21 kB raw, +5.9 kB gzipped.

## Scope

This does not touch #117. That PR adds a parametric `doors` count to the wardrobe glyph; with
`repeat` in the format the same need is met by a contributed `wardrobe7.json`, but which of
those ships is @nicosandller's call, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
