### PR TITLE
Trackers: initials can ride the dot, so people stay tellable apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,10 @@ rings; readings outside `[min, max]` clamp to the rectangle's edge. With one, a 
 pulsating line spans the unknown axis — honest about knowing only one coordinate. With
 neither reporting, nothing renders.
 
-The rectangle itself is editor-only; the card shows just the marker. **Color** and **dot
-size** are per tracker.
+The rectangle itself is editor-only; the card shows just the marker. **Color**, **dot
+size** and **label** are per tracker — a label (initials like `FR`) rides in the
+triangle's place with the same pulse and glide, so several people on one floor stay
+tellable apart when color alone isn't enough.
 
 #### Presence ripples
 
@@ -573,7 +575,7 @@ A live (x, y) position estimate driven by one or two orthogonal distance sensors
 animated inside a rectangular tracked area:
 
 ```yaml
-{ id, x, y, w, h, angle?, color?, dotSize?,
+{ id, x, y, w, h, angle?, color?, dotSize?, label?,
   xSensor?: { entity, min, max, invert?, presence?: { entity, invert? } },
   ySensor?: { entity, min, max, invert?, presence?: { entity, invert? } } }
 ```
@@ -583,6 +585,8 @@ animated inside a rectangular tracked area:
   `[min, max]` onto the rectangle's edges along that axis; `invert` flips the mapping.
 - `presence` — a binary gate per axis; if either reports clear (or `unavailable` /
   `unknown`) the marker hides. `invert` flips on/off, never the unavailable case.
+- `label` — short text (initials) drawn in place of the triangle, keeping its pulse,
+  ripples and glide. Empty / unset keeps the classic triangle.
 - Both sensors → a pulsating triangle with ripple rings. One → a faint pulsating line
   across the unknown axis. The rectangle is editor-only.
 

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -863,6 +863,8 @@ export function trackerForm(tr: Tracker): FormSpec {
         label: "Dot size",
         selector: { number: { min: 6, max: 80, mode: "slider", unit_of_measurement: "px" } },
       },
