### PR TITLE
Openings: an open roll-up reads as open, and a long entity id keeps its buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ distorted anyway.
 | `entity`      | string                      | Contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
 | `secondaryEntity` | string                  | Two-panel sliders (`biparting`, `biparting-bypass`, `converging`): a second contact / `cover` for the other panel, so each leaf moves on its own state. Unset = both follow `entity`. |
 | `invert`      | boolean                     | Flip the open/closed interpretation.                   |
-| `activeColor` | string                      | Leaf/arc color while actively open (default primary).  |
+| `activeColor` | string                      | Leaf/arc color while actively open (default primary). On a roll-up it colours the curtain and the track it leaves behind, so a fully raised shutter still reads as open. |
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
 | `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
 | `showShutterIcon` | boolean                 | Draw that icon (default `true` whenever both are bound). Editor: **Shutter icon**. Turning it off changes nothing about the gestures — for a plan where every window has a shutter and the icons start to shout. |

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
 - **One sensor per panel** — a two-panel slider with a contact on each leaf takes a
   **Second panel** entity, and then each panel opens and accents on its own state: left
   open and right shut draws exactly that. Leave it empty and both panels follow the first
-  entity, as they always have. **Invert** covers both, and a tap still acts on the first.
+  entity, as they always have. The opening's own invert switch covers both, and a tap
+  still acts on the first.
 - **Orientation** — **Hinge** (left / right) and **Opens** (this side / other side) face a
   swing door any of four ways; they're pure mirrors (`flipH` / `flipV`), so the animation
   follows.
@@ -210,8 +211,10 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   against the façade) or *Roll-up*, defaulting from the entity.
 - **Active color** — the leaf, sash and arc take an accent color while open. Defaults to
   the primary color.
-- **Invert** — flip the open/closed interpretation (and the percentage) for sensors wired
-  the other way.
+- **Invert door animation** (**Invert window animation** on a window) — flip the
+  open/closed interpretation (and the percentage) for sensors wired the other way. A bound
+  shutter gets its own **Invert shutter animation**, since a reed contact on the panels
+  routinely disagrees with the sensor behind them about which way round `on` means open.
 - **Tap to control** — a controllable `cover` toggles (`cover.toggle`); read-only sensors
   and position-only covers open the more-info dialog.
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   against the façade) or *Roll-up*, defaulting from the entity.
 - **Active color** — the leaf, sash and arc take an accent color while open. Defaults to
   the primary color.
+- **Show icon** — an optional badge beside the opening carrying its own entity's icon,
+  which changes with the state, and its dialog on a tap. Off by default: a leaf that has
+  swung is still on screen saying so. The roll-up is the case that wants it — raised, its
+  curtain has left the floor plane and only the coloured track remains. With a shutter
+  bound too, the two badges take opposite faces of the wall.
 - **Invert door animation** (**Invert window animation** on a window) — flip the
   open/closed interpretation (and the percentage) for sensors wired the other way. A bound
   shutter gets its own **Invert shutter animation**, since a reed contact on the panels
@@ -407,6 +412,8 @@ distorted anyway.
 | `activeColor` | string                      | Leaf/arc color while actively open (default primary). On a roll-up it colours the curtain and the track it leaves behind, so a fully raised shutter still reads as open. |
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
 | `flipV`       | boolean                     | Mirror across the wall so a swing opening faces the other room. |
+| `showIcon`    | boolean                     | Draw this opening's **own** icon beside it (default `false`). Editor: **Show icon**. For the roll-up: raised, its curtain is gone and only the coloured track is left, which is easy to miss across a room. Tapping the badge opens the entity's dialog. It sits on the opposite face of the wall from the shutter's badge, so an opening with both never stacks them. |
+| `icon`        | string                      | Override that icon. Absent, it is the entity's own — a **pair**, so the glyph itself says open or closed; an override is one glyph for both, and colour still reports the state. |
 | `showShutterIcon` | boolean                 | Draw that icon (default `true` whenever both are bound). Editor: **Shutter icon**. Turning it off changes nothing about the gestures — for a plan where every window has a shutter and the icons start to shout. |
 | `shutterIcon` | string                      | Override the icon's glyph. Left unset it follows the shutter entity, whose default comes in an open/closed pair; an override is one glyph for both states, and colour still reports the state. |
 | `tapTarget`   | `opening` \| `shutter`      | With both entities bound, which one a tap acts on (default `opening`); the other moves to press-and-hold. Editor: **Tap opens**. Pointing it at the shutter opens the shutter's dialog — it does not drive the motor; set `tap_action: toggle` for that. |

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,6 +55,13 @@ immediately — but the browser has already cached the old one, so a change need
 a hard refresh (<kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>). This is the
 one place the container is more friction than the vite harness, which hot-reloads.
 
+Home Assistant serves `/local/` with a month-long `Cache-Control`, so a plain
+reload will happily keep running a card you built last week — which looks like
+your change never compiled. `npm run ha` sidesteps that by registering the
+resource as `/local/easy-floorplan-card.js?v=<hash of the bundle>`: every build
+gets a URL no browser has seen. Only a full `npm run ha` re-registers, which is
+why the `npm run watch` loop above still needs the hard refresh.
+
 Other commands:
 
 ```bash

--- a/docker/prepare.mjs
+++ b/docker/prepare.mjs
@@ -25,6 +25,7 @@
 // being committed -- including right after `npm run ha:reset` has removed it.
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -74,6 +75,22 @@ const storageDir = join(here, "config", ".storage");
 const resourceFile = join(storageDir, "lovelace_resources");
 const URL_PATH = "/local/easy-floorplan-card.js";
 
