### PR TITLE
Sunlight: the sun is outside, so only the openings it shines on are sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ distorted anyway.
 | `id`          | string                      | Unique id.                                             |
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
 | `motion`      | `swing` \| `slide` \| `roll` | How it moves: hinged (default), sliding panels, or a roll-up curtain (garage / roller shutter). |
+| `sunlight`    | boolean                     | `false` takes this opening out of [Sunlight](#sunlight) entirely — it admits no light and blocks it like wall, however open it is drawn. Editor: **Lets sunlight in**. For the solid door with no sensor, which the plan draws open. |
 | `glazed`      | boolean                     | Lets sunlight through even when shut. Defaults per type — a window is glass, a door is not. Set `true` on a **patio or French door**, which is drawn as a door because that is how it swings but is a wall of glass; set `false` on an opaque window like a glass-brick panel or a hatch, which then admits light only as far as it is open. Only [Sunlight](#sunlight) reads it. |
 | `sash`        | `single` \| `double`        | Swing openings only: how many hinged leaves. The default differs by type, because the ordinary cases do — a window opens with `double` (two casement sashes), a door with `single` (one leaf across the opening). Set it to draw a single-sash window or a **double door**; both leaves then hinge at their own jamb and trace their own arc. Ignored by sliding and rolling openings. |
 | `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
@@ -935,10 +936,18 @@ gap moved the same way. So:
 - **walls cast the shade behind them**, cutting the patches — and the part of a door that
   is still shut casts shade like the wall it stands in, while an open doorway casts none,
   the same rule the lamps already follow;
-- an opening standing in a wall's shadow lets nothing in, so an interior door on the dark
-  side of the house does not light the room beyond it out of nothing;
+- **only the openings the sun shines on are sources.** Trace back along the light: if a
+  wall stands between an opening and the sky, that opening is not letting the sun in. So
+  the shaded façade stays dark, and an interior door is never a second sun. Light still
+  travels *through* an interior doorway — the beam from the window upstream carries on,
+  because that wall's shade has the same gap cut in it — it simply does not start there
+  and widen to the doorway's own width (issues #177 / #178);
 - a **shutter that is all the way down** stops the light whatever the glass says — that is
   what a shutter is for, and a window behind a closed one is as dark as a wall;
+- an opening with `sunlight: false` is **wall to the sun**: no patch of its own, and it
+  stops a beam crossing it. That is the answer for a solid front door with no sensor bound
+  — the plan draws such a door open, the light believes the drawing, and the corridor
+  behind it filled with sunshine the door has never let in;
 - everywhere the light never reaches is drawn a shade darker — turn `sunShade` off for the
   patches alone.
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -991,6 +991,19 @@ describe("openingForm — sash and shutter (issues #73 / #74)", () => {
     expect(openingForm(door).toPatch({ glazed: false })).toEqual({ glazed: undefined });
   });
 
+  it("offers the sunlight switch on every opening, defaulting to letting it in", () => {
+    // Unlike glazing, this one is not a fact about the material — it is the
+    // author overruling the drawing, so both types can want it (#177).
+    for (const o of [win, door]) {
+      expect(openingForm(o).fields.map((x) => x.name)).toContain("sunlight");
+      expect(openingForm(o).data.sunlight).toBe(true);
+    }
+    expect(openingForm({ ...door, sunlight: false } as Opening).data.sunlight).toBe(false);
+    // On is the default, so only "off" reaches the YAML.
+    expect(openingForm(door).toPatch({ sunlight: false })).toEqual({ sunlight: false });
+    expect(openingForm(door).toPatch({ sunlight: true })).toEqual({ sunlight: undefined });
+  });
+
   it("every swing opening offers a leaf count; only sliders and rollers don't", () => {
     const names = openingForm(win).fields.map((x) => x.name);
     expect(names).toContain("sash");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -226,6 +226,15 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       selector: { boolean: {} },
     });
   }
+  // The way out of "the plan draws it open, so the sun comes in" (issue #177).
+  // Offered on every opening rather than only the unbound ones: a sensor can
+  // say a door is open without the author wanting daylight through it.
+  fields.push({
+    name: "sunlight",
+    label: "Lets sunlight in",
+    helper: "Off makes it wall to the sun — for a solid door the plan draws open",
+    selector: { boolean: {} },
+  });
   // Hinge applies to anything with ONE hinged leaf. A double is hinged at both
   // jambs, so there is no side left to choose.
   if (motion === "swing" && openingSash(o) === "single") {
@@ -449,6 +458,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       entity: o.entity ?? "",
       secondaryEntity: o.secondaryEntity ?? "",
       glazed: openingIsGlazed(o),
+      sunlight: o.sunlight ?? true,
       shutterEntity: o.shutterEntity ?? "",
       shutterSecondaryEntity: o.shutterSecondaryEntity ?? "",
       shutterStyle: shutterStyleOf(o),
@@ -488,6 +498,9 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             out.showShutterIcon = undefined;
             out.shutterIcon = undefined;
           }
+        } else if (k === "sunlight") {
+          // On is the default, so only "off" is worth writing down.
+          out.sunlight = v ? undefined : false;
         } else if (k === "glazed") {
           // A window is glass whatever this says, so only a door's answer is
           // worth keeping — and only when it differs from its type's default.

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -119,6 +119,75 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(s).toContain("fp-sunbeam");
   });
 
+  it("a window on the shaded façade does not throw sunlight out of the house (#177)", () => {
+    // Two windows facing each other across a room, which is as ordinary as a
+    // plan gets. The far one used to line up with the near one's gap, escape
+    // every shadow, and emit a patch of its own — sweeping *away* from the
+    // building, so the reporter watched sunlight pour out of their apartment.
+    const north = { id: "n", x1: 0, y1: 0, x2: 400, y2: 0 };
+    const south = { id: "s", x1: 0, y1: 300, x2: 400, y2: 300 };
+    const facing = [
+      { ...win, id: "north", y: 0 },
+      { ...win, id: "south", y: 300 },
+    ] as Opening[];
+    const s = light(facing, [north, south]);
+    const beams = s.match(/class="fp-sunbeam"/g) ?? [];
+    expect(beams.length).toBe(1);
+    // …and it is the one on the sunlit side: the patch starts at y=0.
+    expect(s).toContain('points=170,0 230,0');
+    expect(s).not.toContain("230,300");
+  });
+
+  it("an interior door does not re-emit the light that reaches it (#178)", () => {
+    // A 20-wide window upstream of a 120-wide doorway. The doorway used to
+    // become a source in its own right and flood the room behind it six times
+    // wider than the light that arrived — "sunlight spawns at open doors".
+    const mid = { id: "m", x1: 0, y1: 250, x2: 400, y2: 250 };
+    const plan = [
+      { ...win, id: "w", length: 20 },
+      { ...win, id: "d", type: "door", y: 250, length: 120 },
+    ] as Opening[];
+    const s = serialize(
+      renderSunlight([wall, mid], plan, 400, 400, "sun", {
+        dir: sun,
+        openAmount: () => 1,
+        shutterOpen: () => undefined,
+      })
+    );
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1);
+    // The one beam is the window's, 20 across — not the door's 120.
+    expect(s).toContain("points=190,100 210,100");
+    // The light still gets *through* the doorway: the interior wall is cut
+    // there, so its two shadow pieces stop either side of the beam and none
+    // of them covers it. That is what makes re-emitting unnecessary.
+    const shadows = [...s.matchAll(/<polygon points=([\d.,\- ]+) fill=#fff/g)].map((m) => m[1]!);
+    const spans = shadows.map((p) => p.split(" ").map((q) => Number(q.split(",")[0]!)));
+    expect(spans.some((xs) => xs[0]! <= 190 && xs[1]! >= 210)).toBe(false);
+  });
+
+  it("an opening switched out of the sunlight is wall to it (#177)", () => {
+    // The solid front door the plan draws open because nothing is bound to it.
+    const shut = { ...win, type: "door", sunlight: false } as Opening;
+    expect(
+      renderSunlight([wall], [shut], 400, 400, "sun", {
+        dir: sun,
+        openAmount: () => 1,
+        shutterOpen: () => undefined,
+      })
+    ).toBe(nothing);
+    // Its wall keeps its full shadow too — it stops a beam like any wall does.
+    const other = { ...win, id: "o2", x: 60 } as Opening;
+    const s = serialize(
+      renderSunlight([wall], [shut, other], 400, 400, "sun", {
+        dir: sun,
+        openAmount: () => 1,
+        shutterOpen: () => undefined,
+      })
+    );
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1);
+    expect(s).toContain("points=30,100 90,100");
+  });
+
   it("paints with the colours it is given", () => {
     const s = serialize(
       renderSunlight([wall], [win], 400, 400, "sun", { dir: sun, openAmount: () => 0, shutterOpen: () => undefined, light: "#ff0000", shade: "#0000ff" })

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2485,6 +2485,17 @@ describe("sunlight through the openings", () => {
     expect(sunReachesOpening(inside, [north, mid], down)).toBe(false);
     // Its own wall never shades it — the ray starts on that wall's centreline.
     expect(sunReachesOpening(onNorth, [north], down)).toBe(true);
+    // …but only its own. A wall meeting that one at a corner passes within a
+    // wall's thickness of an opening set close to it, and exempting it by
+    // distance alone let that opening answer "the sun reaches me" to a sun the
+    // return wall stood squarely in front of — the leeward leak again, in the
+    // one place the shortcut applied.
+    const west = { id: "we", x1: 0, y1: 0, x2: 0, y2: 300 };
+    const byCorner = win({ x: 6, y: 0, length: 12 });
+    expect(sunReachesOpening(byCorner, [north, west], { x: 0.6, y: -0.8 })).toBe(false);
+    // Turn the sun around and the same opening is lit again: the corner wall
+    // blocks it or it doesn't, on the geometry rather than on how near it is.
+    expect(sunReachesOpening(byCorner, [north, west], { x: 0.6, y: 0.8 })).toBe(true);
     // Turn the sun around and the two swap places, which is the whole point:
     // the far side of the house is the shaded side.
     const up = { x: 0, y: -1 };

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -30,6 +30,7 @@ import {
   planDirection,
   sunBearingOf,
   openingAdmitsSun,
+  sunReachesOpening,
   openingSunFraction,
   openingIsGlazed,
   sunBeamPolygon,
@@ -2470,6 +2471,54 @@ describe("sunlight through the openings", () => {
     // Following the real sun still follows it all the way down.
     expect(sunlightStrengthOf({}, -40)).toBe(0);
     expect(sunlightStrengthOf({}, 50)).toBe(1);
+  });
+
+  it("only the openings the sun actually shines on are sources (#177 / #178)", () => {
+    // The rule the two reports share. Trace back along the light: anything
+    // with a wall between it and the sky is standing behind something, and a
+    // thing standing behind something is not a second sun.
+    const north = { id: "n", x1: 0, y1: 0, x2: 400, y2: 0 };
+    const mid = { id: "m", x1: 0, y1: 150, x2: 400, y2: 150 };
+    const onNorth = win({ x: 200, y: 0 });
+    const inside = win({ x: 200, y: 150 });
+    expect(sunReachesOpening(onNorth, [north, mid], down)).toBe(true);
+    expect(sunReachesOpening(inside, [north, mid], down)).toBe(false);
+    // Its own wall never shades it — the ray starts on that wall's centreline.
+    expect(sunReachesOpening(onNorth, [north], down)).toBe(true);
+    // Turn the sun around and the two swap places, which is the whole point:
+    // the far side of the house is the shaded side.
+    const up = { x: 0, y: -1 };
+    expect(sunReachesOpening(onNorth, [north, mid], up)).toBe(false);
+    expect(sunReachesOpening(inside, [north, mid], up)).toBe(true);
+  });
+
+  it("judges that on the uncut walls, so a lined-up doorway is not a second sun", () => {
+    // The distinction the fix turns on. Light *does* reach a door lined up
+    // with a window, and it does go through — the beam carries on, because
+    // that wall's shadow has the same gap cut in it. What it must not do is
+    // re-emit at its own width: a 20-wide sliver came out of a 120-wide door
+    // as a 120-wide flood (#178).
+    const north = { id: "n", x1: 0, y1: 0, x2: 400, y2: 0 };
+    const mid = { id: "m", x1: 0, y1: 150, x2: 400, y2: 150 };
+    const window = win({ x: 200, y: 0, length: 20 });
+    const door = win({ id: "d", type: "door", x: 200, y: 150, length: 120 });
+    // The gap really is there once the doorway is open…
+    const cut = wallsLightPassesThrough([north, mid], [window, door], () => 1);
+    expect(cut.some((w) => w.id.startsWith("m#"))).toBe(true);
+    // …and the door still is not a source.
+    expect(sunReachesOpening(door, [north, mid], down)).toBe(false);
+  });
+
+  it("an opening can be switched out of the sunlight entirely (#177)", () => {
+    // For the solid front door the plan draws open because nothing is bound to
+    // it. Beats every other rule, including the glass a window is by default.
+    expect(openingSunFraction({ type: "door", sunlight: false }, 1)).toBe(0);
+    expect(openingSunFraction({ type: "window", sunlight: false }, 1)).toBe(0);
+    expect(openingSunFraction({ type: "door", glazed: true, sunlight: false }, 1)).toBe(0);
+    expect(openingAdmitsSun({ type: "door", sunlight: false }, 1)).toBe(false);
+    // Absent and true both mean what they always meant, so nothing existing moves.
+    expect(openingSunFraction({ type: "door", sunlight: true }, 1)).toBe(1);
+    expect(openingSunFraction({ type: "door" }, 1)).toBe(1);
   });
 
   it("reaches across a fair part of the plan, but not forever", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -3023,11 +3023,15 @@ export const SUN_SHADE_COLOR = "var(--fp-skin-sunshade, #000)";
  * travel a leaf has is not the gap it clears.
  */
 export function openingSunFraction(
-  o: Pick<Opening, "type" | "glazed">,
+  o: Pick<Opening, "type" | "glazed" | "sunlight">,
   amount: number,
   /** How far the external shutter is open, or `undefined` when none is bound. */
   shutter?: number,
 ): number {
+  // Above every other rule, because it is the one that is a decision rather
+  // than a reading: an opening switched out of the sunlight is wall to it,
+  // however open, however glazed (issue #177).
+  if (o.sunlight === false) return 0;
   if (shutter !== undefined && shutter <= 0) return 0;
   if (openingIsGlazed(o)) return 1;
   return Math.max(0, Math.min(1, amount));
@@ -3039,7 +3043,7 @@ export function openingSunFraction(
  * light in" is the question most callers are actually asking.
  */
 export function openingAdmitsSun(
-  o: Pick<Opening, "type" | "glazed">,
+  o: Pick<Opening, "type" | "glazed" | "sunlight">,
   amount: number,
   shutter?: number,
 ): boolean {
@@ -3073,8 +3077,9 @@ function openingEnds(o: Opening): [AreaPoint, AreaPoint] {
  * approximate "did this land inside" answer, not exact edge semantics.
  *
  * Here rather than in `editor-geometry`, which is where it started and which
- * still re-exports it: the sunlight has to ask whether an opening stands in a
- * wall's shadow, and that module imports from this one.
+ * still re-exports it: it moved when the sunlight needed it, and while the
+ * sunlight has since stopped asking (see {@link sunReachesOpening}), moving it
+ * back would only churn that module's imports for nothing.
  */
 export function pointInPolygon(points: readonly AreaPoint[], x: number, y: number): boolean {
   let inside = false;
@@ -3086,6 +3091,39 @@ export function pointInPolygon(points: readonly AreaPoint[], x: number, y: numbe
     if (intersects) inside = !inside;
   }
   return inside;
+}
+
+/**
+ * Whether the sun reaches this opening's outside face at all — the test that
+ * decides whether it is a *source* (issues #177 / #178).
+ *
+ * The sun is outside the building, so the only openings that admit it are the
+ * ones it shines on directly: trace back along the light from the opening's
+ * centre and if that ray meets a wall, this opening is standing behind
+ * something. Interior doors are, always — there is a façade between them and
+ * the sky. So are the openings on the shaded side of the house.
+ *
+ * Deliberately against the **uncut** walls, not the ones {@link
+ * wallsLightPassesThrough} has opened up: a doorway lined up with a window is
+ * not a second sun. Light does reach it, and it does go through — the beam
+ * from the window carries on through the gap, because that wall's shadow has
+ * the same gap cut in it. What must not happen is the doorway *re-emitting* at
+ * its own full width, which is how a 20-wide sliver came out the other side of
+ * a 120-wide door as a 120-wide flood, and how a window on the dark façade
+ * came to throw a patch of sunlight out into the garden.
+ *
+ * The opening's own wall is skipped, since the ray starts on its centre line.
+ */
+export function sunReachesOpening(
+  o: Pick<Opening, "x" | "y">,
+  walls: readonly Wall[],
+  dir: { x: number; y: number },
+): boolean {
+  for (const w of walls) {
+    if (pointWallDist(o.x, o.y, w) <= OPENING_ON_WALL_EPS) continue;
+    if (rayWallHit(o.x, o.y, -dir.x, -dir.y, w) !== undefined) return false;
+  }
+  return true;
 }
 
 /**
@@ -3230,14 +3268,13 @@ export function renderSunlight(
   const clear = (o: Opening) => openingSunFraction(o, openAmount(o), shutterOpen(o));
   const blockers = wallsLightPassesThrough(walls, openings, clear);
   const shadowPolys = blockers.map((w) => sunShadowPolygon(w, dir, reach));
-  // An opening only lets light in if light reaches it. Without this every
-  // opening was a source in its own right: an interior door on the dark side
-  // of the house lit the room beyond it out of nothing, and a window on the
-  // shaded façade did the same. Standing in a wall's shadow is exactly what
-  // "no light reaches it" means, and the shadows are already to hand.
-  const lit = openings.filter(
-    (o) => clear(o) > 0 && !shadowPolys.some((sh) => pointInPolygon(sh, o.x, o.y))
-  );
+  // Only the openings the sun actually shines on are sources — see
+  // {@link sunReachesOpening}, which asks it of the *uncut* walls. Testing the
+  // cut ones (which is what standing in a shadow polygon amounts to) made a
+  // second sun of every opening that happened to line up with a window: the
+  // doorway behind it re-emitted at its own full width, and a window on the
+  // shaded façade threw a patch out of the house (issues #177 / #178).
+  const lit = openings.filter((o) => clear(o) > 0 && sunReachesOpening(o, walls, dir));
   if (!lit.length) return nothing;
   const beams = lit.map((o) => polyPoints(sunBeamPolygon(o, dir, reach, clear(o))));
   const shadows = shadowPolys.map(polyPoints);

--- a/src/render.ts
+++ b/src/render.ts
@@ -3112,7 +3112,14 @@ export function pointInPolygon(points: readonly AreaPoint[], x: number, y: numbe
  * a 120-wide door as a 120-wide flood, and how a window on the dark façade
  * came to throw a patch of sunlight out into the garden.
  *
- * The opening's own wall is skipped, since the ray starts on its centre line.
+ * The one wall that must not count is the opening's **own**, since the ray
+ * starts on that wall's centre line and so meets it at zero distance. That is
+ * the test — a hit right at the ray's origin, on a wall this opening lies on —
+ * and not merely "a wall within a wall's thickness", which would also wave
+ * through the wall meeting it at a corner. An opening a few units from a
+ * corner then answered "the sun reaches me" to a sun the return wall was
+ * squarely in front of, and threw its beam back out of the house: the very
+ * bug above, in the one place the shortcut applied.
  */
 export function sunReachesOpening(
   o: Pick<Opening, "x" | "y">,
@@ -3120,8 +3127,11 @@ export function sunReachesOpening(
   dir: { x: number; y: number },
 ): boolean {
   for (const w of walls) {
-    if (pointWallDist(o.x, o.y, w) <= OPENING_ON_WALL_EPS) continue;
-    if (rayWallHit(o.x, o.y, -dir.x, -dir.y, w) !== undefined) return false;
+    // `dir` is a unit vector, so the hit distance is in plan units.
+    const hit = rayWallHit(o.x, o.y, -dir.x, -dir.y, w);
+    if (hit === undefined) continue;
+    const own = hit <= OPENING_ON_WALL_EPS && pointWallDist(o.x, o.y, w) <= OPENING_ON_WALL_EPS;
+    if (!own) return false;
   }
   return true;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,22 @@ export interface Opening {
    */
   glazed?: boolean;
   /**
+   * Whether this opening takes part in the sunlight at all (default `true`).
+   *
+   * `false` makes it wall as far as the sun is concerned: no patch of its own,
+   * and it stops a beam crossing it like any other stretch of wall. Nothing
+   * else changes — it is still drawn, still tappable, still lets a lamp's pool
+   * through if it is open.
+   *
+   * The case it exists for (issue #177): a **solid front door with no sensor
+   * bound**. The plan draws such a door open, because that is the floor-plan
+   * convention and what makes an unwired door useful, and the light believes
+   * the drawing — so a corridor behind the front door filled with sunshine
+   * that the door has never let in. This is how you say "drawn open, but shut
+   * to the sun".
+   */
+  sunlight?: boolean;
+  /**
    * An external shutter sharing this opening's wall gap (issue #74): a
    * `cover` (roller shutter / tapparella) or a `binary_sensor` contact on a
    * hinged shutter (persiana). `entity` keeps driving the opening itself, so


### PR DESCRIPTION
Closes #178, closes #177.

## Reproducing it

Both reports are the same bug, and it takes two windows to see:

```
walls    ──────┬──────      north wall, window at x=200
               │
walls    ──────┴──────      south wall, window at x=200 (facing it)
```

Sun in the north, so the light travels down the canvas. Two beams come out:

| beam | from | sweeping |
| --- | --- | --- |
| `170,0 → 230,0` | the north window | into the room ✅ |
| `170,300 → 230,300` | the south window | **out of the house** ❌ |

That second one is #177's red circle — "somehow those two make sunlight go FROM my apartment".

And with a 20-wide window upstream of a 120-wide interior doorway:

| beam | width |
| --- | --- |
| the window's | 20 |
| the doorway's own | **120** |

That is #178 — "sunlight spawns at open doors connecting rooms", six times wider than the light that arrived.

## Why

An opening was a source unless it stood in a wall's shadow, and the shadows are cast by the walls **with the doorways already cut out of them**. So any opening lined up with an opening upstream escaped every shadow and became a sun in its own right — re-emitting at its own full width, in whatever direction the light happened to be travelling. Two windows facing each other across a room is enough, which is why two people hit it within an hour of each other.

## The fix

Ask whether the sun reaches the opening at all: trace back along the light from its centre and see whether a wall stands between it and the sky. The sun is outside the building, so those are the only openings that let it in.

Against the **uncut** walls, which is the whole point of the change. Light really does reach a doorway lined up with a window, and it really does go through — the beam from the window carries on, because that wall's shade has the same gap cut in it. What must not happen is the doorway *starting a beam of its own* at a width nothing gave it.

So: the shaded façade goes dark, interior doors stop emitting, and light still crosses from room to room through the doorways.

## #177's other half: a door that is drawn open but shut to the sun

`sunlight: false` on an opening takes it out of the daylight entirely — no patch of its own, and it blocks a beam like any stretch of wall. Editor: **Lets sunlight in**.

This is the ask in #177's title. The plan draws a door with no sensor bound *open*, because that is the floor-plan convention and what makes an unwired door useful — and the light believed the drawing, so a solid front door filled the corridor behind it with sunshine it has never let in. There was no way to say "drawn open, shut to the sun". Now there is. Separable from the geometry fix if you would rather it landed on its own.

## Verification

- 1076 unit tests pass, `tsc --noEmit` clean. New tests pin both reports at the markup level (one beam, from the sunlit side, at the width of the window rather than the doorway), the source rule itself including the sun reversed, and the fact that the interior wall's shade still leaves the doorway open so light passes through.
- Driven in a browser on a two-room plan with facing windows, an interior door and an unsensored front door, at four sun bearings: no patch outside the walls, no beam starting at the interior door, light crossing the doorway from the room upstream, and the front door going dark under `sunlight: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)