### PR TITLE
A sensor per leaf, offline devices that read as offline, and a header worth its height (closes #159, #162, #152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ screen size.
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
 - **Animated doors & windows** — bind a contact `binary_sensor` or `cover` and openings swing, slide or roll with their real state, partial positions included.
+  - (${\color{red}NEW!}$) **A sensor per leaf** — anything with two leaves takes a second contact and draws them independently: a casement window with one sash open and one shut, a double door ajar on one side, a pair of shutters with one folded back.
+- (${\color{red}NEW!}$) **Offline devices read as offline** — an entity that is unavailable, unknown, or gone from Home Assistant is dimmed (or crossed out), instead of looking exactly like a device someone switched off.
 - (${\color{red}NEW!}$) **Furniture** — 26 gray line-art diagrams (table, sofa, bed, stove, stairs, tv…), each bindable to an entity, in a searchable picker. Every one is a plain JSON file of numbers you can copy: draw your own in the editor's paste box, use it straight away, and open a PR when it's good. No SVG, so nothing you paste can run anything.
 - **Areas** — trace room polygons that color live from an entity, and link them to Home Assistant areas to scope entity pickers and bulk-add devices.
 - **Live position trackers** — map one or two distance sensors (mmWave / radar) onto a marker that moves across the plan in real time.
@@ -197,18 +199,22 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   fixed panels)* if the outer quarters of your door are fixed glass, and *converging* if
   every leaf slides. **Slide** sets the direction; a style that moves both panels has
   none.
-- **One sensor per panel** — a two-panel slider with a contact on each leaf takes a
-  **Second panel** entity, and then each panel opens and accents on its own state: left
-  open and right shut draws exactly that. Leave it empty and both panels follow the first
-  entity, as they always have. The opening's own invert switch covers both, and a tap
-  still acts on the first.
+- **One sensor per leaf** — anything with two leaves takes a **Second leaf** entity, and
+  then each leaf opens and accents on its own state: left open and right shut draws
+  exactly that. That means the two-panel sliders above, and any hinged double — a
+  casement window (`sash: double`, the window default) or a double door. Leave it empty
+  and both leaves follow the first entity, as they always have. The opening's own invert
+  switch covers both, and a tap still acts on the first.
 - **Orientation** — **Hinge** (left / right) and **Opens** (this side / other side) face a
   swing door any of four ways; they're pure mirrors (`flipH` / `flipV`), so the animation
   follows.
 - **External shutters** — bind a second `cover` or contact as **Shutter** and it shares
   the wall gap with the opening, rendering independently — so an open window behind a
   closed shutter shows both. **Shutter type** picks *Hinged* (louvered panels folding back
-  against the façade) or *Roll-up*, defaulting from the entity.
+  against the façade) or *Roll-up*, defaulting from the entity. A hinged pair has a
+  **Second shutter panel** of its own, on the same terms as the leaf above — a shutter is
+  a layer *over* the opening, so a double casement behind a pair of shutters has four
+  leaves and can carry four contacts.
 - **Active color** — the leaf, sash and arc take an accent color while open. Defaults to
   the primary color.
 - **Show icon** — an optional badge beside the opening carrying its own entity's icon,
@@ -232,6 +238,10 @@ openings:
   - { id: bay, type: window, motion: slide, sliderStyle: biparting-bypass, x: 300, y: 500, length: 200, angle: 0, entity: binary_sensor.sliding_door_left, secondaryEntity: binary_sensor.sliding_door_right }
   # the same door with no fixed glass: both leaves slide and stack in the middle
   - { id: terrace, type: window, motion: slide, sliderStyle: converging, x: 300, y: 700, length: 200, angle: 0, entity: binary_sensor.terrace_left, secondaryEntity: binary_sensor.terrace_right }
+  # a casement window with a contact on each sash: one open, one shut
+  - { id: study, type: window, x: 820, y: 100, length: 120, angle: 0, entity: binary_sensor.study_left, secondaryEntity: binary_sensor.study_right }
+  # a single-sash window behind a pair of shutters, one contact per panel
+  - { id: kitchen, type: window, sash: single, x: 500, y: 100, length: 120, angle: 0, shutterEntity: binary_sensor.persiana_left, shutterStyle: swing, shutterSecondaryEntity: binary_sensor.persiana_right }
   # a swing door hinged on the right, opening into the other room
   - { id: hall, type: door, x: 300, y: 100, length: 80, angle: 0, flipH: true, flipV: true }
 ```
@@ -342,6 +352,8 @@ The editor writes this config for you; manual editing is optional.
 | `sunBrightnessMax` | number | `1` | Brightness in full daylight, 0–1. |
 | `skin`       | string   | `default`          | Built-in look for the whole plan: `default`, `odnetnin`, `pastel` or `tron`. See [Skins](#skins). |
 | `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
+| `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |
+| `compactHeader`| boolean | `false`           | Draw the title inside the plan and the floor buttons in a row, instead of spending a card header row on them. See [Compact header](#compact-header). |
 | `overlayScale`| string  | `fixed`            | How badges, labels, room names and text are sized: `fixed` = screen pixels, `plan` = canvas units so they scale with the drawing. See [Overlay scale](#overlay-scale). |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
@@ -401,13 +413,14 @@ distorted anyway.
 | `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |
 | `shutterInvert` | boolean                   | Flip the shutter's open/closed reading — a reed contact on hinged panels often reads `on` when they are shut. Separate from `invert`. |
+| `shutterSecondaryEntity` | string            | Hinged shutters only: a second contact for the shutter's other panel, so one can be folded back while the other is still across the glass. Its own key rather than `secondaryEntity` — a double casement behind a pair of shutters has four leaves. `shutterInvert` covers both panels; the roll curtain ignores it. |
 | `shutterActiveColor` | string               | Shutter color while open. Falls back to `activeColor`, then the accent. |
 | `shutterFlipV` | boolean                    | Hang hinged panels on the sash's own side of the wall instead of the far side. Ignored by the roll curtain. |
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |
 | `entity`      | string                      | Contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
-| `secondaryEntity` | string                  | Two-panel sliders (`biparting`, `biparting-bypass`, `converging`): a second contact / `cover` for the other panel, so each leaf moves on its own state. Unset = both follow `entity`. |
+| `secondaryEntity` | string                  | Anything with **two leaves**: a second contact / `cover` for the other leaf, so each moves on its own state. That means the two-panel sliders (`biparting`, `biparting-bypass`, `converging`) and any hinged double — a casement window, or a `sash: double` door. `entity` drives the leaf at the −x jamb, so `flipH` swaps which sensor draws which. Unset = both follow `entity`; ignored where there is only one leaf. |
 | `invert`      | boolean                     | Flip the open/closed interpretation.                   |
 | `activeColor` | string                      | Leaf/arc color while actively open (default primary). On a roll-up it colours the curtain and the track it leaves behind, so a fully raised shutter still reads as open. |
 | `flipH`       | boolean                     | Mirror left↔right. Swing door: hinge jamb. Sliding: slide direction. |
@@ -503,11 +516,11 @@ with nothing to configure. Windows behave the same way, so an open one spills li
 outside. A cover reporting a partial position opens a proportional gap, and at night the
 clearing a lit room holds against the dark reaches through the same doorways its pool does.
 
-A two-panel slider counts **both** its leaves, so a door with a sensor on each opens a gap
-when either one does. How wide follows what the style actually draws: `biparting` sends its
-leaves into the walls and can clear the whole opening, while `biparting-bypass` and
-`converging` keep theirs inside the frame and so clear at most half of it however wide open
-they are.
+An opening with two leaves counts **both** of them, so one with a sensor on each opens a
+gap when either one does. How wide follows what the symbol actually draws: `biparting`
+sends its leaves into the walls and can clear the whole opening, as does a hinged double
+— each sash swings clear of its own half — while `biparting-bypass` and `converging` keep
+theirs inside the frame and so clear at most half of it however wide open they are.
 
 Pools are drawn above room fills but below furniture and walls, so light reads as cast onto
 the floor. Furniture under a lit lamp picks up about half the cast, enough to read as lit
@@ -939,6 +952,56 @@ plan at full size, where fixed px is what keeps text legible from across the roo
 for a card so small that scaled text would disappear. The default stays `fixed`, so an
 existing card looks exactly as it did.
 
+## Offline devices
+
+An entity that has dropped out no longer looks like one that is simply switched off.
+
+```yaml
+type: custom:easy-floorplan-card
+offlineStyle: dim      # dim (default) | strike | none
+```
+
+A device counts as **offline** when its entity reads `unavailable` or `unknown`, or when
+the entity id is not in Home Assistant at all — renamed, deleted, or from an integration
+that failed to load. A device with no entity bound is not offline: those are plain
+markers, and there is nothing about them to be wrong.
+
+| `offlineStyle` | What it draws |
+| --- | --- |
+| `dim` *(default)* | The badge, its icon and its label fade back. |
+| `strike` | The same fade, with a diagonal through the badge. Reads from further away. |
+| `none` | The pre-#162 behaviour — an offline device looks like any other. |
+
+The default is `dim`, and that **is** a change on upgrade: until now a dead bulb and a
+bulb someone turned off were the same picture, and the plan gave that answer confidently.
+`none` keeps it for anyone who wants it. Set it in the editor under **Project → Offline
+devices**.
+
+The mark's colour is `--fp-offline-mark`, falling back to the theme's `--error-color`, so
+card-mod can recolour it without touching anything else. A device drawn as a bare ripple,
+or as a label with no badge, has nothing to cross out and takes the fade alone.
+
+## Compact header
+
+For a dashboard where the top of the card is mostly empty:
+
+```yaml
+type: custom:easy-floorplan-card
+title: Ground floor
+compactHeader: true
+```
+
+- The **title** becomes a small chip in the plan's top-left corner instead of an
+  `ha-card` header. That header is a fixed ~76px whatever it says — 48px of line-height
+  plus its padding — and none of it is reachable from outside `ha-card`, so the only way
+  to stop spending it is not to use it.
+- The **floor buttons** lay out as a row rather than a column, sharing that one strip
+  with the title instead of running down the side.
+
+Off by default, because the title then sits over the drawing — the right trade only when
+there is room for it, which is the author's call. Set it in the editor under
+**Project → Compact header**.
+
 ## Styling hooks (card-mod)
 
 Every rendered element carries its config `id` as `data-id`, plus a type class, so
@@ -953,12 +1016,17 @@ it by something stable.
 | Furniture | `fp-furniture`, `fp-furniture-<type>` | `data-id`, `data-entity` |
 | Door / window | `fp-opening`, `fp-opening-door` \| `fp-opening-window` | `data-id`, `data-entity` |
 | Wall | `wall`, `fp-wall` | `data-id` |
-| Device | `item`, `fp-item` | `data-id`, `data-entity`, `data-kind` |
+| Device | `item`, `fp-item` (plus `offline` while its entity has dropped out) | `data-id`, `data-entity`, `data-kind` |
 | Text | `text`, `fp-text` | `data-id` |
 | Room name | `area-label` | — |
 | Tracker | `tracker`, `fp-tracker` | `data-id` |
 
 Ids come from the editor (`area_a5r5nwl`, `furn_3j66s50`, …) and are stable across edits.