+// The URL carries a hash of the bundle, because Home Assistant serves /local/
+// with `Cache-Control: public, max-age=2678400` -- a month. At a fixed URL the
+// browser never asks again: you rebuild, restart the container, reload the
+// page, and Home Assistant still runs the card you built last week. It is a
+// convincing failure, because everything else about the instance is new.
+//
+// So every build gets a URL no browser has seen. This is what HACS does with
+// its own `?hacstag=`, and it is why a real install picks up an update on a
+// plain reload. `npm run watch` still rebuilds behind a URL that was already
+// registered, so that loop keeps needing a hard refresh (see docker/README).
+const bundle = resolve(here, "..", "dist", "easy-floorplan-card.js");
+const version = existsSync(bundle)
+  ? createHash("sha256").update(readFileSync(bundle)).digest("hex").slice(0, 12)
+  : null;
+const resourceUrl = version ? `${URL_PATH}?v=${version}` : URL_PATH;
+
 let store = {
   version: 1,
   minor_version: 1,
@@ -92,17 +109,24 @@ if (existsSync(resourceFile)) {
   }
 }
 
-if (store.data.items.some((item) => item?.url === URL_PATH)) {
-  console.log("Resource already registered; leaving it alone.");
+// Match on the path, not the whole URL: the point is to *replace* the entry
+// this script wrote last time, whatever version it pointed at. Appending a
+// second one would leave the frontend loading both, and two modules defining
+// <easy-floorplan-card> means the second registration throws.
+const existing = store.data.items.find((item) => item?.url?.split("?")[0] === URL_PATH);
+if (existing?.url === resourceUrl) {
+  console.log("Resource already registered at this build; leaving it alone.");
 } else {
-  store.data.items.push({
-    id: "easyfloorplandevresource01",
-    type: "module",
-    url: URL_PATH,
-  });
+  if (existing) existing.url = resourceUrl;
+  else
+    store.data.items.push({
+      id: "easyfloorplandevresource01",
+      type: "module",
+      url: resourceUrl,
+    });
   mkdirSync(storageDir, { recursive: true });
   writeFileSync(resourceFile, JSON.stringify(store, null, 2));
-  console.log(`Registered ${URL_PATH} as a Lovelace resource.`);
+  console.log(`Registered ${resourceUrl} as a Lovelace resource.`);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -122,6 +122,16 @@ describe("openingForm", () => {
     expect(bi.fields.map((x) => x.name)).not.toContain("slide");
   });
 
+  it("names the roll-up motion after the door, not the shutter it isn't", () => {
+    // "Roll up (garage / shutter)" read as the place to set up an external
+    // shutter, which is the Shutter field further down and works on any motion.
+    const motionField = openingForm(door).fields.find((x) => x.name === "motion")!;
+    const labels = (
+      motionField.selector as { select: { options: { label: string; value: string }[] } }
+    ).select.options.map((o) => o.label);
+    expect(labels).toEqual(["Swing", "Slide", "Roll up (garage)"]);
+  });
+
   it("roll-up opening hides swing and slide fields (issue #45)", () => {
     const motionField = openingForm(door).fields.find((x) => x.name === "motion")!;
     const opts = (motionField.selector as { select: { options: { value: string }[] } }).select
@@ -915,6 +925,20 @@ describe("openingForm — shutter invert and side (issue #74 follow-up)", () => 
     expect(names(both)).toContain("shutterInvert");
     expect(openingForm({ ...both, shutterInvert: true, invert: false } as Opening).data)
       .toMatchObject({ shutterInvert: true, invert: false });
+  });
+
+  it("says which animation each invert flips, so the pair can be told apart", () => {
+    // Stacked one above the other, "Invert" and "Invert shutter" left you
+    // guessing which switch drove which layer.
+    const both = { ...hinged, entity: "binary_sensor.win" } as Opening;
+    const labels = new Map(openingForm(both).fields.map((f) => [f.name, f.label]));
+    expect(labels.get("invert")).toBe("Invert window animation");
+    expect(labels.get("shutterInvert")).toBe("Invert shutter animation");
+    // …and the opening's own switch is named after what it actually moves.
+    const door = { ...both, type: "door" } as Opening;
+    expect(new Map(openingForm(door).fields.map((f) => [f.name, f.label])).get("invert")).toBe(
+      "Invert door animation"
+    );
   });
 
   it("asks which side only for hinged panels", () => {

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -941,6 +941,32 @@ describe("openingForm — shutter invert and side (issue #74 follow-up)", () => 
     );
   });
 
+  it("offers the opening's own badge, opt-in and only once bound", () => {
+    const bound = { ...win, entity: "cover.garage" } as Opening;
+    expect(names(win)).not.toContain("showIcon");
+    expect(names(bound)).toContain("showIcon");
+    // The glyph override is only worth asking once the badge is drawn.
+    expect(names(bound)).not.toContain("icon");
+    expect(names({ ...bound, showIcon: true } as Opening)).toContain("icon");
+    // Off is the default, so only "on" is worth writing down — the mirror of
+    // the shutter badge, which defaults the other way.
+    const { toPatch, data } = openingForm(bound);
+    expect(data.showIcon).toBe(false);
+    expect(toPatch({ showIcon: true })).toEqual({ showIcon: true });
+    expect(toPatch({ showIcon: false })).toEqual({ showIcon: undefined, icon: undefined });
+  });
+
+  it("drops the badge with the entity it was badging", () => {
+    const { toPatch } = openingForm({ ...win, entity: "cover.garage", showIcon: true } as Opening);
+    expect(toPatch({ entity: "" })).toEqual({
+      entity: "",
+      showIcon: undefined,
+      icon: undefined,
+    });
+    // Binding a different entity keeps it: the badge is still wanted.
+    expect(toPatch({ entity: "cover.other" })).toEqual({ entity: "cover.other" });
+  });
+
   it("asks which side only for hinged panels", () => {
     // The roll curtain is symmetric about the wall line, so the answer would
     // change nothing on screen.

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -187,7 +187,10 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       selector: dropdown(
         opt("swing", "Swing"),
         opt("slide", "Slide"),
-        opt("roll", "Roll up (garage / shutter)")
+        // Not "garage / shutter": an external shutter is the Shutter field
+        // below, a layer over any opening, and naming it here read as the
+        // place to set one up.
+        opt("roll", "Roll up (garage)")
       ),
     },
     { name: "length", label: "Length", required: true, selector: { number: { min: 1, mode: "box" } } },
@@ -294,10 +297,23 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
     }
     // Its own switch, not the opening's: a reed contact on a hinged shutter
     // routinely reads `on` when the panels are shut, while the window behind
-    // it reads the other way round.
-    fields.push({ name: "shutterInvert", label: "Invert shutter", selector: { boolean: {} } });
+    // it reads the other way round. Both switches say which animation they
+    // invert, because with a shutter bound they sit one above the other and
+    // "Invert" / "Invert shutter" left you guessing which was which.
+    fields.push({
+      name: "shutterInvert",
+      label: "Invert shutter animation",
+      selector: { boolean: {} },
+    });
   }
-  if (o.entity) fields.push({ name: "invert", label: "Invert", selector: { boolean: {} } });
+  // Named after what it flips — the opening's own leaf, which is a door or a
+  // sash depending on what this is, the same way Leaves / Sashes above.
+  if (o.entity)
+    fields.push({
+      name: "invert",
+      label: o.type === "door" ? "Invert door animation" : "Invert window animation",
+      selector: { boolean: {} },
+    });
   fields.push(angleField());
   // With both bound, which one a press leads with. Only a real question when
   // there are two entities to choose between — and the reason it exists: the

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -315,6 +315,31 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       selector: { boolean: {} },
     });
   fields.push(angleField());