+      // Initials in place of the triangle — see Tracker.label.
+      { name: "label", label: "Label", selector: { text: {} } },
     ],
     data: {
       w: tr.w,
@@ -871,6 +873,7 @@ export function trackerForm(tr: Tracker): FormSpec {
       y: Math.round(tr.y),
       angle: tr.angle ?? 0,
       dotSize: tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE,
+      label: tr.label ?? "",
     },
     toPatch: identity,
   };

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -55,6 +55,7 @@ import {
   furnitureColor,
   entityDefaultIcon,
   trackerSensorReading,
+  renderTracker,
   openingInMotion,
   openingIsActive,
   entityStateText,
@@ -107,7 +108,7 @@ import {
   renderGlow,
   renderRipple,
 } from "./render";
-import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
+import type { FloorplanCardConfig, Opening, RenderHass, Tracker } from "./types";
 import { symbolCatalog, symbolSize } from "./symbols";
 
 /**
@@ -512,6 +513,40 @@ describe("trackerSensorReading", () => {
     expect(trackerSensorReading(states, "sensor.missing")).toBeNull();
     expect(trackerSensorReading(states, "sensor.bad")).toBeNull();
     expect(trackerSensorReading(states, "sensor.text")).toBeNull();
+  });
+});
+
+describe("renderTracker label", () => {
+  const base: Tracker = {
+    id: "t1",
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 100,
+    xSensor: { entity: "sensor.x", min: 0, max: 100 },
+    ySensor: { entity: "sensor.y", min: 0, max: 100 },
+  };
+  const opts = { editing: false, xReading: 50, yReading: 50 };
+
+  it("renders the classic triangle without a label", () => {
+    const out = flattenMarkup(renderTracker(base, opts));
+    expect(out).toContain('<polygon class="tracker-dot"');
+    expect(out).not.toContain("<text");
+  });
+
+  it("renders initials in the triangle's place when a label is set", () => {
+    const out = flattenMarkup(renderTracker({ ...base, label: "FR" }, opts));
+    expect(out).toContain('<text class="tracker-dot"');
+    expect(out).toContain("FR");
+    expect(out).not.toContain("<polygon");
+    // Still a marker in the same group, so pulse / glide CSS keeps applying.
+    expect(out).toContain('class="tracker-marker"');
+  });
+
+  it("treats a whitespace-only label as unset", () => {
+    const out = flattenMarkup(renderTracker({ ...base, label: "  " }, opts));
+    expect(out).toContain('<polygon class="tracker-dot"');
+    expect(out).not.toContain("<text");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -3120,6 +3120,17 @@ export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTempla
     // Equilateral-ish triangle pointing up, sized in user units (≈ dotR scale).
     const tri = `0,${-dotR} ${dotR * 0.9},${dotR * 0.7} ${-dotR * 0.9},${dotR * 0.7}`;
     const ringMax = Math.max(dotR * 3.5, Math.min(t.w, t.h) * 0.45);
+    // A label rides in the triangle's place: same class, so it pulses and
+    // glides like the dot it replaces. The paint-order stroke is a halo in
+    // the card's own background color, keeping initials readable over busy
+    // plans without a box around them.
+    const label = t.label?.trim();
+    const dot = label
+      ? svg`<text class="tracker-dot" text-anchor="middle" dominant-baseline="central"
+              font-size=${dotR * 1.6} font-weight="700" fill=${color}
+              stroke="var(--fp-skin-card-bg, #fff)" stroke-width="3"
+              paint-order="stroke" pointer-events="none">${label}</text>`
+      : svg`<polygon class="tracker-dot" points=${tri} fill=${color} />`;
     marker = svg`
       <g class="tracker-marker" style="transform:translate(${mx}px, ${my}px);">
         <circle class="tracker-ring" cx="0" cy="0" r="0"
@@ -3128,7 +3139,7 @@ export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTempla
         <circle class="tracker-ring" cx="0" cy="0" r="0"
                 fill="none" stroke=${color} stroke-width="1.5"
                 style="--fp-tracker-ring-max:${ringMax}px; animation-delay:0.7s;" />
-        <polygon class="tracker-dot" points=${tri} fill=${color} />
+        ${dot}
       </g>`;
   } else if (hasX || hasY) {
     // 1-sensor: faint pulsating line + ripple bands along the unknown axis.

--- a/src/types.ts
+++ b/src/types.ts
@@ -610,6 +610,13 @@ export interface Tracker {
   color?: string;
   /** Marker diameter in pixels. Default 14. */
   dotSize?: number;
+  /**
+   * Short text drawn in place of the triangle marker — initials like "FR",
+   * so several trackers on one floor stay tellable apart when color alone
+   * isn't enough. The label keeps the triangle's pulse, ripples and glide;
+   * only the shape changes. Empty / unset keeps the classic triangle.
+   */
+  label?: string;
   /** Distance sensor mapped to the X axis (rectangle's horizontal span). */
   xSensor?: TrackerSensor;
   /** Distance sensor mapped to the Y axis (rectangle's vertical span). */


### PR DESCRIPTION
## What

An optional `label` on a tracker draws short text (initials like `FR`) in the triangle's place — same class, so it keeps the pulse, the ripple rings and the glide between readings. A `paint-order: stroke` halo in `--fp-skin-card-bg` keeps the initials readable over busy plans without boxing them.

Empty or whitespace-only labels render the classic triangle, so existing configs are untouched.

## Why

We track four people across three floors. Each tracker has its own color, but with several dots on one floor the color legend stops carrying the "who" — you end up cross-referencing a legend in the margin. Initials on the dot answer it in place.

(We've been running exactly this as a local patch on the minified bundle since v1.1.x — upstreaming it so it survives updates.)

## How

- `Tracker.label?: string` in `types.ts`
- `renderTracker`: 2-sensor branch swaps `<polygon>` for `<text class="tracker-dot">` when a trimmed label is present (1-sensor line mode unchanged — there's no dot to label)
- `trackerForm`: a plain text field, same pattern as the area name
- README: editor section + `Tracker` reference
- 3 tests in `render.test.ts` (triangle without label, text with label, whitespace-only falls back)

`vitest` 957/957 green, `tsc --noEmit` clean, `npm run build` ok.