+
+The stage carries the plan-wide modes as classes too — `press-scale` … `press-none`, and
+`offline-dim` / `offline-strike` / `offline-none` — so a rule can be scoped to one of
+them. The offline mark's own colour is `--fp-offline-mark` (see
+[Offline devices](#offline-devices)).
 
 A dead space has no `data-id`, and cannot: it's derived from the walls rather than placed,
 so there's nothing for an id to be stable against. Style them as a group —

--- a/docker/README.md
+++ b/docker/README.md
@@ -126,7 +126,21 @@ there are attribute-only transitions; the door events are short enough that a
 coarse timeline can swallow them. Those are the cases worth having in front of
 you.
 
-Switch the lot off with `input_boolean.history_generator` (on the History view)
+Two of the controls on that view are yours to flip rather than the generator's:
+**Left leaf** and **Right leaf**. They drive one contact pair that every
+two-leaved opening on the plan shares — a casement window's sashes, a double
+door's leaves, and a pair of hinged shutters — so flipping one of them swings
+half of three different symbols at once. That half-open state is the point:
+an opening with a single sensor moves both leaves together by definition, so
+there is no other way to see a sash open beside a sash that is shut.
+
+The plan also carries one device bound to `light.deleted_by_accident`, which is
+not an entity and never will be. It is what a renamed or deleted binding looks
+like, and the reason it is hard-coded rather than switchable is that no live
+entity can produce "not in Home Assistant at all". It is the second flavour of
+offline; `sensor.flaky_sensor` above is the first.
+
+Switch the generators off with `input_boolean.history_generator` (on the History view)
 when you want to read a still plan, or when a state you set by hand keeps
 getting overwritten under you. `script.burst_activity` fires thirty changes in
 six seconds when you want a busy stretch on demand, and `script.all_lights_off`

--- a/docker/config/configuration.yaml
+++ b/docker/config/configuration.yaml
@@ -88,6 +88,18 @@ input_boolean:
     # this off makes that sensor genuinely `unavailable` -- not "off", not
     # empty -- which is the state the card has to survive and the one a fresh
     # instance otherwise never produces.
+  # One contact per leaf (issue #159). Two switches rather than six: the same
+  # pair drives every two-leaved opening on the plan -- a casement window's
+  # sashes, a double door's leaves, and a pair of hinged shutters -- so one
+  # flip shows all three symbols splitting the same way, which is the whole
+  # point of the feature. Nothing else can produce that state: an opening with
+  # one sensor moves both leaves together by definition.
+  left_leaf:
+    name: Left leaf contact
+    icon: mdi:door-open
+  right_leaf:
+    name: Right leaf contact
+    icon: mdi:door-open
 
 input_number:
   living_temperature:
@@ -181,6 +193,17 @@ template:
         unique_id: living_presence
         device_class: occupancy
         state: "{{ is_state('input_boolean.living_presence', 'on') }}"
+      # The per-leaf pair. device_class `window` only sets what the editor
+      # would *default* a new opening to; the plan states its own type, so
+      # these read the same bound to a door.
+      - name: Left leaf
+        unique_id: left_leaf
+        device_class: window
+        state: "{{ is_state('input_boolean.left_leaf', 'on') }}"
+      - name: Right leaf
+        unique_id: right_leaf
+        device_class: window
+        state: "{{ is_state('input_boolean.right_leaf', 'on') }}"
 
 automation: !include automations.yaml
 script: !include scripts.yaml

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -18,7 +18,12 @@
 #                      sensor.living_area_temperature,
 #                      sensor.living_area_humidity,
 #                      sensor.ficus_soil_moisture, sensor.flaky_sensor,
-#                      binary_sensor.front_door
+#                      binary_sensor.front_door,
+#                      binary_sensor.left_leaf, binary_sensor.right_leaf
+#
+# One id here is deliberately *not* real: light.deleted_by_accident, which is
+# what an offline device drawn from a missing entity looks like (issue #162).
+# If you are hunting a broken binding, that is not it.
 #
 # The visual editor opens on this plan directly: pencil, then the card's own
 # edit button. Anything you build there lives in the instance; to bring it
@@ -96,6 +101,48 @@ views:
                 length: 120
                 angle: 0
                 entity: binary_sensor.front_door
+              # One sensor per leaf (issue #159). All three share the same
+              # pair of contacts, so flipping "Left leaf" on the History view
+              # swings a casement sash, a door leaf and a shutter panel at
+              # once -- three symbols, one rule. Flip only one of the pair to
+              # see the half-open state a single-sensor opening cannot reach.
+              #
+              # A casement window: two sashes, one contact each. `sash` is not
+              # stated because `double` is already the window default.
+              - id: o5
+                type: window
+                x: 740
+                y: 100
+                length: 140
+                angle: 0
+                entity: binary_sensor.left_leaf
+                secondaryEntity: binary_sensor.right_leaf
+              # A double door -- the leaf count a door has to be told, since
+              # `single` is its default.
+              - id: o6
+                type: door
+                sash: double
+                x: 720
+                y: 500
+                length: 140
+                angle: 0
+                entity: binary_sensor.left_leaf
+                secondaryEntity: binary_sensor.right_leaf
+              # A single-sash window behind a pair of hinged shutters, each
+              # panel on its own contact. `shutterSecondaryEntity` is a
+              # separate key from `secondaryEntity` precisely because this
+              # opening could have both -- the shutter is a layer over the
+              # window, not part of it.
+              - id: o7
+                type: window
+                sash: single
+                x: 100
+                y: 380
+                length: 120
+                angle: 90
+                shutterEntity: binary_sensor.left_leaf
+                shutterStyle: swing
+                shutterSecondaryEntity: binary_sensor.right_leaf
 
             items:
               # Paired temperature/humidity: stored at two decimals, displayed at
@@ -162,6 +209,18 @@ views:
                 kind: sensor
                 badgeContent: value
                 showState: true
+              # Offline devices (issue #162), second flavour: an entity id
+              # that is not in Home Assistant at all -- renamed, deleted, or
+              # from an integration that failed to load. Before #162 this drew
+              # an ordinary "off" badge for something that does not exist, and
+              # unlike sensor.flaky_sensor above there is no switch that can
+              # produce it, so it is hard-coded here.
+              - id: i6
+                entity: light.deleted_by_accident
+                name: Missing entity
+                x: 300
+                y: 300
+                kind: light
 
             furniture:
               - id: fu1
@@ -248,6 +307,8 @@ views:
           - cover.living_room_window
           - cover.garage_door
           - binary_sensor.front_door
+          - binary_sensor.left_leaf
+          - binary_sensor.right_leaf
           - sensor.flaky_sensor
       - type: entities
         title: Sample data controls
@@ -255,6 +316,10 @@ views:
           - input_boolean.history_generator
           - input_boolean.flaky_sensor_online
           - input_boolean.front_door
+          # Flip these one at a time: every two-leaved opening on the plan
+          # splits, and only the leaf you flipped moves.
+          - input_boolean.left_leaf
+          - input_boolean.right_leaf
           - input_number.living_temperature
           - input_number.living_humidity
           - input_number.ficus_moisture

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -248,6 +248,115 @@ describe("openingForm — two-panel sliders (issue #145)", () => {
   });
 });
 
