### PR TITLE
fix(devices): a press lands on the device, not on the air its ripple fills

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_CUSTOM_PERCENT,
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
+  MIN_TOUCH_TARGET,
   DEFAULT_TEXT_SIZE,
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -4964,15 +4965,44 @@ export class FloorplanCardEditor extends LitElement {
       --mdc-icon-size: 15px;
       display: flex;
     }
+    /* Grab area = the visible device, matching the card's hit area. A presence
+       ripple is mostly empty air, and while the anchor took pointer events for
+       all of it, a 110px square sat over the plan: the wall or door underneath
+       could not be clicked at all, and neither could a device standing inside
+       the ring. The badge and label answer instead — enough to grab and drag,
+       and it puts back what was buried. */
     .edit-item {
       position: absolute;
       transform: translate(-50%, -50%);
-      pointer-events: auto;
+      pointer-events: none;
       cursor: move;
       display: flex;
       flex-direction: column;
       align-items: center;
       touch-action: none;
+    }
+    .edit-item .badge,
+    .edit-item .ilabel {
+      pointer-events: auto;
+    }
+    .stack-icon,
+    .ripple {
+      pointer-events: none;
+    }
+    /* A ripple-only device has no badge to grab, so its centre answers. */
+    .edit-item .ripple .dot {
+      pointer-events: auto;
+      position: relative;
+    }
+    .edit-item .ripple .dot::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: ${MIN_TOUCH_TARGET}px;
+      height: ${MIN_TOUCH_TARGET}px;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
     }
     .badge {
       width: 34px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_TEXT_SIZE,
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_LABEL_SIZE,
+  MIN_TOUCH_TARGET,
   DEFAULT_SUN_MIN,
   DEFAULT_SUN_MAX,
   PRESS_SCALE,
@@ -1272,6 +1273,15 @@ export class FloorplanCard extends LitElement {
       inset: 0;
       pointer-events: none;
     }
+    /* A device's hit area is what you can *see* of it — the badge and its
+       label — not the box its decoration happens to fill.
+
+       A presence ripple is 80–110px of mostly empty air, and the anchor grew
+       to hold it: a 30px motion icon behaved like a 110px square button, which
+       also swallowed taps meant for the plan underneath it. The ring is
+       decoration; it says "presence here", it is not a control. So the anchor
+       stops taking pointer events and the parts that are the device take them
+       back. */
     .item {
       position: absolute;
       /* Counter-scaled against the zoom-to-room transform (--fp-inv-zoom,
@@ -1283,13 +1293,44 @@ export class FloorplanCard extends LitElement {
          every badge is briefly the wrong size mid-transition. */
       transform: translate(-50%, -50%) scale(var(--fp-inv-zoom, 1));
       transition: transform 0.4s ease;
-      pointer-events: auto;
+      pointer-events: none;
       /* Not a hand: a device with nothing bound, or tap_action set to none,
          is not a button (issue #134). Only .interactive gets the pointer. */
       cursor: default;
       display: flex;
       flex-direction: column;
       align-items: center;
+    }
+    .item .badge,
+    .item .label {
+      pointer-events: auto;
+    }
+    /* .stack-icon spans the whole ripple (inset: 0), so it has to stay out of
+       the way too — the badge inside it is the target, not its wrapper. */
+    .stack-icon,
+    .ripple,
+    .press-ink {
+      pointer-events: none;
+    }
+    /* A ripple-only device draws no badge, so its centre has to answer for it,
+       or switching the badge off would leave the device unclickable. The dot
+       is 8px across; this gives it a real touch target without drawing one.
+       Deliberately a fixed size, and not scaled by overlayScale (#148): a
+       minimum touch target is about fingers, which do not shrink with the
+       plan. */
+    .item.interactive .ripple .dot {
+      pointer-events: auto;
+      position: relative;
+    }
+    .item.interactive .ripple .dot::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: ${MIN_TOUCH_TARGET}px;
+      height: ${MIN_TOUCH_TARGET}px;
+      transform: translate(-50%, -50%);
+      border-radius: 50%;
     }
     .item.interactive {
       cursor: pointer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -852,6 +852,15 @@ export const FURNITURE_GLOW_TRANSMISSION = 0.5;
 export const DEFAULT_TRACKER_DOT_SIZE = 14;
 
 export const DEFAULT_ITEM_SIZE = 34;
+/**
+ * Smallest area that answers a press, in screen pixels — for a device whose
+ * only visual is a presence ripple and so has no badge to aim at.
+ *
+ * Screen pixels on purpose, and never scaled by `overlayScale`: this is a
+ * measure of fingers, not of the drawing. A plan shrunk into a narrow card
+ * would otherwise shrink its touch targets with it.
+ */
+export const MIN_TOUCH_TARGET = 34;
 export const DEFAULT_TEXT_SIZE = 16;
 export const DEFAULT_RIPPLE_SIZE = 80;
 /** Neutral gray, so furniture reads differently from the walls. Skinnable (#122). */


### PR DESCRIPTION
### Problem

A presence device with a ripple is a hit target the size of its ring. `.item` takes pointer events for its whole box, and the box grows to hold the decoration, so a 30px motion icon with `rippleSize: 110` answers presses across 110 square pixels — as a *square*, so even the corners outside the visible ring count.

That is wrong twice over. It makes a small icon behave like a large button, and since the overlay sits above the plan it swallows presses meant for whatever is underneath: a door, a device standing inside the ring, or in the editor the wall you are trying to select.

The ring is not a control. It says "presence here"; the badge is what you press.

### Change

The anchor stops taking pointer events, and the parts that *are* the device take them back — the badge and its label. `.stack-icon` goes with the decoration, since it spans the whole ripple (`inset: 0`) and would otherwise keep the old box.

A ripple-only device draws no badge to aim at, so its centre answers instead: a `MIN_TOUCH_TARGET` disc on the ripple's dot, invisible, 34px. Deliberately fixed and **not** scaled by `overlayScale` (#148) — a minimum touch target is a fact about fingers, and those do not shrink with the plan.

The editor gets the same rule, so what you can grab there is what you can press on the card, and the wall under a ripple is selectable again.

### Notes

**Nothing else changes.** A device without a ripple is unaffected: its badge was always the whole of its box.

**Not unit-testable here.** This is CSS, and the suite covers pure functions only — `npx tsc --noEmit` is clean and all tests pass, but none of them speak to this. Verified by hand: with a ripple device on the plan, a press just outside the badge but inside the ring now reaches the plan underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
