### PR TITLE
feat(openings): two leaves, for the doors that have two

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ distorted anyway.
 | `id`          | string                      | Unique id.                                             |
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves: hinged (default), sliding panels, or a roll-up curtain (garage / roller shutter). |
-| `sash`        | `single` \| `double`        | Swing windows only: one full-width sash, or the classic two. Default `double`. |
+| `sash`        | `single` \| `double`        | Swing openings only: how many hinged leaves. The default differs by type, because the ordinary cases do — a window opens with `double` (two casement sashes), a door with `single` (one leaf across the opening). Set it to draw a single-sash window or a **double door**; both leaves then hinge at their own jamb and trace their own arc. Ignored by sliding and rolling openings. |
 | `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |
 | `shutterInvert` | boolean                   | Flip the shutter's open/closed reading — a reed contact on hinged panels often reads `on` when they are shut. Separate from `invert`. |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -819,17 +819,45 @@ describe("wallForm / projectForm / floorImageForm", () => {
 describe("openingForm — sash and shutter (issues #73 / #74)", () => {
   const win = { id: "w1", type: "window", x: 0, y: 0, length: 90, angle: 0 } as Opening;
 
-  it("swing windows offer Sashes; single sash reveals Hinge", () => {
+  it("every swing opening offers a leaf count; only sliders and rollers don't", () => {
     const names = openingForm(win).fields.map((x) => x.name);
     expect(names).toContain("sash");
-    expect(names).not.toContain("hinge"); // double: no single hinge
-    const single = openingForm({ ...win, sash: "single" } as Opening).fields.map((x) => x.name);
-    expect(single).toContain("hinge");
-    // doors and sliders don't get a sash field
-    expect(openingForm(door).fields.map((x) => x.name)).not.toContain("sash");
+    // Doors too now: a double door is as ordinary as a double casement.
+    expect(openingForm(door).fields.map((x) => x.name)).toContain("sash");
     expect(
       openingForm({ ...win, motion: "slide" } as Opening).fields.map((x) => x.name)
     ).not.toContain("sash");
+    expect(
+      openingForm({ ...win, motion: "roll" } as Opening).fields.map((x) => x.name)
+    ).not.toContain("sash");
+  });
+
+  it("names the leaf count after what it is, and opens on this type's default", () => {
+    const field = (o: Opening) => openingForm(o).fields.find((x) => x.name === "sash")!;
+    expect(field(win).label).toBe("Sashes");
+    expect(field(door).label).toBe("Leaves");
+    expect(openingForm(win).data.sash).toBe("double");
+    expect(openingForm(door).data.sash).toBe("single");
+  });
+
+  it("the hinge is offered only where there is one leaf to hang", () => {
+    // A double is hinged at both jambs, so there is no side left to choose.
+    expect(openingForm(win).fields.map((x) => x.name)).not.toContain("hinge");
+    expect(openingForm(door).fields.map((x) => x.name)).toContain("hinge");
+    expect(
+      openingForm({ ...win, sash: "single" } as Opening).fields.map((x) => x.name)
+    ).toContain("hinge");
+    expect(
+      openingForm({ ...door, sash: "double" } as Opening).fields.map((x) => x.name)
+    ).not.toContain("hinge");
+  });
+
+  it("writes down only the value that isn't this type's default", () => {
+    // The defaults run opposite ways, so the same patch means different things.
+    expect(openingForm(win).toPatch({ sash: "single" })).toEqual({ sash: "single" });
+    expect(openingForm(win).toPatch({ sash: "double" })).toEqual({ sash: undefined });
+    expect(openingForm(door).toPatch({ sash: "double" })).toEqual({ sash: "double" });
+    expect(openingForm(door).toPatch({ sash: "single" })).toEqual({ sash: undefined });
   });
 
   it("every opening offers a Shutter picker taking covers or contact sensors", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -53,7 +53,8 @@ import {
   pressEffectOf,
   sliderStyleOf,
   shutterStyleOf,
-  windowSash,
+  openingSash,
+  defaultSash,
 } from "./render";
 import { defaultItemAction } from "./actions";
 import { DEFAULT_SKIN, SKINS, findSkin, MAX_SKIN_WALL_WIDTH } from "./skins";
@@ -191,16 +192,25 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
     },
     { name: "length", label: "Length", required: true, selector: { number: { min: 1, mode: "box" } } },
   ];
-  if (o.type === "window" && motion === "swing") {
+  // Leaf count, for anything hinged. Offered on doors too: a double door is
+  // as ordinary as a double casement, and was previously undrawable — every
+  // door came out as one leaf spanning the whole opening, however wide.
+  if (motion === "swing") {
+    const door = o.type === "door";
     fields.push({
       name: "sash",
-      label: "Sashes",
-      helper: "Single = one full-width sash (issue #73)",
-      selector: dropdown(opt("double", "Double (two leaves)"), opt("single", "Single sash")),
+      label: door ? "Leaves" : "Sashes",
+      helper: door
+        ? "Double = two leaves meeting in the middle, hinged at each jamb"
+        : "Single = one full-width sash (issue #73)",
+      selector: door
+        ? dropdown(opt("single", "Single (one leaf)"), opt("double", "Double (two leaves)"))
+        : dropdown(opt("double", "Double (two leaves)"), opt("single", "Single sash")),
     });
   }
-  // Hinge applies to anything with ONE hinged leaf: doors, and single-sash windows.
-  if (motion === "swing" && (o.type === "door" || windowSash(o) === "single")) {
+  // Hinge applies to anything with ONE hinged leaf. A double is hinged at both
+  // jambs, so there is no side left to choose.
+  if (motion === "swing" && openingSash(o) === "single") {
     fields.push({
       name: "hinge",
       label: "Hinge",
@@ -367,7 +377,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       opens: o.flipV ? "other" : "this",
       slide: o.flipH ? "right" : "left",
       style,
-      sash: windowSash(o),
+      sash: openingSash(o),
       entity: o.entity ?? "",
       secondaryEntity: o.secondaryEntity ?? "",
       shutterEntity: o.shutterEntity ?? "",
@@ -417,7 +427,12 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             out.sliderStyle = undefined;
             out.secondaryEntity = undefined;
           }
-        } else if (k === "sash") out.sash = v === "single" ? "single" : undefined;
+        } else if (k === "sash") {
+          // The two types default the other way round — a window opens with
+          // two sashes, a door with one leaf — so only the value that is *not*
+          // this type's default is worth writing down.
+          out.sash = v === defaultSash(o.type) ? undefined : v;
+        }
         else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
         else if (k === "opens") out.flipV = v === "other" || undefined;
         else if (k === "style") {

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -48,6 +48,66 @@ describe("renderOpening — swing door", () => {
   });
 });
 
+describe("renderOpening — double door", () => {
+  const dbl = { type: "door", sash: "double" } as Partial<Opening>;
+
+  it("splits the opening into two leaves hinged at opposite jambs", () => {
+    const s = svgOf(dbl, { open: false });
+    // length 90 → two 45-wide leaves, one per jamb, meeting in the middle.
+    expect(s.match(/width=45/g)?.length).toBe(2);
+    expect(s).toContain("fp-door-leaf");
+    expect(s).toContain("fp-leaf-r");
+    expect(s).not.toContain("width=90"); // no full-width leaf left
+  });
+
+  it("swings them apart, each its own way", () => {
+    const open = svgOf(dbl, { open: true });
+    expect(open).toContain("rotate(-90deg)");
+    expect(open).toContain("rotate(90deg)");
+    const half = svgOf(dbl, { amount: 0.5 });
+    expect(half).toContain("rotate(-45deg)");
+    expect(half).toContain("rotate(45deg)");
+  });
+
+  it("gives each leaf its own arc, sized to that leaf", () => {
+    const s = svgOf(dbl, { open: true });
+    expect(s.match(/fp-door-arc/g)?.length).toBe(2);
+    // Radius = half the opening, the distance that leaf's tip actually sweeps.
+    expect(s).toContain("A 45 45");
+    expect(s).not.toContain("A 90 90");
+  });
+
+  it("stays a door: no jambs, unlike the casement window it mirrors", () => {
+    const door = svgOf(dbl, { open: false });
+    const window = svgOf({ type: "window" }, { open: false });
+    expect(door).not.toContain('stroke-width="2"'); // jamb lines
+    expect(window).toContain('stroke-width="2"');
+    // Both draw two leaves and two arcs — the jambs are the whole difference.
+    expect(door.match(/fp-door-arc/g)?.length).toBe(window.match(/fp-door-arc/g)?.length);
+  });
+
+  it("a plain door is untouched — one leaf across the whole opening", () => {
+    const single = svgOf({ type: "door" }, { open: true });
+    expect(single).toContain("width=90");
+    expect(single).not.toContain("fp-leaf-r");
+    expect(single.match(/fp-door-arc/g)?.length).toBe(1);
+    expect(single).toContain("A 90 90"); // arc radius = the full opening
+  });
+
+  it("only swings: a sliding or rolling door ignores the leaf count", () => {
+    const slide = svgOf({ type: "door", motion: "slide", sash: "double" } as Partial<Opening>);
+    expect(slide).toContain("fp-slide-panel");
+    expect(slide).not.toContain("fp-door-arc");
+    const roll = svgOf({ type: "door", motion: "roll", sash: "double" } as Partial<Opening>);
+    expect(roll).toContain("fp-roll-curtain");
+    expect(roll).not.toContain("fp-door-arc");
+  });
+
+  it("mirrors as one piece, so flipV opens both leaves into the other room", () => {
+    expect(svgOf({ ...dbl, flipV: true })).toContain("scale(1 -1)");
+  });
+});
+
 const sliding = (extra: Partial<Opening> = {}) =>
   ({ type: "door", motion: "slide", ...extra }) as Partial<Opening>;
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -24,7 +24,8 @@ import {
   sliderStyleHasTwoPanels,
   secondPanelOf,
   openingFromDeviceClass,
-  windowSash,
+  openingSash,
+  defaultSash,
   shutterAmount,
   shutterStyleOf,
   imageFitRatio,
@@ -2077,14 +2078,26 @@ describe("badgeValueSize (#106)", () => {
   });
 });
 
-describe("windowSash (issue #73)", () => {
-  it("defaults to double; single only for swing windows", () => {
-    expect(windowSash({ type: "window" } as Opening)).toBe("double");
-    expect(windowSash({ type: "window", sash: "single" } as Opening)).toBe("single");
-    expect(windowSash({ type: "door", sash: "single" } as Opening)).toBe("double");
-    expect(windowSash({ type: "window", motion: "slide", sash: "single" } as Opening)).toBe(
+describe("openingSash (issues #73 / double doors)", () => {
+  it("defaults per type: a window opens with two sashes, a door with one leaf", () => {
+    expect(defaultSash("window")).toBe("double");
+    expect(defaultSash("door")).toBe("single");
+    expect(openingSash({ type: "window" } as Opening)).toBe("double");
+    expect(openingSash({ type: "door" } as Opening)).toBe("single");
+  });
+
+  it("honours an explicit sash on both types", () => {
+    expect(openingSash({ type: "window", sash: "single" } as Opening)).toBe("single");
+    // The whole point: a door with two leaves used to be undrawable, because
+    // `sash` was read for windows only.
+    expect(openingSash({ type: "door", sash: "double" } as Opening)).toBe("double");
+  });
+
+  it("only hinged openings have leaves — a slider or roller reports its default", () => {
+    expect(openingSash({ type: "window", motion: "slide", sash: "single" } as Opening)).toBe(
       "double",
     );
+    expect(openingSash({ type: "door", motion: "roll", sash: "double" } as Opening)).toBe("single");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -10,6 +10,7 @@ import type {
   FloorplanCardConfig,
   Floor,
   Opening,
+  OpeningType,
   SliderStyle,
   ItemKind,
   IconAnimation,
@@ -1758,12 +1759,29 @@ export function secondPanelOf(o: Opening): Opening {
 }
 
 /**
- * Sash count for a swing window (issue #73): `double` (the historic look) or
- * `single`. Only meaningful for `type: "window"` with swing motion — doors
- * and sliding/rolling openings always resolve to `double` (ignored).
+ * How many hinged leaves an opening has, when nothing is stated: a window
+ * opens with two casement sashes, a door with one leaf.
+ *
+ * Two different defaults for one field, because they are the two ordinary
+ * cases. A window drawn with a single sash is the exception (issue #73); a
+ * double door is the exception the other way round, and until now not
+ * expressible at all — every door was drawn as one leaf across the whole
+ * opening, however wide.
  */
-export function windowSash(o: Opening): "single" | "double" {
-  return o.type === "window" && openingMotion(o) === "swing" ? (o.sash ?? "double") : "double";
+export function defaultSash(type: OpeningType): "single" | "double" {
+  return type === "window" ? "double" : "single";
+}
+
+/**
+ * The leaf count the swing symbol draws. Only hinged openings have leaves, so
+ * a slider or a roller reports its type's default and nothing reads it.
+ *
+ * Supersedes `windowSash`, which answered this for windows only and told
+ * doors they were "double" — harmless while the door branch ignored it, and
+ * wrong the moment a door could have two leaves.
+ */
+export function openingSash(o: Opening): "single" | "double" {
+  return openingMotion(o) === "swing" ? (o.sash ?? defaultSash(o.type)) : defaultSash(o.type);
 }
 
 /**
@@ -2303,58 +2321,58 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
 
   let body: SVGTemplateResult;
-  if (o.type === "window" && openingMotion(o) === "swing" && windowSash(o) === "single") {
-    // One casement sash hinged at the left jamb (issue #73) — the window
-    // counterpart of the door leaf: full-width sash, quarter-circle arc that
-    // draws on as it opens. flipH (via the mirror wrapper below) moves the
-    // hinge to the other jamb.
-    const arcLen = (Math.PI / 2) * o.length;
-    body = svg`
-        <!-- jambs -->
+  if (openingMotion(o) === "swing") {
+    // One symbol for every hinged opening. A single-sash window (issue #73)
+    // and a plain door draw the same thing; so do a double door and a pair of
+    // casement leaves. The differences are the leaf count and the jambs, so
+    // those are what this branch decides — rather than three near-copies of
+    // the same markup, which is how the door came to have no way of being a
+    // double at all.
+    const two = openingSash(o) === "double";
+    // One leaf spans the opening; two split it. The arc radius follows,
+    // because it is the path the leaf's own tip sweeps.
+    const leafW = two ? half : o.length;
+    const arcLen = (Math.PI / 2) * leafW;
+    // Revealed via stroke-dashoffset so each arc "draws on" as its leaf opens.
+    const arc = (d: string) => svg`<path class="fp-door-arc" d=${d}
+              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
+              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />`;
+    // Jambs are what say "glass": a door is drawn by its leaf and arc alone,
+    // and that is what tells the two symbols apart at a glance.
+    const jambs =
+      o.type === "window"
+        ? svg`
         <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
               stroke=${color} stroke-width="2" />
         <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
-              stroke=${color} stroke-width="2" />
-        <path class="fp-door-arc"
-              d="M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}"
-              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
-        <g transform="translate(${-half} 0)">
-          <g class="fp-door-leaf" style="transform:rotate(${-90 * amt}deg);">
-            <rect x="0" y="-1.25" width=${o.length} height="2.5" style="fill:${tone};" />
-          </g>
-        </g>
-      `;
-  } else if (o.type === "window" && openingMotion(o) === "swing") {
-    // Two casement leaves hinged at each jamb. Closed, they meet in the middle
-    // along the wall; open, they swing outward (up) like double doors, each
-    // tracing a quarter-circle arc (radius = half) that draws on as it opens.
-    const arcLen = (Math.PI / 2) * half;
+              stroke=${color} stroke-width="2" />`
+        : nothing;
     body = svg`
-        <!-- jambs -->
-        <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
-              stroke=${color} stroke-width="2" />
-        <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
-              stroke=${color} stroke-width="2" />
-        <!-- swing arcs, drawn from the middle outward -->
-        <path class="fp-door-arc" d="M 0 0 A ${half} ${half} 0 0 0 ${-half} ${-half}"
-              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
-        <path class="fp-door-arc" d="M 0 0 A ${half} ${half} 0 0 1 ${half} ${-half}"
-              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
-        <!-- left leaf, hinged at left jamb -->
+        ${jambs}
+        ${
+          two
+            ? // Two leaves hinged at opposite jambs, meeting in the middle when
+              // shut and each tracing its own quarter circle outward.
+              svg`${arc(`M 0 0 A ${half} ${half} 0 0 0 ${-half} ${-half}`)}${arc(
+                `M 0 0 A ${half} ${half} 0 0 1 ${half} ${-half}`
+              )}`
+            : arc(`M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}`)
+        }
+        <!-- leaf hinged at the left jamb (flipH mirrors it to the right one) -->
         <g transform="translate(${-half} 0)">
           <g class="fp-door-leaf" style="transform:rotate(${-90 * amt}deg);">
-            <rect x="0" y="-1.25" width=${half} height="2.5" style="fill:${tone};" />
+            <rect x="0" y="-1.25" width=${leafW} height="2.5" style="fill:${tone};" />
           </g>
         </g>
-        <!-- right leaf, hinged at right jamb -->
-        <g transform="translate(${half} 0)">
+        ${
+          two
+            ? svg`<g transform="translate(${half} 0)">
           <g class="fp-leaf-r" style="transform:rotate(${90 * amt}deg);">
             <rect x=${-half} y="-1.25" width=${half} height="2.5" style="fill:${tone};" />
           </g>
-        </g>
+        </g>`
+            : nothing
+        }
       `;
   } else if (openingMotion(o) === "roll") {
     // Roll-up cover — garage door, roller shutter (issues #45 / #47). Unlike a
@@ -2372,7 +2390,8 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <line x1=${-half} y1="0" x2=${half} y2="0"
               stroke=${color} stroke-width="0.75" opacity="0.6" />
         ${rollCurtain(o.length, tone, amt)}`;
-  } else if (openingMotion(o) === "slide") {
+  } else {
+    // Sliding — the last of the three motions, so the fallback.
     // A sliding door / window: panel(s) sit in the opening and travel *along* the
     // wall. Closed, they fill the gap; open, they slide aside (single), stack
     // (bypass) or part (biparting). No swing arc. A sliding *window*'s panels are
@@ -2500,28 +2519,6 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
           <rect x=${-half} y=${-t / 2} width=${o.length} height=${t} style="fill:${tone};" />
         </g>`;
     }
-  } else {
-    // Door leaf hinged at the left jamb: lies along the wall when closed,
-    // swings up (−90° when fully open) by `amt`. The leaf is drawn closed and
-    // rotated via CSS.
-    const angle = -90 * amt;
-    // Swing arc revealed via stroke-dashoffset so it "draws on" as the door opens.
-    // Path runs from the closed-leaf tip toward the open-leaf tip, so it traces
-    // the door edge. arcLen is the quarter-circle length (radius = o.length).
-    const arcLen = (Math.PI / 2) * o.length;
-    body = svg`
-        <!-- swing arc: hidden when closed, drawn as it opens -->
-        <path class="fp-door-arc"
-              d="M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}"
-              fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />
-        <!-- door leaf, hinged at left jamb -->
-        <g transform="translate(${-half} 0)">
-          <g class="fp-door-leaf" style="transform:rotate(${angle}deg);">
-            <rect x="0" y="-1.25" width=${o.length} height="2.5" style="fill:${tone};" />
-          </g>
-        </g>
-      `;
   }
   // Orientation mirrors are applied as a single scale wrapper inside the
   // place-into-position transform, so the base symbol (drawn once, centered at


### PR DESCRIPTION
### Problem

A window can say how many sashes it has; a door cannot. Whatever its width, a door is drawn as one leaf spanning the whole opening — so a double door, a French door, a pair of patio leaves all come out as a single slab sweeping an arc twice as wide as any of them really does.

`sash` existed already, but `windowSash()` only read it for windows and told doors they were `"double"`, which was harmless only because the door branch ignored it.

### Change

`sash` now reads on both types, with the default per **type** rather than per field:

| type | default | the exception you write down |
| --- | --- | --- |
| window | `double` — two casement leaves | `single` (issue #73) |
| door | `single` — one leaf | `double` |

Both defaults are the ordinary case for their own type, so existing configs are untouched and neither default lands in the YAML.

A double door keeps the door's own symbol: two leaves and two arcs, **no jambs**. Jambs are what say "glass" and are the whole visual difference from a casement pair. Each leaf is half the opening and its arc has half the radius, because that is the distance that leaf's tip actually sweeps. The animation rides the existing `fp-door-leaf` / `fp-leaf-r` classes, so it opens with everything else.

Only swing motion: a slider or a roller has no hinged leaves, so it reports its type's default and nothing reads it.

**Editor.** The field is offered on doors too, labelled **Leaves** there and **Sashes** on windows, with the options ordered so each type's default comes first. **Hinge** now appears only where there is one leaf to hang — a double is hinged at both jambs, so there is no side left to choose.

**Refactor that came with it.** The three swing branches in `renderOpening` were three near-copies of the same markup, and that is precisely how the door came to have no way of being a double. They are one branch now, deciding the two things that actually differ: the leaf count and the jambs. `windowSash` is superseded by `openingSash`, which answers the same question for both types.

### Notes

`npx tsc --noEmit` clean, **966 tests** passing, 12 of them new: the two-leaf geometry and its arcs, the jamb difference against the casement window it mirrors, the untouched single door, the sliders and rollers that ignore the setting, and the per-type patch round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