+  // The opening's own badge (issue #154 follow-up). Offered for any bound
+  // opening, but sold on the case that needs it: a raised roll-up has nothing
+  // left on the plan but a coloured line.
+  if (o.entity) {
+    fields.push({
+      name: "showIcon",
+      label: "Show icon",
+      helper:
+        openingMotion(o) === "roll"
+          ? "A raised roll-up leaves only a line — this puts its state beside it, and opens its dialog when tapped"
+          : "Shows this opening's state beside it, and opens its dialog when tapped",
+      selector: { boolean: {} },
+    });
+    // Same bargain as the shutter's: only worth asking once the badge is
+    // drawn, and an override trades the entity's open/closed pair for one
+    // glyph, so it is not the default.
+    if (o.showIcon) {
+      fields.push({
+        name: "icon",
+        label: "Icon",
+        helper: "Overrides the entity's own icon, which changes with its state",
+        selector: { icon: {} },
+      });
+    }
+  }
   // With both bound, which one a press leads with. Only a real question when
   // there are two entities to choose between — and the reason it exists: the
   // shutter used to be reachable by hold alone, which is not discoverable and
@@ -402,6 +427,8 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       shutterInvert: o.shutterInvert ?? false,
       showShutterIcon: o.showShutterIcon ?? true,
       shutterIcon: o.shutterIcon ?? "",
+      showIcon: o.showIcon ?? false,
+      icon: o.icon ?? "",
       tapTarget: o.tapTarget ?? "opening",
       invert: o.invert ?? false,
       angle: o.angle,
@@ -429,12 +456,28 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             out.showShutterIcon = undefined;
             out.shutterIcon = undefined;
           }
+        } else if (k === "entity") {
+          out.entity = v;
+          // The badge and its glyph only mean something with an entity to
+          // badge, exactly as the shutter's pair above. Left behind, they
+          // would reappear on whatever gets bound here next.
+          if (!v) {
+            out.showIcon = undefined;
+            out.icon = undefined;
+          }
         } else if (k === "shutterSide") out.shutterFlipV = v === "near" || undefined;
         else if (k === "shutterInvert") out.shutterInvert = v || undefined;
         // The opening is the default, so it stays out of the YAML.
         else if (k === "tapTarget") out.tapTarget = v === "shutter" ? "shutter" : undefined;
         // Shown is the default: only "off" is worth writing down.
         else if (k === "showShutterIcon") out.showShutterIcon = v ? undefined : false;