+describe("openingForm — a hinged double's second leaf (issue #159)", () => {
+  const names = (o: Opening) => openingForm(o).fields.map((x) => x.name);
+  const bound = { entity: "binary_sensor.a" };
+  // The two shapes with two hinged leaves, each by its own type's default.
+  const casement = { ...door, type: "window", ...bound } as Opening;
+  const doubleDoor = { ...door, sash: "double", ...bound } as Opening;
+
+  it("offers the second leaf on a bound hinged double", () => {
+    expect(names(casement)).toContain("secondaryEntity");
+    expect(names(doubleDoor)).toContain("secondaryEntity");
+  });
+
+  it("does not offer it where there is only one leaf", () => {
+    expect(names({ ...door, ...bound } as Opening)).not.toContain("secondaryEntity");
+    expect(names({ ...casement, sash: "single" } as Opening)).not.toContain("secondaryEntity");
+    // A roll-up curtain is one piece, whatever sash is left lying on it.
+    expect(names({ ...casement, motion: "roll" } as Opening)).not.toContain("secondaryEntity");
+  });
+
+  it("waits for the first leaf to be bound, as the slider does", () => {
+    expect(names({ ...door, type: "window" } as Opening)).not.toContain("secondaryEntity");
+  });
+
+  it("talks about leaves, not panels — a sash is not a panel", () => {
+    const field = openingForm(casement).fields.find((x) => x.name === "secondaryEntity")!;
+    expect(field.label).toBe("Second leaf");
+    expect(field.helper).toContain("other leaf");
+    expect(openingForm(casement).fields.find((x) => x.name === "entity")!.helper).toContain(
+      "first leaf"
+    );
+  });
+
+  it("drops the second entity when the double becomes a single", () => {
+    const form = openingForm({ ...casement, secondaryEntity: "binary_sensor.b" } as Opening);
+    expect(form.toPatch({ sash: "single" }).secondaryEntity).toBeUndefined();
+    // …and keeps it while there are still two.
+    expect("secondaryEntity" in form.toPatch({ sash: "double" })).toBe(false);
+    // Rolling up leaves one curtain, so the binding goes with it.
+    expect(form.toPatch({ motion: "roll" }).secondaryEntity).toBeUndefined();
+  });
+
+  it("carries the binding across a change that keeps two leaves", () => {
+    // A two-sensor biparting slider turned into a casement pair keeps both
+    // contacts — the point of asking the *result*, not the motion.
+    const form = openingForm({
+      ...door,
+      type: "window",
+      motion: "slide",
+      sliderStyle: "biparting",
+      entity: "binary_sensor.a",
+      secondaryEntity: "binary_sensor.b",
+    } as Opening);
+    expect("secondaryEntity" in form.toPatch({ motion: "swing" })).toBe(false);
+    // A door has one leaf by default, so the same switch does drop it there.
+    const doorForm = openingForm({
+      ...door,
+      motion: "slide",
+      sliderStyle: "biparting",
+      entity: "binary_sensor.a",
+      secondaryEntity: "binary_sensor.b",
+    } as Opening);
+    expect(doorForm.toPatch({ motion: "swing" }).secondaryEntity).toBeUndefined();
+  });
+});
+
+describe("openingForm — a hinged shutter's second panel (issue #159)", () => {
+  const names = (o: Opening) => openingForm(o).fields.map((x) => x.name);
+  const hinged = {
+    ...door,
+    shutterEntity: "binary_sensor.persiana",
+    shutterStyle: "swing",
+  } as Opening;
+
+  it("offers it for a hinged shutter only", () => {
+    expect(names(hinged)).toContain("shutterSecondaryEntity");
+    expect(names({ ...hinged, shutterStyle: "roll" } as Opening)).not.toContain(
+      "shutterSecondaryEntity"
+    );
+    expect(names(door)).not.toContain("shutterSecondaryEntity");
+  });
+
+  it("is its own key, not the opening's second leaf", () => {
+    // A double casement behind a pair of shutters has four leaves; both
+    // fields appear at once and neither stands in for the other.
+    const both = { ...hinged, type: "window", entity: "binary_sensor.win" } as Opening;
+    expect(names(both)).toContain("secondaryEntity");
+    expect(names(both)).toContain("shutterSecondaryEntity");
+  });
+
+  it("carries the binding in data", () => {
+    expect(openingForm(hinged).data.shutterSecondaryEntity).toBe("");
+    expect(
+      openingForm({ ...hinged, shutterSecondaryEntity: "binary_sensor.b" } as Opening).data
+        .shutterSecondaryEntity
+    ).toBe("binary_sensor.b");
+  });
+
+  it("drops it with the shutter, and when the shutter starts rolling", () => {
+    const form = openingForm({
+      ...hinged,
+      shutterSecondaryEntity: "binary_sensor.b",
+    } as Opening);
+    expect(form.toPatch({ shutterEntity: "" }).shutterSecondaryEntity).toBeUndefined();
+    expect(form.toPatch({ shutterStyle: "roll" }).shutterSecondaryEntity).toBeUndefined();
+    // Staying hinged keeps it.
+    expect("shutterSecondaryEntity" in form.toPatch({ shutterStyle: "swing" })).toBe(false);
+  });
+});
+
 describe("itemForm", () => {
   const item = { id: "i", entity: "light.a", kind: "light", x: 0, y: 0 } as FloorItem;
 
@@ -711,7 +820,12 @@ describe("wallForm / projectForm / floorImageForm", () => {
 
   it("rotation lives in the bottom-row display form, defaults to 0°, and patches as a number", () => {
     const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
-    expect(form.fields.map((x) => x.name)).toEqual(["rotation", "overlayScale"]);
+    expect(form.fields.map((x) => x.name)).toEqual([
+      "rotation",
+      "overlayScale",
+      "compactHeader",
+      "offlineStyle",
+    ]);
     expect(form.data.rotation).toBe("0");
     // 0 comes back as undefined so an unrotated plan stays out of the YAML.
     expect(form.toPatch({ rotation: "0" })).toEqual({ rotation: undefined });
@@ -723,6 +837,41 @@ describe("wallForm / projectForm / floorImageForm", () => {
       rotation: 270,
     } as FloorplanCardConfig);
     expect(rotated.data.rotation).toBe("270");
+  });
+
+  it("compact header is off by default and stays out of the YAML (issue #152)", () => {
+    const base = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    expect(projectDisplayForm(base).data.compactHeader).toBe(false);
+    expect(
+      projectDisplayForm({ ...base, compactHeader: true } as FloorplanCardConfig).data
+        .compactHeader
+    ).toBe(true);
+    expect(projectDisplayForm(base).toPatch({ compactHeader: false })).toEqual({
+      compactHeader: undefined,
+    });
+    expect(projectDisplayForm(base).toPatch({ compactHeader: true })).toEqual({
+      compactHeader: true,
+    });
+  });
+
+  it("offline devices default to dimmed, which stays out of the YAML (issue #162)", () => {
+    const base = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    const form = projectDisplayForm(base);
+    expect(form.data.offlineStyle).toBe("dim");
+    // Every mode the reporter's two mock-ups asked for, plus the way out.
+    const field = form.fields.find((x) => x.name === "offlineStyle")!;
+    const opts = (field.selector as { select: { options: { value: string }[] } }).select.options.map(
+      (o) => o.value
+    );
+    expect(opts).toEqual(["dim", "strike", "none"]);
+    expect(form.toPatch({ offlineStyle: "dim" })).toEqual({ offlineStyle: undefined });
+    expect(form.toPatch({ offlineStyle: "strike" })).toEqual({ offlineStyle: "strike" });
+    expect(form.toPatch({ offlineStyle: "none" })).toEqual({ offlineStyle: "none" });
+    // A hand-edited junk value reads back as the default it renders as.
+    expect(
+      projectDisplayForm({ ...base, offlineStyle: "sparkle" } as unknown as FloorplanCardConfig).data
+        .offlineStyle
+    ).toBe("dim");
   });
 
   it("skin offers every built-in and keeps the default out of the YAML", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_SUN_MIN,
   DEFAULT_SUN_MAX,
   DEFAULT_PRESS_EFFECT,
+  DEFAULT_OFFLINE_STYLE,
 } from "./types";
 import {
   DEFAULT_LABEL_SIZE,
@@ -48,9 +49,10 @@ import {
   normalizePlanRotation,
   openingActionForGesture,
   openingMotion,
-  openingHasTwoPanels,
-  sliderStyleHasTwoPanels,
+  openingHasTwoLeaves,
+  sliderStyleHasTwoLeaves,
   pressEffectOf,
+  offlineStyleOf,
   sliderStyleOf,
   shutterStyleOf,
   openingSash,
@@ -178,7 +180,7 @@ export function furnitureLabel(type: string, catalog: SymbolCatalog = BUILTIN_SY
 export function openingForm(o: Opening, featuresOf: (entityId: string) => number = () => 0): FormSpec {
   const motion = openingMotion(o);
   const style = sliderStyleOf(o);
-  const twoPanels = openingHasTwoPanels(o);
+  const twoLeaves = openingHasTwoLeaves(o);
   const fields: FormField[] = [
     { name: "type", label: "Type", selector: dropdown(opt("door", "Door"), opt("window", "Window")) },
     {
@@ -230,7 +232,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
   if (motion === "slide") {
     // A two-panel slider moves both ways at once, so there is no direction to
     // pick — `flipH` only swaps which panel each sensor drives (issue #145).
-    if (!twoPanels) {
+    if (!twoLeaves) {
       fields.push({
         name: "slide",
         label: "Slide",
@@ -252,19 +254,20 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
   fields.push({
     name: "entity",
     label: "Entity",
-    helper: twoPanels
-      ? "Drives the first panel; type and motion follow its device class"
+    helper: twoLeaves
+      ? "Drives the first leaf; type and motion follow its device class"
       : "Type and motion follow the entity's device class",
     selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
   });
-  // One sensor per leaf (issue #145). Only a two-panel style has a second
-  // moving panel to drive, and only once the first is bound — a slider whose
-  // *second* panel alone has a sensor would be more confusing than useful.
-  if (twoPanels && o.entity) {
+  // One sensor per leaf (issues #145, #159). Only a two-leaved opening has a
+  // second leaf to drive — a two-panel slider, or a hinged double — and only
+  // once the first is bound: an opening whose *second* leaf alone has a sensor
+  // would be more confusing than useful.
+  if (twoLeaves && o.entity) {
     fields.push({
       name: "secondaryEntity",
-      label: "Second panel",
-      helper: "Its own sensor for the other panel — leave empty to move both together",
+      label: "Second leaf",
+      helper: "Its own sensor for the other leaf — leave empty to move both together",
       selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
     });
   }
@@ -293,6 +296,17 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         label: "Shutter side",
         helper: "Which side of the wall the panels hang on",
         selector: dropdown(opt("far", "Away from the sash"), opt("near", "Same side as the sash")),
+      });
+    }
+    // One contact per shutter panel (issue #159), on the same terms as the
+    // opening's own second leaf above: only a hinged pair *has* a second panel
+    // — a roll curtain is one piece — and only once the first is bound.
+    if (shutterStyleOf(o) === "swing") {
+      fields.push({
+        name: "shutterSecondaryEntity",
+        label: "Second shutter panel",
+        helper: "Its own contact for the other panel — leave empty to fold both together",
+        selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
       });
     }
     // Its own switch, not the opening's: a reed contact on a hinged shutter
@@ -422,6 +436,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       entity: o.entity ?? "",
       secondaryEntity: o.secondaryEntity ?? "",
       shutterEntity: o.shutterEntity ?? "",
+      shutterSecondaryEntity: o.shutterSecondaryEntity ?? "",
       shutterStyle: shutterStyleOf(o),
       shutterSide: o.shutterFlipV ? "near" : "far",
       shutterInvert: o.shutterInvert ?? false,
@@ -449,6 +464,9 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             out.shutterFlipV = undefined;
             out.shutterInvert = undefined;
             out.shutterActiveColor = undefined;
+            // Including the other panel's contact (issue #159): a shutter that
+            // isn't there has no second panel.
+            out.shutterSecondaryEntity = undefined;
             // Nothing left to lead with, so the choice goes too — otherwise it
             // would silently point the tap at the next shutter bound here.
             out.tapTarget = undefined;
@@ -479,18 +497,35 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
           if (!v) out.icon = undefined;
         }
         else if (k === "motion") {
-          out.motion = v === "slide" || v === "roll" ? v : undefined;
+          const motion = v === "slide" || v === "roll" ? (v as "slide" | "roll") : undefined;
+          out.motion = motion;
           // sliderStyle only applies while sliding — drop it when switching
-          // away, and with it the second panel's sensor (issue #145).
-          if (v !== "slide") {
-            out.sliderStyle = undefined;
+          // away (issue #145).
+          if (v !== "slide") out.sliderStyle = undefined;
+          // The second leaf's sensor goes only if the opening this *becomes*
+          // has no second leaf. Asked of the result rather than of the motion,
+          // because since issue #159 a hinged double has one too: a two-sensor
+          // slider turned into a casement pair keeps both contacts.
+          if (!openingHasTwoLeaves({
+            ...o,
+            motion,
+            sliderStyle: v === "slide" ? o.sliderStyle : undefined,
+          } as Opening))
             out.secondaryEntity = undefined;
-          }
         } else if (k === "sash") {
           // The two types default the other way round — a window opens with
           // two sashes, a door with one leaf — so only the value that is *not*
           // this type's default is worth writing down.
           out.sash = v === defaultSash(o.type) ? undefined : v;
+          // Dropping to one leaf leaves nothing for the second sensor to
+          // drive (issue #159).
+          if (!openingHasTwoLeaves({ ...o, sash: v as "single" | "double" } as Opening))
+            out.secondaryEntity = undefined;
+        } else if (k === "shutterStyle") {
+          out.shutterStyle = v;
+          // Only a hinged pair has a second panel — a roll curtain is one
+          // piece — so switching to slats drops its contact (issue #159).
+          if (v !== "swing") out.shutterSecondaryEntity = undefined;
         }
         else if (k === "hinge" || k === "slide") out.flipH = v === "right" || undefined;
         else if (k === "opens") out.flipV = v === "other" || undefined;
@@ -498,7 +533,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
           out.sliderStyle = v === "single" ? undefined : v;
           // Only a two-panel style has a second moving panel to bind. Asked of
           // the style itself, so a style added later can't be forgotten here.
-          if (!sliderStyleHasTwoPanels(v as SliderStyle)) out.secondaryEntity = undefined;
+          if (!sliderStyleHasTwoLeaves(v as SliderStyle)) out.secondaryEntity = undefined;
         }
         else if (k === "invert") out.invert = v || undefined;
         else out[k] = v;
@@ -1188,10 +1223,31 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
         helper: `Canvas units scale badges and labels with the drawing — use it when the card renders smaller than its ${c.width}-wide canvas`,
         selector: dropdown(opt("fixed", "Fixed pixels"), opt("plan", "Canvas units")),
       },
+      {
+        name: "compactHeader",
+        label: "Compact header",
+        // Says what it costs as well as what it saves — the title lands on the
+        // drawing, and on a plan that fills the card that is a real trade.
+        helper:
+          "Draws the title inside the plan and the floor buttons in a row, instead of spending a header row on them",
+        selector: { boolean: {} },
+      },
+      {
+        name: "offlineStyle",
+        label: "Offline devices",
+        helper: "How a device is drawn when its entity is unavailable or missing",
+        selector: dropdown(
+          opt("dim", "Dimmed"),
+          opt("strike", "Dimmed and crossed out"),
+          opt("none", "No different")
+        ),
+      },
     ],
     data: {
       rotation: String(normalizePlanRotation(c.rotation)),
       overlayScale: normalizeOverlayScale(c.overlayScale),
+      compactHeader: c.compactHeader ?? false,
+      offlineStyle: offlineStyleOf(c),
     },
     toPatch: (p) => {
       let out = p;
@@ -1201,6 +1257,13 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       // "fixed" is the default, so keep it out of the YAML too.
       if ("overlayScale" in out && out.overlayScale === "fixed")
         out = { ...out, overlayScale: undefined };
+      // As are the ordinary header and the dimmed offline device — every
+      // default here stays out of the YAML, so a config only ever records the
+      // choices someone actually made.
+      if ("compactHeader" in out && !out.compactHeader)
+        out = { ...out, compactHeader: undefined };
+      if ("offlineStyle" in out && out.offlineStyle === DEFAULT_OFFLINE_STYLE)
+        out = { ...out, offlineStyle: undefined };
       return out;
     },
   };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -65,8 +65,8 @@ import {
   openingIsActive,
   wallsLightPassesThrough,
   openingClearFraction,
-  openingHasTwoPanels,
-  secondPanelOf,
+  openingHasTwoLeaves,
+  secondLeafOf,
   renderGlowMask,
   openingDefaultOpen,
   openingMotion,
@@ -2569,9 +2569,9 @@ export class FloorplanCardEditor extends LitElement {
           return openingClearFraction(
             o,
             amt(o.entity),
-            o.secondaryEntity && openingHasTwoPanels(o)
+            o.secondaryEntity && openingHasTwoLeaves(o)
               ? resolveOpeningAmount(
-                  secondPanelOf(o),
+                  secondLeafOf(o),
                   this.hass?.states[o.secondaryEntity]
                 )
               : undefined

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1190,9 +1190,13 @@ export class FloorplanCard extends LitElement {
       flex-direction: row;
       flex-wrap: wrap;
       justify-content: flex-end;
-      /* Room for the title chip on the left. Without it a long floor name and
-         a long title meet in the middle — the chip's own max-width leaves the
-         same margin from the other side. */
+    }
+    /* Room for the title chip on the left, so a long floor name and a long
+       title don't meet in the middle — the chip's own max-width leaves the
+       same margin from the other side. Only when there *is* a chip: a compact
+       card with no title has the whole strip, and reserving 44% of it would
+       wrap the buttons for nothing. */
+    .stage.compact-title .floor-switcher.row {
       left: 44%;
     }
     .floor-switcher button {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -37,8 +37,8 @@ import {
   openingIsActive,
   openingActionForGesture,
   openingIsPressable,
-  openingHasTwoPanels,
-  secondPanelOf,
+  openingHasTwoLeaves,
+  secondLeafOf,
   shutterAmount,
   shutterStyleOf,
   shutterActive,
@@ -80,6 +80,8 @@ import {
   badgeValue,
   badgeValueSize,
   pressEffectOf,
+  offlineStyleOf,
+  itemIsOffline,
   itemHiddenWhenInactive,
   itemLabelSize,
   areaLabelFontSize,
@@ -254,16 +256,31 @@ export class FloorplanCard extends LitElement {
   }
 
   /**
-   * The second panel's own state for a biparting slider with a sensor on each
-   * leaf (issue #145). `undefined` — no second sensor, or a style with only one
-   * moving panel — leaves both panels on the first entity, so nothing about a
-   * single-sensor slider changes.
+   * The second leaf's own state for an opening with a sensor on each — a
+   * two-panel slider (issue #145) or a hinged double (issue #159).
+   * `undefined` — no second sensor, or a shape with only one leaf — leaves both
+   * on the first entity, so nothing about a single-sensor opening changes.
    */
   private _openingSecond(o: Opening): { amount: number; active: boolean } | undefined {
-    if (!o.secondaryEntity || !openingHasTwoPanels(o)) return undefined;
-    const panel = secondPanelOf(o);
+    if (!o.secondaryEntity || !openingHasTwoLeaves(o)) return undefined;
+    const leaf = secondLeafOf(o);
     const state = this.hass?.states[o.secondaryEntity];
-    return { amount: resolveOpeningAmount(panel, state), active: openingIsActive(panel, state) };
+    return { amount: resolveOpeningAmount(leaf, state), active: openingIsActive(leaf, state) };
+  }
+
+  /**
+   * The same for a hinged shutter's other panel (issue #159). Read from its
+   * own key and its own resolvers — the shutter answers to `shutterInvert` and
+   * is drawn from `shutterAmount` / `shutterActive`, not the sash's — and only
+   * for a `swing` shutter, since a roll curtain has no second panel to drive.
+   */
+  private _shutterSecond(o: Opening): { amount: number; active: boolean } | undefined {
+    if (!o.shutterSecondaryEntity || shutterStyleOf(o) !== "swing") return undefined;
+    const state = this.hass?.states[o.shutterSecondaryEntity];
+    return {
+      amount: shutterAmount(state, o.shutterInvert),
+      active: shutterActive(state, o.shutterInvert),
+    };
   }
 
   private _itemIcon(item: FloorItem): string {
@@ -525,6 +542,11 @@ export class FloorplanCard extends LitElement {
     // devices they were written for.
     const stateColor = cssColor(resolveStateColor(item.stateColor, rawValue));
     const labelColor = stateColor;
+    // Offline (issue #162): the entity is unavailable, unknown, or gone from
+    // Home Assistant altogether. Guarded on `hass` — before the first states
+    // arrive every device would answer "offline" and the plan would flash
+    // grey on load.
+    const offline = !!this.hass && itemIsOffline(item, st?.state);
     // "none" is the old `showIcon: false` — no badge, label only (issue #106).
     const showIcon = badgeContentOf(item) !== "none";
     const display = item.display ?? "badge";
@@ -575,9 +597,9 @@ export class FloorplanCard extends LitElement {
     const interactive = itemIsInteractive(item);
     return html`
       <div
-        class="item fp-item ${on ? "on" : "off"} ${stateColor ? "state-colored" : ""} ${interactive
-          ? "interactive"
-          : ""}"
+        class="item fp-item ${on ? "on" : "off"} ${offline ? "offline" : ""} ${stateColor
+          ? "state-colored"
+          : ""} ${interactive ? "interactive" : ""}"
         data-id=${cssIdent(item.id) ?? nothing}
         data-entity=${cssEntityId(item.entity) ?? nothing}
         data-kind=${cssIdent(item.kind) ?? nothing}
@@ -733,6 +755,11 @@ export class FloorplanCard extends LitElement {
     // reframe identically instead of drifting apart under zoom.
     const zoomedArea = active.areas?.find((a) => a.id === this._zoomedAreaId);
     const zoom = zoomedArea ? areaZoomTransform(zoomedArea.points, c.width, c.height, rot) : IDENTITY_ZOOM;
+    // Chrome drawn inside the plan rather than above it (issue #152). The
+    // flag is what the floor buttons follow; the chip needs a title as well,
+    // and a compact card with no title has nothing to draw there.
+    const compact = c.compactHeader === true;
+    const compactTitle = compact && !!c.title;
     return html`
       <!-- The skin (issue #122) rides on the card rather than on .plan, so the
            floor switcher and the card's own background follow it too — a Tron
@@ -740,9 +767,16 @@ export class FloorplanCard extends LitElement {
            card draws with is declared on :host, so this only ever overrides. -->
       <!-- No skin style here: the palette comes from data-skin on the host, so
            a card-mod rule on this element still wins (issue #155). -->
-      <ha-card .header=${c.title ?? nothing}>
+      <!-- The card header is a fixed ~76px whether the title is "U8" or a
+           sentence, and every part of it lives inside ha-card's shadow root
+           where no rule of ours reaches. compactHeader therefore does not
+           shrink it — it declines it, and draws the title inside the stage
+           instead, where it costs no layout height at all (issue #152). -->
+      <ha-card .header=${compact ? nothing : (c.title ?? nothing)}>
         <div
-          class="stage press-${pressEffectOf(c)}"
+          class="stage press-${pressEffectOf(c)} offline-${offlineStyleOf(c)} ${compactTitle
+            ? "compact-title"
+            : ""}"
           style="aspect-ratio: ${dims.w} / ${dims.h};"
         >
           <!-- The plan box: exactly the canvas ratio, fitted inside whatever
@@ -904,6 +938,9 @@ export class FloorplanCard extends LitElement {
                       // opening's and then to the skin's.
                       accent: o.shutterActiveColor ?? o.activeColor ?? SKIN_ACCENT,
                       flip: o.shutterFlipV,
+                      // Per-panel state for a two-contact hinged shutter
+                      // (issue #159).
+                      second: this._shutterSecond(o),
                     }
                   : undefined,
               });
@@ -1007,15 +1044,16 @@ export class FloorplanCard extends LitElement {
                 <ha-icon icon="mdi:magnify-minus-outline"></ha-icon>
               </button>`
             : nothing}
-          ${floors.length > 1 ? this._renderFloorSwitcher(floors, active) : nothing}
+          ${compactTitle ? html`<div class="plan-title">${c.title}</div>` : nothing}
+          ${floors.length > 1 ? this._renderFloorSwitcher(floors, active, compact) : nothing}
         </div>
       </ha-card>
     `;
   }
 
-  private _renderFloorSwitcher(floors: Floor[], active: Floor): TemplateResult {
+  private _renderFloorSwitcher(floors: Floor[], active: Floor, compact = false): TemplateResult {
     return html`
-      <div class="floor-switcher">
+      <div class="floor-switcher ${compact ? "row" : ""}">
         ${floors.map((f) => {
           // Per-floor accent (issue #67): applied only while active so the
           // resting buttons stay theme-neutral. cssColor gates the config
@@ -1142,6 +1180,21 @@ export class FloorplanCard extends LitElement {
       pointer-events: auto;
       z-index: 1;
     }
+    /* Compact chrome (issue #152): the buttons run across the top strip
+       instead of down the side, so they share it with the title chip rather
+       than each claiming their own band. Wrapped, because a plan with eight
+       floors is exactly the case a row is worst at — better a second short
+       row than buttons off the edge of the card. Right-aligned so the row
+       grows back toward the title rather than through it. */
+    .floor-switcher.row {
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      /* Room for the title chip on the left. Without it a long floor name and
+         a long title meet in the middle — the chip's own max-width leaves the
+         same margin from the other side. */
+      left: 44%;
+    }
     .floor-switcher button {
       cursor: pointer;
       border: 1px solid var(--fp-skin-badge-border, var(--divider-color, #ccc));
@@ -1165,6 +1218,31 @@ export class FloorplanCard extends LitElement {
          Tron print near-white on a pale blue and a bright cyan. */
       color: var(--fp-skin-accent-ink, var(--text-primary-color, #fff));
       border-color: var(--fp-skin-accent, var(--primary-color, #03a9f4));
+    }
+    /* The title, drawn inside the plan (issue #152). Styled as a chip rather
+       than as a heading: it is sitting *on* the drawing, and 24px of bare text
+       over a wall reads as part of the plan. Same tokens as the floor buttons
+       beside it, so a skin carries both. */
+    .plan-title {
+      position: absolute;
+      top: 8px;
+      left: 8px;
+      z-index: 1;
+      /* Stops short of the floor row's own edge, so a long title ellipsises
+         rather than running under the buttons. */
+      max-width: 40%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      border: 1px solid var(--fp-skin-badge-border, var(--divider-color, #ccc));
+      background: var(--fp-skin-badge-bg, var(--card-background-color, #fff));
+      color: var(--fp-skin-text, var(--primary-text-color));
+      border-radius: 6px;
+      padding: 4px 8px;
+      font-size: 13px;
+      font-weight: 500;
+      line-height: 1;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     }
     /* Zoom-to-room (tap an area). One wrapper around both the SVG and the
        HTML overlay so a transform here reframes both layers identically —
@@ -1196,6 +1274,12 @@ export class FloorplanCard extends LitElement {
       padding: 4px;
       line-height: 0;
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+    /* The compact title has that corner. The zoom-out button is the transient
+       one — it exists only while a room is zoomed — so it is the one that
+       moves, dropping below the chip rather than landing on top of it. */
+    .stage.compact-title .zoom-out {
+      top: 38px;
     }
     .area-tap-target {
       cursor: pointer;
@@ -1473,6 +1557,7 @@ export class FloorplanCard extends LitElement {
       transform: none;
     }
     .badge {
+      position: relative; /* anchors the offline mark (issue #162) */
       width: 34px;
       height: 34px;
       border-radius: var(--fp-skin-badge-radius, 50%);
@@ -1516,6 +1601,48 @@ export class FloorplanCard extends LitElement {
       background: var(--fp-state);
       border-color: var(--fp-state);
       color: var(--fp-ink, var(--text-primary-color, #212121));
+    }
+
+    /* ---- Offline devices (issue #162) ------------------------------------
+       Until now a device whose entity had dropped out was drawn exactly like
+       one that is simply switched off — a dead bulb and a bulb someone turned
+       off were the same picture, and the plan gave that answer confidently.
+       Chosen plan-wide, so the stage carries offline-dim / offline-strike /
+       offline-none, exactly as it carries the press effect.
+
+       Nothing here recolours the badge, and nothing needs to: an offline
+       entity is never entityIsActive, so it has already fallen back to the
+       resting badge. What is added is the *fading*, which says "we have no
+       reading" rather than "the reading is off".
+
+       offline-none declares nothing at all, which is the point of it. */
+    .offline-dim .item.offline {
+      opacity: 0.45;
+    }
+    /* Strike sits a little brighter than a plain dim, so that the mark drawn
+       across it still reads as red rather than as pink: the whole device is
+       one composited group, so the mark fades with everything else. */
+    .offline-strike .item.offline {
+      opacity: 0.6;
+    }
+    /* The diagonal, drawn across the badge itself rather than the item, so it
+       crosses out the icon and not the label hanging underneath. A little
+       wider than the badge at each end, the way the "no" symbol overhangs. A
+       device drawn as a bare ripple, or as a label with no badge at all, has
+       nothing to cross and keeps the fade alone. */
+    .offline-strike .item.offline .badge::after {
+      content: "";
+      position: absolute;
+      left: -12%;
+      right: -12%;
+      top: 50%;
+      height: 2px;
+      margin-top: -1px;
+      border-radius: 1px;
+      /* Down to the right, the way every mdi "-off" glyph and the reporter's
+         own mock-up draw it. */
+      transform: rotate(45deg);
+      background: var(--fp-offline-mark, var(--error-color, #db4437));
     }
     ha-icon {
       --mdc-icon-size: 22px;

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -289,6 +289,82 @@ describe("renderOpening — a two-panel slider's second panel (issue #145)", () 
   });
 });
 
+describe("renderOpening — a hinged double's second leaf (issue #159)", () => {
+  // Both shapes with two hinged leaves: a window's casement pair (the type's
+  // own default) and the double door #168 added.
+  const DOUBLES = [
+    { what: "casement window", o: { type: "window" } as Partial<Opening> },
+    { what: "double door", o: { type: "door", sash: "double" } as Partial<Opening> },
+  ] as const;
+
+  for (const { what, o } of DOUBLES) {
+    describe(what, () => {
+      it("swings both leaves together when no second state is given", () => {
+        const open = svgOf(o, { amount: 1 });
+        expect(open).toContain("rotate(-90deg)"); // left leaf
+        expect(open).toContain("rotate(90deg)"); // right leaf
+      });
+
+      it("opens one leaf while the other stays shut", () => {
+        const s = svgOf(o, { amount: 1, second: { amount: 0 } });
+        expect(s).toContain("rotate(-90deg)"); // the left one swung
+        expect(s).toContain("rotate(0deg)"); // the right one still shut
+        expect(s).not.toContain("rotate(90deg)");
+      });
+
+      it("opens the second leaf while the first stays shut", () => {
+        const s = svgOf(o, { amount: 0, second: { amount: 1 } });
+        expect(s).toContain("rotate(90deg)");
+        expect(s).toContain("rotate(0deg)");
+        expect(s).not.toContain("rotate(-90deg)");
+      });
+
+      it("gives each leaf its own travel for two position-aware covers", () => {
+        const s = svgOf(o, { amount: 0.5, second: { amount: 1 } });
+        expect(s).toContain("rotate(-45deg)");
+        expect(s).toContain("rotate(90deg)");
+      });
+
+      it("clamps a second leaf's out-of-range amount", () => {
+        expect(svgOf(o, { amount: 0, second: { amount: 4 } })).toContain("rotate(90deg)");
+        expect(svgOf(o, { amount: 0, second: { amount: -2 } })).not.toContain("rotate(90deg)");
+      });
+
+      it("draws each arc from its own leaf's state", () => {
+        // arcLen = (pi/2) * 45; the shut leaf's arc is fully offset, the open
+        // one's not at all — so a half-open pair shows two different offsets.
+        const arcLen = (Math.PI / 2) * 45;
+        const s = svgOf(o, { amount: 1, second: { amount: 0 } });
+        expect(s).toContain(`stroke-dashoffset:0;`); // the open leaf's arc, drawn on
+        expect(s).toContain(`stroke-dashoffset:${arcLen};`); // the shut one's, hidden
+      });
+
+      it("accents only the leaf whose own sensor reads open", () => {
+        const s = svgOf(o, {
+          amount: 1,
+          active: true,
+          accent: "#f00",
+          second: { amount: 0, active: false },
+        });
+        // The open leaf and its arc take the accent; the shut leaf and arc
+        // keep the base colour.
+        expect(s.match(/#f00/g)?.length).toBe(2);
+        expect(s).toContain("fill:#000");
+      });
+    });
+  }
+
+  it("is ignored where there is only one leaf", () => {
+    for (const o of [
+      { type: "door" } as Partial<Opening>, // a plain swing door
+      { type: "window", sash: "single" } as Partial<Opening>, // a single sash (issue #73)
+      { type: "door", motion: "roll" } as Partial<Opening>, // a roll-up curtain
+    ]) {
+      expect(svgOf(o, { amount: 1, second: { amount: 0 } })).toBe(svgOf(o, { amount: 1 }));
+    }
+  });
+});
+
 describe("renderOpening — sliding window", () => {
   it("slides like a slider but with thin glass panels (thickness 1.5)", () => {
     const win = svgOf({ type: "window", motion: "slide" }, { open: true });
@@ -488,6 +564,73 @@ describe("renderOpening — which side the shutter hangs on (issue #74 follow-up
     const plain = svgOf(win, { open: false, shutter: { amount: 0.4, style: "roll" } });
     const flipped = svgOf(win, { open: false, shutter: { amount: 0.4, style: "roll", flip: true } });
     expect(flipped).toBe(plain);
+  });
+});
+
+describe("renderOpening — a hinged shutter's second panel (issue #159)", () => {
+  // A window with a single sash, so the only leaves in the markup are the
+  // shutter's own pair — the sash's own second-leaf plumbing is tested above,
+  // and this keeps the two from being confused for each other.
+  const win = { type: "window", sash: "single" } as Partial<Opening>;
+  const shut = { amount: 0, style: "swing" } as const;
+
+  it("folds both panels together when no second state is given", () => {
+    const s = svgOf(win, { open: false, shutter: { ...shut, amount: 1 } });
+    expect(s).toContain("rotate(90deg)");
+    expect(s).toContain("rotate(-90deg)");
+  });
+
+  it("folds one panel back while the other stays across the glass", () => {
+    const s = svgOf(win, {
+      open: false,
+      shutter: { ...shut, amount: 1, second: { amount: 0 } },
+    });
+    expect(s).toContain("rotate(90deg)"); // the folded panel
+    expect(s).toContain("rotate(0deg)"); // the one still shut
+    expect(s).not.toContain("rotate(-90deg)");
+  });
+
+  it("folds the second panel while the first stays shut", () => {
+    const s = svgOf(win, { open: false, shutter: { ...shut, second: { amount: 1 } } });
+    expect(s).toContain("rotate(-90deg)");
+    expect(s).toContain("rotate(0deg)");
+    expect(s).not.toContain("rotate(90deg)");
+  });
+
+  it("gives each panel its own travel, and clamps a junk reading", () => {
+    expect(
+      svgOf(win, { open: false, shutter: { ...shut, amount: 0.5, second: { amount: 1 } } })
+    ).toContain("rotate(45deg)");
+    expect(svgOf(win, { open: false, shutter: { ...shut, second: { amount: 9 } } })).toContain(
+      "rotate(-90deg)"
+    );
+  });
+
+  it("still swings away from the wall on the near side", () => {
+    // flip mirrors both panels, so the second one's angle flips with it.
+    const s = svgOf(win, {
+      open: false,
+      shutter: { ...shut, flip: true, second: { amount: 1 } },
+    });
+    expect(s).toMatch(/fp-leaf-r" style="transform:rotate\(90deg\)/);
+  });
+
+  it("accents only the panel whose own contact reads open", () => {
+    const s = svgOf(win, {
+      open: false,
+      shutter: { ...shut, amount: 1, active: true, accent: "#0f0", second: { amount: 0 } },
+    });
+    expect(s.match(/fill:#0f0/g)?.length).toBe(1); // the folded panel only
+    expect(s).toContain("fill:#000"); // the shut one keeps the base colour
+  });
+
+  it("the roll curtain ignores it — a slat band is one piece", () => {
+    const plain = svgOf(win, { open: false, shutter: { amount: 0.4, style: "roll" } });
+    const withSecond = svgOf(win, {
+      open: false,
+      shutter: { amount: 0.4, style: "roll", second: { amount: 1 } },
+    });
+    expect(withSecond).toBe(plain);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -9,6 +9,7 @@ import {
   GLOW_MAX_OPACITY,
   GLOW_MIN_RADIUS,
   DEFAULT_PRESS_EFFECT,
+  DEFAULT_OFFLINE_STYLE,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   SUN_ELEVATION_NIGHT,
@@ -20,9 +21,9 @@ import {
   openingMotion,
   openingMirror,
   sliderStyleOf,
-  openingHasTwoPanels,
-  sliderStyleHasTwoPanels,
-  secondPanelOf,
+  openingHasTwoLeaves,
+  sliderStyleHasTwoLeaves,
+  secondLeafOf,
   openingFromDeviceClass,
   openingSash,
   defaultSash,
@@ -83,6 +84,8 @@ import {
   matchStateRule,
   badgeContentOf,
   pressEffectOf,
+  offlineStyleOf,
+  itemIsOffline,
   badgeValue,
   badgeReading,
   badgeValueSize,
@@ -270,22 +273,48 @@ describe("sliderStyleOf", () => {
   });
 });
 
-describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
+describe("openingHasTwoLeaves / secondLeafOf (issue #145)", () => {
   const slider = (extra: Partial<Opening> = {}) =>
     ({ type: "door", motion: "slide", ...extra }) as Opening;
 
   it("is true for exactly the styles that move both panels", () => {
     for (const sliderStyle of ["biparting", "biparting-bypass", "converging"] as const) {
-      expect(openingHasTwoPanels(slider({ sliderStyle }))).toBe(true);
-      expect(sliderStyleHasTwoPanels(sliderStyle)).toBe(true);
+      expect(openingHasTwoLeaves(slider({ sliderStyle }))).toBe(true);
+      expect(sliderStyleHasTwoLeaves(sliderStyle)).toBe(true);
     }
     // bypass moves one panel past a fixed one; single moves the only panel.
-    expect(openingHasTwoPanels(slider({ sliderStyle: "bypass" }))).toBe(false);
-    expect(openingHasTwoPanels(slider())).toBe(false);
-    expect(sliderStyleHasTwoPanels("bypass")).toBe(false);
-    expect(sliderStyleHasTwoPanels("single")).toBe(false);
-    // A swing door has leaves, but no sliding panel to bind a second sensor to.
-    expect(openingHasTwoPanels({ type: "door", sliderStyle: "biparting" } as Opening)).toBe(false);
+    expect(openingHasTwoLeaves(slider({ sliderStyle: "bypass" }))).toBe(false);
+    expect(openingHasTwoLeaves(slider())).toBe(false);
+    expect(sliderStyleHasTwoLeaves("bypass")).toBe(false);
+    expect(sliderStyleHasTwoLeaves("single")).toBe(false);
+    // A single-leaf swing door has no second leaf, whatever slider style is
+    // left lying on it from an earlier motion.
+    expect(openingHasTwoLeaves({ type: "door", sliderStyle: "biparting" } as Opening)).toBe(false);
+  });
+
+  it("is true for a hinged double, by each type's own default (issue #159)", () => {
+    const swing = (extra: Partial<Opening> = {}) => ({ type: "window", ...extra }) as Opening;
+    // A window opens with two casement sashes unless told otherwise…
+    expect(openingHasTwoLeaves(swing())).toBe(true);
+    expect(openingHasTwoLeaves(swing({ sash: "double" }))).toBe(true);
+    expect(openingHasTwoLeaves(swing({ sash: "single" }))).toBe(false);
+    // …a door with one leaf, unless it is a double (issue #168).
+    expect(openingHasTwoLeaves(swing({ type: "door" }))).toBe(false);
+    expect(openingHasTwoLeaves(swing({ type: "door", sash: "double" }))).toBe(true);
+  });
+
+  it("is false for a roll-up, whose curtain is one piece", () => {
+    for (const type of ["door", "window"] as const) {
+      expect(
+        openingHasTwoLeaves({ type, motion: "roll", sash: "double" } as Opening)
+      ).toBe(false);
+    }
+  });
+
+  it("swaps in the second entity for a hinged double too", () => {
+    const o = { type: "window", entity: "binary_sensor.left", secondaryEntity: "binary_sensor.right" } as Opening;
+    expect(secondLeafOf(o).entity).toBe("binary_sensor.right");
+    expect(resolveOpeningAmount(secondLeafOf(o), { state: "on" })).toBe(1);
   });
 
   it("swaps in the second entity and keeps everything else", () => {
@@ -296,7 +325,7 @@ describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
       invert: true,
       length: 90,
     });
-    expect(secondPanelOf(o)).toEqual({ ...o, entity: "binary_sensor.right" });
+    expect(secondLeafOf(o)).toEqual({ ...o, entity: "binary_sensor.right" });
   });
 
   it("resolves the second panel independently, sharing invert", () => {
@@ -305,7 +334,7 @@ describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
       entity: "binary_sensor.left",
       secondaryEntity: "binary_sensor.right",
     });
-    const panel = secondPanelOf(o);
+    const panel = secondLeafOf(o);
     expect(resolveOpeningAmount(panel, { state: "on" })).toBe(1);
     expect(resolveOpeningAmount(panel, { state: "off" })).toBe(0);
     expect(openingIsActive(panel, { state: "on" })).toBe(true);
@@ -315,7 +344,7 @@ describe("openingHasTwoPanels / secondPanelOf (issue #145)", () => {
       resolveOpeningAmount(panel, { state: "open", attributes: { current_position: 40 } }),
     ).toBeCloseTo(0.4);
     expect(
-      resolveOpeningAmount(secondPanelOf({ ...o, invert: true }), {
+      resolveOpeningAmount(secondLeafOf({ ...o, invert: true }), {
         state: "open",
         attributes: { current_position: 40 },
       }),
@@ -1150,6 +1179,31 @@ describe("collectWatchedEntities", () => {
     expect(got.has("sensor.soil")).toBe(true);
     expect(got.size).toBe(1);
   });
+
+  // Miss this and the second panel is not frozen but *intermittent*: it only
+  // catches up when some other watched entity happens to move.
+  it("collects an opening's second leaf and its shutter's (issues #145, #159)", () => {
+    const got = collectWatchedEntities({
+      openings: [
+        {
+          id: "o",
+          type: "window",
+          x: 0,
+          y: 0,
+          entity: "binary_sensor.left",
+          secondaryEntity: "binary_sensor.right",
+          shutterEntity: "binary_sensor.shutter_left",
+          shutterSecondaryEntity: "binary_sensor.shutter_right",
+        },
+      ],
+    } as unknown as FloorplanCardConfig);
+    expect([...got].sort()).toEqual([
+      "binary_sensor.left",
+      "binary_sensor.right",
+      "binary_sensor.shutter_left",
+      "binary_sensor.shutter_right",
+    ]);
+  });
 });
 
 describe("furnitureColor (issue #82)", () => {
@@ -1791,6 +1845,54 @@ describe("pressEffectOf (#134)", () => {
     expect(pressEffectOf({ pressEffect: 42 as never })).toBe("scale");
     // …but an explicit "none" is a real choice and must survive.
     expect(pressEffectOf({ pressEffect: "none" })).toBe("none");
+  });
+});
+
+describe("offlineStyleOf / itemIsOffline (#162)", () => {
+  const light = { entity: "light.ceiling" };
+
+  it("defaults to dimming, and takes every mode the card has a rule for", () => {
+    expect(offlineStyleOf({})).toBe(DEFAULT_OFFLINE_STYLE);
+    expect(offlineStyleOf({})).toBe("dim");
+    for (const v of ["dim", "strike", "none"] as const) {
+      expect(offlineStyleOf({ offlineStyle: v })).toBe(v);
+    }
+  });
+
+  it("falls back to the default rather than to nothing on a junk value", () => {
+    // Same trap as pressEffectOf above: the value becomes a class name.
+    expect(offlineStyleOf({ offlineStyle: "faded" as never })).toBe("dim");
+    expect(offlineStyleOf({ offlineStyle: "" as never })).toBe("dim");
+    expect(offlineStyleOf({ offlineStyle: 0 as never })).toBe("dim");
+    expect(offlineStyleOf({ offlineStyle: "none" })).toBe("none");
+  });
+
+  it("calls a dropped-out entity offline, however it dropped out", () => {
+    expect(itemIsOffline(light, "unavailable")).toBe(true);
+    expect(itemIsOffline(light, "unknown")).toBe(true);
+    // Not in hass at all — renamed, deleted, or an integration that failed to
+    // load. Today that draws an ordinary "off" badge for something gone.
+    expect(itemIsOffline(light, undefined)).toBe(true);
+  });
+
+  it("leaves a device that is merely off alone", () => {
+    for (const state of ["off", "on", "closed", "docked", "locked", "0", "idle"]) {
+      expect({ state, offline: itemIsOffline(light, state) }).toEqual({ state, offline: false });
+    }
+  });
+
+  it("an unbound device is not offline — there is nothing to be wrong", () => {
+    // The plain markers issue #39 added: no entity, so no outage either.
+    expect(itemIsOffline({}, undefined)).toBe(false);
+    expect(itemIsOffline({ entity: "" }, undefined)).toBe(false);
+    expect(itemIsOffline({ entity: "" }, "unavailable")).toBe(false);
+  });
+
+  it("agrees with the active test: an offline device is never active", () => {
+    for (const state of ["unavailable", "unknown"]) {
+      expect(entityIsActive(light.entity, state)).toBe(false);
+      expect(itemIsOffline(light, state)).toBe(true);
+    }
   });
 });
 
@@ -3567,6 +3669,23 @@ describe("openingClearFraction (#145 / #143)", () => {
   it("clamps a junk reading rather than cutting a gap wider than the wall", () => {
     expect(openingClearFraction(slider("biparting"), 5, 5)).toBe(1);
     expect(openingClearFraction(slider("converging"), -3, -3)).toBe(0);
+  });
+
+  it("a hinged double clears half per open sash (issue #159)", () => {
+    const casement = (extra: Partial<Opening> = {}) =>
+      ({ id: "w", type: "window", x: 0, y: 0, length: 90, angle: 0, ...extra }) as Opening;
+    // Each sash covers its own half, and clears it completely when open.
+    expect(openingClearFraction(casement(), 1, 1)).toBe(1);
+    expect(openingClearFraction(casement(), 1, 0)).toBe(0.5);
+    expect(openingClearFraction(casement(), 0, 1)).toBe(0.5);
+    expect(openingClearFraction(casement(), 0, 0)).toBe(0);
+    // A double door reads the same way (issue #168).
+    expect(openingClearFraction(casement({ type: "door", sash: "double" }), 1, 0)).toBe(0.5);
+    // One sash means one amount, exactly as before.
+    expect(openingClearFraction(casement({ sash: "single" }), 0.4, 1)).toBe(0.4);
+    expect(openingClearFraction(casement({ type: "door" }), 0.4, 1)).toBe(0.4);
+    // …as does a double with a single sensor: the mean of one amount is itself.
+    expect(openingClearFraction(casement(), 0.6)).toBeCloseTo(0.6, 10);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -18,6 +18,7 @@ import type {
   BadgeContent,
   BadgeEntity,
   PressEffect,
+  OfflineStyle,
   Furniture,
   Tracker,
   Area,
@@ -47,6 +48,7 @@ import {
   GLOW_MAX_OPACITY,
   GLOW_MIN_RADIUS,
   DEFAULT_PRESS_EFFECT,
+  DEFAULT_OFFLINE_STYLE,
   BADGE_MIN_LIGHTNESS,
   FURNITURE_GLOW_TRANSMISSION,
   getFloors,
@@ -115,11 +117,12 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     for (const o of f.openings) {
       if (o.entity) ids.add(o.entity);
       if (o.shutterEntity) ids.add(o.shutterEntity);
-      // The second panel of a two-panel slider (issue #145). Exactly the trap
-      // named above, and the worst version of it: the panel is not frozen, it
-      // catches up whenever some *other* watched entity moves, so it reads as
+      // The opening's second leaf (issues #145, #159). Exactly the trap named
+      // above, and the worst version of it: the leaf is not frozen, it catches
+      // up whenever some *other* watched entity moves, so it reads as
       // intermittent rather than broken.
       if (o.secondaryEntity) ids.add(o.secondaryEntity);
+      if (o.shutterSecondaryEntity) ids.add(o.shutterSecondaryEntity);
     }
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);
@@ -544,15 +547,23 @@ function clipWallToBox(
  *  | `biparting`              | all of it | half     |
  *  | `biparting-bypass`       | half      | a quarter|
  *  | `converging`             | half      | a quarter|
+ *  | hinged double            | all of it | half     |
  *
- * Every other opening keeps `amount` untouched, so a swing door, a roll-up and
- * a single-panel slider all behave exactly as they did — as does a
- * single-sensor `biparting`, where both leaves share one amount and the mean
- * of it is itself.
+ * The hinged double joined the table with issue #159, and swings the same way
+ * `biparting` slides: each leaf covers its own half of the opening and clears
+ * it completely when open, so one open sash of a casement pair lets through
+ * half the light.
+ *
+ * Every other opening keeps `amount` untouched, so a single-leaf swing door, a
+ * roll-up and a single-panel slider all behave exactly as they did — as does a
+ * single-sensor `biparting` or double sash, where both leaves share one amount
+ * and the mean of it is itself.
  */
 export function openingClearFraction(o: Opening, amount: number, secondAmount?: number): number {
   const a1 = Math.max(0, Math.min(1, amount));
   const a2 = Math.max(0, Math.min(1, secondAmount ?? amount));
+  if (openingMotion(o) === "swing")
+    return openingSash(o) === "double" ? (a1 + a2) / 2 : a1;
   switch (sliderStyleOf(o)) {
     case "biparting":
       // Each leaf recesses into its own wall, so between them they can clear
@@ -1434,6 +1445,43 @@ export function pressEffectOf(c: { pressEffect?: PressEffect }): PressEffect {
 }
 
 /**
+ * Which offline treatment a plan uses (issue #162), resolving anything
+ * unrecognised to the default — the value becomes a class name, exactly as
+ * {@link pressEffectOf}'s does, so an unchecked string would silently mean
+ * "no treatment".
+ */
+export function offlineStyleOf(c: { offlineStyle?: OfflineStyle }): OfflineStyle {
+  const v = c.offlineStyle;
+  return v === "dim" || v === "strike" || v === "none" ? v : DEFAULT_OFFLINE_STYLE;
+}
+
+/**
+ * Whether a device's entity has dropped out (issue #162) — the reporter's
+ * "offline" ceiling light. Three things count, because on the plan they are
+ * the same thing:
+ *
+ * - `unavailable` — the integration says the device is not answering;
+ * - `unknown` — it is answering but has no reading, which is Home Assistant's
+ *   other half of the same story (`isSensorOutage`, and the rule every other
+ *   fail-closed reader in this file already follows);
+ * - **no state at all** — the entity id is not in `hass`. Renamed, deleted, or
+ *   from an integration that failed to load. Today that draws a perfectly
+ *   ordinary "off" badge for something that does not exist.
+ *
+ * A device with no entity bound at all is *not* offline: those are the plain
+ * markers issue #39 added, and there is nothing about them to be wrong.
+ *
+ * The caller passes the state string it already looked up, so this stays pure
+ * and the card does not resolve the same entity twice. A card with no `hass`
+ * yet must not call this — before the first state arrives everything would
+ * read as offline, and the plan would flash grey on load.
+ */
+export function itemIsOffline(item: { entity?: string }, state: string | undefined): boolean {
+  if (!item.entity) return false;
+  return state === undefined || isSensorOutage(state);
+}
+
+/**
  * The reading a domain shows in its badge when the config does not name one,
  * with the compact unit that goes with it (issue #106). A thermostat's *state*
  * is its mode — "heat" — so without this the one device the issue was opened
@@ -1737,24 +1785,41 @@ export function sliderStyleOf(o: Opening): SliderStyle {
  * Takes the style rather than the opening because the editor asks about a style
  * the user has just picked, before it is on any opening.
  */
-export function sliderStyleHasTwoPanels(style: SliderStyle): boolean {
+export function sliderStyleHasTwoLeaves(style: SliderStyle): boolean {
   return style === "biparting" || style === "biparting-bypass" || style === "converging";
 }
 
-/** {@link sliderStyleHasTwoPanels} for an opening as configured. */
-export function openingHasTwoPanels(o: Opening): boolean {
-  return sliderStyleHasTwoPanels(sliderStyleOf(o));
+/**
+ * Whether an opening has **two** moving leaves, and so a second one for
+ * `secondaryEntity` to drive. The single predicate everything downstream keys
+ * off — the editor's field, the card's resolver, which drawing reads the
+ * second amount — so widening it is what gives a new shape per-leaf sensors
+ * (issue #159).
+ *
+ * Two shapes qualify, for the same reason:
+ *
+ * - a **hinged double** — a casement window's two sashes, or the double door
+ *   #168 added — each leaf on its own jamb, each with its own contact;
+ * - a **two-panel slider** (issue #145), by {@link sliderStyleHasTwoLeaves}.
+ *
+ * A single-leaf swing door does not: there is nothing to split. Nor does a
+ * roll-up, whose curtain is one piece.
+ */
+export function openingHasTwoLeaves(o: Opening): boolean {
+  return openingMotion(o) === "swing"
+    ? openingSash(o) === "double"
+    : sliderStyleHasTwoLeaves(sliderStyleOf(o));
 }
 
 /**
- * The second moving panel as an opening in its own right, so it can go through
+ * The second leaf as an opening in its own right, so it can go through
  * {@link resolveOpeningAmount} / {@link openingIsActive} unchanged rather than
- * threading a "which panel" argument down the whole resolver chain (issue #145).
+ * threading a "which leaf" argument down the whole resolver chain (issue #145).
  * Shares the geometry and `invert`; only the bound entity differs. Callers must
- * check {@link openingHasTwoPanels} and a set `secondaryEntity` first — with no
- * entity this resolves to the type default, not to the first panel's state.
+ * check {@link openingHasTwoLeaves} and a set `secondaryEntity` first — with no
+ * entity this resolves to the type default, not to the first leaf's state.
  */
-export function secondPanelOf(o: Opening): Opening {
+export function secondLeafOf(o: Opening): Opening {
   return { ...o, entity: o.secondaryEntity };
 }
 
@@ -2088,13 +2153,19 @@ function rollCurtain(length: number, tone: string, amt: number): SVGTemplateResu
  * side from the sashes, `-1` the sash's own side, for a window whose outside
  * is the near side of the wall. It flips both the offset and the fold
  * direction, so the panels still swing *away* from the wall either way.
+ *
+ * `tone2` / `amt2` are the right-hand panel's, for a shutter with a contact on
+ * each panel (issue #159). They default to the left's, so a single-sensor
+ * shutter folds symmetrically exactly as it always has.
  */
 function swingShutter(
   length: number,
   cutH: number,
   tone: string,
   amt: number,
-  side: 1 | -1 = 1
+  side: 1 | -1 = 1,
+  tone2: string = tone,
+  amt2: number = amt
 ): SVGTemplateResult {
   const half = length / 2;
   const t = 3;
@@ -2123,8 +2194,8 @@ function swingShutter(
         </g>
       </g>
       <g transform="translate(${half} ${y0})">
-        <g class="fp-leaf-r" style="transform:rotate(${-side * 90 * amt}deg);">
-          <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone};" />
+        <g class="fp-leaf-r" style="transform:rotate(${-side * 90 * amt2}deg);">
+          <rect x=${-half} y=${-t / 2} width=${half} height=${t} style="fill:${tone2};" />
           ${louvers(-half, half)}
         </g>
       </g>`;
@@ -2384,12 +2455,21 @@ export interface OpeningStyle {
     style?: "roll" | "swing";
     accent?: string;
     flip?: boolean;
+    /**
+     * The hinged shutter's **other** panel, when it has a contact of its own
+     * (issue #159) — the second half of a pair of persiane, one folded back
+     * and one still across the glass. Omitted, both panels share `amount` and
+     * `active`, which is what a single-sensor shutter has always drawn. The
+     * roll curtain ignores it: a rolling slat band is one piece.
+     */
+    second?: { amount: number; active?: boolean };
   };
   /**
-   * The second moving panel of a biparting slider (issue #145), when it has a
-   * sensor of its own. Omitted — the only case before that issue — leaves both
-   * panels sharing `amount` and `active`, so a single-entity slider parts
-   * symmetrically exactly as it always has. Ignored by every other style.
+   * The opening's second leaf, when it has a sensor of its own — a biparting
+   * slider's other panel (issue #145), or the other sash of a hinged double
+   * (issue #159). Omitted — the only case before those issues — leaves both
+   * leaves sharing `amount` and `active`, so a single-entity opening moves
+   * symmetrically exactly as it always has. Ignored by anything with one leaf.
    */
   second?: { amount: number; active?: boolean };
 }
@@ -2411,6 +2491,15 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
   // Fraction open (0..1) drives partial swing/slide. Defaults to the binary
   // `open` so callers that don't pass `amount` render exactly as before.
   const amt = Math.max(0, Math.min(1, style.amount ?? (open ? 1 : 0)));
+  // The second leaf's own state, when it has a sensor of its own (issues #145,
+  // #159). Omitted it mirrors the first, which is what every opening drew
+  // before there was a second sensor to read. Resolved here rather than inside
+  // a branch because two shapes now have two leaves — sliding panels and a
+  // hinged double — and both read the same pair.
+  const amt2 = style.second ? Math.max(0, Math.min(1, style.second.amount)) : amt;
+  const tone2 = style.second
+    ? cssColorOr(style.second.active ? accent : color, SKIN_ACCENT)
+    : tone;
 
   let body: SVGTemplateResult;
   if (openingMotion(o) === "swing") {
@@ -2426,9 +2515,11 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     const leafW = two ? half : o.length;
     const arcLen = (Math.PI / 2) * leafW;
     // Revealed via stroke-dashoffset so each arc "draws on" as its leaf opens.
-    const arc = (d: string) => svg`<path class="fp-door-arc" d=${d}
+    // Each arc is drawn from its own leaf's state, so a pair of casement sashes
+    // with a contact each traces two different arcs (issue #159).
+    const arc = (d: string, tn: string, a: number) => svg`<path class="fp-door-arc" d=${d}
               fill="none" stroke-width="1.5" stroke-dasharray=${arcLen}
-              style="stroke:${tone};stroke-dashoffset:${arcLen * (1 - amt)};" />`;
+              style="stroke:${tn};stroke-dashoffset:${arcLen * (1 - a)};" />`;
     // Jambs are what say "glass": a door is drawn by its leaf and arc alone,
     // and that is what tells the two symbols apart at a glance.
     const jambs =
@@ -2445,10 +2536,12 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
           two
             ? // Two leaves hinged at opposite jambs, meeting in the middle when
               // shut and each tracing its own quarter circle outward.
-              svg`${arc(`M 0 0 A ${half} ${half} 0 0 0 ${-half} ${-half}`)}${arc(
-                `M 0 0 A ${half} ${half} 0 0 1 ${half} ${-half}`
+              svg`${arc(`M 0 0 A ${half} ${half} 0 0 0 ${-half} ${-half}`, tone, amt)}${arc(
+                `M 0 0 A ${half} ${half} 0 0 1 ${half} ${-half}`,
+                tone2,
+                amt2
               )}`
-            : arc(`M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}`)
+            : arc(`M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}`, tone, amt)
         }
         <!-- leaf hinged at the left jamb (flipH mirrors it to the right one) -->
         <g transform="translate(${-half} 0)">
@@ -2458,9 +2551,12 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         </g>
         ${
           two
-            ? svg`<g transform="translate(${half} 0)">
-          <g class="fp-leaf-r" style="transform:rotate(${90 * amt}deg);">
-            <rect x=${-half} y="-1.25" width=${half} height="2.5" style="fill:${tone};" />
+            ? // The other leaf, on its own sensor when it has one (issue #159):
+              // a casement pair with a contact per sash draws left-open /
+              // right-shut, exactly as a two-sensor slider parts unevenly.
+              svg`<g transform="translate(${half} 0)">
+          <g class="fp-leaf-r" style="transform:rotate(${90 * amt2}deg);">
+            <rect x=${-half} y="-1.25" width=${half} height="2.5" style="fill:${tone2};" />
           </g>
         </g>`
             : nothing
@@ -2501,15 +2597,6 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
         <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
               stroke=${color} stroke-width="2" />`;
     const sliderStyle = sliderStyleOf(o);
-    // The second moving panel of a biparting slider (issue #145). With a sensor
-    // of its own it opens and accents independently; without one it mirrors the
-    // first panel, which is what a single-entity slider has always drawn.
-    const amt2 = style.second
-      ? Math.max(0, Math.min(1, style.second.amount))
-      : amt;
-    const tone2 = style.second
-      ? cssColorOr(style.second.active ? accent : color, SKIN_ACCENT)
-      : tone;
     if (sliderStyle === "bypass") {
       // Double bypass: two half-width panels on parallel tracks. The moving
       // (back) panel slides left to stack behind the fixed (front) panel.
@@ -2629,11 +2716,29 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
       style.shutter.active ? (style.shutter.accent ?? accent) : color,
       SKIN_ACCENT
     );
-    const amt2 = Math.max(0, Math.min(1, style.shutter.amount));
+    const shutterAmt = Math.max(0, Math.min(1, style.shutter.amount));
+    // The hinged pair's other panel, on its own contact when it has one
+    // (issue #159); without one it folds with the first, as before.
+    const second = style.shutter.second;
+    const shutterTone2 = second
+      ? cssColorOr(
+          second.active ? (style.shutter.accent ?? accent) : color,
+          SKIN_ACCENT
+        )
+      : shutterTone;
+    const shutterAmt2 = second ? Math.max(0, Math.min(1, second.amount)) : shutterAmt;
     body = svg`${body}${
       style.shutter.style === "swing"
-        ? swingShutter(o.length, cutH, shutterTone, amt2, style.shutter.flip ? -1 : 1)
-        : rollCurtain(o.length, shutterTone, amt2)
+        ? swingShutter(
+            o.length,
+            cutH,
+            shutterTone,
+            shutterAmt,
+            style.shutter.flip ? -1 : 1,
+            shutterTone2,
+            shutterAmt2
+          )
+        : rollCurtain(o.length, shutterTone, shutterAmt)
     }`;
   }
   const { sx, sy } = openingMirror(o);

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,12 +93,16 @@ export interface Opening {
    */
   entity?: string;
   /**
-   * Two-panel sliders only: a second contact / `cover` driving the **other**
-   * moving panel (issue #145), for a two-panel door with a sensor on each leaf.
-   * `entity` keeps the first panel — the one at the −x jamb in the opening's own
-   * frame, so `flipH` swaps which panel each sensor draws, exactly as it mirrors
-   * everything else. Unset (the default) leaves both panels on `entity`, which
-   * is what a single-sensor slider has always drawn. `invert` covers both.
+   * A second contact / `cover` driving the opening's **other** leaf, for
+   * anything two-leaved with a sensor on each: a two-panel slider (issue
+   * #145), or a hinged double — a casement window's two sashes, a double door
+   * (issue #159). See {@link openingHasTwoLeaves} for which shapes qualify;
+   * anything with one leaf ignores this.
+   *
+   * `entity` keeps the first leaf — the one at the −x jamb in the opening's own
+   * frame, so `flipH` swaps which leaf each sensor draws, exactly as it mirrors
+   * everything else. Unset (the default) leaves both on `entity`, which is what
+   * a single-sensor opening has always drawn. `invert` covers both.
    */
   secondaryEntity?: string;
   /** Flip the open/closed interpretation of `entity` (for inverted sensors). */
@@ -117,10 +121,13 @@ export interface Opening {
    */
   flipV?: boolean;
   /**
-   * Swing windows only: how many sashes. `double` (the default, today's look)
-   * draws two casement leaves meeting in the middle; `single` draws one sash
-   * hinged at a jamb (issue #73) — `flipH` picks which jamb. Ignored for
-   * doors and for sliding / rolling openings.
+   * Swing openings only: how many hinged leaves. The two types default the
+   * other way round, because the ordinary cases do — a window opens with
+   * `double` (two casement sashes), a door with `single` (one leaf across the
+   * opening). Set it for a single-sash window (issue #73) or a double door
+   * (issue #168); either way both leaves hinge at their own jamb and trace
+   * their own arc, and `flipH` picks the jamb for a single. Ignored by sliding
+   * and rolling openings. See {@link defaultSash} / {@link openingSash}.
    */
   sash?: "single" | "double";
   /**
@@ -151,6 +158,18 @@ export interface Opening {
    * both.
    */
   shutterInvert?: boolean;
+  /**
+   * A second contact driving the hinged shutter's **other** panel (issue
+   * #159) — the pair of persiane with a reed switch on each, one folded back
+   * and one still across the glass.
+   *
+   * Its own key rather than reusing {@link secondaryEntity}, because the
+   * shutter is a layer over the opening rather than part of it: a double
+   * casement behind a pair of shutters has four leaves and can want four
+   * contacts. Read only by a `swing` shutter — a roll curtain is one piece —
+   * and {@link shutterInvert} covers it, as {@link invert} covers both sashes.
+   */
+  shutterSecondaryEntity?: string;
   /**
    * Colour of the shutter while it is (partly) open. Falls back to
    * {@link activeColor}, then the skin accent — so a plan that only wants one
@@ -797,6 +816,26 @@ export type PressEffect = "scale" | "ripple" | "flash" | "none";
 export const DEFAULT_PRESS_EFFECT: PressEffect = "scale";
 
 /**
+ * How a device whose entity has dropped out is drawn (issue #162):
+ *
+ * - `dim` — the badge, its icon and its label all fade back.
+ * - `strike` — the same fade, with a diagonal mark through the badge, for a
+ *   plan that has to say it from across the room.
+ * - `none` — the pre-#162 behaviour: an offline device looks like any other.
+ */
+export type OfflineStyle = "dim" | "strike" | "none";
+
+/**
+ * Dimmed by default, and this one *is* a change on upgrade — deliberately.
+ *
+ * Until now an unavailable device was drawn exactly like a device that is
+ * simply off: a dead bulb and a bulb someone switched off were the same
+ * picture. That is not a neutral default, it is a wrong answer, and the plan
+ * was giving it confidently. `none` keeps it for anyone who wants it.
+ */
+export const DEFAULT_OFFLINE_STYLE: OfflineStyle = "dim";
+
+/**
  * How far a pressed device shrinks. Deep enough to read at a 34px badge,
  * shallow enough not to look like the icon is falling over.
  */
@@ -1001,6 +1040,22 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /** Canvas background color (CSS / hex). Falls back to the skin's paper, then the card background. */
   background?: string;
   /**
+   * Draw the card's own chrome *inside* the plan instead of above it (issue
+   * #152), for a dashboard where the top of the card is mostly empty:
+   *
+   * - the **title** becomes a small chip in the plan's top-left corner rather
+   *   than an `ha-card` header. That header is a fixed ~76px whatever it says
+   *   — 48px of line-height plus its padding — and none of it can be reached
+   *   from outside `ha-card`'s shadow root, so the only way to stop spending
+   *   it is not to use it;
+   * - the **floor buttons** lay out as a row rather than a column, so they
+   *   share that one strip with the title instead of running down the side.
+   *
+   * Off by default: the title then sits over the drawing, which is the right
+   * trade only when there is room for it — and it is the author who knows.
+   */
+  compactHeader?: boolean;
+  /**
    * Hatch the plan's dead spaces (issue #88): every region the walls close off
    * completely that no door or window opens onto — the void behind a boxed-in
    * stairwell, a service shaft, the pocket left between two rooms.
@@ -1052,6 +1107,17 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * worse than none.
    */
   pressEffect?: PressEffect;
+  /**
+   * How a device whose entity is **offline** is drawn (issue #162) —
+   * `unavailable`, `unknown`, or an entity id that is not in Home Assistant at
+   * all (renamed, or the integration is down).
+   *
+   * Plan-wide, for the same reason `pressEffect` is: it is a drawing
+   * convention, and a plan where half the dead devices announced themselves
+   * would read as broken rather than as configured. Default
+   * {@link DEFAULT_OFFLINE_STYLE}.
+   */
+  offlineStyle?: OfflineStyle;
   /**
    * Multi-floor data. When present and non-empty this is the source of truth.
    * When absent, the legacy flat arrays below describe a single implicit floor


### PR DESCRIPTION
Three independent reports, one PR. They touch different files and can be read in any order.

## Per-leaf sensors for the other two-part openings — closes #159

#151 gave a sliding opening a sensor per panel, but the predicate deciding an opening *had* two parts was slider-shaped. It is now `openingHasTwoLeaves`, and a hinged double answers yes — a casement window's two sashes, and the **double door** #168 added, which did not exist when the issue was written. Each leaf draws its own arc, travel and accent, so a window with a contact per sash renders left-open / right-shut.

**Hinged shutters** get the same through a `shutterSecondaryEntity` of their own — the issue flagged this as an open decision, and it needs a *third* entity because `shutterEntity` is taken. Its own key because the shutter is a layer *over* the opening: a double casement behind a pair of shutters has four leaves.

`openingClearFraction` counts both sashes, so one open leaf of a pair clears half the opening for light. Naming moved panel→leaf as the issue asked (`sliderStyleHasTwoLeaves`, `secondLeafOf`, a **Second leaf** field); the config key `secondaryEntity` was already generic, so there is no migration.

## Offline devices look offline — closes #162

An entity reading `unavailable` or `unknown` — or missing from Home Assistant entirely — was drawn **exactly** like a device someone had switched off. New plan-wide `offlineStyle`: `dim` (default), `strike` (dimmed with a diagonal, the reporter's second mock-up), or `none`.

The default changes how an offline device looks on upgrade, deliberately: a dead bulb and a bulb someone turned off were the same picture, and the plan gave that answer confidently. The mark's colour is `--fp-offline-mark`.

## A header that doesn't cost a row — closes #152

`ha-card`'s header is a fixed ~76px whatever the title says, and unreachable from outside its shadow root. `compactHeader: true` declines it: the title becomes a chip in the plan's top-left, and the floor buttons lay out as a row in the same strip. Both then cost zero layout height. Off by default, since the title then sits over the drawing.

## Verification

`npm test` (1025 tests, 45 new), `npm run typecheck`, `npm run build` clean.

Rendering checked in a browser against the built bundle: a casement with one sash open draws one arc and one flat leaf; a shutter with a contact per panel folds one and leaves the other across the glass; `offlineStyle: none` is pixel-identical to today; compact header reclaims the header's height and holds with long titles and floor names.

The dev container grows fixtures for all of it — a shared **Left leaf** / **Right leaf** contact pair driving a casement, a double door and a pair of shutters at once, plus `sensor.flaky_sensor` and a deliberately missing entity for the two flavours of offline.

---

*Multi-reading devices (#180) and the `overlayScale` default (#179) were written after this merged and live in #186, not here.*