### PR TITLE
Multi-reading devices, label position, and canvas units by default (closes #180, #179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ The editor writes this config for you; manual editing is optional.
 | `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
 | `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |
 | `compactHeader`| boolean | `false`           | Draw the title inside the plan and the floor buttons in a row, instead of spending a card header row on them. See [Compact header](#compact-header). |
-| `overlayScale`| string  | `fixed`            | How badges, labels, room names and text are sized: `fixed` = screen pixels, `plan` = canvas units so they scale with the drawing. See [Overlay scale](#overlay-scale). |
+| `overlayScale`| string  | `plan`             | How badges, labels, room names and text are sized: `plan` = canvas units so they scale with the drawing, `fixed` = screen pixels. See [Overlay scale](#overlay-scale). |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
@@ -639,7 +639,8 @@ animated inside a rectangular tracked area:
 - `points` — `{ x, y }` vertices in drawing order, implicitly closed last-to-first.
 - `name` / `showName` — label centered on the polygon (`showName` defaults `true`).
   Mirrors the linked HA area's name when `haArea` is set.
-- `labelSize` — that label's size, `8`–`40`, default `14`. Px under `overlayScale: fixed`,
+- `labelSize` — that label's size, `8`–`40`, default `14`. Canvas units under the default
+  `overlayScale: plan`, px under `fixed`,
   canvas units under `plan`. Small rooms want a smaller number than the big ones beside them.
   Left unset on a `fixed` card the size stays in the stylesheet, so a card-mod rule on
   `.area-label` still wins; set it, or switch to `plan`, and it moves inline and takes over.
@@ -992,46 +993,55 @@ Skins can restyle both through `--fp-skin-sunlight` and `--fp-skin-sunshade`.
 
 The card draws in two layers. Walls, doors, furniture and room fills are SVG, scaled from
 the canvas to whatever width the card gets — draw at any size, they always fit. Badges,
-labels, room names and text are HTML on top of that, so they stay upright under
-`rotation` and can take clicks, and by default they are sized in **screen pixels**.
+labels, room names and text are HTML on top of that, so they stay upright under `rotation`
+and can take clicks.
 
-Those two agree while the card renders at roughly its canvas size. Below that they drift
-apart: a `980`-wide plan shown `500` wide draws every wall at half size while a 14px room
-name stays 14px, so names spill past their rooms and collide with the badges under them.
-Nothing in the config can fix that, because a label's px size doesn't know what scale the
-plan ended up at.
+**By default the overlay is sized in canvas units too** (`overlayScale: plan`), so both
+layers shrink together and the card looks the same at every size — a scale drawing rather
+than a drawing with fixed-size furniture on it. Every measure follows: `size` and
+`labelSize` on a device, the reading drawn inside a badge, `size` on text, an area's
+`labelSize`, and `rippleSize`. Hairlines deliberately don't — a badge border and a label's
+drop shadow are about a pixel either way, and scaling them down is how you lose them.
 
-`overlayScale: plan` sizes the overlay in **canvas units** instead, so both layers shrink
-together and the card looks the same at every size — a scale drawing rather than a drawing
-with fixed-size furniture on it. Every measure follows: `size` and `labelSize` on a
-device, the reading drawn inside a badge, `size` on text, an area's `labelSize`, and
-`rippleSize`. Hairlines deliberately don't — a badge border and a label's drop shadow
-are about a pixel either way, and scaling them down is how you lose them.
+Sizes then mean the same thing as everything else in the config: `labelSize: 14` is 14
+units on a `980`-unit-wide canvas, about 1.4 % of the card's width whatever that turns out
+to be.
+
+### `fixed`, and why it isn't the default
+
+`overlayScale: fixed` pins the overlay to **screen pixels** instead:
 
 ```yaml
 type: custom:easy-floorplan-card
 width: 980
 height: 700
-overlayScale: plan
+overlayScale: fixed
 ```
 
-Sizes are read in canvas units under `plan`, so the numbers mean the same thing as
-everything else in the config: `labelSize: 14` is 14 units on a `980`-unit-wide canvas,
-about 1.4 % of the card's width whatever that turns out to be.
+That was the original behaviour, and the original default. It agrees with the drawing only
+while the card renders at roughly its canvas size — which is not something a plan gets to
+decide, because the dashboard hands it whatever width it has. Below that the two come
+apart: a `980`-wide plan shown `500` wide draws every wall at half size while a 14px room
+name stays 14px, so names spill past their rooms and collide with the badges under them.
+Nothing in the config fixes it, because a label's px size doesn't know what scale the plan
+ended up at.
 
-### It also keeps a cluster together
+It also loses a **cluster**. A group of badges placed close together — three sensors of the
+same physical device, say — has positions that scale with the plan and sizes that do not,
+so a cluster neatly spaced on a wide card collides on a narrow one: the badges stay 34px
+while the gaps between them shrink. Under `plan` the whole cluster shrinks as one and the
+spacing you set is the spacing you keep. (That is the answer to "my grouped icons drift
+apart when the card resizes" — though the better answer is often to have no cluster at
+all: put the readings on **one** device with [`readings`](#more-readings-per-device) and
+there is no relative position left to preserve.)
 
-A group of badges placed close together — three sensors of the same physical device, say —
-is the case this is most visibly *for*. Under the default `fixed`, their positions scale
-with the plan while their size does not, so a cluster that is neatly spaced on a wide card
-collides on a narrow one: the badges stay 34px while the gaps between them shrink. Under
-`plan` the whole cluster shrinks as one and the spacing you set is the spacing you keep, at
-every card width.
+Reach for `fixed` when the card renders **larger** than its canvas, or on a wall tablet
+where a px floor under the text is what keeps it readable from across the room.
 
-That is the answer to "my grouped icons drift apart when the card resizes". It is
-plan-wide and it costs legibility at small sizes (see below), so the other answer — often
-the better one — is not to have a cluster at all: put the readings on **one** device with
-[`readings`](#more-readings-per-device) and there is no relative position left to preserve.
+> **Upgrading?** The default changed, so a plan that never set `overlayScale` now scales
+> its overlay with the drawing. If your card renders at about its canvas width you will
+> barely see it; if it renders much smaller, labels get smaller (which is the point) and if
+> much larger, bigger. Setting `overlayScale: fixed` restores the old behaviour exactly.
 
 ### Where it helps, and where it costs
 
@@ -1053,11 +1063,13 @@ to compensate — a `labelSize` of `20`–`24` on a card at half its canvas widt
 where the default was. That is a real trade, not a free win: sizes are relative, and
 nothing puts a floor under them.
 
-Use it whenever the card renders smaller than its canvas but not drastically so — a
-dashboard tile, a sidebar, a desktop widget. Leave it off for a wall tablet showing the
-plan at full size, where fixed px is what keeps text legible from across the room, and
-for a card so small that scaled text would disappear. The default stays `fixed`, so an
-existing card looks exactly as it did.
+So the escape hatch runs both ways. On a card **much** smaller than its canvas, raise the
+sizes rather than switching to `fixed` — the geometry is still right, only the numbers are
+too small. Switch to `fixed` when the card is rendered **larger** than its canvas, or on a
+wall tablet showing the plan at full size where a px floor is what keeps text legible from
+across the room.
+
+The rule of thumb: `plan` is what a plan wants, and the size numbers are yours to set.
 
 ## More readings per device
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ then pick the entity in the **Element** section below the canvas.
   both read `Name · state`. **Label size** sets the font size. The editor canvas draws
   the same line the card will, so turning one on is visible straight away; a device
   showing neither still gets a dimmed editor-only label so you can tell it apart.
-- **Two readings in one** — add a **Second entity** to render e.g. `21.5 °C · 45%`. Or set
-  **Attribute** / **2nd attribute** to read attributes instead of states, so a single
-  climate entity shows its temperature and humidity.
-- **More readings** — beyond those two, **+ Add reading** appends as many as you like.
-  See [More readings per device](#more-readings-per-device).
+- **More readings** — **+ Add reading**, right under the entity, appends as many as the
+  device has: `21.5 °C · 45% · 1013 hPa`. Each row picks an entity, an attribute, or both
+  — leave the entity empty and it reads that attribute off this device, so one climate
+  entity can show four of its own numbers. See
+  [More readings per device](#more-readings-per-device).
 - **Label position** — **Below** the badge (the default), or hung off its **left** or
   **right**. A reading under a badge grows in both directions and meets whatever sits
   beside it; hung off one side it grows one way only.
@@ -461,9 +461,9 @@ distorted anyway.
 | ------------- | -------------------------------------- | ------------ | ------------------------------------------------------ |
 | `id`          | string                                 | —            | Unique id.                                             |
 | `entity`      | string                                 | —            | Entity to bind. Without one the device is a static badge. |
-| `secondaryEntity` | string                             | —            | Second entity shown alongside (e.g. humidity).         |
+| `secondaryEntity` | string                             | —            | **Legacy** spelling of the first `readings` row. Still read — it goes at the head of the list — but it has no editor field, and editing a device's readings rewrites it. Use `readings`. |
 | `attribute`   | string                                 | —            | Show this attribute instead of the state (e.g. `current_temperature`). |
-| `secondaryAttribute` | string                          | —            | Attribute for the 2nd reading — from `secondaryEntity`, or from `entity` when none. |
+| `secondaryAttribute` | string                          | —            | **Legacy**, as above: the attribute for that first row — from `secondaryEntity`, or from `entity` when none. |
 | `stateColor`  | rule[]                                 | —            | Badge/label color rules, regardless of on/off; beats `activeColor`. Each is `{ above? , state?, color, icon? }` — an exact `state` beats a threshold, the highest matching `above` wins, neither is the default, and a matching `icon` beats the device's own. |
 | `x`, `y`      | number                                 | —            | Position.                                              |
 | `kind`        | light/switch/sensor/binary_sensor/climate/cover/media_player/fan/camera/lock/humidifier/vacuum/generic | inferred | Used for the default icon. |
@@ -480,12 +480,12 @@ distorted anyway.
 | `glowRadius`  | number                                 | `140`        | Radius of the cast pool at full brightness, in canvas units. A dimmer lamp casts a proportionally smaller pool, down to half this. |
 | `glowColor`   | string                                 | `#ffd9a0`    | Pool color for a bulb that can't report one; color-capable lights use their own. |
 | `badgeContent` | `icon` \| `value` \| `none`           | `icon`       | What the badge holds. `value` draws the reading inside it, falling back to the icon when there is no number; `none` leaves the label alone. |
-| `badgeEntity` | `primary` \| `secondary`               | automatic    | Which entity a `value` badge reads. Unset picks the first with a number to show; set, only that entity is read. |
+| `badgeEntity` | `primary` \| number                    | automatic    | Which reading a `value` badge shows: the device's own entity, or an index into `readings`. Unset picks the first with a number; set, only that one is read (an index past the end shows the icon). `secondary` is accepted as the legacy spelling of `0`. |
 | `showIcon`    | boolean                                | `true`       | **Deprecated** — use `badgeContent`. Honoured only when it is unset (`false` = `none`). |
 | `hideWhenInactive` | boolean                           | `false`      | Hide on the card while the entity is inactive. Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line. Governs this device's **own** state only — `readings` show regardless. |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
-| `readings`    | `{ entity?, attribute? }[]`            | —            | Further readings appended to the label — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
+| `readings`    | `{ entity?, attribute? }[]`            | —            | Everything this device reads beyond its own state — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
 | `labelPosition` | `below` \| `left` \| `right`         | `below`      | Where the label sits relative to the badge. |
 | `labelSize`   | number                                 | `12`         | Label line font size (px).                             |
 | `tap_action`  | ActionConfig                           | per domain   | Standard Lovelace action. By default `light`, `switch`, `fan` and `input_boolean` toggle and everything else — covers included — opens more-info. |
@@ -1121,19 +1121,39 @@ its label should carry the *other* numbers and not the word "on":
       - { attribute: battery }
 ```
 
-→ `Desk plug · 1.2 kW · 84 · 84`. `showState` governs the device's **own** state line;
-`readings` are their own statement. A plan with no `readings` therefore gains nothing on
-upgrade.
+→ `Desk plug · 1.2 kW · 84 · 84`. `showState` is about the device's **own state**;
+`readings` are their own statement.
 
-### Why not more entity boxes
+### One list, not two mechanisms
 
-`readings` is additive rather than a replacement for `secondaryEntity`. That key is the
-*paired* reading — joined with the same separator, and offered to the badge itself through
-`badgeEntity` (see **Badge reads**) — so folding it into `readings[0]` would have broken
-both. The order on the label is `entity`, then `secondaryEntity`, then these.
+There used to be a `secondaryEntity` / `secondaryAttribute` pair — one extra reading, with
+its own pair of dropdowns and its own rule about when it showed. It is now simply the
+**first row of `readings`**: still read, so no existing plan breaks, but with no field of
+its own in the editor, and rewritten into `readings` the first time you touch a device's
+readings. The order on the label is `entity`, then that legacy row, then the rest.
 
-In the editor they are added one at a time with **+ Add reading**, rather than by putting
-four entity dropdowns on every device that will never use them.
+The badge follows the same list. **Badge reads** offers one option per reading rather than
+just "the second one", so a plug reporting power, link quality and battery can badge
+whichever it likes:
+
+```yaml
+    badgeContent: value
+    badgeEntity: 1            # index into readings; "primary" is the device itself
+```
+
+`badgeEntity: secondary` still works and means index `0`.
+
+> **Upgrading?** One behaviour changed with the merge. `secondaryEntity` used to be part of
+> the state line, so it only showed while **Show state** was on — which is off by default
+> for anything that isn't a `sensor`. As a reading it now shows on its own terms. If you
+> have a light or a switch with a second entity and Show state off, a reading will appear
+> under it that wasn't there before; delete that row, or leave it — it is the number you
+> pointed the device at. Sensors, which show state by default, are unaffected.
+
+In the editor the readings sit **directly under the entity**, added one at a time with
+**+ Add reading** rather than by putting four entity dropdowns on every device that will
+never use them. Each row's attribute box is HA's own attribute picker, listing what that
+entity actually has.
 
 ## Offline devices
 

--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,7 @@ label gets no Label group, and an opening with no shutter gets no Shutter group.
 | Furniture | Shape · What it reads · Color |
 | Area | Identity · What it reads · Color · Home Assistant area |
 | Tracker | Zone · Sensors · Marker |
+| Project | Project · Look · Floor image · Display · Sunlight · Night dimming · Devices · Symbols |
 
 Walls and text keep a plain list: a wall is thickness and length, a text is its words, size
 and angle. A heading over one or two fields is chrome rather than structure.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ screen size.
 <img width="195" height="278" alt="light blend" src="https://github.com/user-attachments/assets/23104587-687b-4c9a-83e8-e83c3d5eb6eb" />
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
-- (${\color{red}NEW!}$) **Many readings, one device** — a sensor that reports temperature, humidity and pressure needs one badge, not three. Add readings one at a time; they show whether or not the device's own state does, so a smart plug can label itself `1.2 kW · 84 · 5 min ago` while the badge colour carries the on/off. The label can sit below, left or right of the badge.
+- (${\color{red}NEW!}$) **Many readings, one device** — a sensor that reports temperature, humidity and pressure needs one badge, not three. Add entities one at a time; they show whether or not the device's own state does, so a smart plug can label itself `1.2 kW · 84 · 5 min ago` while the badge colour carries the on/off. The label can sit below, left or right of the badge.
 - **Animated doors & windows** — bind a contact `binary_sensor` or `cover` and openings swing, slide or roll with their real state, partial positions included.
   - (${\color{red}NEW!}$) **A sensor per leaf** — anything with two leaves takes a second contact and draws them independently: a casement window with one sash open and one shut, a double door ajar on one side, a pair of shutters with one folded back.
 - (${\color{red}NEW!}$) **Offline devices read as offline** — an entity that is unavailable, unknown, or gone from Home Assistant is dimmed (or crossed out), instead of looking exactly like a device someone switched off.
@@ -103,7 +103,7 @@ then pick the entity in the **Element** section below the canvas.
   both read `Name · state`. **Label size** sets the font size. The editor canvas draws
   the same line the card will, so turning one on is visible straight away; a device
   showing neither still gets a dimmed editor-only label so you can tell it apart.
-- **More readings** — **+ Add reading**, right under the entity, appends as many as the
+- **Other entities** — **+ Add entity**, right under the first one, appends as many as the
   device has: `21.5 °C · 45% · 1013 hPa`. Each row picks an entity, an attribute, or both
   — leave the entity empty and it reads that attribute off this device, so one climate
   entity can show four of its own numbers. See
@@ -1101,7 +1101,7 @@ from:
 | — | — | nothing — a blank row draws no text |
 
 The third row is what lets one climate entity show four of its own attributes without
-naming itself four times. The fourth is why the editor's **+ Add reading** can hand you an
+naming itself four times. The fourth is why the editor's **+ Add entity** can hand you an
 empty row without a `—` appearing on the plan.
 
 ### Readings ignore "Show state"
@@ -1150,10 +1150,15 @@ whichever it likes:
 > under it that wasn't there before; delete that row, or leave it — it is the number you
 > pointed the device at. Sensors, which show state by default, are unaffected.
 
-In the editor the readings sit **directly under the entity**, added one at a time with
-**+ Add reading** rather than by putting four entity dropdowns on every device that will
-never use them. Each row's attribute box is HA's own attribute picker, listing what that
-entity actually has.
+In the editor these sit **directly under the entity** as **Other entities**, added one at a
+time with **+ Add entity** rather than by putting four entity dropdowns on every device
+that will never use them. Each row's attribute box is HA's own attribute picker, listing
+what that entity actually has.
+
+The device panel is grouped: **Identity** (name, show name), **What it reads** (entity,
+attribute, show state, other entities), **Label**, **Badge**, **Color**, **Effects** and
+**Behavior**, each with its own heading. Groups that have nothing to offer are left out —
+a sensor gets no Effects group, and a device that draws no label gets no Label group.
 
 ## Offline devices
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ screen size.
 <img width="195" height="278" alt="light blend" src="https://github.com/user-attachments/assets/23104587-687b-4c9a-83e8-e83c3d5eb6eb" />
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
+- (${\color{red}NEW!}$) **Many readings, one device** — a sensor that reports temperature, humidity and pressure needs one badge, not three. Add readings one at a time; they show whether or not the device's own state does, so a smart plug can label itself `1.2 kW · 84 · 5 min ago` while the badge colour carries the on/off. The label can sit below, left or right of the badge.
 - **Animated doors & windows** — bind a contact `binary_sensor` or `cover` and openings swing, slide or roll with their real state, partial positions included.
   - (${\color{red}NEW!}$) **A sensor per leaf** — anything with two leaves takes a second contact and draws them independently: a casement window with one sash open and one shut, a double door ajar on one side, a pair of shutters with one folded back.
 - (${\color{red}NEW!}$) **Offline devices read as offline** — an entity that is unavailable, unknown, or gone from Home Assistant is dimmed (or crossed out), instead of looking exactly like a device someone switched off.
@@ -105,6 +106,11 @@ then pick the entity in the **Element** section below the canvas.
 - **Two readings in one** — add a **Second entity** to render e.g. `21.5 °C · 45%`. Or set
   **Attribute** / **2nd attribute** to read attributes instead of states, so a single
   climate entity shows its temperature and humidity.
+- **More readings** — beyond those two, **+ Add reading** appends as many as you like.
+  See [More readings per device](#more-readings-per-device).
+- **Label position** — **Below** the badge (the default), or hung off its **left** or
+  **right**. A reading under a badge grows in both directions and meets whatever sits
+  beside it; hung off one side it grows one way only.
 - **Badge shows** — one dropdown for what the device draws: *Icon* — **still**,
   **spinning** or **pulsing** — its *Value*, or *Nothing* (label only). **Value** draws
   the reading inside the badge — a thermostat reads `21°` in the circle your state rules
@@ -477,8 +483,10 @@ distorted anyway.
 | `badgeEntity` | `primary` \| `secondary`               | automatic    | Which entity a `value` badge reads. Unset picks the first with a number to show; set, only that entity is read. |
 | `showIcon`    | boolean                                | `true`       | **Deprecated** — use `badgeContent`. Honoured only when it is unset (`false` = `none`). |
 | `hideWhenInactive` | boolean                           | `false`      | Hide on the card while the entity is inactive. Always shown, dimmed, in the editor. |
-| `showState`   | boolean                                | sensors only | Show the entity state in the label line.               |
+| `showState`   | boolean                                | sensors only | Show the entity state in the label line. Governs this device's **own** state only — `readings` show regardless. |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
+| `readings`    | `{ entity?, attribute? }[]`            | —            | Further readings appended to the label — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
+| `labelPosition` | `below` \| `left` \| `right`         | `below`      | Where the label sits relative to the badge. |
 | `labelSize`   | number                                 | `12`         | Label line font size (px).                             |
 | `tap_action`  | ActionConfig                           | per domain   | Standard Lovelace action. By default `light`, `switch`, `fan` and `input_boolean` toggle and everything else — covers included — opens more-info. |
 | `hold_action` / `double_tap_action` | ActionConfig         | —            | Optional extra gestures.                               |
@@ -1011,6 +1019,20 @@ Sizes are read in canvas units under `plan`, so the numbers mean the same thing 
 everything else in the config: `labelSize: 14` is 14 units on a `980`-unit-wide canvas,
 about 1.4 % of the card's width whatever that turns out to be.
 
+### It also keeps a cluster together
+
+A group of badges placed close together — three sensors of the same physical device, say —
+is the case this is most visibly *for*. Under the default `fixed`, their positions scale
+with the plan while their size does not, so a cluster that is neatly spaced on a wide card
+collides on a narrow one: the badges stay 34px while the gaps between them shrink. Under
+`plan` the whole cluster shrinks as one and the spacing you set is the spacing you keep, at
+every card width.
+
+That is the answer to "my grouped icons drift apart when the card resizes". It is
+plan-wide and it costs legibility at small sizes (see below), so the other answer — often
+the better one — is not to have a cluster at all: put the readings on **one** device with
+[`readings`](#more-readings-per-device) and there is no relative position left to preserve.
+
 ### Where it helps, and where it costs
 
 Scaling with the drawing cuts both ways: it stops text overflowing its room, and it also
@@ -1036,6 +1058,70 @@ dashboard tile, a sidebar, a desktop widget. Leave it off for a wall tablet show
 plan at full size, where fixed px is what keeps text legible from across the room, and
 for a card so small that scaled text would disappear. The default stays `fixed`, so an
 existing card looks exactly as it did.
+
+## More readings per device
+
+One device, as many readings as it has. A sensor that reports temperature,
+humidity and pressure needs one badge, not three:
+
+```yaml
+items:
+  - id: study
+    entity: sensor.study_temperature
+    kind: sensor
+    showName: true
+    showState: true
+    readings:
+      - { entity: sensor.study_humidity }
+      - { entity: sensor.study_pressure }
+```
+
+→ `Study · 21.5 °C · 48% · 1013 hPa`, on one line, in the order written.
+
+Each row is `{ entity?, attribute? }`, and between them they say where the number comes
+from:
+
+| `entity` | `attribute` | reads |
+| --- | --- | --- |
+| set | — | that entity's state |
+| set | set | that attribute of that entity |
+| — | set | that attribute of **this device's own** entity |
+| — | — | nothing — a blank row draws no text |
+
+The third row is what lets one climate entity show four of its own attributes without
+naming itself four times. The fourth is why the editor's **+ Add reading** can hand you an
+empty row without a `—` appearing on the plan.
+
+### Readings ignore "Show state"
+
+That is the point of them. A smart plug already says on/off through its badge colour, so
+its label should carry the *other* numbers and not the word "on":
+
+```yaml
+  - id: desk_plug
+    entity: switch.desk_plug
+    kind: switch
+    showName: true
+    showState: false          # the badge colour already says on/off
+    readings:
+      - { entity: sensor.desk_plug_power }
+      - { entity: sensor.desk_plug_lqi }
+      - { attribute: battery }
+```
+
+→ `Desk plug · 1.2 kW · 84 · 84`. `showState` governs the device's **own** state line;
+`readings` are their own statement. A plan with no `readings` therefore gains nothing on
+upgrade.
+
+### Why not more entity boxes
+
+`readings` is additive rather than a replacement for `secondaryEntity`. That key is the
+*paired* reading — joined with the same separator, and offered to the badge itself through
+`badgeEntity` (see **Badge reads**) — so folding it into `readings[0]` would have broken
+both. The order on the label is `entity`, then `secondaryEntity`, then these.
+
+In the editor they are added one at a time with **+ Add reading**, rather than by putting
+four entity dropdowns on every device that will never use them.
 
 ## Offline devices
 

--- a/README.md
+++ b/README.md
@@ -1155,10 +1155,21 @@ time with **+ Add entity** rather than by putting four entity dropdowns on every
 that will never use them. Each row's attribute box is HA's own attribute picker, listing
 what that entity actually has.
 
-The device panel is grouped: **Identity** (name, show name), **What it reads** (entity,
-attribute, show state, other entities), **Label**, **Badge**, **Color**, **Effects** and
-**Behavior**, each with its own heading. Groups that have nothing to offer are left out —
-a sensor gets no Effects group, and a device that draws no label gets no Label group.
+Every element's panel is grouped under headings, on the same criteria: what it **is**
+first, then what it **reads**, then how it **looks**, then what it **does**. Groups with
+nothing to offer are left out — a sensor gets no Effects group, a device that draws no
+label gets no Label group, and an opening with no shutter gets no Shutter group.
+
+| Element | Groups |
+| --- | --- |
+| Device | Identity · What it reads · Label · Badge · Color · Effects · Behavior |
+| Door / window | Shape · What it reads · Sunlight · Shutter · Badge · Color · Behavior |
+| Furniture | Shape · What it reads · Color |
+| Area | Identity · What it reads · Color · Home Assistant area |
+| Tracker | Zone · Sensors · Marker |
+
+Walls and text keep a plain list: a wall is thickness and length, a text is its words, size
+and angle. A heading over one or two fields is chrome rather than structure.
 
 ## Offline devices
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -134,6 +134,15 @@ half of three different symbols at once. That half-open state is the point:
 an opening with a single sensor moves both leaves together by definition, so
 there is no other way to see a sash open beside a sash that is shut.
 
+Two devices carry the multi-reading work (issue #180). The sensor in the middle
+of the plan shows three numbers from one badge — its own temperature, the paired
+humidity, and a third `readings` row — which is the ordering worth checking:
+`entity`, then `secondaryEntity`, then `readings`, in that order. The fan stands
+in for the smart plug from discussion #173: `showState: false`, one reading off
+its own `percentage` attribute, and its label hung to the **left** of the badge,
+so a device that labels itself *without* its own state and a label that is not
+underneath are both on the plan at once.
+
 The plan also carries one device bound to `light.deleted_by_accident`, which is
 not an entity and never will be. It is what a renamed or deleted binding looks
 like, and the reason it is hard-coded rather than switchable is that no live

--- a/docker/README.md
+++ b/docker/README.md
@@ -137,7 +137,10 @@ there is no other way to see a sash open beside a sash that is shut.
 Two devices carry the multi-reading work (issue #180). The sensor in the middle
 of the plan shows three numbers from one badge — its own temperature, the paired
 humidity, and a third `readings` row — which is the ordering worth checking:
-`entity`, then `secondaryEntity`, then `readings`, in that order. The fan stands
+`entity`, then the legacy `secondaryEntity`, then `readings`. That device is
+deliberately left on the old spelling, so the plan exercises the compatibility
+path too: the card reads both as one pool, and opening the device in the editor
+rewrites the pair into `readings` in front of you. The fan stands
 in for the smart plug from discussion #173: `showState: false`, one reading off
 its own `percentage` attribute, and its label hung to the **left** of the badge,
 so a device that labels itself *without* its own state and a label that is not

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -147,9 +147,15 @@ views:
             items:
               # Paired temperature/humidity: stored at two decimals, displayed at
               # one. Should read like "17.9 °C · 49.3%".
+              # Many readings on one device (issue #180). The first two are the
+              # old pair (`entity` + `secondaryEntity`); `readings` stacks on
+              # top of them rather than replacing them, which is the ordering
+              # this is here to prove: entity, then secondary, then these.
               - id: i1
                 entity: sensor.living_area_temperature
                 secondaryEntity: sensor.living_area_humidity
+                readings:
+                  - { entity: sensor.ficus_soil_moisture }
                 x: 500
                 y: 300
                 kind: sensor
@@ -195,8 +201,21 @@ views:
                 y: 180
                 kind: cover
                 activeColor: "#8e24aa"
+              # Readings without the device's own state (issue #180) -- the
+              # smart-plug pattern from discussion #173, with the demo's fan
+              # standing in for the plug. Its badge colour already says on or
+              # off, so the label carries the speed instead of the word "on".
+              # `showState: false` silences the state line; the reading is not
+              # gated on it, which is the whole point.
+              #
+              # Also the one device with its label beside the badge rather than
+              # under it, so both label positions are on the plan at once.
               - id: i4
                 entity: fan.living_room_fan
+                showState: false
+                readings:
+                  - { attribute: percentage }
+                labelPosition: left
                 x: 220
                 y: 180
                 kind: fan

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -147,10 +147,12 @@ views:
             items:
               # Paired temperature/humidity: stored at two decimals, displayed at
               # one. Should read like "17.9 °C · 49.3%".
-              # Many readings on one device (issue #180). The first two are the
-              # old pair (`entity` + `secondaryEntity`); `readings` stacks on
-              # top of them rather than replacing them, which is the ordering
-              # this is here to prove: entity, then secondary, then these.
+              # Many readings on one device (issue #180): one list, in the
+              # order the label prints them. This one deliberately still uses
+              # the legacy `secondaryEntity` for its second reading, so the
+              # plan proves the compatibility path as well as the new key --
+              # the card reads both as one pool, and opening this device in
+              # the editor rewrites the old spelling into `readings`.
               - id: i1
                 entity: sensor.living_area_temperature
                 secondaryEntity: sensor.living_area_humidity

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -4,8 +4,13 @@ import {
   diffFormValue,
   normalizeFormPatch,
   openingForm,
-  itemForm,
   itemEntityForm,
+  itemIdentityForm,
+  itemShowStateForm,
+  itemLabelForm,
+  itemBadgeForm,
+  itemEffectsForm,
+  itemBehaviourForm,
   textForm,
   furnitureForm,
   trackerForm,
@@ -21,6 +26,7 @@ import {
   areaForm,
   areaNameForm,
 } from "./editor-forms";
+import { itemHasLabel } from "./render";
 import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
@@ -363,6 +369,79 @@ describe("openingForm — a hinged shutter's second panel (issue #159)", () => {
 describe("itemForm", () => {
   const item = { id: "i", entity: "light.a", kind: "light", x: 0, y: 0 } as FloorItem;
 
+  // The device panel is seven groups now rather than one form, but almost
+  // every question below is about the panel as a whole — "is this control
+  // offered", "what does it open on". These two view it that way, so the tests
+  // keep asking what they always asked and stay indifferent to which group a
+  // control ended up in.
+  const groups = (
+    it: FloorItem,
+    deviceClass?: string,
+    badgeSource?: Parameters<typeof itemBadgeForm>[1]
+  ) =>
+    [
+      itemIdentityForm(it),
+      itemEntityForm(it),
+      itemShowStateForm(it),
+      itemHasLabel(it) ? itemLabelForm(it) : undefined,
+      itemBadgeForm(it, badgeSource),
+      itemEffectsForm(it, deviceClass),
+      itemBehaviourForm(it),
+    ].filter((g): g is NonNullable<typeof g> => !!g);
+  const itemForm = (
+    it: FloorItem,
+    deviceClass?: string,
+    badgeSource?: Parameters<typeof itemBadgeForm>[1]
+  ) => {
+    const gs = groups(it, deviceClass, badgeSource);
+    return {
+      fields: gs.flatMap((g) => g.fields),
+      data: Object.assign({}, ...gs.map((g) => g.data)) as Record<string, unknown>,
+      /** Routed to whichever group owns the key, as the editor routes it. */
+      toPatch: (patch: Record<string, unknown>) => {
+        const owner =
+          gs.find((g) => g.fields.some((f) => f.name in patch)) ?? gs[gs.length - 1];
+        return owner.toPatch(patch);
+      },
+    };
+  };
+
+  it("groups the panel, in the order the questions get asked", () => {
+    // The panel is two dozen controls; this pins the shape of it, because the
+    // order is a design decision and not an accident of what was added when.
+    const sensor = { ...item, entity: "sensor.t", kind: "sensor" } as FloorItem;
+    expect(groups(sensor).map((g) => g.fields.map((f) => f.name))).toEqual([
+      ["name", "showName"], // 1. Identity — what it is
+      ["entity", "attribute"], // 2. What it reads…
+      ["showState"], //         …including whether its own state shows
+      ["labelPosition", "labelSize"], // 3. Label
+      ["badgeMode", "size", "angle"], // 4. Badge
+      // 5. Colour and the readings list are hand-rolled rows, not ha-form
+      //    fields, so they do not appear here — the editor slots them into
+      //    their groups.
+      // 6. Effects is absent: a plain sensor neither rings nor casts light.
+      ["hideWhenInactive", "tap_action", "hold_action", "double_tap_action"], // 7. Behaviour
+    ]);
+  });
+
+  it("leaves out the groups a device has nothing to put in", () => {
+    // A light casts, so Effects appears; a sensor does not.
+    const light = { ...item, glow: true } as FloorItem;
+    expect(itemEffectsForm(light)?.fields.map((f) => f.name)).toEqual([
+      "glow",
+      "glowRadius",
+      "glowColor",
+    ]);
+    expect(itemEffectsForm({ ...item, kind: "sensor", entity: "sensor.t" } as FloorItem)).toBeUndefined();
+    // …and the Label group is skipped entirely while nothing labels the device.
+    expect(groups(item).some((g) => g.fields.some((f) => f.name === "labelPosition"))).toBe(false);
+    expect(
+      groups({ ...item, showName: true } as FloorItem).some((g) =>
+        g.fields.some((f) => f.name === "labelPosition")
+      )
+    ).toBe(true);
+  });
+
   it("offers Cast light on lights only, with its controls behind the toggle (#6)", () => {
     const names = (it: FloorItem) => itemForm(it).fields.map((x) => x.name);
     expect(names(item)).toContain("glow");
@@ -538,17 +617,16 @@ describe("itemForm", () => {
       display: "badge",
       showIcon: undefined,
     });
-    // The ring toggle alone is still a complete statement about `display`:
-    // the mode comes off the item.
-    expect(f.toPatch({ ripple: true }).display).toBe("iconRipple");
-    expect(
-      itemForm({ ...item, badgeContent: "none" } as FloorItem).toPatch({ ripple: true }).display
-    ).toBe("ripple");
-    expect(
-      itemForm({ ...item, display: "iconRipple" } as FloorItem).toPatch({ ripple: false }).display
-    ).toBe("badge");
-    // Both at once, and unrelated edits, pass through untouched.
-    expect(f.toPatch({ badgeMode: "none", ripple: true }).display).toBe("ripple");
+    // The ring toggle alone is still a complete statement about `display`: the
+    // mode comes off the item. It lives in the Effects group and is offered
+    // only to a presence device, which is the only device that can emit it.
+    const ring = { ...item, entity: "binary_sensor.hall", kind: "binary_sensor" } as FloorItem;
+    const rf = (extra: Partial<FloorItem> = {}) =>
+      itemEffectsForm({ ...ring, ...extra } as FloorItem, "motion")!;
+    expect(rf().toPatch({ ripple: true }).display).toBe("iconRipple");
+    expect(rf({ badgeContent: "none" }).toPatch({ ripple: true }).display).toBe("ripple");
+    expect(rf({ display: "iconRipple" }).toPatch({ ripple: false }).display).toBe("badge");
+    // Unrelated edits pass through untouched, in whichever group owns them.
     expect(f.toPatch({ size: 40 })).toEqual({ size: 40 });
     expect(f.toPatch({ size: 40, badgeMode: "value" }).size).toBe(40);
   });

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1684,6 +1684,20 @@ describe("every field lands in exactly one panel group", () => {
     }
   });
 
+  it("covers every project field — offlineStyle is sliced away from its form", () => {
+    // projectDisplayForm still owns rotation / overlayScale / compactHeader /
+    // offlineStyle as one form with one toPatch, but the panel renders the
+    // first three under "Display" and the last under "Devices". Miss it in
+    // both slices and the control silently disappears.
+    const DISPLAY = ["rotation", "overlayScale", "compactHeader"];
+    const DEVICES = ["offlineStyle"];
+    const cfg = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    check(projectDisplayForm(cfg).fields, [DISPLAY, DEVICES], "project display");
+    // Both slices resolve, and neither can emit the other's key.
+    expect(formSlice(projectDisplayForm(cfg), DISPLAY).fields.map((f) => f.name)).toEqual(DISPLAY);
+    expect(formSlice(projectDisplayForm(cfg), DEVICES).fields.map((f) => f.name)).toEqual(DEVICES);
+  });
+
   it("covers every furniture, tracker and area field", () => {
     const f = { id: "f", type: "sofa", x: 0, y: 0, w: 40, h: 40 } as Furniture;
     check(furnitureForm(f).fields, FURNITURE_GROUPS, "furniture");

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -413,6 +413,39 @@ describe("itemForm", () => {
     ).toBe(20);
   });
 
+  it("reveals the label controls for a device labelled by its readings alone (#180)", () => {
+    const names = (it: FloorItem) => itemForm(it).fields.map((x) => x.name);
+    // Both toggles off, so before #180 this device had no label — and now it
+    // has one made of nothing but extra readings.
+    const byReadings = { ...item, readings: [{ entity: "sensor.power" }] } as FloorItem;
+    expect(names(byReadings)).toContain("labelSize");
+    expect(names(byReadings)).toContain("labelPosition");
+    // A row that names nothing is not a label, so the controls stay away.
+    expect(names({ ...item, readings: [{}] } as FloorItem)).not.toContain("labelPosition");
+    expect(names(item)).not.toContain("labelPosition");
+  });
+
+  it("offers the three label positions, keeping the default out of the YAML (#180)", () => {
+    const labelled = { ...item, showName: true } as FloorItem;
+    const form = itemForm(labelled);
+    const field = form.fields.find((x) => x.name === "labelPosition")!;
+    const opts = (field.selector as { select: { options: { value: string }[] } }).select.options.map(
+      (o) => o.value
+    );
+    expect(opts).toEqual(["below", "left", "right"]);
+    expect(form.data.labelPosition).toBe("below");
+    expect(
+      itemForm({ ...labelled, labelPosition: "left" } as FloorItem).data.labelPosition
+    ).toBe("left");
+    // Below is the default, so it is not worth writing down.
+    expect(form.toPatch({ labelPosition: "below" }).labelPosition).toBeUndefined();
+    expect(form.toPatch({ labelPosition: "right" }).labelPosition).toBe("right");
+    // A hand-edited junk value reads back as what it renders as.
+    expect(
+      itemForm({ ...labelled, labelPosition: "above" } as unknown as FloorItem).data.labelPosition
+    ).toBe("below");
+  });
+
   it("offers the three action fields with behavior-preserving defaults", () => {
     const fs = itemForm(item).fields;
     expect(fs.find((x) => x.name === "tap_action")!.selector).toEqual({

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -968,20 +968,28 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(form.fields[0].helper).toBe(tron.description);
   });
 
-  it("overlay scale shares that form, defaults to fixed, and stays out of the YAML when default", () => {
+  it("overlay scale shares that form, defaults to plan, and stays out of the YAML when default", () => {
     const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
-    expect(form.data.overlayScale).toBe("fixed");
-    expect(form.toPatch({ overlayScale: "fixed" })).toEqual({ overlayScale: undefined });
-    expect(form.toPatch({ overlayScale: "plan" })).toEqual({ overlayScale: "plan" });
+    expect(form.data.overlayScale).toBe("plan");
+    // Canvas units are the default, so they are what stays unwritten; "fixed"
+    // is the choice that has to be recorded.
+    expect(form.toPatch({ overlayScale: "plan" })).toEqual({ overlayScale: undefined });
+    expect(form.toPatch({ overlayScale: "fixed" })).toEqual({ overlayScale: "fixed" });
     // Patching one field must not invent a value for the other.
     expect(form.toPatch({ rotation: "90" })).toEqual({ rotation: 90 });
-    const scaled = projectDisplayForm({
+    const pinned = projectDisplayForm({
       type: "t",
       width: 1000,
       height: 600,
-      overlayScale: "plan",
+      overlayScale: "fixed",
     } as FloorplanCardConfig);
-    expect(scaled.data.overlayScale).toBe("plan");
+    expect(pinned.data.overlayScale).toBe("fixed");
+    // The default leads the dropdown, so the list opens on what a plan wants.
+    const field = form.fields.find((x) => x.name === "overlayScale")!;
+    const opts = (field.selector as { select: { options: { value: string }[] } }).select.options.map(
+      (o) => o.value
+    );
+    expect(opts).toEqual(["plan", "fixed"]);
   });
 
   it("image opacity appears only when an image is set", () => {

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeFormPatch,
   openingForm,
   itemForm,
+  itemEntityForm,
   textForm,
   furnitureForm,
   trackerForm,
@@ -377,7 +378,7 @@ describe("itemForm", () => {
 
   it("offers Ripple on presence devices only, sized behind the toggle (#127)", () => {
     const motion = { ...item, entity: "binary_sensor.hall", kind: "binary_sensor" } as FloorItem;
-    const names = (it: FloorItem, dc?: string) => itemForm(it, undefined, dc).fields.map((x) => x.name);
+    const names = (it: FloorItem, dc?: string) => itemForm(it, dc).fields.map((x) => x.name);
     // A light is not something that detects presence, whatever it can do.
     expect(names(item)).not.toContain("ripple");
     expect(names(item, "motion")).not.toContain("ripple");
@@ -560,10 +561,10 @@ describe("itemForm", () => {
       secondaryEntity: "sensor.plug_power",
       badgeContent: "value",
     } as FloorItem;
-    const names = (it: FloorItem, src?: Parameters<typeof itemForm>[3]) =>
-      itemForm(it, undefined, undefined, src).fields.map((x) => x.name);
+    const names = (it: FloorItem, src?: Parameters<typeof itemForm>[2]) =>
+      itemForm(it, undefined, src).fields.map((x) => x.name);
 
-    it("appears only when the badge shows a value AND there is a second entity", () => {
+    it("appears only when the badge shows a value AND there is another reading", () => {
       expect(names(plug)).toContain("badgeEntity");
       // Nothing to choose between with one entity.
       expect(names({ ...plug, secondaryEntity: undefined } as FloorItem)).not.toContain(
@@ -581,27 +582,52 @@ describe("itemForm", () => {
       // fallback, with no badgeEntity stored. A form defaulting to "primary"
       // would name the switch while the badge shows watts — and the next
       // unrelated edit would save that and drop the reading to an icon.
-      const asRead = itemForm(plug, undefined, undefined, { source: "secondary" });
-      expect(asRead.data.badgeEntity).toBe("secondary");
+      const asRead = itemForm(plug, undefined, { source: 0 });
+      expect(asRead.data.badgeEntity).toBe("0");
       // A stored choice always wins over the live reading.
       expect(
-        itemForm({ ...plug, badgeEntity: "primary" } as FloorItem, undefined, undefined, {
-          source: "secondary",
+        itemForm({ ...plug, badgeEntity: "primary" } as FloorItem, undefined, {
+          source: 0,
         }).data.badgeEntity,
       ).toBe("primary");
+      // …including the legacy spelling, which means index 0.
+      expect(
+        itemForm({ ...plug, badgeEntity: "secondary" } as FloorItem, undefined, {
+          source: "primary",
+        }).data.badgeEntity,
+      ).toBe("0");
     });
 
     it("names the entities, with no 'Automatic' among them (#127's precedent)", () => {
-      const field = itemForm(plug, undefined, undefined, {
-        source: "secondary",
+      const field = itemForm(plug, undefined, {
+        source: 0,
         primaryLabel: "Kitchen plug",
-        secondaryLabel: "Kitchen plug power",
+        readingLabels: ["Kitchen plug power"],
       }).fields.find((x) => x.name === "badgeEntity")!;
       const opts = (field.selector as { select: { options: { value: string; label: string }[] } })
         .select.options;
-      expect(opts.map((o) => o.value)).toEqual(["primary", "secondary"]);
+      expect(opts.map((o) => o.value)).toEqual(["primary", "0"]);
       expect(opts.map((o) => o.label)).toEqual(["Kitchen plug", "Kitchen plug power"]);
       expect(opts.map((o) => o.value)).not.toContain("auto");
+    });
+
+    it("offers one option per reading, not just the second (#180)", () => {
+      const many = {
+        ...plug,
+        secondaryEntity: undefined,
+        readings: [
+          { entity: "sensor.plug_power" },
+          { entity: "sensor.plug_lqi" },
+          { attribute: "battery" },
+        ],
+      } as FloorItem;
+      const field = itemForm(many).fields.find((x) => x.name === "badgeEntity")!;
+      const opts = (field.selector as { select: { options: { value: string; label: string }[] } })
+        .select.options;
+      expect(opts.map((o) => o.value)).toEqual(["primary", "0", "1", "2"]);
+      // A reading with no entity of its own is read off this device, and the
+      // label says so rather than leaving the row nameless.
+      expect(opts[3].label).toContain("battery");
     });
 
     it("falls back to entity ids when hass has no friendly names", () => {
@@ -610,8 +636,10 @@ describe("itemForm", () => {
       expect(opts.map((o) => o.label)).toEqual(["switch.plug", "sensor.plug_power"]);
     });
 
-    it("passes the choice straight through as a config key", () => {
-      expect(itemForm(plug).toPatch({ badgeEntity: "secondary" }).badgeEntity).toBe("secondary");
+    it("stores the choice as an index, so the legacy spelling stops spreading", () => {
+      expect(itemForm(plug).toPatch({ badgeEntity: "0" }).badgeEntity).toBe(0);
+      expect(itemForm(plug).toPatch({ badgeEntity: "2" }).badgeEntity).toBe(2);
+      expect(itemForm(plug).toPatch({ badgeEntity: "primary" }).badgeEntity).toBe("primary");
     });
   });
 
@@ -620,32 +648,33 @@ describe("itemForm", () => {
     expect(itemForm(item).data.icon).toBeUndefined();
   });
 
-  it("scopes the entity/secondaryEntity pickers to the area's entities when given", () => {
-    const unscoped = itemForm(item);
+  it("scopes the entity picker to the area's entities when given", () => {
+    const unscoped = itemEntityForm(item);
     expect(unscoped.fields.find((x) => x.name === "entity")!.selector).toEqual({ entity: {} });
-    const scoped = itemForm({ ...item, entity: "light.kitchen" } as FloorItem, {
+    const scoped = itemEntityForm({ ...item, entity: "light.kitchen" } as FloorItem, {
       entities: ["light.kitchen", "switch.kitchen"],
       name: "Kitchen",
     });
     expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({
       entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
     });
-    expect(scoped.fields.find((x) => x.name === "secondaryEntity")!.selector).toEqual({
-      entity: { include_entities: ["light.kitchen", "switch.kitchen"] },
-    });
+    // There is no second entity *field* to scope any more (issue #180) — the
+    // readings rows are hand-rolled, and the editor scopes their pickers off
+    // the same _areaEntitiesAt call.
+    expect(scoped.fields.map((x) => x.name)).toEqual(["entity", "attribute"]);
   });
 
   it("an empty area list does NOT filter — an empty picker would hide everything", () => {
     // Regression: `[]` is truthy, so the old code emitted
     // `include_entities: []` and the picker listed nothing at all — the
     // common case when a linked HA area has no entities assigned.
-    const scoped = itemForm(item, { entities: [], name: "Kitchen" });
+    const scoped = itemEntityForm(item, { entities: [], name: "Kitchen" });
     expect(scoped.fields.find((x) => x.name === "entity")!.selector).toEqual({ entity: {} });
     expect(scoped.fields.find((x) => x.name === "entity")!.helper).toBeUndefined();
   });
 
   it("always keeps the bound entity pickable, even from another area", () => {
-    const scoped = itemForm({ ...item, entity: "light.hallway" } as FloorItem, {
+    const scoped = itemEntityForm({ ...item, entity: "light.hallway" } as FloorItem, {
       entities: ["light.kitchen"],
       name: "Kitchen",
     });
@@ -655,14 +684,10 @@ describe("itemForm", () => {
   });
 
   it("says why the list is short, and how to widen it", () => {
-    const scoped = itemForm(item, { entities: ["light.kitchen"], name: "Kitchen" });
+    const scoped = itemEntityForm(item, { entities: ["light.kitchen"], name: "Kitchen" });
     const helper = scoped.fields.find((x) => x.name === "entity")!.helper!;
     expect(helper).toContain("Kitchen");
     expect(helper).toContain("Filter entities");
-    // The secondary picker keeps its own explanation too.
-    expect(scoped.fields.find((x) => x.name === "secondaryEntity")!.helper).toContain(
-      "Shown next to the primary state"
-    );
   });
 });
 
@@ -1376,12 +1401,12 @@ describe("area scoping never traps you (issue reported on #83)", () => {
 
   it("outside every area, and inside an empty one, nothing is filtered", () => {
     // No scope at all — the element sits outside every area.
-    expect(itemForm(item).fields.find((x) => x.name === "entity")!.selector).toEqual({
+    expect(itemEntityForm(item).fields.find((x) => x.name === "entity")!.selector).toEqual({
       entity: {},
     });
     // Inside an area whose HA area has no entities: same, unfiltered.
     expect(
-      itemForm(item, { entities: [], name: "Spare" }).fields.find((x) => x.name === "entity")!
+      itemEntityForm(item, { entities: [], name: "Spare" }).fields.find((x) => x.name === "entity")!
         .selector
     ).toEqual({ entity: {} });
   });

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -4,6 +4,7 @@ import {
   diffFormValue,
   normalizeFormPatch,
   openingForm,
+  formSlice,
   itemEntityForm,
   itemIdentityForm,
   itemShowStateForm,
@@ -28,7 +29,7 @@ import {
 } from "./editor-forms";
 import { itemHasLabel } from "./render";
 import type { FormField } from "./editor-forms";
-import type { Area, Opening, FloorItem, Floor, FloorplanCardConfig } from "./types";
+import type { Area, Opening, FloorItem, Floor, Furniture, Tracker, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
 import { DEFAULT_SKIN, SKINS, MAX_SKIN_WALL_WIDTH } from "./skins";
 import { DEFAULT_SUN_BEARING } from "./render";
@@ -1626,5 +1627,99 @@ describe("projectSunForm (issue #113)", () => {
     // Leaving them behind would resurrect stale values on re-enable.
     expect(toPatch({ sunDimming: true }).sunDimming).toBe(true);
     expect(toPatch({ sunBrightnessMin: 0.3 })).toEqual({ sunBrightnessMin: 0.3 });
+  });
+});
+
+// The panels are grouped by lists of field names living in editor.ts. A field
+// the form produces that no group names would silently stop being editable —
+// it would simply never render, with nothing failing. These lists are copied
+// from FloorplanCardEditor's static group tables; the test is that every field
+// each form can produce appears in exactly one of them.
+describe("every field lands in exactly one panel group", () => {
+  const OPENING_GROUPS = [
+    ["type", "motion", "length", "sash", "hinge", "opens", "slide", "style", "angle"],
+    ["entity", "secondaryEntity", "invert"],
+    ["glazed", "sunlight"],
+    [
+      "shutterEntity",
+      "shutterStyle",
+      "shutterSide",
+      "shutterSecondaryEntity",
+      "shutterInvert",
+      "showShutterIcon",
+      "shutterIcon",
+    ],
+    ["showIcon", "icon"],
+    ["tapTarget", "tap_action", "hold_action", "double_tap_action"],
+  ];
+  const FURNITURE_GROUPS = [["type", "hand", "w", "h", "angle"], ["entity"]];
+  const TRACKER_GROUPS = [["w", "h", "x", "y", "angle"], ["dotSize"]];
+  const AREA_GROUPS = [["showName", "labelSize"], ["entity"], ["highlight", "opacity", "activeOpacity"]];
+
+  const check = (fields: { name: string }[], groups: string[][], what: string) => {
+    const grouped = groups.flat();
+    const dupes = grouped.filter((n, i) => grouped.indexOf(n) !== i);
+    expect({ what, dupes }).toEqual({ what, dupes: [] });
+    const ungrouped = fields.map((f) => f.name).filter((n) => !grouped.includes(n));
+    expect({ what, ungrouped }).toEqual({ what, ungrouped: [] });
+  };
+
+  it("covers every opening field, across every shape an opening can take", () => {
+    const base = { id: "o", type: "door", x: 0, y: 0, length: 90, angle: 0 } as Opening;
+    // Walk the variants that reveal conditional fields, so the union of
+    // everything an opening can offer is checked rather than one example.
+    for (const extra of [
+      {},
+      { entity: "binary_sensor.a" },
+      { type: "window", entity: "binary_sensor.a" },
+      { type: "window", sash: "single", entity: "binary_sensor.a" },
+      { motion: "slide", sliderStyle: "biparting", entity: "binary_sensor.a" },
+      { motion: "roll", entity: "cover.g" },
+      { shutterEntity: "binary_sensor.s", shutterStyle: "swing" },
+      { shutterEntity: "cover.s", shutterStyle: "roll", entity: "binary_sensor.a" },
+      { entity: "binary_sensor.a", showIcon: true },
+      { shutterEntity: "binary_sensor.s", showShutterIcon: true },
+    ]) {
+      check(openingForm({ ...base, ...extra } as Opening).fields, OPENING_GROUPS, JSON.stringify(extra));
+    }
+  });
+
+  it("covers every furniture, tracker and area field", () => {
+    const f = { id: "f", type: "sofa", x: 0, y: 0, w: 40, h: 40 } as Furniture;
+    check(furnitureForm(f).fields, FURNITURE_GROUPS, "furniture");
+    check(
+      furnitureForm({ ...f, type: "sectional", entity: "sensor.a" } as Furniture).fields,
+      FURNITURE_GROUPS,
+      "furniture sectional"
+    );
+    const tr = { id: "t", x: 0, y: 0, w: 10, h: 10 } as Tracker;
+    check(trackerForm(tr).fields, TRACKER_GROUPS, "tracker");
+    const a = { id: "a", points: [{ x: 0, y: 0 }] } as Area;
+    check(areaForm(a).fields, AREA_GROUPS, "area");
+    check(areaForm({ ...a, entity: "light.a", haArea: "kitchen" } as Area).fields, AREA_GROUPS, "area linked");
+  });
+});
+
+describe("formSlice", () => {
+  const spec = openingForm({ id: "o", type: "door", x: 0, y: 0, length: 90, angle: 0 } as Opening);
+
+  it("keeps the named fields, in the order named", () => {
+    expect(formSlice(spec, ["length", "type"]).fields.map((f) => f.name)).toEqual([
+      "length",
+      "type",
+    ]);
+  });
+
+  it("shares the whole data and toPatch, so a group cannot diverge", () => {
+    const slice = formSlice(spec, ["type"]);
+    expect(slice.data).toBe(spec.data);
+    expect(slice.toPatch({ motion: "roll" })).toEqual(spec.toPatch({ motion: "roll" }));
+  });
+
+  it("skips a name the form did not produce — the forms are conditional", () => {
+    // No shutter on this opening, so a Shutter group asking for its style
+    // renders nothing rather than throwing.
+    expect(formSlice(spec, ["shutterStyle", "type"]).fields.map((f) => f.name)).toEqual(["type"]);
+    expect(formSlice(spec, []).fields).toEqual([]);
   });
 });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -7,7 +7,6 @@
  */
 import type {
   Area,
-  BadgeEntity,
   Floor,
   FloorItem,
   FloorText,
@@ -54,6 +53,8 @@ import {
   pressEffectOf,
   labelPositionOf,
   itemHasLabel,
+  itemReadings,
+  badgeEntityIndex,
   offlineStyleOf,
   sliderStyleOf,
   shutterStyleOf,
@@ -698,55 +699,72 @@ function badgeModePatch(mode: BadgeMode, ripple: boolean): Record<string, unknow
  * and drop the reading to an icon.
  */
 export interface BadgeSourceInfo {
-  source: BadgeEntity;
+  /** Where the badge's number is coming from right now. */
+  source: "primary" | number;
   /** Friendly names, falling back to the entity ids when hass has none. */
   primaryLabel?: string;
-  secondaryLabel?: string;
+  /** One per reading, positionally, so the dropdown can name each. */
+  readingLabels?: (string | undefined)[];
 }
 
 /**
- * `deviceClass` is the entity's HA device class, the one hass-derived fact the
- * device form needs: it is what separates a motion sensor from a door contact,
- * and so decides whether the ripple ring is offered at all (issue #127). The
- * editor reads it off `hass` at the call site, as it already does for openings.
+ * The device's remaining fields — everything except its entity and attribute,
+ * which are {@link itemEntityForm} so the readings list can sit between them
+ * (issue #180). Takes no `areaScope`: the only pickers that were scoped were
+ * the entity ones, and they have moved.
+ *
+ * `deviceClass` is the entity's HA device class, the one hass-derived fact this
+ * form needs: it is what separates a motion sensor from a door contact, and so
+ * decides whether the ripple ring is offered at all (issue #127). The editor
+ * reads it off `hass` at the call site, as it already does for openings.
  * `badgeSource` is the second such fact — see {@link BadgeSourceInfo}.
  */
+/**
+ * The device's own entity and attribute — the first reading, and the one
+ * `showState` governs.
+ *
+ * Split from {@link itemForm} so the editor can slot the repeatable "More
+ * readings" rows *directly beneath it* (issue #180), which is where the old
+ * "Second entity" / "2nd attribute" pair used to sit. Everything a device
+ * reads is then in one place and in the order it appears on the label, rather
+ * than the second reading being a form field and the third onwards being a
+ * list further down. Both halves still render through `ha-form`, exactly as
+ * {@link areaNameForm} and {@link areaForm} do.
+ */
+export function itemEntityForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
+  return {
+    fields: [
+      {
+        name: "entity",
+        label: "Entity",
+        required: true,
+        helper: areaScopeHelper(areaScope),
+        selector: areaScopedEntity(areaScope, it.entity),
+      },
+      {
+        name: "attribute",
+        label: "Attribute",
+        helper: "Show this attribute instead of the state (e.g. current_temperature)",
+        selector: { attribute: { entity_id: it.entity } },
+      },
+    ],
+    data: { entity: it.entity ?? "", attribute: it.attribute ?? "" },
+    toPatch: identity,
+  };
+}
+
 export function itemForm(
   it: FloorItem,
-  areaScope?: AreaEntityScope,
   deviceClass?: string,
   badgeSource?: BadgeSourceInfo
 ): FormSpec {
   const ripple = itemHasRipple(it);
   const presence = isPresenceEntity(it.entity, deviceClass);
   const fields: FormField[] = [
-    {
-      name: "entity",
-      label: "Entity",
-      required: true,
-      helper: areaScopeHelper(areaScope),
-      selector: areaScopedEntity(areaScope, it.entity),
-    },
-    {
-      name: "attribute",
-      label: "Attribute",
-      helper: "Show this attribute instead of the state (e.g. current_temperature)",
-      selector: { attribute: { entity_id: it.entity } },
-    },
-    {
-      name: "secondaryEntity",
-      label: "Second entity",
-      helper: areaScopeHelper(areaScope, "Shown next to the primary state"),
-      selector: areaScopedEntity(areaScope, it.secondaryEntity),
-    },
-    {
-      name: "secondaryAttribute",
-      label: "2nd attribute",
-      helper: "From the second entity, or this entity if none",
-      selector: { attribute: { entity_id: it.secondaryEntity || it.entity } },
-    },
-    // The icon is *not* here: it sits by the state rules that can override it
-    // (issue #127), rendered by the editor next to them.
+    // Entity and Attribute are not here: they are {@link itemEntityForm}, so
+    // the readings list can sit between them and the rest (issue #180). Nor is
+    // the icon — it sits by the state rules that can override it (issue #127),
+    // rendered by the editor next to them.
     { name: "name", label: "Name", selector: { text: {} } },
     {
       name: "size",
@@ -768,21 +786,32 @@ export function itemForm(
       ),
     },
   ];
-  // Which entity the value comes from (issue #136) — offered only where it is
-  // a real question: the badge has to be showing a value, and the device has
-  // to have a second entity to choose between. Most devices never see this.
+  // Which reading the value comes from (issue #136) — offered only where it is
+  // a real question: the badge has to be showing a value, and the device has to
+  // have more than one reading to choose between. Most devices never see this.
   //
   // The options name the entities rather than offering an "Automatic", the
   // precedent from #127's dropdown above: "auto" is a fact about the config
   // format, not about what the user is looking at.
-  if (badgeModeOf(it) === "value" && it.secondaryEntity) {
+  //
+  // One option per reading now, not just "the second one" — a plug showing
+  // power, link quality and battery can badge whichever it likes (issue #180).
+  const readings = itemReadings(it);
+  if (badgeModeOf(it) === "value" && readings.length) {
     fields.push({
       name: "badgeEntity",
       label: "Badge reads",
-      helper: "Which of this device's entities the badge shows",
+      helper: "Which of this device's readings the badge shows",
       selector: dropdown(
         opt("primary", badgeSource?.primaryLabel || it.entity || "Main entity"),
-        opt("secondary", badgeSource?.secondaryLabel || it.secondaryEntity)
+        ...readings.map((r, i) =>
+          opt(
+            String(i),
+            badgeSource?.readingLabels?.[i] ||
+              r.entity ||
+              (r.attribute ? `${it.entity || "this device"} · ${r.attribute}` : `Reading ${i + 1}`)
+          )
+        )
       ),
     });
   }
@@ -883,10 +912,8 @@ export function itemForm(
   return {
     fields,
     data: {
-      entity: it.entity,
-      secondaryEntity: it.secondaryEntity ?? "",
-      attribute: it.attribute ?? "",
-      secondaryAttribute: it.secondaryAttribute ?? "",
+      // entity / attribute live in itemEntityForm; the legacy secondary pair
+      // has no field at all now (issue #180) — the readings list owns it.
       name: it.name ?? "",
       size: it.size ?? DEFAULT_ITEM_SIZE,
       angle: it.angle ?? 0,
@@ -894,7 +921,11 @@ export function itemForm(
       // The stored choice, else the entity the badge is *actually* reading —
       // never a bare "primary" default, which would contradict the canvas for
       // every device relying on the fallback. See {@link BadgeSourceInfo}.
-      badgeEntity: it.badgeEntity ?? badgeSource?.source ?? "primary",
+      // The dropdown's values are strings, so the stored index (or the legacy
+      // "secondary") is spelled the same way here; toPatch turns it back into
+      // a number. Opens on what the badge is *actually* reading when nothing
+      // is chosen, which is the whole point of badgeSource (issue #136).
+      badgeEntity: String(badgeEntityIndex(it.badgeEntity) ?? badgeSource?.source ?? "primary"),
       ripple,
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       glow: it.glow ?? false,
@@ -917,6 +948,11 @@ export function itemForm(
       // Below is the default, so it stays out of the YAML.
       if ("labelPosition" in out && out.labelPosition === "below")
         out = { ...out, labelPosition: undefined };
+      // The dropdown speaks strings; the config stores "primary" or an index.
+      // Written as a number so the legacy "secondary" spelling stops spreading
+      // to configs that never had it.
+      if ("badgeEntity" in out && typeof out.badgeEntity === "string" && out.badgeEntity !== "primary")
+        out = { ...out, badgeEntity: Number(out.badgeEntity) };
       if (!("badgeMode" in out) && !("ripple" in out)) return out;
       const { badgeMode, ripple: ring, ...rest } = out;
       return {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -52,7 +52,6 @@ import {
   sliderStyleHasTwoLeaves,
   pressEffectOf,
   labelPositionOf,
-  itemHasLabel,
   itemReadings,
   badgeEntityIndex,
   offlineStyleOf,
@@ -753,25 +752,103 @@ export function itemEntityForm(it: FloorItem, areaScope?: AreaEntityScope): Form
   };
 }
 
-export function itemForm(
-  it: FloorItem,
-  deviceClass?: string,
-  badgeSource?: BadgeSourceInfo
-): FormSpec {
-  const ripple = itemHasRipple(it);
-  const presence = isPresenceEntity(it.entity, deviceClass);
-  const fields: FormField[] = [
-    // Entity and Attribute are not here: they are {@link itemEntityForm}, so
-    // the readings list can sit between them and the rest (issue #180). Nor is
-    // the icon — it sits by the state rules that can override it (issue #127),
-    // rendered by the editor next to them.
-    { name: "name", label: "Name", selector: { text: {} } },
-    {
-      name: "size",
-      label: "Size",
-      selector: { number: { min: 16, max: 160, step: 2, mode: "slider", unit_of_measurement: "px" } },
+/**
+ * The device panel, in groups (issue #180 follow-up).
+ *
+ * It had grown to two dozen controls in one flat run — Name between Attribute
+ * and Badge shows, Show state eleven rows below the entity it describes — and
+ * the order was the order things had been added in rather than any order you
+ * would look for them in. So the panel is now seven groups, each rendered with
+ * its own heading and rule by the editor, and each of these functions is one
+ * of them.
+ *
+ * They are separate `FormSpec`s rather than one form with dividers because the
+ * hand-rolled rows (the readings list, the icon, the colour pickers) have to
+ * interleave with the `ha-form` fields, and `ha-form` renders one flat block.
+ * Same reason {@link areaNameForm} and {@link areaForm} are two.
+ *
+ * Group order, and the reasoning:
+ *
+ * 1. **Identity** — Name, Show name. What the thing *is*, and it is the first
+ *    question anyone answers.
+ * 2. **What it reads** — Entity, Attribute, Show state, then the other
+ *    entities. Show state sits with the entity whose state it shows.
+ * 3. **Label** — position and size, offered only while a label renders.
+ * 4. **Badge** — the circle: what it holds, which reading, its glyph and size.
+ * 5. **Colour** — the active colour and the state rules that supersede it.
+ * 6. **Effects** — ripple and cast light, each offered only where it means
+ *    something.
+ * 7. **Behaviour** — when it is drawn at all, and what a press does.
+ */
+
+/** Group 1: what this device is called. */
+export function itemIdentityForm(it: FloorItem): FormSpec {
+  return {
+    fields: [
+      { name: "name", label: "Name", selector: { text: {} } },
+      {
+        name: "showName",
+        label: "Show name",
+        helper: "Adds the name to the label line",
+        selector: { boolean: {} },
+      },
+    ],
+    data: { name: it.name ?? "", showName: it.showName ?? false },
+    toPatch: identity,
+  };
+}
+
+/**
+ * Group 2, second half: whether the device's own state joins the label.
+ *
+ * Its own one-field spec so the editor can put it directly under the entity
+ * and attribute it describes, with the readings list below it — the whole of
+ * "what this device reads", in the order the label prints it.
+ */
+export function itemShowStateForm(it: FloorItem): FormSpec {
+  return {
+    fields: [
+      {
+        name: "showState",
+        label: "Show state",
+        helper: "Adds this entity's own state to the label line",
+        selector: { boolean: {} },
+      },
+    ],
+    data: { showState: it.showState ?? it.kind === "sensor" },
+    toPatch: identity,
+  };
+}
+
+/** Group 3: where the label sits and how big it is. */
+export function itemLabelForm(it: FloorItem): FormSpec {
+  return {
+    fields: [
+      {
+        name: "labelPosition",
+        label: "Label position",
+        helper: "Beside the badge instead of under it — a long reading then grows one way only",
+        selector: dropdown(opt("below", "Below"), opt("left", "Left"), opt("right", "Right")),
+      },
+      {
+        name: "labelSize",
+        label: "Label size",
+        selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
+      },
+    ],
+    data: {
+      labelPosition: labelPositionOf(it),
+      labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
     },
-    angleField(),
+    // Below is the default, so it stays out of the YAML.
+    toPatch: (p) =>
+      "labelPosition" in p && p.labelPosition === "below" ? { ...p, labelPosition: undefined } : p,
+  };
+}
+
+/** Group 4: the badge — what it holds, which reading, and how big it is. */
+export function itemBadgeForm(it: FloorItem, badgeSource?: BadgeSourceInfo): FormSpec {
+  const fields: FormField[] = [
     {
       name: "badgeMode",
       label: "Badge shows",
@@ -791,11 +868,10 @@ export function itemForm(
   // have more than one reading to choose between. Most devices never see this.
   //
   // The options name the entities rather than offering an "Automatic", the
-  // precedent from #127's dropdown above: "auto" is a fact about the config
-  // format, not about what the user is looking at.
-  //
-  // One option per reading now, not just "the second one" — a plug showing
-  // power, link quality and battery can badge whichever it likes (issue #180).
+  // precedent from #127's dropdown: "auto" is a fact about the config format,
+  // not about what the user is looking at. One option per reading, not just
+  // "the second one" — a plug showing power, link quality and battery can badge
+  // whichever it likes (issue #180).
   const readings = itemReadings(it);
   if (badgeModeOf(it) === "value" && readings.length) {
     fields.push({
@@ -815,9 +891,60 @@ export function itemForm(
       ),
     });
   }
-  // A presence device can ring the spot it watches (issue #127) — the same
-  // shape of option as "Cast light" below, offered only where it means
-  // something. A ring on a thermostat says "someone is here", which is a lie.
+  fields.push(
+    {
+      name: "size",
+      label: "Size",
+      selector: { number: { min: 16, max: 160, step: 2, mode: "slider", unit_of_measurement: "px" } },
+    },
+    angleField()
+  );
+  return {
+    fields,
+    data: {
+      badgeMode: badgeModeOf(it),
+      // The dropdown's values are strings, so the stored index (or the legacy
+      // "secondary") is spelled the same way here; toPatch turns it back into
+      // a number. Opens on what the badge is *actually* reading when nothing
+      // is chosen, which is the whole point of badgeSource (issue #136).
+      badgeEntity: String(badgeEntityIndex(it.badgeEntity) ?? badgeSource?.source ?? "primary"),
+      size: it.size ?? DEFAULT_ITEM_SIZE,
+      angle: it.angle ?? 0,
+    },
+    // "Badge shows" is the editor's spelling of three config keys (issue
+    // #127) — expand it back, carrying the ripple state off the item since
+    // that control lives in another group now.
+    toPatch: (p) => {
+      let out = p;
+      // The dropdown speaks strings; the config stores "primary" or an index.
+      // Written as a number so the legacy "secondary" spelling stops spreading
+      // to configs that never had it.
+      if ("badgeEntity" in out && typeof out.badgeEntity === "string" && out.badgeEntity !== "primary")
+        out = { ...out, badgeEntity: Number(out.badgeEntity) };
+      if (!("badgeMode" in out)) return out;
+      const { badgeMode, ...rest } = out;
+      return {
+        ...rest,
+        ...badgeModePatch((badgeMode as BadgeMode | undefined) ?? badgeModeOf(it), itemHasRipple(it)),
+      };
+    },
+  };
+}
+
+/**
+ * Group 6: the optional visual extras, each offered only where it means
+ * something — a ring on a thermostat says "someone is here", which is a lie,
+ * and nothing but a light has a colour to cast.
+ *
+ * Returns `undefined` when this device qualifies for neither, so the editor
+ * can leave the whole group out rather than print an empty heading.
+ */
+export function itemEffectsForm(it: FloorItem, deviceClass?: string): FormSpec | undefined {
+  const ripple = itemHasRipple(it);
+  const presence = isPresenceEntity(it.entity, deviceClass);
+  const lights = it.kind === "light" || it.entity?.startsWith("light.");
+  if (!presence && !lights) return undefined;
+  const fields: FormField[] = [];
   if (presence) {
     fields.push({
       name: "ripple",
@@ -837,9 +964,7 @@ export function itemForm(
       });
     }
   }
-  // A light can cast a pool of light onto the plan from where it sits (issue
-  // #6). Offered only for lights, since nothing else has a color to cast.
-  if (it.kind === "light" || it.entity?.startsWith("light.")) {
+  if (lights) {
     fields.push({
       name: "glow",
       label: "Cast light",
@@ -862,109 +987,57 @@ export function itemForm(
       );
     }
   }
-  fields.push(
-    {
-      name: "hideWhenInactive",
-      label: "Only when active",
-      helper: "Hide on the card while the entity is off/idle (still editable here)",
-      selector: { boolean: {} },
-    },
-    { name: "showState", label: "Show state", selector: { boolean: {} } },
-    {
-      name: "showName",
-      label: "Show name",
-      helper: "Adds the device's name to the label line",
-      selector: { boolean: {} },
-    }
-  );
-  // Label size and placement only matter while a label line renders — and
-  // since issue #180 a device can have one from its extra readings alone, with
-  // both toggles above switched off. That is the plug case: on/off read from
-  // the badge colour, Power - LQI - Last seen as the only text.
-  if (itemHasLabel(it)) {
-    fields.push(
-      {
-        name: "labelSize",
-        label: "Label size",
-        selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
-      },
-      {
-        name: "labelPosition",
-        label: "Label position",
-        helper: "Beside the badge instead of under it — a long reading then grows one way only",
-        selector: dropdown(opt("below", "Below"), opt("left", "Left"), opt("right", "Right")),
-      }
-    );
-  }
-  fields.push(
-    {
-      name: "tap_action",
-      label: "Tap action",
-      selector: { ui_action: { default_action: defaultItemAction(it.entity).action } },
-    },
-    { name: "hold_action", label: "Hold action", selector: { ui_action: { default_action: "none" } } },
-    {
-      name: "double_tap_action",
-      label: "Double-tap action",
-      selector: { ui_action: { default_action: "none" } },
-    }
-  );
   return {
     fields,
     data: {
-      // entity / attribute live in itemEntityForm; the legacy secondary pair
-      // has no field at all now (issue #180) — the readings list owns it.
-      name: it.name ?? "",
-      size: it.size ?? DEFAULT_ITEM_SIZE,
-      angle: it.angle ?? 0,
-      badgeMode: badgeModeOf(it),
-      // The stored choice, else the entity the badge is *actually* reading —
-      // never a bare "primary" default, which would contradict the canvas for
-      // every device relying on the fallback. See {@link BadgeSourceInfo}.
-      // The dropdown's values are strings, so the stored index (or the legacy
-      // "secondary") is spelled the same way here; toPatch turns it back into
-      // a number. Opens on what the badge is *actually* reading when nothing
-      // is chosen, which is the whole point of badgeSource (issue #136).
-      badgeEntity: String(badgeEntityIndex(it.badgeEntity) ?? badgeSource?.source ?? "primary"),
       ripple,
       rippleSize: it.rippleSize ?? DEFAULT_RIPPLE_SIZE,
       glow: it.glow ?? false,
       glowRadius: it.glowRadius ?? DEFAULT_GLOW_RADIUS,
       glowColor: it.glowColor ?? "",
+    },
+    // "Ripple" is the other half of #127's three-key spelling — same expansion
+    // as the badge group's, with the badge mode read off the item.
+    toPatch: (p) => {
+      if (!("ripple" in p)) return p;
+      const { ripple: ring, ...rest } = p;
+      return { ...rest, ...badgeModePatch(badgeModeOf(it), !!ring) };
+    },
+  };
+}
+
+/** Group 7: when the device is drawn at all, and what a press does. */
+export function itemBehaviourForm(it: FloorItem): FormSpec {
+  return {
+    fields: [
+      {
+        name: "hideWhenInactive",
+        label: "Only when active",
+        helper: "Hide on the card while the entity is off/idle (still editable here)",
+        selector: { boolean: {} },
+      },
+      {
+        name: "tap_action",
+        label: "Tap action",
+        selector: { ui_action: { default_action: defaultItemAction(it.entity).action } },
+      },
+      { name: "hold_action", label: "Hold action", selector: { ui_action: { default_action: "none" } } },
+      {
+        name: "double_tap_action",
+        label: "Double-tap action",
+        selector: { ui_action: { default_action: "none" } },
+      },
+    ],
+    data: {
       hideWhenInactive: it.hideWhenInactive ?? false,
-      showState: it.showState ?? false,
-      showName: it.showName ?? false,
-      labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
-      labelPosition: labelPositionOf(it),
       tap_action: it.tap_action,
       hold_action: it.hold_action,
       double_tap_action: it.double_tap_action,
     },
-    // "Badge shows" and "Ripple" are the editor's spelling of three config
-    // keys (issue #127) — expand them back. Either control alone is a complete
-    // statement about both, so the untouched one is read off the item.
-    toPatch: (patch) => {
-      let out = patch;
-      // Below is the default, so it stays out of the YAML.
-      if ("labelPosition" in out && out.labelPosition === "below")
-        out = { ...out, labelPosition: undefined };
-      // The dropdown speaks strings; the config stores "primary" or an index.
-      // Written as a number so the legacy "secondary" spelling stops spreading
-      // to configs that never had it.
-      if ("badgeEntity" in out && typeof out.badgeEntity === "string" && out.badgeEntity !== "primary")
-        out = { ...out, badgeEntity: Number(out.badgeEntity) };
-      if (!("badgeMode" in out) && !("ripple" in out)) return out;
-      const { badgeMode, ripple: ring, ...rest } = out;
-      return {
-        ...rest,
-        ...badgeModePatch(
-          (badgeMode as BadgeMode | undefined) ?? badgeModeOf(it),
-          ring === undefined ? ripple : !!ring
-        ),
-      };
-    },
+    toPatch: identity,
   };
 }
+
 
 export function textForm(t: FloorText): FormSpec {
   return {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -144,6 +144,35 @@ export interface FormSpec {
 
 const identity = (patch: Record<string, unknown>) => patch;
 
+/**
+ * The named fields of `spec`, in the order given, sharing its data and its
+ * `toPatch` — one group of a panel that is otherwise one form.
+ *
+ * The device panel was split into real per-group specs because its groups
+ * interleave with hand-rolled rows and each group's patch logic was separable.
+ * The other elements are not like that: an opening's `toPatch` is one chain of
+ * interdependent clears (drop the shutter, and its style, side, invert, badge
+ * and second contact go with it), and cutting that into six pieces to gain a
+ * heading would be trading a real invariant for a cosmetic one.
+ *
+ * So grouping them is presentation only. Every group renders the same `data`
+ * and the same `toPatch`; only the visible field list differs. `ha-form` reads
+ * just the keys in its own schema, and `diffFormValue` diffs against the slice,
+ * so a group cannot emit a key it does not show.
+ *
+ * A field named here that the spec did not produce is skipped — the forms are
+ * conditional, and a group asking for "shutterStyle" on an opening with no
+ * shutter should render nothing rather than crash. The reverse (a field the
+ * spec produced that no group names) would silently hide a control, which is
+ * why `everyFieldIsGrouped` in the tests exists.
+ */
+export function formSlice(spec: FormSpec, names: readonly string[]): FormSpec {
+  const fields = names
+    .map((n) => spec.fields.find((f) => f.name === n))
+    .filter((f): f is FormField => !!f);
+  return { fields, data: spec.data, toPatch: spec.toPatch };
+}
+
 const angleField = (): FormField => ({
   name: "angle",
   label: "Angle",

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1269,8 +1269,11 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       {
         name: "overlayScale",
         label: "Badge & label size",
-        helper: `Canvas units scale badges and labels with the drawing — use it when the card renders smaller than its ${c.width}-wide canvas`,
-        selector: dropdown(opt("fixed", "Fixed pixels"), opt("plan", "Canvas units")),
+        // The default first, and the helper describes the *exception* now:
+        // canvas units are what a plan wants unless it is being shown bigger
+        // than it was drawn.
+        helper: `Canvas units scale badges and labels with the drawing. Fixed pixels suit a card rendered larger than its ${c.width}-wide canvas, or a wall tablet`,
+        selector: dropdown(opt("plan", "Canvas units"), opt("fixed", "Fixed pixels")),
       },
       {
         name: "compactHeader",
@@ -1303,8 +1306,9 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       if ("rotation" in out)
         // Stored as a number; 0 means "not rotated", so keep it out of the YAML.
         out = { ...out, rotation: out.rotation === "0" ? undefined : Number(out.rotation) };
-      // "fixed" is the default, so keep it out of the YAML too.
-      if ("overlayScale" in out && out.overlayScale === "fixed")
+      // Canvas units are the default now, so they are what stays out of the
+      // YAML — and "fixed" is what has to be written down.
+      if ("overlayScale" in out && out.overlayScale === "plan")
         out = { ...out, overlayScale: undefined };
       // As are the ordinary header and the dimmed offline device — every
       // default here stays out of the YAML, so a config only ever records the

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -52,6 +52,8 @@ import {
   openingHasTwoLeaves,
   sliderStyleHasTwoLeaves,
   pressEffectOf,
+  labelPositionOf,
+  itemHasLabel,
   offlineStyleOf,
   sliderStyleOf,
   shutterStyleOf,
@@ -846,13 +848,24 @@ export function itemForm(
       selector: { boolean: {} },
     }
   );
-  // Label size only matters while a label line renders.
-  if (it.showName || (it.showState ?? it.kind === "sensor")) {
-    fields.push({
-      name: "labelSize",
-      label: "Label size",
-      selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
-    });
+  // Label size and placement only matter while a label line renders — and
+  // since issue #180 a device can have one from its extra readings alone, with
+  // both toggles above switched off. That is the plug case: on/off read from
+  // the badge colour, Power - LQI - Last seen as the only text.
+  if (itemHasLabel(it)) {
+    fields.push(
+      {
+        name: "labelSize",
+        label: "Label size",
+        selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
+      },
+      {
+        name: "labelPosition",
+        label: "Label position",
+        helper: "Beside the badge instead of under it — a long reading then grows one way only",
+        selector: dropdown(opt("below", "Below"), opt("left", "Left"), opt("right", "Right")),
+      }
+    );
   }
   fields.push(
     {
@@ -891,6 +904,7 @@ export function itemForm(
       showState: it.showState ?? false,
       showName: it.showName ?? false,
       labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
+      labelPosition: labelPositionOf(it),
       tap_action: it.tap_action,
       hold_action: it.hold_action,
       double_tap_action: it.double_tap_action,
@@ -899,8 +913,12 @@ export function itemForm(
     // keys (issue #127) — expand them back. Either control alone is a complete
     // statement about both, so the untouched one is read off the item.
     toPatch: (patch) => {
-      if (!("badgeMode" in patch) && !("ripple" in patch)) return patch;
-      const { badgeMode, ripple: ring, ...rest } = patch;
+      let out = patch;
+      // Below is the default, so it stays out of the YAML.
+      if ("labelPosition" in out && out.labelPosition === "below")
+        out = { ...out, labelPosition: undefined };
+      if (!("badgeMode" in out) && !("ripple" in out)) return out;
+      const { badgeMode, ripple: ring, ...rest } = out;
       return {
         ...rest,
         ...badgeModePatch(

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -717,7 +717,7 @@ function badgeModePatch(mode: BadgeMode, ripple: boolean): Record<string, unknow
 
 /**
  * What the badge is reading *right now*, for the "Badge reads" row (issue
- * #136). Resolved off `hass` at the call site, like {@link itemForm}'s
+ * #136). Resolved off `hass` at the call site, like {@link itemEffectsForm}'s
  * `deviceClass`, because this file stays pure.
  *
  * `source` is load-bearing rather than cosmetic. A plug whose badge shows its
@@ -736,28 +736,14 @@ export interface BadgeSourceInfo {
 }
 
 /**
- * The device's remaining fields — everything except its entity and attribute,
- * which are {@link itemEntityForm} so the readings list can sit between them
- * (issue #180). Takes no `areaScope`: the only pickers that were scoped were
- * the entity ones, and they have moved.
- *
- * `deviceClass` is the entity's HA device class, the one hass-derived fact this
- * form needs: it is what separates a motion sensor from a door contact, and so
- * decides whether the ripple ring is offered at all (issue #127). The editor
- * reads it off `hass` at the call site, as it already does for openings.
- * `badgeSource` is the second such fact — see {@link BadgeSourceInfo}.
- */
-/**
  * The device's own entity and attribute — the first reading, and the one
  * `showState` governs.
  *
- * Split from {@link itemForm} so the editor can slot the repeatable "More
- * readings" rows *directly beneath it* (issue #180), which is where the old
- * "Second entity" / "2nd attribute" pair used to sit. Everything a device
- * reads is then in one place and in the order it appears on the label, rather
- * than the second reading being a form field and the third onwards being a
- * list further down. Both halves still render through `ha-form`, exactly as
- * {@link areaNameForm} and {@link areaForm} do.
+ * Its own group so the editor can slot the repeatable "Other entities" rows
+ * *directly beneath it* (issue #180), which is where the old "Second entity" /
+ * "2nd attribute" pair used to sit. Everything a device reads is then in one
+ * place and in the order it appears on the label, rather than the second
+ * reading being a form field and the third onwards being a list further down.
  */
 export function itemEntityForm(it: FloorItem, areaScope?: AreaEntityScope): FormSpec {
   return {
@@ -781,34 +767,36 @@ export function itemEntityForm(it: FloorItem, areaScope?: AreaEntityScope): Form
   };
 }
 
-/**
- * The device panel, in groups (issue #180 follow-up).
- *
- * It had grown to two dozen controls in one flat run — Name between Attribute
- * and Badge shows, Show state eleven rows below the entity it describes — and
- * the order was the order things had been added in rather than any order you
- * would look for them in. So the panel is now seven groups, each rendered with
- * its own heading and rule by the editor, and each of these functions is one
- * of them.
- *
- * They are separate `FormSpec`s rather than one form with dividers because the
- * hand-rolled rows (the readings list, the icon, the colour pickers) have to
- * interleave with the `ha-form` fields, and `ha-form` renders one flat block.
- * Same reason {@link areaNameForm} and {@link areaForm} are two.
- *
- * Group order, and the reasoning:
- *
- * 1. **Identity** — Name, Show name. What the thing *is*, and it is the first
- *    question anyone answers.
- * 2. **What it reads** — Entity, Attribute, Show state, then the other
- *    entities. Show state sits with the entity whose state it shows.
- * 3. **Label** — position and size, offered only while a label renders.
- * 4. **Badge** — the circle: what it holds, which reading, its glyph and size.
- * 5. **Colour** — the active colour and the state rules that supersede it.
- * 6. **Effects** — ripple and cast light, each offered only where it means
- *    something.
- * 7. **Behaviour** — when it is drawn at all, and what a press does.
- */
+// ---- the device panel, in groups (issue #180 follow-up) --------------------
+//
+// A section header rather than a doc comment: it describes the seven functions
+// below rather than any one of them, and the repo spells that with a banner.
+//
+// It had grown to two dozen controls in one flat run — Name between Attribute
+// and Badge shows, Show state eleven rows below the entity it describes — and
+// the order was the order things had been added in rather than any order you
+// would look for them in. So the panel is now seven groups, each rendered with
+// its own heading and rule by the editor, and each of these functions is one
+// of them.
+//
+// They are separate `FormSpec`s rather than one form with dividers because the
+// hand-rolled rows (the readings list, the icon, the colour pickers) have to
+// interleave with the `ha-form` fields, and `ha-form` renders one flat block.
+// Same reason {@link areaNameForm} and {@link areaForm} are two.
+//
+// Group order, and the reasoning:
+//
+// 1. **Identity** — Name, Show name. What the thing *is*, and it is the first
+//    question anyone answers.
+// 2. **What it reads** — Entity, Attribute, Show state, then the other
+//    entities. Show state sits with the entity whose state it shows.
+// 3. **Label** — position and size, offered only while a label renders.
+// 4. **Badge** — the circle: what it holds, which reading, its glyph and size.
+// 5. **Colour** — the active colour and the state rules that supersede it.
+// 6. **Effects** — ripple and cast light, each offered only where it means
+//    something.
+// 7. **Behaviour** — when it is drawn at all, and what a press does.
+//
 
 /** Group 1: what this device is called. */
 export function itemIdentityForm(it: FloorItem): FormSpec {
@@ -875,7 +863,13 @@ export function itemLabelForm(it: FloorItem): FormSpec {
   };
 }
 
-/** Group 4: the badge — what it holds, which reading, and how big it is. */
+/**
+ * Group 4: the badge — what it holds, which reading, and how big it is.
+ *
+ * `badgeSource` is a hass-derived fact resolved at the call site rather than
+ * here: what the badge is reading *right now*, so "Badge reads" can open on it
+ * instead of on a guess. See {@link BadgeSourceInfo}.
+ */
 export function itemBadgeForm(it: FloorItem, badgeSource?: BadgeSourceInfo): FormSpec {
   const fields: FormField[] = [
     {
@@ -967,6 +961,11 @@ export function itemBadgeForm(it: FloorItem, badgeSource?: BadgeSourceInfo): For
  *
  * Returns `undefined` when this device qualifies for neither, so the editor
  * can leave the whole group out rather than print an empty heading.
+ *
+ * `deviceClass` is the entity's HA device class, resolved off `hass` at the
+ * call site as the openings already do theirs: it is what separates a motion
+ * sensor from a door contact, and so decides whether the ring is offered at
+ * all (issue #127).
  */
 export function itemEffectsForm(it: FloorItem, deviceClass?: string): FormSpec | undefined {
   const ripple = itemHasRipple(it);
@@ -1086,7 +1085,7 @@ export function textForm(t: FloorText): FormSpec {
 
 /**
  * `areaEntities` scopes the entity picker to a linked HA area, exactly as in
- * {@link itemForm} — a plant drawn inside the Living Room offers the Living
+ * {@link itemEntityForm} — a plant drawn inside the Living Room offers the Living
  * Room's sensors first.
  */
 export function furnitureForm(

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4041,76 +4041,113 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
+  /**
+   * The Project panel, grouped on the same criteria as the element panels:
+   * what the plan *is*, then how it *looks*, then what it *does*.
+   *
+   * It had the same problem the device panel had — nineteen controls in one
+   * run, with the sun's five aiming fields separated from the two brightness
+   * sliders by a press-effect dropdown, and "Offline devices" filed under
+   * display next to the card's rotation.
+   *
+   * `offlineStyle` moves out of the display slice and joins the press effect:
+   * both are statements about how *devices* look and answer, not about how the
+   * card is framed. It stays in `projectDisplayForm` as a field — one form, one
+   * `toPatch` — and is sliced into the group it belongs to (see `formSlice`).
+   */
   private _renderPanelBody(): TemplateResult {
+    const c = this._config;
+    const patch = (p: Record<string, unknown>) =>
+      this._patchConfig(p as Partial<FloorplanCardConfig>);
+    const display = projectDisplayForm(c);
     return html`
       <div class="rows panel-body">
-        ${this._renderForm(projectForm(this._config), (patch, live) => {
-          if ("grid" in patch && typeof patch.grid === "number") {
-            // The grid change rescales a custom snap step. ha-form's number
-            // box fires per keystroke — respect the burst path so typing
-            // "24" isn't two history commits (grid=2, then grid=24).
-            patch = { ...patch, ...this._gridPatch(patch.grid) };
-          }
-          if (live) this._patchConfigLive(patch as Partial<FloorplanCardConfig>);
-          else this._patchConfig(patch as Partial<FloorplanCardConfig>);
-        })}
-        ${this._renderForm(projectSkinForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          "Project",
+          this._renderForm(projectForm(c), (p, live) => {
+            if ("grid" in p && typeof p.grid === "number") {
+              // The grid change rescales a custom snap step. ha-form's number
+              // box fires per keystroke — respect the burst path so typing
+              // "24" isn't two history commits (grid=2, then grid=24).
+              p = { ...p, ...this._gridPatch(p.grid) };
+            }
+            if (live) this._patchConfigLive(p as Partial<FloorplanCardConfig>);
+            else this._patchConfig(p as Partial<FloorplanCardConfig>);
+          })
         )}
-        ${this._renderColorRow({
-          label: "Background",
-          value: this._config.background,
-          swatch: "#ffffff",
-          placeholder: "#ffffff or empty",
-          onLive: (background) => this._patchConfigLive({ background }),
-          onCommit: (background) => this._patchConfig({ background }),
-        })}
-        ${this._renderForm(floorImageForm(this._floor()), (patch, live) => {
-          if (live) this._patchFloorLive(patch as Partial<Floor>);
-          else this._commitFloor(patch as Partial<Floor>);
-        })}
-        ${this._renderForm(projectDisplayForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          // The plan's own look: its palette, its paper, and the one drawing
+          // convention that is a plan-wide choice rather than an element's.
+          "Look",
+          this._renderForm(projectSkinForm(c), patch),
+          this._renderColorRow({
+            label: "Background",
+            value: c.background,
+            swatch: "#ffffff",
+            placeholder: "#ffffff or empty",
+            onLive: (background) => this._patchConfigLive({ background }),
+            onCommit: (background) => this._patchConfig({ background }),
+          }),
+          this._renderForm(projectDeadSpaceForm(c), patch)
         )}
-        ${this._renderForm(projectSunForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          // Per floor, not per project — but it is the floor's paper, so it
+          // belongs beside the plan's own.
+          "Floor image",
+          this._renderForm(floorImageForm(this._floor()), (p, live) => {
+            if (live) this._patchFloorLive(p as Partial<Floor>);
+            else this._commitFloor(p as Partial<Floor>);
+          })
         )}
-        ${this._renderForm(projectReliefForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          // How the card is framed on the dashboard, as opposed to what is
+          // drawn inside it. Set once for a surface and rarely touched again.
+          "Display",
+          this._renderForm(formSlice(display, ["rotation", "overlayScale", "compactHeader"]), patch)
         )}
-        ${this._config.sunlight
-          ? // Beside the sliders that aim the light, since they are the same
-            // decision: what the light looks like where it lands, and where it
-            // does not. Colour rows rather than form fields, like every other
-            // colour in this editor.
-            html`${this._renderColorRow({
-              label: "Sun color",
-              title: "Color of the light the openings let in",
-              value: this._config.sunlightColor,
-              swatch: "#ffd9a0",
-              placeholder: "(warm white)",
-              onLive: (sunlightColor) => this._patchConfigLive({ sunlightColor }),
-              onCommit: (sunlightColor) => this._patchConfig({ sunlightColor }),
-            })}
-            ${this._config.sunShade === false
-              ? nothing
-              : this._renderColorRow({
-              label: "Shade color",
-              title: "Color of everywhere the light does not reach",
-              value: this._config.sunShadeColor,
-              swatch: "#000000",
-              placeholder: "(black)",
-              onLive: (sunShadeColor) => this._patchConfigLive({ sunShadeColor }),
-              onCommit: (sunShadeColor) => this._patchConfig({ sunShadeColor }),
-            })}`
-          : nothing}
-        ${this._renderForm(projectPressForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          // Light through the openings (issue #177) — where it comes from and
+          // what it looks like where it lands.
+          "Sunlight",
+          this._renderForm(projectReliefForm(c), patch),
+          c.sunlight
+            ? html`${this._renderColorRow({
+                label: "Sun color",
+                title: "Color of the light the openings let in",
+                value: c.sunlightColor,
+                swatch: "#ffd9a0",
+                placeholder: "(warm white)",
+                onLive: (sunlightColor) => this._patchConfigLive({ sunlightColor }),
+                onCommit: (sunlightColor) => this._patchConfig({ sunlightColor }),
+              })}
+              ${c.sunShade === false
+                ? nothing
+                : this._renderColorRow({
+                    label: "Shade color",
+                    title: "Color of everywhere the light does not reach",
+                    value: c.sunShadeColor,
+                    swatch: "#000000",
+                    placeholder: "(black)",
+                    onLive: (sunShadeColor) => this._patchConfigLive({ sunShadeColor }),
+                    onCommit: (sunShadeColor) => this._patchConfig({ sunShadeColor }),
+                  })}`
+            : nothing
         )}
-        ${this._renderForm(projectDeadSpaceForm(this._config), (patch) =>
-          this._patchConfig(patch as Partial<FloorplanCardConfig>)
+        ${this._renderGroup(
+          // The other half of following the sun, and a separate switch: this
+          // one dims the whole plan after dark rather than casting anything.
+          "Night dimming",
+          this._renderForm(projectSunForm(c), patch)
         )}
-        ${this._renderSymbolsPanel()}
+        ${this._renderGroup(
+          // How devices look and answer, plan-wide. "Offline devices" lived
+          // under display, beside the card's rotation, which is not what it is
+          // about.
+          "Devices",
+          this._renderForm(formSlice(display, ["offlineStyle"]), patch),
+          this._renderForm(projectPressForm(c), patch)
+        )}
+        ${this._renderGroup("Symbols", this._renderSymbolsPanel())}
       </div>
     `;
   }
@@ -4133,7 +4170,6 @@ export class FloorplanCardEditor extends LitElement {
     const own = Object.keys(this._config.symbols ?? {});
     return html`
       <div class="row col symbols-panel">
-        <label>Custom symbols</label>
         ${own.length
           ? html`<div class="symbol-list">
               ${own.map(

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -149,6 +149,7 @@ import {
   floorImageForm,
   furnitureForm,
   isLiveField,
+  formSlice,
   itemEntityForm,
   itemIdentityForm,
   itemShowStateForm,
@@ -1993,6 +1994,57 @@ export class FloorplanCardEditor extends LitElement {
    * useful configuration — it reads that attribute off the device's own
    * entity, which is how one climate shows four of its own numbers.
    */
+  /**
+   * Which fields each element panel's groups hold, in order.
+   *
+   * Declared as data rather than inline at the render site so the whole shape
+   * of a panel can be read (and tested) in one place — every field a form
+   * produces has to appear in exactly one group, or it silently stops being
+   * editable.
+   *
+   * The criteria are the device panel's, applied to what each element actually
+   * has: what it *is* first, then what it *reads*, then how it *looks*, then
+   * what it *does*. Elements with only a couple of controls — a wall, a text —
+   * are left ungrouped: a heading over a single field is chrome, not structure.
+   */
+  private static readonly OPENING_GROUPS = [
+    // What it is, and how it is drawn.
+    ["Shape", ["type", "motion", "length", "sash", "hinge", "opens", "slide", "style", "angle"]],
+    // Which contacts drive it — the opening's own, before the shutter's.
+    ["What it reads", ["entity", "secondaryEntity", "invert"]],
+    // How it behaves toward the sun (issue #177), which is neither shape nor
+    // state but gets asked about as its own thing.
+    ["Sunlight", ["glazed", "sunlight"]],
+    // The shutter is a layer over the opening with its own entity, style,
+    // side, second contact, badge and colour — so it gets its own group
+    // rather than being scattered through the others.
+    ["Shutter", [
+      "shutterEntity",
+      "shutterStyle",
+      "shutterSide",
+      "shutterSecondaryEntity",
+      "shutterInvert",
+      "showShutterIcon",
+      "shutterIcon",
+    ]],
+    ["Badge", ["showIcon", "icon"]],
+    // No fields of its own — the opening's accent is a colour row, not an
+    // ha-form field. It is listed here so it lands in the same place in the
+    // order as every other panel's Color group, rather than after Behavior.
+    ["Color", []],
+    ["Behavior", ["tapTarget", "tap_action", "hold_action", "double_tap_action"]],
+  ] as const;
+
+  private static readonly FURNITURE_GROUPS = [
+    ["Shape", ["type", "hand", "w", "h", "angle"]],
+    ["What it reads", ["entity"]],
+  ] as const;
+
+  private static readonly TRACKER_GROUPS = [
+    ["Zone", ["w", "h", "x", "y", "angle"]],
+    ["Marker", ["dotSize"]],
+  ] as const;
+
   /**
    * One titled group of the element panel, with a rule above it.
    *
@@ -4167,47 +4219,67 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "opening") {
       const o = this._floor().openings.find((x) => x.id === sel.id);
       if (!o) return html`${nothing}`;
+      const spec = openingForm(o, (id) => this._supportedFeatures(id));
+      const apply = (patch: Record<string, unknown>, live: boolean): void => {
+        if ("entity" in patch) {
+          // Infer type/motion from the entity's HA device_class (e.g. a
+          // `cover` with device_class `window` → a window; a `garage`
+          // roller → a sliding door). Only when the class is known, so we
+          // never clobber a hand-set type with a guess.
+          const entity = patch.entity as string | undefined;
+          const dc = entity
+            ? (this.hass?.states[entity]?.attributes?.device_class as string | undefined)
+            : undefined;
+          patch = { ...patch, ...(dc ? openingFromDeviceClass(dc) : {}) };
+        }
+        this._applyElementPatch("opening", o.id, patch, live);
+      };
+      /** A group, skipped when this opening has none of its fields. */
+      const group = (title: string, names: readonly string[], ...extra: unknown[]) => {
+        const slice = formSlice(spec, names);
+        if (!slice.fields.length && !extra.some((x) => x && x !== nothing)) return nothing;
+        return this._renderGroup(title, this._renderForm(slice, apply), ...extra);
+      };
       return html`
-        ${this._renderForm(openingForm(o, (id) => this._supportedFeatures(id)), (patch, live) => {
-          if ("entity" in patch) {
-            // Infer type/motion from the entity's HA device_class (e.g. a
-            // `cover` with device_class `window` → a window; a `garage`
-            // roller → a sliding door). Only when the class is known, so we
-            // never clobber a hand-set type with a guess.
-            const entity = patch.entity as string | undefined;
-            const dc = entity
-              ? (this.hass?.states[entity]?.attributes?.device_class as string | undefined)
-              : undefined;
-            patch = { ...patch, ...(dc ? openingFromDeviceClass(dc) : {}) };
-          }
-          this._applyElementPatch("opening", o.id, patch, live);
-        })}
-        ${o.entity
-          ? this._renderColorRow({
-              label: "Active color",
-              value: o.activeColor,
-              swatch: "#03a9f4",
-              placeholder: "(primary)",
-              onLive: (activeColor) => this._updateOpeningLive(o.id, { activeColor }),
-              onCommit: (activeColor) => this._updateOpening(o.id, { activeColor }),
-            })
-          : nothing}
-        ${o.shutterEntity
-          ? // The shutter's own accent, so an open shutter over a shut window
-            // can read as a separate thing from the sash it covers. Falls back
-            // to the opening's active color, hence the placeholder.
-            this._renderColorRow({
-              label: "Shutter color",
-              title: "Shutter color while it is open",
-              value: o.shutterActiveColor,
-              swatch: o.activeColor ?? "#03a9f4",
-              placeholder: o.activeColor ? "(active color)" : "(primary)",
-              onLive: (shutterActiveColor) =>
-                this._updateOpeningLive(o.id, { shutterActiveColor }),
-              onCommit: (shutterActiveColor) =>
-                this._updateOpening(o.id, { shutterActiveColor }),
-            })
-          : nothing}
+        ${FloorplanCardEditor.OPENING_GROUPS.map(([title, names]) =>
+          title === "Color"
+            ? group(
+                title,
+                names,
+                o.entity
+                  ? this._renderColorRow({
+                      label: "Active color",
+                      value: o.activeColor,
+                      swatch: "#03a9f4",
+                      placeholder: "(primary)",
+                      onLive: (activeColor) => this._updateOpeningLive(o.id, { activeColor }),
+                      onCommit: (activeColor) => this._updateOpening(o.id, { activeColor }),
+                    })
+                  : nothing
+              )
+            : title === "Shutter"
+            ? group(
+                title,
+                names,
+                // The shutter's own accent, so an open shutter over a shut
+                // window can read as a separate thing from the sash it
+                // covers. Falls back to the opening's, hence the placeholder.
+                o.shutterEntity
+                  ? this._renderColorRow({
+                      label: "Shutter color",
+                      title: "Shutter color while it is open",
+                      value: o.shutterActiveColor,
+                      swatch: o.activeColor ?? "#03a9f4",
+                      placeholder: o.activeColor ? "(active color)" : "(primary)",
+                      onLive: (shutterActiveColor) =>
+                        this._updateOpeningLive(o.id, { shutterActiveColor }),
+                      onCommit: (shutterActiveColor) =>
+                        this._updateOpening(o.id, { shutterActiveColor }),
+                    })
+                  : nothing
+              )
+            : group(title, names)
+        )}
       `;
     }
 
@@ -4333,34 +4405,41 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "furniture") {
       const f = this._floor().furniture.find((x) => x.id === sel.id);
       if (!f) return html`${nothing}`;
+      const fSpec = furnitureForm(f, this._areaEntitiesAt(f.x, f.y), this._symbols());
+      const fApply = (patch: Record<string, unknown>, live: boolean) =>
+        this._applyElementPatch("furniture", f.id, patch, live);
       return html`
-        ${this._renderForm(furnitureForm(f, this._areaEntitiesAt(f.x, f.y), this._symbols()), (patch, live) =>
-          this._applyElementPatch("furniture", f.id, patch, live)
+        ${FloorplanCardEditor.FURNITURE_GROUPS.map(([title, names]) =>
+          this._renderGroup(title, this._renderForm(formSlice(fSpec, names), fApply))
         )}
-        ${this._renderColorRow({
+        ${this._renderGroup(
+          "Color",
+          this._renderColorRow({
           label: "Color",
           value: f.color,
           swatch: "#9e9e9e",
           placeholder: "(gray)",
-          onLive: (color) => this._updateFurnitureLive(f.id, { color }),
-          onCommit: (color) => this._updateFurniture(f.id, { color }),
-        })}
-        ${f.entity
-          ? html`
-              ${this._renderColorRow({
-                label: "Active color",
-                title: "Color while the entity is on",
-                value: f.activeColor,
-                swatch: "#03a9f4",
-                placeholder: "(no change)",
-                onLive: (activeColor) => this._updateFurnitureLive(f.id, { activeColor }),
-                onCommit: (activeColor) => this._updateFurniture(f.id, { activeColor }),
-              })}
-              ${this._renderStateColorRules(f.stateColor, (stateColor) =>
-                this._updateFurniture(f.id, { stateColor })
-              )}
-            `
-          : nothing}
+            onLive: (color) => this._updateFurnitureLive(f.id, { color }),
+            onCommit: (color) => this._updateFurniture(f.id, { color }),
+          }),
+          // Without an entity there is nothing to condition a colour on.
+          f.entity
+            ? html`
+                ${this._renderColorRow({
+                  label: "Active color",
+                  title: "Color while the entity is on",
+                  value: f.activeColor,
+                  swatch: "#03a9f4",
+                  placeholder: "(no change)",
+                  onLive: (activeColor) => this._updateFurnitureLive(f.id, { activeColor }),
+                  onCommit: (activeColor) => this._updateFurniture(f.id, { activeColor }),
+                })}
+                ${this._renderStateColorRules(f.stateColor, (stateColor) =>
+                  this._updateFurniture(f.id, { stateColor })
+                )}
+              `
+            : nothing
+        )}
       `;
     }
 
@@ -4369,27 +4448,38 @@ export class FloorplanCardEditor extends LitElement {
       if (!a) return html`${nothing}`;
       const haAreas = haAreasOf(this.hass);
       const pendingEntities = a.haArea ? this._pendingAreaEntities(a) : [];
+      const aSpec = areaForm(a);
+      const aApply = (patch: Record<string, unknown>, live: boolean) =>
+        this._applyElementPatch("area", a.id, patch, live);
       return html`
-        ${this._renderForm(
-          areaNameForm(a, haAreas.map((ha) => ha.name)),
-          (patch, live) =>
-            // The name field doubles as the HA-area link, so a name change also
-            // decides `haArea` (see areaNamePatch).
-            this._applyElementPatch("area", a.id, areaNamePatch(patch, haAreas), live)
+        ${this._renderGroup(
+          // The name doubles as the HA-area link, so the link status line and
+          // the name-related toggles belong with it.
+          "Identity",
+          this._renderForm(
+            areaNameForm(a, haAreas.map((ha) => ha.name)),
+            (patch, live) =>
+              // A name change also decides `haArea` (see areaNamePatch).
+              this._applyElementPatch("area", a.id, areaNamePatch(patch, haAreas), live)
+          ),
+          this._renderAreaLinkRow(a, haAreas),
+          this._renderForm(formSlice(aSpec, ["showName", "labelSize"]), aApply)
         )}
-        ${this._renderAreaLinkRow(a, haAreas)}
-        ${this._renderForm(areaForm(a), (patch, live) =>
-          this._applyElementPatch("area", a.id, patch, live)
+        ${this._renderGroup(
+          "What it reads",
+          this._renderForm(formSlice(aSpec, ["entity"]), aApply)
         )}
-        ${this._renderColorRow({
-          label: "Color",
-          value: a.color,
-          swatch: "#03a9f4",
-          placeholder: "(primary)",
-          onLive: (color) => this._updateAreaLive(a.id, { color }),
-          onCommit: (color) => this._updateArea(a.id, { color }),
-        })}
-        ${
+        ${this._renderGroup(
+          "Color",
+          this._renderForm(formSlice(aSpec, ["highlight", "opacity", "activeOpacity"]), aApply),
+          this._renderColorRow({
+            label: "Color",
+            value: a.color,
+            swatch: "#03a9f4",
+            placeholder: "(primary)",
+            onLive: (color) => this._updateAreaLive(a.id, { color }),
+            onCommit: (color) => this._updateArea(a.id, { color }),
+          }),
           // The colours the bound entity drives. Same shape furniture and
           // devices already use, and gated the same way — without an entity
           // there is nothing to condition on. Until this existed the Entity
@@ -4412,39 +4502,42 @@ export class FloorplanCardEditor extends LitElement {
                 )}
               `
             : nothing
-        }
+        )}
         ${a.haArea
-          ? html`<div class="row wide">
-              <label>Filter entities</label>
-              <input
-                type="checkbox"
-                .checked=${a.filterEntities ?? true}
-                @change=${(e: Event) =>
-                  this._updateArea(a.id, {
-                    filterEntities: (e.target as HTMLInputElement).checked,
-                  })}
-              />
-              <span class="hint"
-                >Scope the entity picker, for devices placed inside this room, to this HA
-                area's entities.</span
-              >
-            </div>`
-          : nothing}
-        ${a.haArea
-          ? html`<div class="row wide">
-              <button
-                ?disabled=${!pendingEntities.length}
-                title=${pendingEntities.length
-                  ? `Add ${pendingEntities.length} device${pendingEntities.length === 1 ? "" : "s"} from this HA area, spread out across the room`
-                  : "Every entity in this HA area is already placed on this floor"}
-                @click=${() => this._addAreaEntities(a)}
-              >
-                <ha-icon icon="mdi:shape-square-plus"></ha-icon>
-                Add all devices in this HA area${pendingEntities.length
-                  ? ` (${pendingEntities.length})`
-                  : ""}
-              </button>
-            </div>`
+          ? this._renderGroup(
+              // Everything that only exists because this room is linked to a
+              // Home Assistant area.
+              "Home Assistant area",
+              html`<div class="row wide">
+                <label>Filter entities</label>
+                <input
+                  type="checkbox"
+                  .checked=${a.filterEntities ?? true}
+                  @change=${(e: Event) =>
+                    this._updateArea(a.id, {
+                      filterEntities: (e.target as HTMLInputElement).checked,
+                    })}
+                />
+                <span class="hint"
+                  >Scope the entity picker, for devices placed inside this room, to this HA
+                  area's entities.</span
+                >
+              </div>`,
+              html`<div class="row wide">
+                <button
+                  ?disabled=${!pendingEntities.length}
+                  title=${pendingEntities.length
+                    ? `Add ${pendingEntities.length} device${pendingEntities.length === 1 ? "" : "s"} from this HA area, spread out across the room`
+                    : "Every entity in this HA area is already placed on this floor"}
+                  @click=${() => this._addAreaEntities(a)}
+                >
+                  <ha-icon icon="mdi:shape-square-plus"></ha-icon>
+                  Add all devices in this HA area${pendingEntities.length
+                    ? ` (${pendingEntities.length})`
+                    : ""}
+                </button>
+              </div>`
+            )
           : nothing}
         <p class="hint">
           Drag inside the fill to move the whole room; drag a vertex handle to reshape it.
@@ -4455,20 +4548,34 @@ export class FloorplanCardEditor extends LitElement {
     if (sel.kind === "tracker") {
       const tr = (this._floor().trackers ?? []).find((x) => x.id === sel.id);
       if (!tr) return html`${nothing}`;
+      const trSpec = trackerForm(tr);
+      const trApply = (patch: Record<string, unknown>, live: boolean) =>
+        this._applyElementPatch("tracker", tr.id, patch, live);
       return html`
-        ${this._renderTrackerSensorRows(tr, "xSensor", "X sensor")}
-        ${this._renderTrackerSensorRows(tr, "ySensor", "Y sensor")}
-        ${this._renderForm(trackerForm(tr), (patch, live) =>
-          this._applyElementPatch("tracker", tr.id, patch, live)
+        ${this._renderGroup(
+          "Zone",
+          this._renderForm(formSlice(trSpec, FloorplanCardEditor.TRACKER_GROUPS[0][1]), trApply)
         )}
-        ${this._renderColorRow({
-          label: "Color",
-          value: tr.color,
-          swatch: "#03a9f4",
-          placeholder: "(primary)",
-          onLive: (color) => this._updateTrackerLive(tr.id, { color }),
-          onCommit: (color) => this._updateTracker(tr.id, { color }),
-        })}
+        ${this._renderGroup(
+          // The two distance sensors that place the marker inside the zone —
+          // the thing a tracker actually is, so it gets its own group rather
+          // than two unlabelled blocks above the box.
+          "Sensors",
+          this._renderTrackerSensorRows(tr, "xSensor", "X sensor"),
+          this._renderTrackerSensorRows(tr, "ySensor", "Y sensor")
+        )}
+        ${this._renderGroup(
+          "Marker",
+          this._renderForm(formSlice(trSpec, FloorplanCardEditor.TRACKER_GROUPS[1][1]), trApply),
+          this._renderColorRow({
+            label: "Color",
+            value: tr.color,
+            swatch: "#03a9f4",
+            placeholder: "(primary)",
+            onLive: (color) => this._updateTrackerLive(tr.id, { color }),
+            onCommit: (color) => this._updateTracker(tr.id, { color }),
+          })
+        )}
       `;
     }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -111,6 +111,7 @@ import {
   itemIconSize,
   itemLabelSize,
   labelPositionOf,
+  itemReadings,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -148,6 +149,7 @@ import {
   furnitureForm,
   isLiveField,
   itemForm,
+  itemEntityForm,
   itemHasRipple,
   normalizeFormPatch,
   openingForm,
@@ -478,7 +480,13 @@ export class FloorplanCardEditor extends LitElement {
     void this._ensureHaComponents();
     // Upgrade the plain-input fallbacks in place whenever a component gets
     // defined later (by us or by another editor the user opened).
-    for (const tag of ["ha-form", "ha-entity-picker", "ha-icon-picker", "ha-combo-box"]) {
+    for (const tag of [
+      "ha-form",
+      "ha-entity-picker",
+      "ha-entity-attribute-picker",
+      "ha-icon-picker",
+      "ha-combo-box",
+    ]) {
       if (!customElements.get(tag)) {
         void customElements.whenDefined(tag).then(() => this.requestUpdate());
       }
@@ -1980,14 +1988,29 @@ export class FloorplanCardEditor extends LitElement {
    * entity, which is how one climate shows four of its own numbers.
    */
   private _renderItemReadings(it: FloorItem): TemplateResult {
-    const list = it.readings ?? [];
+    // The pool as the card sees it, legacy pair included — so a device
+    // configured before #180 shows its second entity here as the first row
+    // rather than as an invisible extra the editor cannot reach.
+    const list = itemReadings(it);
+    // Writing the list writes the *whole* pool into `readings` and clears the
+    // legacy keys, which is the migration: touch a device once and its config
+    // stops using the old spelling. Done here rather than as a config-wide
+    // upgrade so nothing rewrites a plan the user has not edited.
     const commit = (next: ItemReading[]): void =>
-      this._updateItem(it.id, { readings: next.length ? next : undefined });
+      this._updateItem(it.id, {
+        readings: next.length ? next : undefined,
+        secondaryEntity: undefined,
+        secondaryAttribute: undefined,
+        // `badgeEntity: "secondary"` meant index 0, which is where the legacy
+        // pair still is — restate it as the index so the old spelling does not
+        // outlive the keys it referred to.
+        ...(it.badgeEntity === "secondary" ? { badgeEntity: 0 } : {}),
+      });
     const patch = (i: number, part: Partial<ItemReading>): void =>
       commit(list.map((r, j) => (j === i ? { ...r, ...part } : r)));
     return html`
       <div class="row wide">
-        <label title="Extra entities whose readings join this device's label line"
+        <label title="Further entities and attributes whose readings join this device's label line"
           >More readings</label
         >
       </div>
@@ -2003,15 +2026,12 @@ export class FloorplanCardEditor extends LitElement {
               // the same room as the first one.
               this._areaEntitiesAt(it.x, it.y)?.entities
             )}
-            <input
-              type="text"
-              class="reading-attr"
-              placeholder="attribute"
-              title="Read this attribute instead of the state — with no entity above, from this device's own entity"
-              .value=${reading.attribute ?? ""}
-              @change=${(e: Event) =>
-                patch(i, { attribute: (e.target as HTMLInputElement).value || undefined })}
-            />
+            ${this._renderAttributePicker(
+              reading.entity || it.entity,
+              reading.attribute ?? "",
+              (attribute) => patch(i, { attribute: attribute || undefined }),
+              "Read this attribute instead of the state — with no entity beside it, from this device's own entity"
+            )}
             <button
               class="rule-remove"
               aria-label="Remove reading"
@@ -2030,8 +2050,8 @@ export class FloorplanCardEditor extends LitElement {
       </div>
       ${list.length
         ? html`<p class="hint rule-note">
-            Shown whether or not "Show state" is on, so a device can label itself
-            with these alone.
+            Shown whether or not "Show state" is on — that toggle is about this
+            device's own state, so a device can label itself with these alone.
           </p>`
         : nothing}
     `;
@@ -3315,6 +3335,49 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * Attribute field for the hand-rolled rows, mirroring
+   * {@link _renderEntityPicker}: HA's own attribute dropdown when the frontend
+   * has registered it, a plain text input otherwise.
+   *
+   * The dropdown is the whole point — it lists the attributes the entity
+   * *actually has*, which is what `ha-form`'s `attribute` selector gives the
+   * device's own Attribute field. A repeatable row cannot go through `ha-form`,
+   * but that is no reason for it to be a worse control: typing `curent_temp`
+   * into a free-text box fails silently at render time, which is exactly the
+   * bug a picker cannot have.
+   *
+   * `entityId` is what the attributes are listed from — the row's own entity
+   * when it names one, else the device's, which is the same fallback the
+   * reading itself resolves through.
+   */
+  private _renderAttributePicker(
+    entityId: string | undefined,
+    value: string,
+    onChange: (attribute: string) => void,
+    title?: string
+  ): TemplateResult {
+    if (customElements.get("ha-entity-attribute-picker") && entityId) {
+      return html`<ha-entity-attribute-picker
+        class="reading-attr"
+        .hass=${this.hass}
+        .entityId=${entityId}
+        .value=${value}
+        allow-custom-value
+        title=${title ?? nothing}
+        @value-changed=${(e: CustomEvent) => onChange((e.detail.value as string) ?? "")}
+      ></ha-entity-attribute-picker>`;
+    }
+    return html`<input
+      type="text"
+      class="reading-attr"
+      placeholder="attribute"
+      title=${title ?? nothing}
+      .value=${value}
+      @change=${(e: Event) => onChange((e.target as HTMLInputElement).value)}
+    />`;
+  }
+
+  /**
    * Icon field for the hand-rolled rows (issue #106), mirroring
    * {@link _renderEntityPicker}: HA's searchable picker when the frontend has
    * registered it, a plain text input otherwise. Used by the state-rule list,
@@ -4139,10 +4202,25 @@ export class FloorplanCardEditor extends LitElement {
       const badgeSource = {
         source: badgeReading(this.hass, it)?.source ?? "primary",
         primaryLabel: friendly(it.entity),
-        secondaryLabel: friendly(it.secondaryEntity),
+        // One label per reading, positionally — the dropdown names each rather
+        // than numbering them, and a reading with no entity of its own is read
+        // off this device, so that is the name to show for it (issue #180).
+        readingLabels: itemReadings(it).map((r) => friendly(r.entity || it.entity)),
       } as const;
       return html`
-        ${this._renderForm(itemForm(it, areaEntities, deviceClass, badgeSource), (patch, live) => {
+        <!-- Entity, Attribute, then every other reading, then the rest: the
+             device's readings all sit together and in the order the label
+             prints them (issue #180). -->
+        ${this._renderForm(itemEntityForm(it, areaEntities), (patch, live) => {
+          // Any entity change re-derives the item kind (icon defaults etc.) —
+          // including clearing it, which resets kind to "generic".
+          if ("entity" in patch && typeof patch.entity === "string") {
+            patch = { ...patch, kind: kindFromEntity(patch.entity) };
+          }
+          this._applyElementPatch("item", it.id, patch, live);
+        })}
+        ${this._renderItemReadings(it)}
+        ${this._renderForm(itemForm(it, deviceClass, badgeSource), (patch, live) => {
           // Any entity change re-derives the item kind (icon defaults etc.) —
           // including clearing it, which resets kind to "generic".
           if ("entity" in patch && typeof patch.entity === "string") {
@@ -4176,7 +4254,6 @@ export class FloorplanCardEditor extends LitElement {
               onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
             })
           : nothing}
-        ${this._renderItemReadings(it)}
         ${this._renderItemIconRow(it)}
         ${this._renderStateColorRules(
           it.stateColor,
@@ -5558,8 +5635,8 @@ export class FloorplanCardEditor extends LitElement {
       flex: 1 1 auto;
       min-width: 0;
     }
-    .reading-attr {
-      flex: 0 0 90px;
+    .item-reading .reading-attr {
+      flex: 0 0 130px;
       min-width: 0;
     }
     /* The panel ("Project" config) and the new element-edit area share the

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -13,6 +13,7 @@ import type {
   FloorText,
   Furniture,
   ItemKind,
+  ItemReading,
   Tracker,
   TrackerSensor,
   Area,
@@ -109,6 +110,7 @@ import {
   resolveIconAnimation,
   itemIconSize,
   itemLabelSize,
+  labelPositionOf,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -1964,6 +1966,78 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
+   * Extra readings on a device (issue #180): the third, fourth, fifth line of
+   * text, added one at a time with a "+" rather than by putting four entity
+   * dropdowns on every device that will never use them — which is what the
+   * issue asked for and what the panel could not afford.
+   *
+   * Plain rows for the same reason the state rules below are: the list is
+   * repeatable and `ha-form` has no selector for that.
+   *
+   * The attribute box is offered on every row, not only once an entity is
+   * picked, because a row with an attribute and *no* entity is a real and
+   * useful configuration — it reads that attribute off the device's own
+   * entity, which is how one climate shows four of its own numbers.
+   */
+  private _renderItemReadings(it: FloorItem): TemplateResult {
+    const list = it.readings ?? [];
+    const commit = (next: ItemReading[]): void =>
+      this._updateItem(it.id, { readings: next.length ? next : undefined });
+    const patch = (i: number, part: Partial<ItemReading>): void =>
+      commit(list.map((r, j) => (j === i ? { ...r, ...part } : r)));
+    return html`
+      <div class="row wide">
+        <label title="Extra entities whose readings join this device's label line"
+          >More readings</label
+        >
+      </div>
+      ${list.map(
+        (reading, i) => html`
+          <div class="row wide item-reading">
+            ${this._renderEntityPicker(
+              reading.entity ?? "",
+              (entity) => patch(i, { entity: entity || undefined }),
+              undefined,
+              // Scoped to the room the device sits in, exactly as its own
+              // entity picker is — an extra reading is as likely to come from
+              // the same room as the first one.
+              this._areaEntitiesAt(it.x, it.y)?.entities
+            )}
+            <input
+              type="text"
+              class="reading-attr"
+              placeholder="attribute"
+              title="Read this attribute instead of the state — with no entity above, from this device's own entity"
+              .value=${reading.attribute ?? ""}
+              @change=${(e: Event) =>
+                patch(i, { attribute: (e.target as HTMLInputElement).value || undefined })}
+            />
+            <button
+              class="rule-remove"
+              aria-label="Remove reading"
+              title="Remove this reading"
+              @click=${() => commit(list.filter((_, j) => j !== i))}
+            >
+              <ha-icon icon="mdi:close"></ha-icon>
+            </button>
+          </div>
+        `
+      )}
+      <div class="row wide state-color-add">
+        <button @click=${() => commit([...list, {}])}>
+          <ha-icon icon="mdi:plus"></ha-icon>Add reading
+        </button>
+      </div>
+      ${list.length
+        ? html`<p class="hint rule-note">
+            Shown whether or not "Show state" is on, so a device can label itself
+            with these alone.
+          </p>`
+        : nothing}
+    `;
+  }
+
+  /**
    * The "Color by state" block (issues #68, #79, #82): a list of rules, each
    * one a condition and a colour, plus an "Add rule" button.
    *
@@ -3771,7 +3845,7 @@ export class FloorplanCardEditor extends LitElement {
         ${this._hideLabels
           ? nothing
           : html`<span
-              class="ilabel ${cardLabel ? "live" : ""}"
+              class="ilabel ${cardLabel ? "live" : ""} ilabel-${labelPositionOf(it)}"
               style="font-size:${cardLabel || it.labelSize != null
                 ? itemLabelSize(it.labelSize)
                 : 11}px;${cardLabel && stateColor ? `color:${stateColor};` : ""}"
@@ -4102,6 +4176,7 @@ export class FloorplanCardEditor extends LitElement {
               onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
             })
           : nothing}
+        ${this._renderItemReadings(it)}
         ${this._renderItemIconRow(it)}
         ${this._renderStateColorRules(
           it.stateColor,
@@ -5450,6 +5525,21 @@ export class FloorplanCardEditor extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    /* Label beside the badge (issue #180), mirroring the card's own rule so
+       moving it here shows what the card will do rather than only what the
+       config now says. */
+    .ilabel-left,
+    .ilabel-right {
+      top: 50%;
+      transform: translateY(-50%);
+    }
+    .ilabel-left {
+      left: auto;
+      right: calc(100% + 4px);
+    }
+    .ilabel-right {
+      left: calc(100% + 4px);
+    }
     /* The card's own label line, drawn as the card draws it (issue #135):
        full-strength ink, and no width clamp — the card has none, and clipping
        is exactly what would make a long label look right here and wrong live.
@@ -5459,6 +5549,18 @@ export class FloorplanCardEditor extends LitElement {
       color: var(--fp-skin-text, var(--primary-text-color));
       max-width: none;
       overflow: visible;
+    }
+    /* An extra-reading row (issue #180): the entity picker takes the space and
+       the attribute box stays narrow beside it, the same proportions the
+       state-rule rows use for their condition and colour. */
+    .item-reading ha-entity-picker,
+    .item-reading input[type="text"]:not(.reading-attr) {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+    .reading-attr {
+      flex: 0 0 90px;
+      min-width: 0;
     }
     /* The panel ("Project" config) and the new element-edit area share the
        same boxed look so the two sections below the canvas read as siblings. */

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -112,6 +112,7 @@ import {
   itemLabelSize,
   labelPositionOf,
   itemReadings,
+  itemHasLabel,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -148,8 +149,13 @@ import {
   floorImageForm,
   furnitureForm,
   isLiveField,
-  itemForm,
   itemEntityForm,
+  itemIdentityForm,
+  itemShowStateForm,
+  itemLabelForm,
+  itemBadgeForm,
+  itemEffectsForm,
+  itemBehaviourForm,
   itemHasRipple,
   normalizeFormPatch,
   openingForm,
@@ -1987,6 +1993,27 @@ export class FloorplanCardEditor extends LitElement {
    * useful configuration — it reads that attribute off the device's own
    * entity, which is how one climate shows four of its own numbers.
    */
+  /**
+   * One titled group of the element panel, with a rule above it.
+   *
+   * The device panel had grown to two dozen controls in one flat run, in the
+   * order they had been added rather than any order you would look for them
+   * in. Grouping them costs a heading and a hairline each; what it buys is
+   * that "where do I set the label position" has an answer you can guess.
+   *
+   * Takes the content rather than a field list because a group is rarely all
+   * `ha-form` — the readings list, the icon row and the colour pickers are
+   * hand-rolled, and they belong *inside* the group whose subject they share.
+   */
+  private _renderGroup(title: string, ...content: unknown[]): TemplateResult {
+    return html`
+      <div class="cfg-group">
+        <p class="cfg-group-title">${title}</p>
+        ${content}
+      </div>
+    `;
+  }
+
   private _renderItemReadings(it: FloorItem): TemplateResult {
     // The pool as the card sees it, legacy pair included — so a device
     // configured before #180 shows its second entity here as the first row
@@ -2011,7 +2038,7 @@ export class FloorplanCardEditor extends LitElement {
     return html`
       <div class="row wide">
         <label title="Further entities and attributes whose readings join this device's label line"
-          >More readings</label
+          >Other entities</label
         >
       </div>
       ${list.map(
@@ -2034,8 +2061,8 @@ export class FloorplanCardEditor extends LitElement {
             )}
             <button
               class="rule-remove"
-              aria-label="Remove reading"
-              title="Remove this reading"
+              aria-label="Remove entity"
+              title="Remove this entity"
               @click=${() => commit(list.filter((_, j) => j !== i))}
             >
               <ha-icon icon="mdi:close"></ha-icon>
@@ -2045,7 +2072,7 @@ export class FloorplanCardEditor extends LitElement {
       )}
       <div class="row wide state-color-add">
         <button @click=${() => commit([...list, {}])}>
-          <ha-icon icon="mdi:plus"></ha-icon>Add reading
+          <ha-icon icon="mdi:plus"></ha-icon>Add entity
         </button>
       </div>
       ${list.length
@@ -4207,62 +4234,81 @@ export class FloorplanCardEditor extends LitElement {
         // off this device, so that is the name to show for it (issue #180).
         readingLabels: itemReadings(it).map((r) => friendly(r.entity || it.entity)),
       } as const;
+      // One handler for every group: they all patch the same item, and only
+      // the entity field needs anything extra.
+      const apply = (patch: Record<string, unknown>, live: boolean): void => {
+        if ("entity" in patch && typeof patch.entity === "string") {
+          // Any entity change re-derives the item kind (icon defaults etc.) —
+          // including clearing it, which resets kind to "generic".
+          patch = { ...patch, kind: kindFromEntity(patch.entity) };
+        }
+        this._applyElementPatch("item", it.id, patch, live);
+      };
+      const effects = itemEffectsForm(it, deviceClass);
       return html`
-        <!-- Entity, Attribute, then every other reading, then the rest: the
-             device's readings all sit together and in the order the label
-             prints them (issue #180). -->
-        ${this._renderForm(itemEntityForm(it, areaEntities), (patch, live) => {
-          // Any entity change re-derives the item kind (icon defaults etc.) —
-          // including clearing it, which resets kind to "generic".
-          if ("entity" in patch && typeof patch.entity === "string") {
-            patch = { ...patch, kind: kindFromEntity(patch.entity) };
-          }
-          this._applyElementPatch("item", it.id, patch, live);
-        })}
-        ${this._renderItemReadings(it)}
-        ${this._renderForm(itemForm(it, deviceClass, badgeSource), (patch, live) => {
-          // Any entity change re-derives the item kind (icon defaults etc.) —
-          // including clearing it, which resets kind to "generic".
-          if ("entity" in patch && typeof patch.entity === "string") {
-            patch = { ...patch, kind: kindFromEntity(patch.entity) };
-          }
-          this._applyElementPatch("item", it.id, patch, live);
-        })}
-        ${it.stateColor?.length
-          ? // Colour by state supersedes the fixed active colour, so showing
-            // both invites setting one and seeing the other. Say which one is
-            // in charge instead of leaving a dead control on screen.
-            html`<p class="hint rule-note">
-              Colored by the state rules below — they replace the active color.
-            </p>`
-          : this._renderColorRow({
-              label: "Active color",
-              title: "Badge color while this device is on (issue #79)",
-              value: it.activeColor,
-              swatch: "#fdd835",
-              placeholder: "(theme)",
-              onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
-              onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
-            })}
-        ${isPresenceEntity(it.entity, deviceClass) && itemHasRipple(it)
-          ? this._renderColorRow({
-              label: "Ripple color",
-              value: it.rippleColor,
-              swatch: it.activeColor ?? "#03a9f4",
-              placeholder: it.activeColor ? "(active color)" : "(primary)",
-              onLive: (rippleColor) => this._updateItemLive(it.id, { rippleColor }),
-              onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
-            })
-          : nothing}
-        ${this._renderItemIconRow(it)}
-        ${this._renderStateColorRules(
-          it.stateColor,
-          (stateColor) => this._updateItem(it.id, { stateColor }),
-          // Only a device draws a glyph, so only a device's rules offer an
-          // icon — furniture and areas share this rule shape but paint
-          // polygons (issue #106).
-          { icons: true, iconPlaceholder: this._itemDefaultIcon(it) }
+        ${this._renderGroup("Identity", this._renderForm(itemIdentityForm(it), apply))}
+        ${this._renderGroup(
+          "What it reads",
+          // Entity, its attribute, whether its own state shows, then every
+          // other entity — the order the label prints them in (issue #180).
+          this._renderForm(itemEntityForm(it, areaEntities), apply),
+          this._renderForm(itemShowStateForm(it), apply),
+          this._renderItemReadings(it)
         )}
+        ${itemHasLabel(it)
+          ? // Nothing to place or size while the device draws no label at all.
+            this._renderGroup("Label", this._renderForm(itemLabelForm(it), apply))
+          : nothing}
+        ${this._renderGroup(
+          "Badge",
+          this._renderForm(itemBadgeForm(it, badgeSource), apply),
+          this._renderItemIconRow(it)
+        )}
+        ${this._renderGroup(
+          "Color",
+          it.stateColor?.length
+            ? // Colour by state supersedes the fixed active colour, so showing
+              // both invites setting one and seeing the other. Say which one is
+              // in charge instead of leaving a dead control on screen.
+              html`<p class="hint rule-note">
+                Colored by the state rules below — they replace the active color.
+              </p>`
+            : this._renderColorRow({
+                label: "Active color",
+                title: "Badge color while this device is on (issue #79)",
+                value: it.activeColor,
+                swatch: "#fdd835",
+                placeholder: "(theme)",
+                onLive: (activeColor) => this._updateItemLive(it.id, { activeColor }),
+                onCommit: (activeColor) => this._updateItem(it.id, { activeColor }),
+              }),
+          this._renderStateColorRules(
+            it.stateColor,
+            (stateColor) => this._updateItem(it.id, { stateColor }),
+            // Only a device draws a glyph, so only a device's rules offer an
+            // icon — furniture and areas share this rule shape but paint
+            // polygons (issue #106).
+            { icons: true, iconPlaceholder: this._itemDefaultIcon(it) }
+          )
+        )}
+        ${effects
+          ? this._renderGroup(
+              "Effects",
+              this._renderForm(effects, apply),
+              // The ring's colour belongs with the ring, not with the badge's.
+              isPresenceEntity(it.entity, deviceClass) && itemHasRipple(it)
+                ? this._renderColorRow({
+                    label: "Ripple color",
+                    value: it.rippleColor,
+                    swatch: it.activeColor ?? "#03a9f4",
+                    placeholder: it.activeColor ? "(active color)" : "(primary)",
+                    onLive: (rippleColor) => this._updateItemLive(it.id, { rippleColor }),
+                    onCommit: (rippleColor) => this._updateItem(it.id, { rippleColor }),
+                  })
+                : nothing
+            )
+          : nothing}
+        ${this._renderGroup("Behavior", this._renderForm(itemBehaviourForm(it), apply))}
       `;
     }
 
@@ -5742,6 +5788,40 @@ export class FloorplanCardEditor extends LitElement {
     .rows > .hint,
     .rows > p {
       grid-column: 1 / -1;
+    }
+    /* ---- Element panel groups --------------------------------------------
+       The device panel is two dozen controls; ungrouped, finding one meant
+       reading all of them. Each group is a heading and a hairline above it,
+       with real space between groups so the eye can skip a whole section it
+       does not want.
+
+       The rule is on the group rather than between them, and the first group
+       drops it: a line above the very first heading would read as a border
+       around the panel rather than as a separator inside it. */
+    .cfg-group {
+      border-top: 1px solid var(--divider-color, #e0e0e0);
+      padding-top: 14px;
+      margin-top: 18px;
+    }
+    .cfg-group:first-of-type {
+      border-top: none;
+      padding-top: 0;
+      margin-top: 0;
+    }
+    /* The heading names the group without competing with the field labels
+       beneath it: same size, but the primary ink and a little letter-spacing,
+       so it reads as a heading rather than as one more row label. */
+    .cfg-group-title {
+      margin: 0 0 10px;
+      font-size: 13px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      color: var(--primary-text-color);
+    }
+    /* ha-form packs its own fields tightly; the last one in a group should not
+       sit flush against the next group's rule. */
+    .cfg-group > *:last-child {
+      margin-bottom: 0;
     }
     .row {
       display: flex;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1981,20 +1981,6 @@ export class FloorplanCardEditor extends LitElement {
   }
 
   /**
-   * Extra readings on a device (issue #180): the third, fourth, fifth line of
-   * text, added one at a time with a "+" rather than by putting four entity
-   * dropdowns on every device that will never use them — which is what the
-   * issue asked for and what the panel could not afford.
-   *
-   * Plain rows for the same reason the state rules below are: the list is
-   * repeatable and `ha-form` has no selector for that.
-   *
-   * The attribute box is offered on every row, not only once an entity is
-   * picked, because a row with an attribute and *no* entity is a real and
-   * useful configuration — it reads that attribute off the device's own
-   * entity, which is how one climate shows four of its own numbers.
-   */
-  /**
    * Which fields each element panel's groups hold, in order.
    *
    * Declared as data rather than inline at the render site so the whole shape
@@ -2066,6 +2052,20 @@ export class FloorplanCardEditor extends LitElement {
     `;
   }
 
+  /**
+   * A device's other entities (issue #180): every reading beyond its own
+   * state, added one at a time with "+ Add entity" rather than by putting four
+   * entity dropdowns on every device that will never use them.
+   *
+   * Plain rows rather than `ha-form` fields for the same reason the state
+   * rules are: the list is repeatable and `ha-form` has no selector for that.
+   *
+   * The attribute box is offered on every row, not only once an entity is
+   * picked, because a row with an attribute and *no* entity is a real and
+   * useful configuration — it reads that attribute off the device's own
+   * entity, which is how one climate shows four of its own numbers. It is HA's
+   * own attribute picker, so it lists what that entity actually has.
+   */
   private _renderItemReadings(it: FloorItem): TemplateResult {
     // The pool as the card sees it, legacy pair included — so a device
     // configured before #180 shows its second entity here as the first row

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -81,6 +81,7 @@ import {
   badgeValue,
   badgeValueSize,
   pressEffectOf,
+  labelPositionOf,
   offlineStyleOf,
   itemIsOffline,
   itemHiddenWhenInactive,
@@ -636,7 +637,7 @@ export class FloorplanCard extends LitElement {
           : nothing}
         ${labelText
           ? html`<span
-              class="label ${visual === nothing ? "inflow" : ""}"
+              class="label ${visual === nothing ? "inflow" : ""} label-${labelPositionOf(item)}"
               style="font-size:${overlayLength(itemLabelSize(item.labelSize), scale)};${labelColor
                 ? `color:${labelColor};`
                 : ""}"
@@ -1229,6 +1230,19 @@ export class FloorplanCard extends LitElement {
     .plan.scale-plan .item > .label {
       top: calc(100% + 0.17em);
     }
+    /* The side positions measure their gap in em too, so it tracks the label
+       with the plan exactly as the below position's does. Restating top
+       because the rule above sets it for every label. */
+    .plan.scale-plan .item > .label.label-left,
+    .plan.scale-plan .item > .label.label-right {
+      top: 50%;
+    }
+    .plan.scale-plan .item > .label.label-left {
+      right: calc(100% + 0.33em);
+    }
+    .plan.scale-plan .item > .label.label-right {
+      left: calc(100% + 0.33em);
+    }
     .floor-switcher {
       position: absolute;
       top: 8px;
@@ -1659,6 +1673,27 @@ export class FloorplanCard extends LitElement {
       left: 50%;
       transform: translateX(-50%);
       white-space: nowrap;
+    }
+    /* Label beside the badge instead of under it (issue #180). A reading under
+       a badge grows in both directions at once and meets whatever is next to
+       it; hung off one side it grows one way, which is what a row of devices
+       along a wall needs.
+
+       Vertically centred on the badge rather than baseline-aligned with it:
+       the label is one line and the badge is a circle, so centres are what the
+       eye actually pairs up. .inflow (a label-only device) ignores all of
+       this — with no badge there is no side to sit on. */
+    .item > .label.label-left,
+    .item > .label.label-right {
+      top: 50%;
+      transform: translateY(-50%);
+    }
+    .item > .label.label-left {
+      left: auto;
+      right: calc(100% + 4px);
+    }
+    .item > .label.label-right {
+      left: calc(100% + 4px);
     }
     /* Label-only items (showIcon: false) have no badge to hang under, so the
        absolute label would drop to y + 2px on a zero-height item. Put it back

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -81,6 +81,9 @@ import {
   entityStateText,
   itemStateText,
   itemBadgeLabel,
+  itemReadingText,
+  itemHasLabel,
+  labelPositionOf,
   editorItemLabel,
   itemHiddenWhenInactive,
   resolveStateColor,
@@ -802,6 +805,142 @@ describe("itemBadgeLabel (issues #61, #59)", () => {
     expect(
       itemBadgeLabel(named(), { entity: "", kind: "sensor", showName: true, name: "Detector" }),
     ).toBe("Detector");
+  });
+});
+
+describe("more readings per device (issue #180)", () => {
+  const named = () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).friendly_name = "Living Temp";
+    return h;
+  };
+
+  it("appends each reading to the label line", () => {
+    expect(
+      itemBadgeLabel(named(), {
+        entity: TEMP,
+        kind: "sensor",
+        readings: [{ entity: HUMIDITY }],
+      }),
+    ).toBe("17.9 °C · 49.3%");
+  });
+
+  it("takes as many as are configured, in order", () => {
+    const h = named();
+    expect(
+      itemBadgeLabel(h, {
+        entity: TEMP,
+        kind: "sensor",
+        showName: true,
+        readings: [{ entity: HUMIDITY }, { entity: TEMP }],
+      }),
+    ).toBe("Living Temp · 17.9 °C · 49.3% · 17.9 °C");
+  });
+
+  it("shows readings even with the device's own state hidden", () => {
+    // I-G-1-1's plug in discussion #173: on/off is already in the badge
+    // colour, so the label is to carry the *other* numbers and not "on".
+    expect(
+      itemBadgeLabel(named(), {
+        entity: TEMP,
+        kind: "sensor",
+        showState: false,
+        readings: [{ entity: HUMIDITY }],
+      }),
+    ).toBe("49.3%");
+    // …and with the name back on, the state is still the only thing missing.
+    expect(
+      itemBadgeLabel(named(), {
+        entity: TEMP,
+        kind: "sensor",
+        showState: false,
+        showName: true,
+        readings: [{ entity: HUMIDITY }],
+      }),
+    ).toBe("Living Temp · 49.3%");
+  });
+
+  it("reads an attribute of the device's own entity when the row names none", () => {
+    const h = named();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).battery = 84;
+    expect(
+      itemBadgeLabel(h, { entity: TEMP, kind: "sensor", readings: [{ attribute: "battery" }] }),
+    ).toBe("17.9 °C · 84");
+  });
+
+  it("draws nothing for a row that names nothing — the editor's fresh row", () => {
+    // "+" adds {} and the picker is filled in afterwards; a dash appearing on
+    // the plan the moment you click it would be its own bug report.
+    expect(itemBadgeLabel(named(), { entity: TEMP, kind: "sensor", readings: [{}] })).toBe(
+      "17.9 °C",
+    );
+    expect(itemReadingText(named(), { entity: TEMP }, {})).toBe("");
+  });
+
+  it("a device with no entity of its own still shows a reading that names one", () => {
+    expect(
+      itemBadgeLabel(named(), { entity: "", kind: "light", readings: [{ entity: HUMIDITY }] }),
+    ).toBe("49.3%");
+    // …but an attribute row with nothing to read it off stays silent.
+    expect(
+      itemBadgeLabel(named(), { entity: "", kind: "light", readings: [{ attribute: "battery" }] }),
+    ).toBe("");
+  });
+
+  it("leaves a device with no readings exactly as it was", () => {
+    for (const readings of [undefined, []]) {
+      expect(itemBadgeLabel(named(), { entity: TEMP, kind: "sensor", readings })).toBe("17.9 °C");
+    }
+  });
+
+  it("still watches every reading's entity, or the line goes intermittent", () => {
+    const got = collectWatchedEntities({
+      items: [
+        {
+          id: "i",
+          kind: "sensor",
+          x: 0,
+          y: 0,
+          entity: TEMP,
+          readings: [{ entity: HUMIDITY }, { attribute: "battery" }, {}],
+        },
+      ],
+    } as unknown as FloorplanCardConfig);
+    expect([...got].sort()).toEqual([TEMP, HUMIDITY].sort());
+  });
+});
+
+describe("itemHasLabel / labelPositionOf (issue #180)", () => {
+  it("knows a device labels itself from its readings alone", () => {
+    // Both toggles off, so the historic test would have said "no label" and
+    // hidden the size and position controls for a label that is on screen.
+    expect(itemHasLabel({ kind: "light", readings: [{ entity: HUMIDITY }] })).toBe(true);
+    expect(itemHasLabel({ kind: "light", showState: false, readings: [{ attribute: "b" }] })).toBe(
+      true,
+    );
+    // A row that names nothing is not a label.
+    expect(itemHasLabel({ kind: "light", readings: [{}] })).toBe(false);
+    expect(itemHasLabel({ kind: "light" })).toBe(false);
+  });
+
+  it("keeps the historic answers for everything else", () => {
+    expect(itemHasLabel({ kind: "sensor" })).toBe(true); // sensors show state
+    expect(itemHasLabel({ kind: "sensor", showState: false })).toBe(false);
+    expect(itemHasLabel({ kind: "light", showName: true })).toBe(true);
+    expect(itemHasLabel({ kind: "light", showState: true })).toBe(true);
+  });
+
+  it("resolves the label position, defaulting to below", () => {
+    expect(labelPositionOf({})).toBe("below");
+    expect(labelPositionOf({ labelPosition: "below" })).toBe("below");
+    expect(labelPositionOf({ labelPosition: "left" })).toBe("left");
+    expect(labelPositionOf({ labelPosition: "right" })).toBe("right");
+  });
+
+  it("falls back to below on a junk value — it becomes a class name", () => {
+    expect(labelPositionOf({ labelPosition: "above" as never })).toBe("below");
+    expect(labelPositionOf({ labelPosition: "" as never })).toBe("below");
+    expect(labelPositionOf({ labelPosition: 3 as never })).toBe("below");
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1006,12 +1006,16 @@ describe("editorItemLabel (#135)", () => {
 });
 
 describe("overlay scaling", () => {
-  it("normalizes the mode, defaulting anything unrecognized to fixed", () => {
-    expect(normalizeOverlayScale("plan")).toBe("plan");
-    expect(normalizeOverlayScale(undefined)).toBe("fixed");
+  it("normalizes the mode, defaulting anything unrecognized to plan", () => {
+    // The default is canvas units: a plan is shown at whatever width the
+    // dashboard has, so pinning the overlay to px only agrees with the drawing
+    // by luck. `fixed` is now the value you have to ask for by name.
     expect(normalizeOverlayScale("fixed")).toBe("fixed");
-    expect(normalizeOverlayScale("PLAN")).toBe("fixed");
-    expect(normalizeOverlayScale(1)).toBe("fixed");
+    expect(normalizeOverlayScale("plan")).toBe("plan");
+    expect(normalizeOverlayScale(undefined)).toBe("plan");
+    expect(normalizeOverlayScale("FIXED")).toBe("plan");
+    expect(normalizeOverlayScale(1)).toBe("plan");
+    expect(normalizeOverlayScale("")).toBe("plan");
   });
 
   it("emits screen pixels under fixed and canvas units under plan", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -82,6 +82,8 @@ import {
   itemStateText,
   itemBadgeLabel,
   itemReadingText,
+  itemReadings,
+  badgeEntityIndex,
   itemHasLabel,
   labelPositionOf,
   editorItemLabel,
@@ -739,20 +741,60 @@ describe("entityStateText", () => {
 });
 
 describe("itemStateText", () => {
-  it("renders the primary entity alone when no secondary is paired", () => {
+  it("renders the device's own state", () => {
     expect(itemStateText(livingArea(), { entity: TEMP })).toBe("17.9 °C");
   });
 
-  it("pairs a temperature entity with its humidity entity", () => {
-    expect(itemStateText(livingArea(), { entity: TEMP, secondaryEntity: HUMIDITY })).toBe(
+  it("renders an attribute of it when one is named (issue #70)", () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).battery = 84;
+    expect(itemStateText(h, { entity: TEMP, attribute: "battery" })).toBe("84");
+  });
+});
+
+// The legacy pair is a *spelling* of the first extra reading now (issue #180),
+// not a mechanism of its own — so what matters is that a config written before
+// that change still draws the same line.
+describe("the legacy secondaryEntity pair, through the pool", () => {
+  const sensor = (extra: Record<string, unknown> = {}) =>
+    ({ entity: TEMP, kind: "sensor", ...extra }) as Parameters<typeof itemBadgeLabel>[1];
+
+  it("still pairs a temperature entity with its humidity entity", () => {
+    expect(itemBadgeLabel(livingArea(), sensor({ secondaryEntity: HUMIDITY }))).toBe(
       "17.9 °C · 49.3%",
     );
   });
 
-  it("still renders the primary when the secondary entity is missing", () => {
-    expect(itemStateText(livingArea(), { entity: TEMP, secondaryEntity: "sensor.gone" })).toBe(
+  it("still renders the primary when the second entity is missing", () => {
+    expect(itemBadgeLabel(livingArea(), sensor({ secondaryEntity: "sensor.gone" }))).toBe(
       "17.9 °C · —",
     );
+  });
+
+  it("is the first entry of the pool, ahead of any readings", () => {
+    expect(
+      itemReadings({ secondaryEntity: HUMIDITY, readings: [{ entity: TEMP }] }),
+    ).toEqual([{ entity: HUMIDITY, attribute: undefined }, { entity: TEMP }]);
+    expect(itemReadings({})).toEqual([]);
+    expect(itemReadings({ readings: [{ entity: TEMP }] })).toEqual([{ entity: TEMP }]);
+  });
+
+  it("a lone secondaryAttribute still reads the device's own entity", () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).battery = 84;
+    expect(itemBadgeLabel(h, sensor({ secondaryAttribute: "battery" }))).toBe("17.9 °C · 84");
+    expect(itemReadings({ secondaryAttribute: "battery" })).toEqual([
+      { entity: undefined, attribute: "battery" },
+    ]);
+  });
+
+  it("mixes with readings, in written order", () => {
+    expect(
+      itemBadgeLabel(
+        livingArea(),
+        sensor({ secondaryEntity: HUMIDITY, readings: [{ entity: TEMP }] }),
+      ),
+    ).toBe("17.9 °C · 49.3% · 17.9 °C");
   });
 });
 
@@ -1833,21 +1875,23 @@ describe("itemStateText with attributes (issue #70)", () => {
 
   it("secondaryAttribute without a second entity reads the same entity", () => {
     expect(
-      itemStateText(climate(), {
+      itemBadgeLabel(climate(), {
         entity: "climate.home",
+        kind: "sensor",
         attribute: "current_temperature",
         secondaryAttribute: "current_humidity",
-      }),
+      } as Parameters<typeof itemBadgeLabel>[1]),
     ).toBe("21.5 · 45");
   });
 
   it("secondaryAttribute applies to secondaryEntity when both are set", () => {
     expect(
-      itemStateText(climate(), {
+      itemBadgeLabel(climate(), {
         entity: "climate.home",
+        kind: "sensor",
         secondaryEntity: TEMP,
         secondaryAttribute: "unit_of_measurement",
-      }),
+      } as Parameters<typeof itemBadgeLabel>[1]),
     ).toBe("heat · °C");
   });
 
@@ -2191,10 +2235,46 @@ describe("badgeValue (#106)", () => {
     it("reports which entity the reading came from", () => {
       // The plug's switch says "on" — not a number — so the badge is showing
       // the power sensor. The form has to be able to say so.
+      // `source` is the reading's *index* in the pool since issue #180 — the
+      // legacy pair is index 0, which is where it always sat.
       expect(badgeReading(plug(), { entity: "switch.plug", secondaryEntity: "sensor.plug_power" }))
-        .toEqual({ text: "1.2kW", source: "secondary" });
+        .toEqual({ text: "1.2kW", source: 0 });
       expect(badgeReading(twoSensors(), { entity: "sensor.a", secondaryEntity: "sensor.b" }))
         .toEqual({ text: "21°", source: "primary" });
+      // …and a reading further down the pool reports its own index.
+      expect(
+        badgeReading(plug(), {
+          entity: "switch.plug",
+          readings: [{ entity: "sensor.nothing" }, { entity: "sensor.plug_power" }],
+        }),
+      ).toEqual({ text: "1.2kW", source: 1 });
+    });
+
+    it("takes the legacy 'secondary' and a modern index to the same place (#180)", () => {
+      const item = { entity: "sensor.a", secondaryEntity: "sensor.b" } as const;
+      expect(badgeReading(twoSensors(), { ...item, badgeEntity: "secondary" })).toEqual(
+        badgeReading(twoSensors(), { ...item, badgeEntity: 0 }),
+      );
+      expect(badgeEntityIndex("secondary")).toBe(0);
+      expect(badgeEntityIndex("primary")).toBe("primary");
+      expect(badgeEntityIndex(2)).toBe(2);
+      // Nothing chosen, and nonsense, both mean "work it out".
+      expect(badgeEntityIndex(undefined)).toBeUndefined();
+      expect(badgeEntityIndex(-1 as never)).toBeUndefined();
+      expect(badgeEntityIndex(1.5 as never)).toBeUndefined();
+      expect(badgeEntityIndex("third" as never)).toBeUndefined();
+    });
+
+    it("an index past the end shows the icon rather than another reading", () => {
+      // Naming a reading that no longer exists must not slide quietly onto a
+      // different sensor — the badge falls back to its glyph instead.
+      expect(
+        badgeReading(plug(), {
+          entity: "switch.plug",
+          readings: [{ entity: "sensor.plug_power" }],
+          badgeEntity: 7,
+        }),
+      ).toBeUndefined();
     });
 
     it("badgeValue is exactly badgeReading's text, across the whole chain", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -17,6 +17,8 @@ import type {
   StateColorRule,
   BadgeContent,
   BadgeEntity,
+  ItemReading,
+  LabelPosition,
   PressEffect,
   OfflineStyle,
   Furniture,
@@ -135,6 +137,10 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);
       if (it.secondaryEntity) ids.add(it.secondaryEntity);
+      // Every further reading (issue #180). Same trap as the opening's second
+      // leaf above: miss one and that line of the label is not frozen but
+      // *intermittent*, catching up only when some other watched entity moves.
+      for (const r of it.readings ?? []) if (r.entity) ids.add(r.entity);
     }
     // Entity-bound furniture (issue #82) — without this the card never
     // re-renders when the soil sensor moves, and the plant stays its
@@ -179,10 +185,39 @@ export function entityAttributeText(
 }
 
 /**
+ * One {@link ItemReading}'s text (issue #180), or `""` when the row says
+ * nothing yet.
+ *
+ * The empty answer is load-bearing: the editor adds a reading as a blank row
+ * for you to fill in, and a blank row that rendered `entityStateText`'s "—"
+ * would put a dash on the plan the moment you clicked "+". So a row with
+ * neither an entity nor an attribute draws nothing at all, and only a row that
+ * names *something* gets to fail visibly.
+ */
+export function itemReadingText(
+  hass: RenderHass | undefined,
+  item: { entity?: string },
+  reading: ItemReading,
+): string {
+  // An attribute with no entity of its own means "this device's own entity",
+  // which is what lets one climate show four of its attributes (issue #70's
+  // trick, generalised).
+  const entity = reading.entity || (reading.attribute ? item.entity : undefined);
+  if (!entity) return "";
+  return reading.attribute
+    ? entityAttributeText(hass, entity, reading.attribute)
+    : entityStateText(hass, entity);
+}
+
+/**
  * State text for an item: primary reading (state, or `attribute` of the
  * entity — issue #70), plus a secondary one when configured. The secondary
  * reading comes from `secondaryEntity` when set, else from the same entity —
  * so one climate device can show `21.5 °C · 45%` from two attributes.
+ *
+ * This is the *state line* only. Further readings (issue #180) are appended by
+ * {@link itemBadgeLabel}, not here, because they are shown independently of
+ * `showState` and this function is what `showState` gates.
  */
 export function itemStateText(
   hass: RenderHass | undefined,
@@ -963,6 +998,7 @@ export function itemBadgeLabel(
     kind: ItemKind;
     showName?: boolean;
     showState?: boolean;
+    readings?: ItemReading[];
   },
 ): string {
   const parts: string[] = [];
@@ -973,7 +1009,54 @@ export function itemBadgeLabel(
   }
   if (!!item.entity && (item.showState ?? item.kind === "sensor"))
     parts.push(itemStateText(hass, item));
+  // Further readings (issue #180), deliberately *not* gated on `showState`:
+  // the case they were asked for is a plug that says on/off through its badge
+  // colour and wants "1.2 kW · 84 · 5 min ago" without the word "on" in front
+  // of it. Each is added only if it resolves to something, so the blank row
+  // the editor's "+" creates stays invisible until it is filled in.
+  for (const reading of item.readings ?? []) {
+    const text = itemReadingText(hass, item, reading);
+    if (text) parts.push(text);
+  }
   return parts.join(" · ");
+}
+
+/**
+ * Whether a device draws a label line at all.
+ *
+ * Was `showName || (showState ?? kind === "sensor")` written out at each call
+ * site, which stopped being the whole truth with issue #180: a device can now
+ * have a label from its extra readings alone, both toggles off. The editor
+ * offers the label's size and position off this, so getting it wrong hides the
+ * controls for a label that is on screen.
+ *
+ * Deliberately *not* "would `itemBadgeLabel` return something": that depends
+ * on live state, and a control that vanishes when a sensor drops out is worse
+ * than one that is occasionally offered for an empty line.
+ */
+export function itemHasLabel(item: {
+  kind: ItemKind;
+  showName?: boolean;
+  showState?: boolean;
+  readings?: ItemReading[];
+}): boolean {
+  if (item.showName) return true;
+  if (item.showState ?? item.kind === "sensor") return true;
+  return (item.readings ?? []).some((r) => r.entity || r.attribute);
+}
+
+/**
+ * Where a device's label sits (issue #180), resolving anything unrecognised to
+ * the historic `below`.
+ *
+ * Checked rather than trusted for the same reason {@link pressEffectOf} is: the
+ * value becomes a class name, so a hand-edited typo would otherwise land as
+ * `label-blow`, match no rule, and leave the label in whatever position the
+ * base stylesheet happens to give it.
+ */
+export function labelPositionOf(item: { labelPosition?: LabelPosition }): LabelPosition {
+  const v = item.labelPosition;
+  return v === "left" || v === "right" ? v : "below";
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -136,11 +136,12 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
     }
     for (const it of f.items) {
       if (it.entity) ids.add(it.entity);
-      if (it.secondaryEntity) ids.add(it.secondaryEntity);
-      // Every further reading (issue #180). Same trap as the opening's second
-      // leaf above: miss one and that line of the label is not frozen but
-      // *intermittent*, catching up only when some other watched entity moves.
-      for (const r of it.readings ?? []) if (r.entity) ids.add(r.entity);
+      // Every reading beyond the device's own state (issue #180), legacy
+      // second entity included — one pool, so one loop. Same trap as the
+      // opening's second leaf above: miss one and that line of the label is
+      // not frozen but *intermittent*, catching up only when some other
+      // watched entity happens to move.
+      for (const r of itemReadings(it)) if (r.entity) ids.add(r.entity);
     }
     // Entity-bound furniture (issue #82) — without this the card never
     // re-renders when the soil sensor moves, and the plant stays its
@@ -210,33 +211,52 @@ export function itemReadingText(
 }
 
 /**
- * State text for an item: primary reading (state, or `attribute` of the
- * entity — issue #70), plus a secondary one when configured. The secondary
- * reading comes from `secondaryEntity` when set, else from the same entity —
- * so one climate device can show `21.5 °C · 45%` from two attributes.
+ * Every reading a device carries **beyond its own state**, as one list
+ * (issue #180).
  *
- * This is the *state line* only. Further readings (issue #180) are appended by
- * {@link itemBadgeLabel}, not here, because they are shown independently of
- * `showState` and this function is what `showState` gates.
+ * There used to be two mechanisms with two different rules: `secondaryEntity`
+ * / `secondaryAttribute` — one extra reading, joined to the state line and
+ * shown only while `showState` was on — and then `readings`, any number of
+ * them, shown always. Two ways to say the same thing, one of them capped at
+ * one, is a distinction nothing outside the config format cared about.
+ *
+ * So there is one pool, and this builds it: the legacy pair first (it was
+ * always the *second* reading, so it keeps that place), then `readings` in
+ * order. Everything downstream — the label, the badge, the watched-entity set,
+ * the editor — reads this rather than either key, which is what makes the
+ * legacy pair a spelling rather than a special case.
+ *
+ * `secondaryAttribute` with no `secondaryEntity` meant "that attribute of this
+ * device's own entity"; an {@link ItemReading} with an attribute and no entity
+ * means exactly the same thing, so it survives the translation unchanged.
+ */
+export function itemReadings(item: {
+  secondaryEntity?: string;
+  secondaryAttribute?: string;
+  readings?: ItemReading[];
+}): ItemReading[] {
+  const legacy: ItemReading[] =
+    item.secondaryEntity || item.secondaryAttribute
+      ? [{ entity: item.secondaryEntity, attribute: item.secondaryAttribute }]
+      : [];
+  return [...legacy, ...(item.readings ?? [])];
+}
+
+/**
+ * A device's own state as text: its `state`, or its `attribute` when one is
+ * named (issue #70).
+ *
+ * The *primary* reading only. Everything else the device shows comes from
+ * {@link itemReadings} and is appended by {@link itemBadgeLabel} — this is the
+ * one `showState` gates, because it is the one that is the device's own state.
  */
 export function itemStateText(
   hass: RenderHass | undefined,
-  item: {
-    entity: string;
-    attribute?: string;
-    secondaryEntity?: string;
-    secondaryAttribute?: string;
-  },
+  item: { entity: string; attribute?: string },
 ): string {
-  const primary = item.attribute
+  return item.attribute
     ? entityAttributeText(hass, item.entity, item.attribute)
     : entityStateText(hass, item.entity);
-  const secondaryEntity = item.secondaryEntity ?? (item.secondaryAttribute ? item.entity : undefined);
-  if (!secondaryEntity) return primary;
-  const secondary = item.secondaryAttribute
-    ? entityAttributeText(hass, secondaryEntity, item.secondaryAttribute)
-    : entityStateText(hass, secondaryEntity);
-  return `${primary} · ${secondary}`;
 }
 
 /**
@@ -998,6 +1018,7 @@ export function itemBadgeLabel(
     kind: ItemKind;
     showName?: boolean;
     showState?: boolean;
+    secondaryAttribute?: string;
     readings?: ItemReading[];
   },
 ): string {
@@ -1009,12 +1030,14 @@ export function itemBadgeLabel(
   }
   if (!!item.entity && (item.showState ?? item.kind === "sensor"))
     parts.push(itemStateText(hass, item));
-  // Further readings (issue #180), deliberately *not* gated on `showState`:
+  // Every other reading (issue #180), deliberately *not* gated on `showState`:
   // the case they were asked for is a plug that says on/off through its badge
   // colour and wants "1.2 kW · 84 · 5 min ago" without the word "on" in front
-  // of it. Each is added only if it resolves to something, so the blank row
-  // the editor's "+" creates stays invisible until it is filled in.
-  for (const reading of item.readings ?? []) {
+  // of it. `showState` is about the device's own state, and these are not it.
+  //
+  // Each is added only if it resolves to something, so the blank row the
+  // editor's "+" creates stays invisible until it is filled in.
+  for (const reading of itemReadings(item)) {
     const text = itemReadingText(hass, item, reading);
     if (text) parts.push(text);
   }
@@ -1038,11 +1061,13 @@ export function itemHasLabel(item: {
   kind: ItemKind;
   showName?: boolean;
   showState?: boolean;
+  secondaryEntity?: string;
+  secondaryAttribute?: string;
   readings?: ItemReading[];
 }): boolean {
   if (item.showName) return true;
   if (item.showState ?? item.kind === "sensor") return true;
-  return (item.readings ?? []).some((r) => r.entity || r.attribute);
+  return itemReadings(item).some((r) => r.entity || r.attribute);
 }
 
 /**
@@ -1687,13 +1712,33 @@ export interface BadgeReadingItem {
   attribute?: string;
   secondaryEntity?: string;
   secondaryAttribute?: string;
+  readings?: ItemReading[];
   badgeEntity?: BadgeEntity;
 }
 
-/** What a badge is showing, and which of the device's entities it came from. */
+/** What a badge is showing, and which of the device's readings it came from. */
 export interface BadgeReading {
   text: string;
-  source: BadgeEntity;
+  /** `"primary"`, or the index into {@link itemReadings} that supplied it. */
+  source: "primary" | number;
+}
+
+/**
+ * Which reading {@link FloorItem.badgeEntity} points at, as an index into
+ * {@link itemReadings} — or `"primary"` for the device's own entity, or
+ * `undefined` for "work it out".
+ *
+ * One place translates the stored value, so the historic `"secondary"` (index
+ * 0, from when a device had exactly two entities) and a modern index arrive at
+ * the same answer and the card and the editor cannot disagree about it. An
+ * index past the end of the pool resolves to nothing rather than silently
+ * sliding to another reading — a config that names a reading which no longer
+ * exists should show its icon, not a number off some other sensor.
+ */
+export function badgeEntityIndex(v: BadgeEntity | undefined): "primary" | number | undefined {
+  if (v === "primary") return "primary";
+  if (v === "secondary") return 0;
+  return typeof v === "number" && Number.isInteger(v) && v >= 0 ? v : undefined;
 }
 
 /**
@@ -1716,9 +1761,10 @@ export function badgeReading(
 ): BadgeReading | undefined {
   if (!hass || !item.entity) return undefined;
 
-  // The secondary, resolved as the label line resolves it ({@link itemStateText}),
-  // so the two never disagree about which entity the second reading comes from.
-  const secondaryEntity = item.secondaryEntity ?? (item.secondaryAttribute ? item.entity : undefined);
+  // The other readings, resolved from the same pool the label line uses
+  // ({@link itemReadings}), so the badge and the label can never disagree
+  // about which entity a reading comes from.
+  const readings = itemReadings(item);
 
   const primary = (): string | undefined => {
     const st = hass.states[item.entity as string];
@@ -1740,34 +1786,45 @@ export function badgeReading(
     return own === undefined ? undefined : formatReading(own, attrs?.unit_of_measurement);
   };
 
-  const secondary = (): string | undefined => {
-    if (!secondaryEntity) return undefined;
-    const sec = hass.states[secondaryEntity];
-    const secAttrs = sec?.attributes as Record<string, unknown> | undefined;
-    if (item.secondaryAttribute) {
-      const n = numericReading(secAttrs?.[item.secondaryAttribute]);
+  /** The numeric value of one reading in the pool, or undefined. */
+  const readingAt = (i: number): string | undefined => {
+    const r = readings[i];
+    if (!r) return undefined;
+    const entity = r.entity || (r.attribute ? item.entity : undefined);
+    if (!entity) return undefined;
+    const st = hass.states[entity];
+    const attrs = st?.attributes as Record<string, unknown> | undefined;
+    if (r.attribute) {
+      const n = numericReading(attrs?.[r.attribute]);
       return n === undefined ? undefined : compactNumber(n);
     }
-    const n = numericReading(sec?.state);
-    return n === undefined ? undefined : formatReading(n, secAttrs?.unit_of_measurement);
+    const n = numericReading(st?.state);
+    return n === undefined ? undefined : formatReading(n, attrs?.unit_of_measurement);
   };
 
-  // An explicit choice reads that entity and stops. Falling through to the
-  // other one would quietly show a different device than the one asked for;
-  // no number at all is honest, and the badge draws its icon instead.
-  if (item.badgeEntity === "secondary") {
-    const text = secondary();
-    return text === undefined ? undefined : { text, source: "secondary" };
-  }
-  if (item.badgeEntity === "primary") {
+  // An explicit choice reads that entity and stops. Falling through to another
+  // would quietly show a different device than the one asked for; no number at
+  // all is honest, and the badge draws its icon instead.
+  const chosen = badgeEntityIndex(item.badgeEntity);
+  if (chosen === "primary") {
     const text = primary();
     return text === undefined ? undefined : { text, source: "primary" };
   }
+  if (typeof chosen === "number") {
+    const text = readingAt(chosen);
+    return text === undefined ? undefined : { text, source: chosen };
+  }
 
+  // Nothing chosen: the first candidate with a number wins, the device's own
+  // entity first. A plug that reads "on" falls through to its power sensor
+  // without anything being configured.
   const own = primary();
   if (own !== undefined) return { text: own, source: "primary" };
-  const other = secondary();
-  return other === undefined ? undefined : { text: other, source: "secondary" };
+  for (let i = 0; i < readings.length; i++) {
+    const text = readingAt(i);
+    if (text !== undefined) return { text, source: i };
+  }
+  return undefined;
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -1145,9 +1145,25 @@ export function wallStrokeStyle(thickness: unknown): string {
 // inside it, see the card's stylesheet) is one canvas unit as a length, so
 // `calc(14 * var(--fp-u))` is 14 canvas units however large the card ends up.
 
-/** Coerce a config `overlayScale`; anything unrecognised means the default. */
+/**
+ * Coerce a config `overlayScale`; anything unrecognised means the default,
+ * which is `plan`.
+ *
+ * The default flipped here, and it is the one change in this file that every
+ * existing plan sees. `fixed` was the historic behaviour and the wrong default:
+ * it only agrees with the drawing when the card renders at roughly its canvas
+ * size, and a plan is shown at whatever width the dashboard gives it. Sizing
+ * the overlay in canvas units is what makes a plan a *drawing* — it looks the
+ * same at every width, and a cluster of badges keeps the spacing it was given
+ * (issue #179).
+ *
+ * `fixed` remains a real choice, and the one to make for a card rendered much
+ * *larger* than its canvas, or a wall tablet where a fixed px floor is what
+ * keeps text readable from across the room. See the README's "Where it helps,
+ * and where it costs".
+ */
 export function normalizeOverlayScale(v: unknown): OverlayScale {
-  return v === "plan" ? "plan" : "fixed";
+  return v === "fixed" ? "fixed" : "plan";
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -323,6 +323,43 @@ export type ItemKind =
   | "vacuum"
   | "generic";
 
+/**
+ * One **extra** reading on a device (issue #180) — the third, fourth, fifth
+ * line of text after `entity` and `secondaryEntity` have had their turn.
+ *
+ * Both fields are optional, and between them they say where the number comes
+ * from:
+ *
+ * | `entity` | `attribute` | reads                                    |
+ * | -------- | ----------- | ---------------------------------------- |
+ * | set      | unset       | that entity's state                      |
+ * | set      | set         | that attribute of that entity            |
+ * | unset    | set         | that attribute of the **device's own** entity |
+ * | unset    | unset       | nothing — a blank row draws no text      |
+ *
+ * The third row is what makes one climate device able to show four of its own
+ * attributes without naming itself four times; the fourth is what keeps a row
+ * the editor has just added from printing "—" before anything is picked.
+ */
+export interface ItemReading {
+  /** Entity to read. Omitted, the device's own {@link FloorItem.entity}. */
+  entity?: string;
+  /** Attribute to read instead of the state. */
+  attribute?: string;
+}
+
+/**
+ * Where a device's label sits relative to its badge (issue #180, and the
+ * discussion behind it). `below` is the historic centre-under-the-icon
+ * position and stays the default.
+ *
+ * `left` / `right` exist because a long reading under a badge grows in both
+ * directions and collides with whatever is beside it, while a label hung off
+ * one side grows only one way — which is what a row of devices along a wall
+ * needs.
+ */
+export type LabelPosition = "below" | "left" | "right";
+
 /** An entity icon placed on the plan. */
 export interface FloorItem {
   id: string;
@@ -387,6 +424,27 @@ export interface FloorItem {
    * "Name · state". Default false.
    */
   showName?: boolean;
+  /**
+   * Further readings appended to the label (issue #180) — a temperature
+   * sensor that also reports humidity and pressure, or a plug that reports
+   * power, link quality and last-seen.
+   *
+   * Additive rather than a replacement for {@link secondaryEntity}: that key
+   * is the *paired* reading, joined to the primary with the same separator and
+   * offered to the badge itself through `badgeEntity`, and rewriting it as
+   * `readings[0]` would have broken both. So `entity`, then `secondaryEntity`,
+   * then these, in order.
+   *
+   * **Shown whether or not `showState` is** — which is the point of them. A
+   * plug says on/off through its badge colour, so its owner wants Power · LQI
+   * · Last seen and *not* the word "on" (I-G-1-1's case in discussion #173).
+   * `showState` therefore governs the device's own state line only, and these
+   * are their own statement. An existing plan gains nothing it did not ask
+   * for, because a plan with no `readings` has no extra rows to show.
+   */
+  readings?: ItemReading[];
+  /** Where the label sits relative to the badge (issue #180). Default `below`. */
+  labelPosition?: LabelPosition;
   /** Label line font size in pixels (issue #59). Default 12. */
   labelSize?: number;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -365,9 +365,18 @@ export interface FloorItem {
   id: string;
   entity: string;
   /**
-   * Optional second entity (e.g. a humidity sensor paired with a temperature
-   * entity). When set and the state is shown, both values are displayed in the
-   * same element. The primary `entity` drives on/off state and click actions.
+   * **Legacy spelling of the first {@link readings} row.** A second entity
+   * shown alongside the primary — e.g. a humidity sensor paired with a
+   * temperature one.
+   *
+   * Kept because plans in the wild use it, and still read: `itemReadings`
+   * puts it at the head of the pool, where it always sat. It has no field in
+   * the editor any more, and touching a device's readings rewrites it as a
+   * `readings` entry. New configs should just use `readings`.
+   *
+   * One behaviour did change with issue #180: it used to be part of the state
+   * line and so appeared only while `showState` was on. It is a reading now,
+   * and readings show on their own terms — see {@link readings}.
    */
   secondaryEntity?: string;
   /**
@@ -377,9 +386,11 @@ export interface FloorItem {
    */
   attribute?: string;
   /**
-   * Attribute for the second reading. Applies to `secondaryEntity` when set,
-   * else to `entity` — so one climate device can show
-   * `current_temperature · current_humidity` without a second entity.
+   * Attribute for {@link secondaryEntity}, and legacy in the same way. Applies
+   * to `secondaryEntity` when set, else to `entity` — so one climate device
+   * could show `current_temperature · current_humidity` without a second
+   * entity. A {@link ItemReading} with an attribute and no entity means
+   * exactly that, which is how it translates into the pool.
    */
   secondaryAttribute?: string;
   /**
@@ -425,22 +436,20 @@ export interface FloorItem {
    */
   showName?: boolean;
   /**
-   * Further readings appended to the label (issue #180) — a temperature
-   * sensor that also reports humidity and pressure, or a plug that reports
-   * power, link quality and last-seen.
+   * Everything this device reads **beyond its own state** (issue #180) — a
+   * temperature sensor that also reports humidity and pressure, a plug that
+   * reports power, link quality and battery.
    *
-   * Additive rather than a replacement for {@link secondaryEntity}: that key
-   * is the *paired* reading, joined to the primary with the same separator and
-   * offered to the badge itself through `badgeEntity`, and rewriting it as
-   * `readings[0]` would have broken both. So `entity`, then `secondaryEntity`,
-   * then these, in order.
+   * This is *the* list. {@link secondaryEntity} is a legacy spelling of its
+   * first entry rather than a parallel mechanism, so there is one pool, one
+   * order (`entity`, then any legacy pair, then these) and one rule about when
+   * they show. Resolve with `itemReadings`, never by reading either key
+   * directly.
    *
-   * **Shown whether or not `showState` is** — which is the point of them. A
-   * plug says on/off through its badge colour, so its owner wants Power · LQI
-   * · Last seen and *not* the word "on" (I-G-1-1's case in discussion #173).
-   * `showState` therefore governs the device's own state line only, and these
-   * are their own statement. An existing plan gains nothing it did not ask
-   * for, because a plan with no `readings` has no extra rows to show.
+   * **Shown whether or not `showState` is**, which is the point of them. A plug
+   * says on/off through its badge colour, so its owner wants Power · LQI ·
+   * Battery and *not* the word "on" (I-G-1-1's case in discussion #173).
+   * `showState` is about the device's *own state*; these are not it.
    */
   readings?: ItemReading[];
   /** Where the label sits relative to the badge (issue #180). Default `below`. */
@@ -469,8 +478,8 @@ export interface FloorItem {
   badgeContent?: BadgeContent;
   /**
    * Which of this device's own entities the badge reads while
-   * `badgeContent: "value"` (issue #136) — the main `entity`, or
-   * {@link secondaryEntity}.
+   * `badgeContent: "value"` (issue #136) — the main `entity`, or one of its
+   * other {@link readings} by index.
    *
    * Absent means "work it out", which is what {@link badgeValue} has always
    * done: the first candidate with a number wins, so a switch that reads "on"
@@ -478,10 +487,11 @@ export interface FloorItem {
    * but it is only a guess, and there was no way to overrule it when the main
    * entity happens to be numeric too.
    *
-   * Set, it is the *only* entity read. No falling back to the other one:
-   * having asked for the power sensor, being shown the switch instead would
-   * be worse than being shown the icon — which is what a device with no
-   * number to display falls back to anyway.
+   * Set, it is the *only* reading read. No falling back to another: having
+   * asked for the power sensor, being shown the switch instead would be worse
+   * than being shown the icon — which is what a device with no number to
+   * display falls back to anyway. An index past the end of the pool behaves
+   * the same way, rather than sliding onto a neighbouring reading.
    */
   badgeEntity?: BadgeEntity;
   /**
@@ -562,11 +572,21 @@ export type ItemDisplay = "badge" | "ripple" | "iconRipple";
 export type BadgeContent = "icon" | "value" | "none";
 
 /**
- * Which of a device's two entities feeds its value badge — see
- * {@link FloorItem.badgeEntity} (issue #136). Named by role rather than by
- * entity id so renaming an entity in Home Assistant cannot orphan the choice.
+ * Which of a device's readings feeds its value badge — see
+ * {@link FloorItem.badgeEntity} (issue #136).
+ *
+ * - `"primary"` — the device's own entity.
+ * - a **number** — that index into the device's other readings (see
+ *   `itemReadings`), so a plug with power, link quality and battery can badge
+ *   whichever of them it likes.
+ * - `"secondary"` — the historic spelling of index `0`, from when a device had
+ *   exactly two entities and the second had a name rather than a position.
+ *   Still read, so no stored config is orphaned; the editor writes indices.
+ *
+ * Addressed by role or position rather than by entity id, so renaming an
+ * entity in Home Assistant cannot strand the choice.
  */
-export type BadgeEntity = "primary" | "secondary";
+export type BadgeEntity = "primary" | "secondary" | number;
 
 /**
  * One colour rule for {@link FloorItem.stateColor} / {@link Furniture.stateColor}.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1123,16 +1123,25 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /**
    * How the HTML overlay (badges, labels, room names, text) is sized.
    *
-   * - **`fixed`** (default) — screen pixels, whatever size the card renders at.
-   * - **`plan`** — canvas units, so the overlay scales with the drawing exactly
-   *   as the SVG does.
+   * - **`plan`** (default) — canvas units, so the overlay scales with the
+   *   drawing exactly as the SVG does.
+   * - **`fixed`** — screen pixels, whatever size the card renders at.
    *
-   * `fixed` is the historic behaviour and is right when the card renders at
-   * roughly its canvas size. It falls apart below that: a plan drawn at 980
-   * wide and rendered 510 wide draws every wall at half size while a 14px room
-   * name stays 14px, so labels collide with the badges and each other. `plan`
-   * makes the two layers shrink together. Default stays `fixed` so no existing
-   * card changes appearance on upgrade.
+   * `fixed` was the historic behaviour and the historic default, and it is
+   * right only when the card renders at roughly its canvas size — which is not
+   * something a plan gets to decide, since the dashboard hands it whatever
+   * width it has. Below that it comes apart: a plan drawn at 980 wide and
+   * rendered 510 wide draws every wall at half size while a 14px room name
+   * stays 14px, so labels collide with the badges and each other, and a
+   * carefully spaced cluster of badges overlaps (issue #179).
+   *
+   * `plan` makes the two layers shrink together, which is what makes the thing
+   * a drawing rather than a drawing with fixed-size furniture on it. It is now
+   * the default, and that **does** change how an existing card looks: an
+   * overlay that was pinned to px now tracks the plan. The trade runs the other
+   * way at the extremes — see the README's "Where it helps, and where it
+   * costs" — so `fixed` stays a real choice for a card rendered much larger
+   * than its canvas, or a wall tablet that wants a px floor under its text.
    */
   overlayScale?: OverlayScale;
   /** Canvas background color (CSS / hex). Falls back to the skin's paper, then the card background. */


### PR DESCRIPTION
Follow-on to #174, which was already merged when this work was written — so it lands on its own rather than in that PR. Rebased onto current `main` (after the sunlight PRs); tests, typecheck and build are clean against it.

## More readings per device — closes #180

A device takes a `readings: [{ entity?, attribute? }]` list, appended to the label after `entity` and `secondaryEntity` have had their turn. A sensor reporting temperature, humidity and pressure needs one badge, not three.

| `entity` | `attribute` | reads |
| --- | --- | --- |
| set | — | that entity's state |
| set | set | that attribute of that entity |
| — | set | that attribute of **the device's own** entity |
| — | — | nothing — a blank row draws no text |

The third row is what lets one climate entity show four of its own numbers without naming itself four times. The fourth is why the editor's **+ Add reading** can hand you an empty row without a `—` landing on the plan.

**Readings ignore `showState`**, which is the point of them (I-G-1-1 in discussion #173): a smart plug already says on/off through its badge colour and wants `1.2 kW · 84 · 5 min ago` without the word "on" in front of it. `showState` governs the device's own state line only. That also means a device can be labelled by its readings alone, so `itemHasLabel` is now one predicate rather than the two-term test spelled out at each call site — get it wrong and the editor hides the label controls for a label that is on screen.

Additive rather than replacing `secondaryEntity`: that key is the *paired* reading, joined with the same separator and offered to the badge through `badgeEntity`, so folding it into `readings[0]` would have broken both. No migration.

**`labelPosition: below | left | right`** — the discussion's first ask, with mock-ups. A reading under a badge grows both ways and meets whatever is beside it; hung off one side it grows one way. `below` stays the default, and the editor canvas mirrors it.

## Canvas units by default — closes #179

`overlayScale` now defaults to `plan`; `fixed` is the value you ask for by name.

Measured before deciding. Badge **positions** are canvas units and scale with the plan; badge **sizes** were screen pixels and did not. So a cluster spaced to look right on a wide card collides on a narrow one — I rendered three bunched sensor badges at 760 / 420 / 260px and under `fixed` they overlap and the labels crush together by 420px, while under `plan` the cluster shrinks intact and keeps its spacing at every width. That is the whole of the drift #179 reports.

Between that and `readings` above — which removes the cluster entirely for the case #179 actually describes — a group primitive had no case left that needed it. It would be a new element type through the editor's selection, drag, undo and copy/paste paths, and it would be the *weaker* fix anyway: it would pin the cluster's internal geometry while the badges still didn't scale, giving you a tidy cluster that is collectively too big for its room.

⚠️ **This changes how existing cards look** — the one change here that every plan sees. A card rendering at about its canvas width barely moves; one rendering smaller gets smaller labels (the point); one rendering larger gets bigger ones. `overlayScale: fixed` restores the old behaviour exactly, and stays right for a card shown larger than its canvas or a wall tablet that wants a px floor under its text. The README has an upgrade note and the trade-off table.

## Verification

`npm test` (1090 passing, 59 new), `npm run typecheck`, `npm run build` clean on top of current `main`.

Checked in a browser against the built bundle: three readings render as one line; the plug case drops "on" while keeping the rest; all three label positions sit where they should. For the default flip, a card with no `overlayScale` now gets `scale-plan`, and halving its width halves both the label (12→6px) and the badge (34→17px) — the intended behaviour, and the reason the README says to raise the sizes rather than switch modes on a much-smaller card.

The dev container carries fixtures: the middle sensor shows three numbers from one badge, and the fan stands in for the plug — state hidden, one attribute reading, label to the left.