+        // The opening's badge defaults the other way round, so only "on" is.
+        // Switching it off takes the glyph with it: kept, it would silently
+        // reapply the next time someone turned the badge back on.
+        else if (k === "showIcon") {
+          out.showIcon = v ? true : undefined;
+          if (!v) out.icon = undefined;
+        }
         else if (k === "motion") {
           out.motion = v === "slide" || v === "roll" ? v : undefined;
           // sliderStyle only applies while sliding — drop it when switching

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,6 +62,7 @@ import {
   editorGlowPaint,
   renderGlow,
   resolveOpeningAmount,
+  openingIsActive,
   wallsLightPassesThrough,
   openingClearFraction,
   openingHasTwoPanels,
@@ -75,6 +76,10 @@ import {
   shutterMarkIcon,
   shutterMarkPoint,
   shutterMarkNormal,
+  openingMarkIcon,
+  openingMarkPoint,
+  openingMarkNormal,
+  hasOpeningMark,
   SHUTTER_MARK_PIXEL_OFFSET,
   SHUTTER_MARK_SIZE,
   hasShutterMark,
@@ -2983,6 +2988,9 @@ export class FloorplanCardEditor extends LitElement {
               ${floor.openings
                 .filter((o) => hasShutterMark(o))
                 .map((o) => this._renderShutterMarkOverlay(o, c))}
+              ${floor.openings
+                .filter((o) => hasOpeningMark(o))
+                .map((o) => this._renderOpeningMarkOverlay(o, c))}
               ${floor.items.map((it) => this._renderItemOverlay(it, c))}
             </div>
           </div>
@@ -3638,6 +3646,32 @@ export class FloorplanCardEditor extends LitElement {
                n.y * SHUTTER_MARK_PIXEL_OFFSET
              }px);--fp-active:${accent};"
       title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open the shutter`}
+    >
+      <ha-icon icon=${icon}></ha-icon>
+    </div>`;
+  }
+
+  /**
+   * The card's opening badge, previewed (issue #154 follow-up). Same reason as
+   * the shutter's preview above: turning **Show icon** on and finding out where
+   * the badge lands is the whole point of having a canvas. Inert here too.
+   */
+  private _renderOpeningMarkOverlay(o: Opening, c: FloorplanCardConfig): TemplateResult {
+    const id = o.entity!;
+    const st = this.hass?.states[id];
+    const open = resolveOpeningAmount(o, st) > 0;
+    const icon = openingMarkIcon(o, st, open, this.hass?.entities?.[id]?.icon);
+    const accent = cssColor(o.activeColor) ?? SKIN_ACCENT;
+    const at = openingMarkPoint(o);
+    const n = openingMarkNormal(o);
+    return html`<div
+      class="shutter-mark ${openingIsActive(o, st) ? "on" : "off"}"
+      style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;
+             width:${SHUTTER_MARK_SIZE}px;height:${SHUTTER_MARK_SIZE}px;
+             transform:translate(-50%,-50%) translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
+               n.y * SHUTTER_MARK_PIXEL_OFFSET
+             }px);--fp-active:${accent};"
+      title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open its dialog`}
     >
       <ha-icon icon=${icon}></ha-icon>
     </div>`;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3401,7 +3401,7 @@ export class FloorplanCardEditor extends LitElement {
       <section class="edit-area">
         <div class="edit-head">
           <ha-icon icon=${icon}></ha-icon>
-          <span class="edit-title">${summary}</span>
+          <span class="edit-title" title=${summary}>${summary}</span>
           <span class="head-spacer"></span>
           <button aria-label="Duplicate" title="Duplicate (Ctrl/Cmd+D)" @click=${this._duplicate}>
             <ha-icon icon="mdi:content-duplicate"></ha-icon>
@@ -5382,7 +5382,12 @@ export class FloorplanCardEditor extends LitElement {
       letter-spacing: 0.06em;
       color: var(--secondary-text-color);
     }
-    /* Element header: kind icon + summary + the selection's actions. */
+    /* Element header: kind icon + summary + the selection's actions.
+       The actions are the fixed part and the summary is the elastic one: a
+       device named after a long entity id used to push Duplicate and Delete
+       off the panel entirely (issue #163), which is unreachable rather than
+       merely ugly. So everything but the title refuses to shrink, and the
+       title truncates instead — its full text stays available on hover. */
     .edit-head {
       display: flex;
       align-items: center;
@@ -5392,18 +5397,28 @@ export class FloorplanCardEditor extends LitElement {
     .edit-head ha-icon {
       --mdc-icon-size: 18px;
       color: var(--secondary-text-color);
+      flex: none;
     }
     .edit-head .edit-title {
       font-size: 13px;
       font-weight: 600;
+      /* min-width:0 is what lets a flex item shrink below its content. */
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .edit-head .head-spacer {
-      flex: 1;
+      /* Grows to push the actions right, but never shrinks the title away
+         while there is still slack of its own to give back. */
+      flex: 1 1 0;
+      min-width: 0;
     }
     .edit-head button {
       display: inline-flex;
       align-items: center;
       padding: 4px 8px;
+      flex: none;
     }
     .edit-head button ha-icon {
       --mdc-icon-size: 16px;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -45,6 +45,10 @@ import {
   shutterMarkPoint,
   shutterMarkIcon,
   shutterMarkNormal,
+  openingMarkPoint,
+  openingMarkIcon,
+  openingMarkNormal,
+  hasOpeningMark,
   SHUTTER_MARK_PIXEL_OFFSET,
   SHUTTER_MARK_SIZE,
   SHUTTER_MARK_ICON_SIZE,
@@ -351,6 +355,63 @@ export class FloorplanCard extends LitElement {
     // badge's own unit: fixed pixels never shrink with the plan, and would
     // otherwise cover the opening on a large canvas in a narrow card.
     const n = shutterMarkNormal(o, rot);
+    const step = overlayLength(SHUTTER_MARK_PIXEL_OFFSET, scale);
+    const push = `translate(calc(${n.x} * ${step}), calc(${n.y} * ${step}))`;
+    const box = overlayLength(SHUTTER_MARK_SIZE, scale);
+    const name =
+      (this.hass?.states[id]?.attributes?.friendly_name as string | undefined) ?? id;
+    return html`
+      <div
+        class="shutter-mark ${active ? "on" : "off"}"
+        data-entity=${cssEntityId(id) ?? nothing}
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;
+               width:${box};height:${box};
+               transform:translate(-50%,-50%) ${push};--fp-active:${accent};"
+        title="${name} · ${entityStateText(this.hass, id)}"
+        role="button"
+        tabindex="0"
+        @action=${() => {
+          if (this.hass) executeAction(this, this.hass, { entity: id }, { action: "more-info" });
+        }}
+        .actionHandler=${actionHandler({})}
+      >
+        <ha-icon
+          icon=${icon}
+          style="--mdc-icon-size:${overlayLength(SHUTTER_MARK_ICON_SIZE, scale)};"
+        ></ha-icon>
+      </div>
+    `;
+  }
+
+  /**
+   * The opening's own badge (issue #154 follow-up) — the same circle as the
+   * shutter's, for the entity the opening symbol itself draws.
+   *
+   * Opt-in, because most symbols need no help: a leaf that has swung and a
+   * panel that has slid are both still on screen, in the accent, saying so. A
+   * roll-up is the one that isn't — its curtain leaves the floor plane, and
+   * wide open the gap holds a single coloured line. That line is honest and
+   * easy to miss, so this puts the entity's own open/closed glyph beside it.
+   *
+   * It sits on the far side of the wall from the shutter's badge, which is
+   * what keeps the two from stacking on an opening that draws both.
+   */
+  private _renderOpeningMark(
+    o: Opening,
+    c: FloorplanCardConfig,
+    rot: PlanRotation,
+    scale: OverlayScale
+  ): TemplateResult {
+    const id = o.entity!;
+    const st = this.hass?.states[id];
+    const open = this._openingAmount(o) > 0;
+    const active = this._openingActive(o);
+    const icon = openingMarkIcon(o, st, open, this.hass?.entities?.[id]?.icon);
+    const accent = cssColor(o.activeColor) ?? SKIN_ACCENT;
+    const at = openingMarkPoint(o);
+    const p = rotatePlanPoint(at.x, at.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
+    const n = openingMarkNormal(o, rot);
     const step = overlayLength(SHUTTER_MARK_PIXEL_OFFSET, scale);
     const push = `translate(calc(${n.x} * ${step}), calc(${n.y} * ${step}))`;
     const box = overlayLength(SHUTTER_MARK_SIZE, scale);
@@ -912,6 +973,11 @@ export class FloorplanCard extends LitElement {
               active.openings.filter((o) => hasShutterMark(o)),
               (o, i) => `${o.id || i}-shutter`,
               (o) => this._renderShutterMark(o, c, rot, scale)
+            )}
+            ${repeat(
+              active.openings.filter((o) => hasOpeningMark(o)),
+              (o, i) => `${o.id || i}-opening`,
+              (o) => this._renderOpeningMark(o, c, rot, scale)
             )}
             ${repeat(
               // No entity filter: devices that exist physically but have no HA

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -329,6 +329,36 @@ describe("renderOpening — roll-up cover (issue #45)", () => {
   });
 });
 
+describe("renderOpening — an open roll-up reads as open (issue #154)", () => {
+  const roll = { type: "door", motion: "roll" } as Partial<Opening>;
+
+  it("accents the track, the only mark a wide-open garage leaves behind", () => {
+    // The curtain has scaled to nothing at amount 1, so a base-coloured track
+    // is indistinguishable from a shut garage — the bug this fixes.
+    const open = svgOf(roll, { open: true, active: true, accent: "#ff0000" });
+    expect(open).toContain('stroke=#ff0000 stroke-width="0.75"');
+    expect(open).toContain('opacity=1'); // full strength: a 0.6 accent reads as neither colour
+  });
+
+  it("still accents it half-open, where curtain and track are both on screen", () => {
+    const half = svgOf(roll, { amount: 0.5, active: true, accent: "#ff0000" });
+    expect(half).toContain('stroke=#ff0000 stroke-width="0.75"');
+    expect(half).toContain("scaleY(0.5)");
+  });
+
+  it("leaves a shut garage exactly as it was — dimmed track in the base colour", () => {
+    const shut = svgOf(roll, { open: false, accent: "#ff0000" });
+    expect(shut).toContain('stroke=#000 stroke-width="0.75"');
+    expect(shut).toContain('opacity=0.6');
+    expect(shut).not.toContain("#ff0000");
+  });
+
+  it("keeps the jambs structural: they are wall, not cover, so they never accent", () => {
+    const open = svgOf(roll, { open: true, active: true, accent: "#ff0000" });
+    expect(open.match(/stroke=#000 stroke-width="2"/g)?.length).toBe(2);
+  });
+});
+
 describe("renderOpening — single-sash window (issue #73)", () => {
   const single = { type: "window", sash: "single" } as Partial<Opening>;
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -42,6 +42,10 @@ import {
   openingIsPressable,
   hasShutterMark,
   shutterMarkPoint,
+  hasOpeningMark,
+  openingMarkIcon,
+  openingMarkPoint,
+  openingMarkNormal,
   shutterMarkIcon,
   shutterMarkNormal,
   SHUTTER_MARK_OFFSET,
@@ -2483,6 +2487,99 @@ describe("the shutter badge (issue #74 follow-up)", () => {
       expect(Math.sign(at.x - o.x) || 0).toBe(Math.sign(Number(n.x.toFixed(6))) || 0);
       expect(Math.sign(at.y - o.y) || 0).toBe(Math.sign(Number(n.y.toFixed(6))) || 0);
     }
+  });
+});
+
+describe("the opening's own badge (issue #154 follow-up)", () => {
+  const win = (extra: Partial<Opening> = {}) =>
+    ({ id: "o", type: "window", x: 500, y: 100, length: 90, angle: 0, ...extra }) as Opening;
+  const garage = (extra: Partial<Opening> = {}) =>
+    ({
+      id: "g",
+      type: "door",
+      motion: "roll",
+      x: 500,
+      y: 100,
+      length: 140,
+      angle: 0,
+      ...extra,
+    }) as Opening;
+
+  it("is opt-in, unlike the shutter's — most symbols say it themselves", () => {
+    expect(hasOpeningMark(garage({ entity: "cover.garage" }))).toBe(false);
+    expect(hasOpeningMark(garage({ entity: "cover.garage", showIcon: true }))).toBe(true);
+    // Nothing to badge without an entity, however loudly the config asks.
+    expect(hasOpeningMark(garage({ showIcon: true }))).toBe(false);
+  });
+
+  it("sits on the far side of the wall from the shutter's, so the two never stack", () => {
+    // The whole point of the placement: an opening drawing both badges puts
+    // one on each face, at any angle and under any flipV.
+    const both = win({ entity: "binary_sensor.win", shutterEntity: "cover.t", showIcon: true });
+    expect(openingMarkPoint(both)).toEqual({ x: 500, y: 100 - SHUTTER_MARK_OFFSET });
+    expect(shutterMarkPoint(both)).toEqual({ x: 500, y: 100 + SHUTTER_MARK_OFFSET });
+    for (const o of [
+      both,
+      win({ ...both, flipV: true }),
+      win({ ...both, angle: -90 }),
+      win({ ...both, angle: 37, flipV: true }),
+    ]) {
+      const a = openingMarkPoint(o);
+      const b = shutterMarkPoint(o);
+      // Two badge-widths apart is the test that matters: they are circles.
+      expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeCloseTo(SHUTTER_MARK_OFFSET * 2);
+    }
+  });
+
+  it("pushes its pixel offset the same way its anchor went", () => {
+    for (const o of [win(), win({ flipV: true }), win({ angle: -90 }), win({ angle: 37 })]) {
+      const at = openingMarkPoint(o);
+      const n = openingMarkNormal(o);
+      expect(Math.sign(at.x - o.x) || 0).toBe(Math.sign(Number(n.x.toFixed(6))) || 0);
+      expect(Math.sign(at.y - o.y) || 0).toBe(Math.sign(Number(n.y.toFixed(6))) || 0);
+    }
+    // …and away from the shutter's, in screen space as well as plan space.
+    const n = openingMarkNormal(win());
+    const s = shutterMarkNormal(win());
+    expect(n.x).toBeCloseTo(-s.x);
+    expect(n.y).toBeCloseTo(-s.y);
+    // Rotating the plan turns both together (issue #33).
+    expect(openingMarkNormal(win(), 90).x).toBeCloseTo(1);
+  });
+
+  it("shows the entity's own icon, state-aware, on the shutter badge's terms", () => {
+    const g = { type: "door", entity: "cover.garage" } as Pick<Opening, "type" | "entity" | "icon">;
+    const st = (state: string) => ({ state, attributes: { device_class: "garage" } });
+    expect(openingMarkIcon(g, st("open"), true)).toBe("mdi:garage-open");
+    expect(openingMarkIcon(g, st("closed"), false)).toBe("mdi:garage");
+    // Override, registry, then the icon on the state — same order as always.
+    expect(openingMarkIcon({ ...g, icon: "mdi:mine" }, st("open"), true, "mdi:reg")).toBe("mdi:mine");
+    expect(openingMarkIcon(g, st("open"), true, "mdi:reg")).toBe("mdi:reg");
+  });
+
+  it("falls back to a door or a window when the entity declares no class", () => {
+    // A bare contact has no pair of its own, and the symbol it decorates does.
+    expect(openingMarkIcon({ type: "door", entity: "binary_sensor.d" }, undefined, true)).toBe(
+      "mdi:door-open"
+    );
+    expect(openingMarkIcon({ type: "door", entity: "binary_sensor.d" }, undefined, false)).toBe(
+      "mdi:door-closed"
+    );
+    expect(openingMarkIcon({ type: "window", entity: "binary_sensor.w" }, undefined, true)).toBe(
+      "mdi:window-open"
+    );
+    expect(openingMarkIcon({ type: "window", entity: "binary_sensor.w" }, undefined, false)).toBe(
+      "mdi:window-closed"
+    );
+  });
+
+  it("refuses an icon string that isn't one, at every level", () => {
+    const nasty = { state: "open", attributes: { icon: "mdi:x;background:url(//evil)" } };
+    const o = { type: "window", entity: "cover.w", icon: "mdi:evil;}" } as Pick<
+      Opening,
+      "type" | "entity" | "icon"
+    >;
+    expect(openingMarkIcon(o, nasty, true, "mdi:y;}")).toBe("mdi:window-open");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -2386,9 +2386,15 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
               stroke=${color} stroke-width="2" />
         <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
               stroke=${color} stroke-width="2" />
-        <!-- track: stays when the curtain is up so the gap still reads as an opening -->
+        <!-- Track: stays when the curtain is up so the gap still reads as an
+             opening — and wears the accent while the cover is open or moving
+             (issue #154). Wide open the curtain has scaled away to nothing, so
+             this line is the *only* mark left: drawn in the base colour it read
+             exactly like a shut garage, which is the one thing it must not do.
+             Full strength when accented, since a 0.6 tint of the accent reads
+             as neither colour. -->
         <line x1=${-half} y1="0" x2=${half} y2="0"
-              stroke=${color} stroke-width="0.75" opacity="0.6" />
+              stroke=${tone} stroke-width="0.75" opacity=${active ? 1 : 0.6} />
         ${rollCurtain(o.length, tone, amt)}`;
   } else {
     // Sliding — the last of the three motions, so the fallback.

--- a/src/render.ts
+++ b/src/render.ts
@@ -2224,6 +2224,45 @@ export function hasShutterMark(
 /** Last-resort shutter glyphs, for an entity with no device class of its own. */
 const SHUTTER_FALLBACK_ICON = { on: "mdi:window-shutter-open", off: "mdi:window-shutter" };
 
+/** The same, for an opening's own badge — a door reads as a door, glass as glass. */
+const OPENING_FALLBACK_ICON: Record<OpeningType, { on: string; off: string }> = {
+  door: { on: "mdi:door-open", off: "mdi:door-closed" },
+  window: { on: "mdi:window-open", off: "mdi:window-closed" },
+};
+
+/**
+ * The badge glyph for one bound entity: the author's override first, then the
+ * entity's **own** icon resolved exactly as Home Assistant resolves it —
+ * registry override, then the icon on the state, then the domain/device-class
+ * default — and a state-aware pair as the last resort.
+ *
+ * Shared by both badges an opening can draw, because "show whatever this
+ * entity shows everywhere else in HA" is the same promise either time. `open`
+ * is the already-inverted reading, so a sensor wired the other way round still
+ * picks the right half of every pair.
+ */
+function markIcon(
+  entityId: string,
+  configured: string | undefined,
+  st: { state: string; attributes?: Record<string, unknown> } | undefined,
+  open: boolean,
+  fallback: { on: string; off: string },
+  registryIcon?: string,
+): string {
+  // The author's own choice first, as it is for a device (issue #106) — the
+  // one candidate that is a decision rather than a default.
+  const chosen = cssIcon(configured);
+  if (chosen) return chosen;
+  const registry = cssIcon(registryIcon);
+  if (registry) return registry;
+  const attr = cssIcon(st?.attributes?.icon);
+  if (attr) return attr;
+  return (
+    entityDefaultIcon(entityId, st?.attributes?.device_class as string | undefined, open) ??
+    (open ? fallback.on : fallback.off)
+  );
+}
+
 /**
  * The glyph for an opening's shutter badge — the shutter entity's **own**
  * icon, resolved exactly as Home Assistant resolves it, so the badge shows
@@ -2242,19 +2281,72 @@ export function shutterMarkIcon(
   open: boolean,
   registryIcon?: string,
 ): string {
-  const entityId = o.shutterEntity ?? "";
-  // The author's own choice first, as it is for a device (issue #106) — the
-  // one candidate that is a decision rather than a default.
-  const configured = cssIcon(o.shutterIcon);
-  if (configured) return configured;
-  const registry = cssIcon(registryIcon);
-  if (registry) return registry;
-  const attr = cssIcon(st?.attributes?.icon);
-  if (attr) return attr;
-  return (
-    entityDefaultIcon(entityId, st?.attributes?.device_class as string | undefined, open) ??
-    (open ? SHUTTER_FALLBACK_ICON.on : SHUTTER_FALLBACK_ICON.off)
+  return markIcon(
+    o.shutterEntity ?? "",
+    o.shutterIcon,
+    st,
+    open,
+    SHUTTER_FALLBACK_ICON,
+    registryIcon,
   );
+}
+
+/**
+ * Whether an opening draws a badge for its **own** entity (issue #154
+ * follow-up).
+ *
+ * Off unless asked for, unlike the shutter's: the symbol already carries the
+ * state for anything that stays on screen while it moves. A roll-up is the
+ * case that doesn't — its curtain leaves the floor plane, so wide open there
+ * is only a coloured track line left, which is a lot to read across a room.
+ */
+export function hasOpeningMark(o: Pick<Opening, "entity" | "showIcon">): boolean {
+  return !!o.entity && (o.showIcon ?? false);
+}
+
+/**
+ * The glyph for that badge — the opening entity's own icon, on the same terms
+ * as the shutter's, falling back to a door/window pair for an entity with no
+ * device class to speak for it.
+ */
+export function openingMarkIcon(
+  o: Pick<Opening, "type" | "entity" | "icon">,
+  st: { state: string; attributes?: Record<string, unknown> } | undefined,
+  open: boolean,
+  registryIcon?: string,
+): string {
+  return markIcon(
+    o.entity ?? "",
+    o.icon,
+    st,
+    open,
+    OPENING_FALLBACK_ICON[o.type] ?? OPENING_FALLBACK_ICON.door,
+    registryIcon,
+  );
+}
+
+/**
+ * Where that badge sits, and which way it is pushed: the mirror image of the
+ * shutter's, on the other face of the wall.
+ *
+ * Not a style choice — it is what keeps the two badges apart. A shutter hangs
+ * outside, so its badge follows it there; the opening belongs to the room, so
+ * its own badge sits inside. An opening drawing both then has one on each
+ * side, at any angle and under any `flipV`, without either having to know the
+ * other exists.
+ */
+export function openingMarkPoint(
+  o: Pick<Opening, "x" | "y" | "angle" | "flipV">,
+): { x: number; y: number } {
+  return shutterMarkPoint(o, -SHUTTER_MARK_OFFSET);
+}
+
+export function openingMarkNormal(
+  o: Pick<Opening, "angle" | "flipV">,
+  rot: PlanRotation = 0,
+): { x: number; y: number } {
+  const n = shutterMarkNormal(o, rot);
+  return { x: -n.x, y: -n.y };
 }
 
 /** Style options for {@link renderOpening}. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,27 @@ export interface Opening {
    */
   tapTarget?: OpeningTapTarget;
   /**
+   * Draw the opening's **own** icon beside it (default false).
+   *
+   * The symbol usually says everything: a leaf swings, a panel slides. A
+   * roll-up is the exception — its curtain leaves the floor plane, so wide
+   * open there is nothing left but a coloured line, and a garage door across
+   * the room is a state you want to read at a glance rather than infer from a
+   * hairline (issue #154 follow-up). Off by default because a plan of swing
+   * doors does not need a badge on every one of them.
+   *
+   * Sits on the opposite side of the wall from {@link showShutterIcon}'s
+   * badge, so an opening that draws both never stacks them.
+   */
+  showIcon?: boolean;
+  /**
+   * Override that icon. Absent, it is the opening entity's own, resolved the
+   * way {@link shutterIcon} describes — a **pair**, so the glyph carries
+   * open/closed by itself. An override is one glyph for both states; colour
+   * still reports the state.
+   */
+  icon?: string;
+  /**
    * Draw the shutter's icon beside the opening (default true, whenever both
    * entities are bound). It is what makes the second entity visible at all —
    * and a control of its own, since tapping it opens the shutter — but on a


### PR DESCRIPTION
Closes #154, closes #163. Rebased on `main` (the HA-in-a-container harness).

## An open roll-up had no colour (#154)

A roll-up's curtain scales to nothing as it opens, so wide open the track line is the only mark left. It was drawn in the base colour, which made a raised garage door read exactly like a shut one — the same "thin line" reported in discussion #150 for a roller shutter layered over a slider.

The track now takes the accent whenever the cover is open or in motion, at full strength (a 0.6 tint of the accent reads as neither colour). The jambs stay in the wall colour — they are structure, not cover — and a shut garage renders exactly as before.

### …and an optional badge, for when a coloured hairline isn't enough

Colour fixes the bug, but a raised roll-up is still just a line. So openings get the badge shutters already have: `showIcon` draws the opening entity's own icon beside it — `mdi:garage-open` against `mdi:garage`, resolved exactly as Home Assistant resolves it — accented while open, and opening the entity's dialog on a tap. `icon` overrides the glyph.

Off by default, which is the opposite of the shutter badge's default. A leaf that has swung and a panel that has slid are both still on screen in the accent, saying so themselves; the roll-up is the one symbol that leaves nothing behind, and a badge on every swing door in a plan is noise.

On the overlap: it sits on the **far face of the wall from the shutter badge**, so an opening drawing both puts one on each side rather than stacking them — at any angle, under any `flipV`, and through the plan's own display rotation. That is asserted rather than eyeballed: the two anchors stay exactly two offsets apart across angles and mirrors.

## A long entity id pushed Duplicate and Delete off the panel (#163)

The Element header's title is a single unbreakable token when the selection is a device named after its entity id. Nothing in the header could shrink, so the actions were pushed out of the panel entirely — unreachable, and with them the tooltips that name their keyboard shortcuts.

The title now truncates with an ellipsis and carries its full text in a `title` tooltip; the icon, spacer and buttons refuse to shrink.

Before / after with the same 88-character entity id at HA-dialog width:
- before: header wraps to two lines, both buttons past the panel's right edge (x=645 and 687 in a 533-wide header)
- after: one line, title ellipsised, both buttons inside the panel

## While we were in there: the opening form's wording

- With a shutter bound, the form stacked **Invert** directly above **Invert shutter** — two booleans, neither saying which layer it moved. Now **Invert door animation** and **Invert shutter animation**. The first follows what the opening actually is, so a window reads **Invert window animation**, the way **Leaves** / **Sashes** already does.
- **Motion** loses a word: *Roll up (garage / shutter)* → *Roll up (garage)*. Naming shutters there read as the place to set one up, but an external shutter is the **Shutter** field further down and layers over any motion.

## And a dev-harness fix that this PR walked straight into

Home Assistant serves `/local/` with `Cache-Control: public, max-age=2678400`. At a fixed resource URL the browser never asks again, so you rebuild, restart the container, reload — and still run the card you built last week, with nothing in the failure pointing at caching.

`docker/prepare.mjs` now registers `/local/easy-floorplan-card.js?v=<sha256 of the bundle>`, so every build lands on a URL nothing has cached (the trick HACS plays with `?hacstag=`). It rewrites the existing entry rather than adding one — two modules defining `<easy-floorplan-card>` would make the second registration throw. `npm run watch` rebuilds behind an already-registered URL, so that loop still wants a hard refresh, and the README says so.

Separable from the rest of the PR if you'd rather it landed on its own.

## Verification

- 980 unit tests pass, `tsc --noEmit` clean. New tests cover the accented track (open, half-open, shut, jambs staying structural), the badge (opt-in, icon resolution and its door/window fallback, anti-collision placement, rotation), and both label changes.
- Driven in a browser: the garage door at 0 / 45 / 100 % and open vs shut with the badge on (`mdi:garage-open` accented → `mdi:garage` grey); a window with both badges bound, measured apart at rotation 0 and 90; a device re-bound to a long entity id in the editor at 560px width.
- The resource change was checked against a running container: `prepare.mjs` is idempotent per build, the registered URL matches the bundle's hash, and HA serves that URL with the new code in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)