### PR TITLE
Openings read locks, and rooms answer gestures (closes #176, #181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,9 +1055,13 @@ openings:
 
 `unlocked` draws the door open, `locked` draws it shut. The in-between states follow the
 lock domain's own reading, the same table the device badges use: `unlocking` and a latch
-`open` / `opening` count as open, `locking` is on its way to shut and draws shut, and
-`jammed` — like any unavailable or unknown state — fails closed. `invert` flips it for a
-lock wired the other way round.
+`open` / `opening` count as open, and `locking` is on its way to shut and draws shut.
+`invert` flips all of those, for a lock wired the other way round.
+
+**`jammed` is not one of those readings.** A lock that tried to move and could not has a
+bolt that is neither thrown nor withdrawn, so it is the same "we don't know" as an
+`unavailable` or `unknown` entity: the door draws shut, and `invert` does not get to turn
+that into a door standing open.
 
 A lock publishes no position, so the door is fully open or fully shut, never partway.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ screen size.
 <img width="195" height="278" alt="light blend" src="https://github.com/user-attachments/assets/23104587-687b-4c9a-83e8-e83c3d5eb6eb" />
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
-- **Animated doors & windows** — bind a contact `binary_sensor` or `cover` and openings swing, slide or roll with their real state, partial positions included.
+- **Animated doors & windows** — bind a contact `binary_sensor`, `cover` or `lock` and openings swing, slide or roll with their real state, partial positions included. A lock reads `unlocked` as open, so a door with no contact sensor still animates.
   - (${\color{red}NEW!}$) **A sensor per leaf** — anything with two leaves takes a second contact and draws them independently: a casement window with one sash open and one shut, a double door ajar on one side, a pair of shutters with one folded back.
 - (${\color{red}NEW!}$) **Offline devices read as offline** — an entity that is unavailable, unknown, or gone from Home Assistant is dimmed (or crossed out), instead of looking exactly like a device someone switched off.
 - (${\color{red}NEW!}$) **Furniture** — 26 gray line-art diagrams (table, sofa, bed, stove, stairs, tv…), each bindable to an entity, in a searchable picker. Every one is a plain JSON file of numbers you can copy: draw your own in the editor's paste box, use it straight away, and open a PR when it's good. No SVG, so nothing you paste can run anything.
@@ -434,7 +434,7 @@ distorted anyway.
 | `x`, `y`      | number                      | Center position.                                       |
 | `length`      | number                      | Length along the wall.                                 |
 | `angle`       | number                      | Rotation in degrees.                                   |
-| `entity`      | string                      | Contact `binary_sensor` / `cover` driving open/closed (or `current_position` for partial). |
+| `entity`      | string                      | Contact `binary_sensor`, `cover` or `lock` driving open/closed (a `cover`'s `current_position` gives partial travel). A **lock** reads `unlocked` as open and `locked` as closed — see [Doors on locks](#doors-on-locks). |
 | `secondaryEntity` | string                  | Anything with **two leaves**: a second contact / `cover` for the other leaf, so each moves on its own state. That means the two-panel sliders (`biparting`, `biparting-bypass`, `converging`) and any hinged double — a casement window, or a `sash: double` door. `entity` drives the leaf at the −x jamb, so `flipH` swaps which sensor draws which. Unset = both follow `entity`; ignored where there is only one leaf. |
 | `invert`      | boolean                     | Flip the open/closed interpretation.                   |
 | `activeColor` | string                      | Leaf/arc color while actively open (default primary). On a roll-up it colours the curtain and the track it leaves behind, so a fully raised shutter still reads as open. |
@@ -626,7 +626,7 @@ animated inside a rectangular tracked area:
 
 ### Area
 
-`{ id, points, name?, showName?, labelSize?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight? }`
+`{ id, points, name?, showName?, labelSize?, color?, opacity?, haArea?, filterEntities?, entity?, stateColor?, activeColor?, activeOpacity?, borderColor?, borderWidth?, highlight?, tap_action?, hold_action?, double_tap_action? }`
 
 - `points` — `{ x, y }` vertices in drawing order, implicitly closed last-to-first.
 - `name` / `showName` — label centered on the polygon (`showName` defaults `true`).
@@ -654,6 +654,12 @@ animated inside a rectangular tracked area:
   down the middle, an exterior wall colors on its inside face only. `borderWidth` is the
   width seen on the room's own side and defaults to `4` here; widen it and the band runs
   past the wall onto the floor.
+- `tap_action` / `hold_action` / `double_tap_action` — standard Lovelace actions on the
+  room itself. **Tap already does something** — it zooms the plan to the room — so setting
+  `tap_action` *replaces* that zoom; leaving it unset keeps it. Put the action on hold or
+  double-tap to have both. An action's `entity` falls back to the area's own, so a room
+  bound to a presence sensor needs no second mention of it. `tap_action: { action: none }`
+  turns the zoom off without adding anything.
 
 ```yaml
 areas:
@@ -1036,6 +1042,62 @@ dashboard tile, a sidebar, a desktop widget. Leave it off for a wall tablet show
 plan at full size, where fixed px is what keeps text legible from across the room, and
 for a card so small that scaled text would disappear. The default stays `fixed`, so an
 existing card looks exactly as it did.
+
+## Doors on locks
+
+A door with a smart lock and no contact sensor already knows whether it is shut. Bind the
+lock and it drives the door (issue #176):
+
+```yaml
+openings:
+  - { id: front, type: door, x: 300, y: 100, length: 90, angle: 0, entity: lock.front_door }
+```
+
+`unlocked` draws the door open, `locked` draws it shut. The in-between states follow the
+lock domain's own reading, the same table the device badges use: `unlocking` and a latch
+`open` / `opening` count as open, `locking` is on its way to shut and draws shut, and
+`jammed` — like any unavailable or unknown state — fails closed. `invert` flips it for a
+lock wired the other way round.
+
+A lock publishes no position, so the door is fully open or fully shut, never partway.
+
+**A tap on a lock-driven door opens its dialog; it never turns the lock.** That is the
+same rule that keeps a tap off a shutter motor: unlocking a front door by brushing the
+plan is the worst version of an accidental hardware move. `tap_action: { action: toggle }`
+opts in, explicitly.
+
+## Actions on rooms
+
+Rooms answer gestures (issue #181) — tap the floor of a room to run a scene, toggle its
+lights, or open a dashboard for it:
+
+```yaml
+areas:
+  - id: kitchen
+    points: [ … ]
+    entity: light.kitchen_lights
+    hold_action: { action: toggle }
+```
+
+**Tap already does something**: it zooms the plan to that room, and has since zooming
+existed. So `tap_action` *replaces* the zoom rather than joining it, and leaving it unset
+keeps the zoom exactly as it was — every plan drawn before this behaves identically.
+
+That gives three arrangements:
+
+| You want | Set |
+| --- | --- |
+| Zoom, and an action | the action on `hold_action` or `double_tap_action` |
+| An action instead of the zoom | `tap_action` |
+| Neither | `tap_action: { action: none }` |
+
+An action's own `entity` wins; without one it falls back to the area's `entity`, so the
+example above toggles `light.kitchen_lights` without naming it twice. With no entity
+anywhere, only the actions that need none — `navigate`, `url`, `call-service` — do
+anything.
+
+A room with an action bound announces itself as a button and takes a tab stop; a room that
+only zooms does not, exactly as before.
 
 ## Offline devices
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -150,12 +150,18 @@ describe("openingForm", () => {
     });
   });
 
-  it("invert only offered with an entity; entity filter targets covers and binary_sensors", () => {
+  it("invert only offered with an entity; the picker takes contacts, covers and locks", () => {
     expect(openingForm(door).fields.map((x) => x.name)).not.toContain("invert");
     const bound = openingForm({ ...door, entity: "cover.x" } as Opening);
     expect(bound.fields.map((x) => x.name)).toContain("invert");
     const entity = bound.fields.find((x) => x.name === "entity")!;
-    expect(entity.selector).toEqual({ entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } });
+    // `lock` joined with issue #176 — a door with a smart lock and no contact.
+    expect(entity.selector).toEqual({
+      entity: { filter: [{ domain: ["binary_sensor", "cover", "lock"] }] },
+    });
+    // …and the helper says so, because nothing else would: a lock is neither
+    // a contact nor a cover and its states look nothing like open/closed.
+    expect(entity.helper).toContain("lock");
   });
 
   it("maps view-model patches back to config shape", () => {
@@ -215,9 +221,9 @@ describe("openingForm — two-panel sliders (issue #145)", () => {
       const bound = openingForm(slider({ sliderStyle, entity: "binary_sensor.a" }));
       expect(bound.fields.map((x) => x.name)).toContain("secondaryEntity");
       const field = bound.fields.find((x) => x.name === "secondaryEntity")!;
-      // Same pickers as the first panel: a contact or a cover per leaf.
+      // Same pickers as the first leaf: a contact, a cover or a lock per leaf.
       expect(field.selector).toEqual({
-        entity: { filter: [{ domain: ["binary_sensor", "cover"] }] },
+        entity: { filter: [{ domain: ["binary_sensor", "cover", "lock"] }] },
       });
     }
   });
@@ -1482,5 +1488,38 @@ describe("projectSunForm (issue #113)", () => {
     // Leaving them behind would resurrect stale values on re-enable.
     expect(toPatch({ sunDimming: true }).sunDimming).toBe(true);
     expect(toPatch({ sunBrightnessMin: 0.3 })).toEqual({ sunBrightnessMin: 0.3 });
+  });
+});
+
+describe("areaForm — actions on rooms (issue #181)", () => {
+  const area = (extra: Partial<Area> = {}): Area =>
+    ({ id: "a", points: [{ x: 0, y: 0 }], ...extra }) as Area;
+
+  it("offers the three gestures on every room", () => {
+    const names = areaForm(area()).fields.map((x) => x.name);
+    expect(names).toContain("tap_action");
+    expect(names).toContain("hold_action");
+    expect(names).toContain("double_tap_action");
+  });
+
+  it("says what tap costs — the zoom — and how to keep it", () => {
+    const tap = areaForm(area()).fields.find((x) => x.name === "tap_action")!;
+    expect(tap.helper).toContain("zoom");
+    expect(tap.helper).toContain("hold");
+  });
+
+  it("carries the stored actions, and leaves unset ones unset", () => {
+    expect(areaForm(area()).data.tap_action).toBeUndefined();
+    const d = areaForm(area({ tap_action: { action: "toggle" } })).data;
+    expect(d.tap_action).toEqual({ action: "toggle" });
+    expect(d.hold_action).toBeUndefined();
+  });
+
+  it("does not disturb the highlight default it shares a toPatch with", () => {
+    const form = areaForm(area({ entity: "light.k" }));
+    expect(form.toPatch({ highlight: "fill" })).toEqual({ highlight: undefined });
+    expect(form.toPatch({ tap_action: { action: "toggle" } })).toEqual({
+      tap_action: { action: "toggle" },
+    });
   });
 });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -142,6 +142,19 @@ export interface FormSpec {
 
 const identity = (patch: Record<string, unknown>) => patch;
 
+/**
+ * What an opening's leaf can be bound to.
+ *
+ * `lock` joined with issue #176: a door with a smart lock and no contact
+ * sensor knows perfectly well whether it is shut, and `locked` / `unlocked` is
+ * the domain's way of saying so. See `resolveOpeningOpen`, which reads those
+ * states through the same domain table the badges use.
+ *
+ * The shutter's picker is deliberately *not* this list — a shutter is a cover
+ * or a reed contact, and a lock on one would not mean anything.
+ */
+const OPENING_ENTITY_DOMAINS = ["binary_sensor", "cover", "lock"] as const;
+
 const angleField = (): FormField => ({
   name: "angle",
   label: "Angle",
@@ -276,10 +289,13 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
   fields.push({
     name: "entity",
     label: "Entity",
+    // Says locks are usable, because nothing else would: a lock is neither a
+    // contact nor a cover, and its states are `locked` / `unlocked` rather
+    // than anything that looks like open/closed (issue #176).
     helper: twoLeaves
-      ? "Drives the first leaf; type and motion follow its device class"
-      : "Type and motion follow the entity's device class",
-    selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
+      ? "Contact, cover or lock. Drives the first leaf; type and motion follow its device class"
+      : "Contact, cover or lock — a lock reads unlocked as open. Type and motion follow its device class",
+    selector: { entity: { filter: [{ domain: OPENING_ENTITY_DOMAINS }] } },
   });
   // One sensor per leaf (issues #145, #159). Only a two-leaved opening has a
   // second leaf to drive — a two-panel slider, or a hinged double — and only
@@ -290,7 +306,7 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       name: "secondaryEntity",
       label: "Second leaf",
       helper: "Its own sensor for the other leaf — leave empty to move both together",
-      selector: { entity: { filter: [{ domain: ["binary_sensor", "cover"] }] } },
+      selector: { entity: { filter: [{ domain: OPENING_ENTITY_DOMAINS }] } },
     });
   }
   // Offered on doors too: French doors and patio doors get shutters as well.
@@ -1105,6 +1121,22 @@ export function areaForm(a: Area): FormSpec {
             },
           ]
         : []),
+      // Actions on the room itself (issue #181). Tap already does something —
+      // it zooms — so its default is named here rather than left blank: the
+      // dropdown says "Zoom to room", which is what leaving it alone gives
+      // you, on the same principle as the opening's "Tap opens".
+      {
+        name: "tap_action",
+        label: "Tap action",
+        helper: "Replaces the zoom. Put an action on hold or double-tap to keep both",
+        selector: { ui_action: { default_action: "none" } },
+      },
+      { name: "hold_action", label: "Hold action", selector: { ui_action: { default_action: "none" } } },
+      {
+        name: "double_tap_action",
+        label: "Double-tap action",
+        selector: { ui_action: { default_action: "none" } },
+      },
     ],
     data: {
       showName: a.showName ?? true,
@@ -1113,6 +1145,9 @@ export function areaForm(a: Area): FormSpec {
       entity: a.entity ?? "",
       activeOpacity: a.activeOpacity ?? a.opacity ?? DEFAULT_AREA_OPACITY,
       highlight: a.highlight ?? "fill",
+      tap_action: a.tap_action,
+      hold_action: a.hold_action,
+      double_tap_action: a.double_tap_action,
     },
     // "fill" is the default, so keep it out of the YAML.
     toPatch: (p) => ("highlight" in p && p.highlight === "fill" ? { ...p, highlight: undefined } : p),

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -38,6 +38,8 @@ import {
   openingIsActive,
   openingActionForGesture,
   openingIsPressable,
+  areaActionForGesture,
+  areaHasActions,
   openingHasTwoLeaves,
   secondLeafOf,
   shutterAmount,
@@ -468,6 +470,27 @@ export class FloorplanCard extends LitElement {
     this._zoomedAreaId = this._zoomedAreaId === a.id ? undefined : a.id;
   }
 
+  /**
+   * A gesture on a room (issue #181): its configured action, or — for a tap
+   * with nothing configured — the zoom the room has always done.
+   *
+   * The fallback is what keeps this backwards compatible. Every plan drawn
+   * before areas had actions has three unset gestures, so every tap still
+   * zooms and hold and double-tap still do nothing.
+   */
+  private _onAreaAction(
+    ev: CustomEvent<{ action: "tap" | "hold" | "double_tap" }>,
+    a: Area,
+  ): void {
+    const press = areaActionForGesture(a, ev.detail.action);
+    if (!press) {
+      if (ev.detail.action === "tap") this._onAreaClick(a);
+      return;
+    }
+    if (!this.hass) return;
+    executeAction(this, this.hass, { entity: press.entity }, press.config);
+  }
+
   private _renderBadge(item: FloorItem, scale: OverlayScale): TemplateResult {
     const size = cssNumber(item.size, DEFAULT_ITEM_SIZE);
     const box = overlayLength(size, scale);
@@ -842,12 +865,26 @@ export class FloorplanCard extends LitElement {
                           preserveAspectRatio=${imageFitRatio(active.imageFit)}
                           opacity=${active.imageOpacity ?? 1} />`
               : nothing}
-            ${active.areas?.map(
-              (a) =>
-                svg`<g class="area-tap-target" @click=${() => this._onAreaClick(a)}>
+            ${active.areas?.map((a) => {
+              // Rooms answer gestures now (issue #181). The hit target is
+              // unconditional, as it always was — every room zooms — so only
+              // the role and the tab stop are earned by having an action.
+              const acts = areaHasActions(a);
+              return svg`<g class="area-tap-target"
+                    role=${acts ? "button" : nothing}
+                    tabindex=${acts ? "0" : nothing}
+                    @action=${(ev: CustomEvent<{ action: "tap" | "hold" | "double_tap" }>) =>
+                      this._onAreaAction(ev, a)}
+                    .actionHandler=${actionHandler({
+                      // Only wait out the timers when a gesture can resolve:
+                      // otherwise every tap on an ordinary room would sit for
+                      // 500ms before zooming.
+                      hasHold: hasAction(areaActionForGesture(a, "hold")?.config),
+                      hasDoubleClick: hasAction(areaActionForGesture(a, "double_tap")?.config),
+                    })}>
                   ${renderArea(a, areaColor(a, a.entity ? this.hass?.states[a.entity]?.state : undefined))}
-                </g>`
-            )}
+                </g>`;
+            })}
             <!-- Dead spaces (issue #88): the regions the walls seal off that no
                  door or window reaches, hatched. Above the room fills, so a
                  region someone has also drawn an area over still reads as

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -4660,19 +4660,41 @@ describe("a lock drives a door (issue #176)", () => {
     }
     // `locking` is on its way to shut, so it draws shut.
     expect(resolveOpeningOpen(door(), "locking")).toBe(false);
-    expect(resolveOpeningOpen(door(), "jammed")).toBe(false);
   });
 
-  it("fails closed on an outage, before invert can flip it", () => {
-    for (const state of ["unavailable", "unknown"]) {
-      expect(resolveOpeningOpen(door(), state)).toBe(false);
-      expect(resolveOpeningOpen(door({ invert: true }), state)).toBe(false);
+  it("fails closed on no reliable reading, before invert can flip it", () => {
+    // `jammed` belongs here rather than with the ordinary readings: the lock
+    // tried to move and could not, so the bolt is neither thrown nor
+    // withdrawn. Inverting it would draw a jammed front door wide open, which
+    // is the one picture a jam must not paint.
+    for (const state of ["unavailable", "unknown", "jammed"]) {
+      expect({ state, open: resolveOpeningOpen(door(), state) }).toEqual({ state, open: false });
+      expect({ state, inverted: resolveOpeningOpen(door({ invert: true }), state) }).toEqual({
+        state,
+        inverted: false,
+      });
     }
+  });
+
+  it("only a lock's jam fails closed — no other domain reports one", () => {
+    // A `sensor.jammed` reading the literal word keeps meaning whatever its
+    // own domain says, and there `jammed` is simply not an open state, so
+    // invert may flip it like any other.
+    const contact = (extra = {}) =>
+      ({ ...door({ ...extra }), entity: "binary_sensor.d" }) as Opening;
+    expect(resolveOpeningOpen(contact(), "jammed")).toBe(false);
+    expect(resolveOpeningOpen(contact({ invert: true }), "jammed")).toBe(true);
   });
 
   it("inverts for a lock wired the other way round", () => {
     expect(resolveOpeningOpen(door({ invert: true }), "locked")).toBe(true);
     expect(resolveOpeningOpen(door({ invert: true }), "unlocked")).toBe(false);
+  });
+
+  it("a jam is never active, and lets no light through", () => {
+    expect(openingIsActive(door(), { state: "jammed" })).toBe(false);
+    expect(openingIsActive(door({ invert: true }), { state: "jammed" })).toBe(false);
+    expect(resolveOpeningAmount(door({ invert: true }), { state: "jammed" })).toBe(0);
   });
 
   it("drives the amount, the accent and the light like any other opening", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -78,6 +78,8 @@ import {
   trackerSensorReading,
   openingInMotion,
   openingIsActive,
+  areaActionForGesture,
+  areaHasActions,
   entityStateText,
   itemStateText,
   itemBadgeLabel,
@@ -4637,5 +4639,119 @@ describe("itemHiddenWhenInactive (issue #55)", () => {
     expect(itemHiddenWhenInactive({ entity: "light.a", hideWhenInactive: true }, undefined))
       .toBe(true);
     expect(itemHiddenWhenInactive({ hideWhenInactive: true }, "on")).toBe(true);
+  });
+});
+
+describe("a lock drives a door (issue #176)", () => {
+  const door = (extra: Partial<Opening> = {}) =>
+    ({ id: "d", type: "door", x: 0, y: 0, length: 90, angle: 0, entity: "lock.front", ...extra }) as Opening;
+
+  it("reads unlocked as open and locked as closed", () => {
+    expect(resolveOpeningOpen(door(), "unlocked")).toBe(true);
+    expect(resolveOpeningOpen(door(), "locked")).toBe(false);
+  });
+
+  it("takes the transient and latch states from the domain's own table", () => {
+    // Exactly entityIsActive's lock set, so a door and a badge bound to the
+    // same lock can never disagree about it.
+    for (const state of ["unlocked", "unlocking", "open", "opening"]) {
+      expect({ state, open: resolveOpeningOpen(door(), state) }).toEqual({ state, open: true });
+      expect({ state, active: entityIsActive("lock.front", state) }).toEqual({ state, active: true });
+    }
+    // `locking` is on its way to shut, so it draws shut.
+    expect(resolveOpeningOpen(door(), "locking")).toBe(false);
+    expect(resolveOpeningOpen(door(), "jammed")).toBe(false);
+  });
+
+  it("fails closed on an outage, before invert can flip it", () => {
+    for (const state of ["unavailable", "unknown"]) {
+      expect(resolveOpeningOpen(door(), state)).toBe(false);
+      expect(resolveOpeningOpen(door({ invert: true }), state)).toBe(false);
+    }
+  });
+
+  it("inverts for a lock wired the other way round", () => {
+    expect(resolveOpeningOpen(door({ invert: true }), "locked")).toBe(true);
+    expect(resolveOpeningOpen(door({ invert: true }), "unlocked")).toBe(false);
+  });
+
+  it("drives the amount, the accent and the light like any other opening", () => {
+    expect(resolveOpeningAmount(door(), { state: "unlocked" })).toBe(1);
+    expect(resolveOpeningAmount(door(), { state: "locked" })).toBe(0);
+    expect(openingIsActive(door(), { state: "unlocked" })).toBe(true);
+    expect(openingIsActive(door(), { state: "locked" })).toBe(false);
+    // A lock has no position to publish, so it stays binary.
+    expect(
+      resolveOpeningAmount(door(), { state: "unlocked", attributes: { current_position: 40 } }),
+    ).toBeCloseTo(0.4);
+  });
+
+  it("leaves every other domain reading exactly as it did", () => {
+    const contact = (state: string) =>
+      resolveOpeningOpen({ ...door(), entity: "binary_sensor.d" } as Opening, state);
+    expect(contact("on")).toBe(true);
+    expect(contact("off")).toBe(false);
+    // A contact that somehow reads "unlocked" is not a lock, and does not
+    // silently become one.
+    expect(contact("unlocked")).toBe(false);
+    const cover = (state: string) =>
+      resolveOpeningOpen({ ...door(), entity: "cover.d" } as Opening, state);
+    for (const state of ["open", "opening", "closing"]) expect(cover(state)).toBe(true);
+    expect(cover("closed")).toBe(false);
+  });
+
+  it("never toggles a lock on a tap — it opens its dialog", () => {
+    // The accidental-hardware rule the shutter defaults already follow, and
+    // unlocking a front door by brushing the plan is the worst version of it.
+    expect(openingClickAction("lock.front", 0)).toBe("more-info");
+    expect(openingClickAction("lock.front", 255)).toBe("more-info");
+    expect(
+      openingActionForGesture({ entity: "lock.front" }, "tap", () => 255)?.config.action,
+    ).toBe("more-info");
+  });
+});
+
+describe("actions on rooms (issue #181)", () => {
+  const area = (extra: Partial<Area> = {}) =>
+    ({ id: "a", points: [{ x: 0, y: 0 }], ...extra }) as Area;
+
+  it("resolves only what is configured — tap is left to the zoom otherwise", () => {
+    expect(areaActionForGesture(area(), "tap")).toBeUndefined();
+    expect(areaActionForGesture(area(), "hold")).toBeUndefined();
+    expect(areaActionForGesture(area(), "double_tap")).toBeUndefined();
+  });
+
+  it("takes the action's own entity, else the room's", () => {
+    const a = area({ entity: "light.kitchen", tap_action: { action: "toggle" } });
+    expect(areaActionForGesture(a, "tap")).toEqual({
+      entity: "light.kitchen",
+      config: { action: "toggle" },
+    });
+    // An action naming its own entity wins over the room's.
+    const b = area({
+      entity: "light.kitchen",
+      hold_action: { action: "more-info", entity: "sensor.temp" },
+    });
+    expect(areaActionForGesture(b, "hold")?.entity).toBe("sensor.temp");
+    // …and with no entity anywhere, only actions that need none do anything.
+    expect(areaActionForGesture(area({ tap_action: { action: "navigate" } }), "tap")).toEqual({
+      entity: undefined,
+      config: { action: "navigate" },
+    });
+  });
+
+  it("a room can zoom and act — the two live on different gestures", () => {
+    const a = area({ entity: "light.k", hold_action: { action: "toggle" } });
+    // Tap unset, so the card falls back to the zoom.
+    expect(areaActionForGesture(a, "tap")).toBeUndefined();
+    expect(areaActionForGesture(a, "hold")?.config).toEqual({ action: "toggle" });
+  });
+
+  it("knows whether a room does anything a plain zoom would not", () => {
+    expect(areaHasActions(area())).toBe(false);
+    // "none" is a real choice — it turns the zoom off — but it is not an action.
+    expect(areaHasActions(area({ tap_action: { action: "none" } }))).toBe(false);
+    expect(areaHasActions(area({ tap_action: { action: "toggle" } }))).toBe(true);
+    expect(areaHasActions(area({ double_tap_action: { action: "more-info" } }))).toBe(true);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -2031,6 +2031,46 @@ export function openingActionForGesture(
 }
 
 /**
+ * What a gesture on a room resolves to (issue #181), or `undefined` for
+ * "nothing configured".
+ *
+ * Tap is the one with a prior claim: an area has zoomed to itself on tap since
+ * zooming existed, and plans rely on it. So this answers only for *configured*
+ * actions, and the card falls back to the zoom when tap resolves to nothing —
+ * which keeps every existing plan behaving exactly as it did, and leaves hold
+ * and double-tap free for a room that wants both.
+ *
+ * The action's own `entity` wins, else the area's. A room bound to a presence
+ * sensor can therefore say `tap_action: { action: toggle }` and mean it,
+ * without naming the entity twice.
+ */
+export function areaActionForGesture(
+  a: Pick<Area, "entity" | "tap_action" | "hold_action" | "double_tap_action">,
+  gesture: "tap" | "hold" | "double_tap",
+): { entity?: string; config: ActionConfig } | undefined {
+  const configured =
+    gesture === "tap" ? a.tap_action : gesture === "hold" ? a.hold_action : a.double_tap_action;
+  if (!configured) return undefined;
+  return { entity: configured.entity ?? a.entity, config: configured };
+}
+
+/**
+ * Whether a room does anything a plain zoom would not — i.e. whether any of
+ * its three gestures is configured.
+ *
+ * The card uses it for the `button` role and the tab stop. Not for the *hit
+ * target*: every area is already tappable because every area zooms, so unlike
+ * an opening there is no affordance here that has to be earned.
+ */
+export function areaHasActions(
+  a: Pick<Area, "tap_action" | "hold_action" | "double_tap_action">,
+): boolean {
+  return (["tap", "hold", "double_tap"] as const).some((g) =>
+    hasAction(areaActionForGesture(a, g)?.config),
+  );
+}
+
+/**
  * Whether pressing an opening does anything at all — the mirror of
  * {@link itemIsInteractive}, and used for the same things: the hit target, the
  * `button` role and the tab stop. An opening with nothing bound draws no
@@ -2068,11 +2108,28 @@ export function resolveOpeningOpen(o: Opening, state: string | undefined): boole
   // Fail closed on an outage before applying invert — a stale "open" during a
   // sensor dropout is worse than showing closed.
   if (isSensorOutage(state)) return false;
-  // `opening`/`closing` are transient cover states: the cover is in motion and
-  // not fully closed, so draw it open. Anything else (closed/off/…) reads closed.
-  const open =
-    state === "on" || state === "open" || state === "opening" || state === "closing";
+  const open = openingEntityReadsOpen(o.entity, state);
   return o.invert ? !open : open;
+}
+
+/**
+ * Whether a bound entity's raw state means "open", by the rules of its domain.
+ *
+ * A **lock** says it the domain's own way (issue #176): `locked` is a shut
+ * door and `unlocked` an open one, and neither word is `on` or `open`, so the
+ * generic test called every lock closed forever. The states that count come
+ * from {@link entityIsActive} rather than a second list here — that table
+ * already answers "is this lock doing its active thing" for devices, and two
+ * copies of it would be two chances for a door and its badge to disagree about
+ * the same entity.
+ *
+ * Everything else keeps the generic reading: `on`/`open` are open, and
+ * `opening`/`closing` are transient cover states — the cover is in motion and
+ * not fully closed, so it draws open.
+ */
+function openingEntityReadsOpen(entityId: string, state: string): boolean {
+  if (entityId.split(".")[0] === "lock") return entityIsActive(entityId, state);
+  return state === "on" || state === "open" || state === "opening" || state === "closing";
 }
 
 /** A `cover` in transit. Its `current_position` may not have caught up yet. */

--- a/src/render.ts
+++ b/src/render.ts
@@ -2105,11 +2105,31 @@ function isSensorOutage(state: string | undefined): boolean {
  */
 export function resolveOpeningOpen(o: Opening, state: string | undefined): boolean {
   if (!o.entity || state === undefined) return openingDefaultOpen(o);
-  // Fail closed on an outage before applying invert — a stale "open" during a
-  // sensor dropout is worse than showing closed.
-  if (isSensorOutage(state)) return false;
+  // Fail closed before applying invert — a stale "open" while we have no
+  // reliable reading is worse than showing closed.
+  if (openingReadingFailsClosed(o.entity, state)) return false;
   const open = openingEntityReadsOpen(o.entity, state);
   return o.invert ? !open : open;
+}
+
+/**
+ * States that mean "no reliable reading", so the opening draws shut and
+ * `invert` does not get to flip that into a door standing open.
+ *
+ * The outages every entity can report, plus one the lock domain adds:
+ * **`jammed`**, which is a lock that tried to move and could not. The bolt is
+ * neither thrown nor withdrawn — or is, and the lock does not know — so it is
+ * the same "we do not know" the dropouts are, not a third open/closed reading.
+ * Treating it as merely "not unlocked" would leave `invert: true` drawing a
+ * jammed front door wide open, which is the one picture a jam must not paint.
+ *
+ * Lock-domain only: no other domain reports `jammed`, and a hypothetical
+ * `sensor.jammed` reading the literal word should keep meaning whatever its
+ * own domain says.
+ */
+function openingReadingFailsClosed(entityId: string, state: string): boolean {
+  if (isSensorOutage(state)) return true;
+  return entityId.split(".")[0] === "lock" && state === "jammed";
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -808,6 +808,28 @@ export interface Area {
    * everything inside it — which reads better on a busy plan.
    */
   highlight?: "fill" | "border" | "both";
+  /**
+   * Lovelace actions for the room itself (issue #181) — tapping the floor of a
+   * room to run a scene, toggle its lights, or open a dashboard for it.
+   *
+   * Same shape as {@link FloorItem.tap_action}, with one difference that comes
+   * from a room already doing something when you tap it: **tap defaults to
+   * zoom-to-room**, which is what an area has done since zooming existed.
+   * Setting `tap_action` replaces that zoom; leaving it unset keeps it. Hold
+   * and double-tap have no default and are free.
+   *
+   * So a room can zoom *and* act: put the action on hold or double-tap. A room
+   * that should act on tap and never zoom sets `tap_action`; a room that should
+   * do neither sets `tap_action: { action: "none" }`.
+   *
+   * An action's `entity` falls back to the area's own {@link entity}, so a room
+   * already bound to a presence sensor needs no second mention of it. With no
+   * entity anywhere, only actions that need none (navigate, url, call-service)
+   * do anything. See `areaActionForGesture`.
+   */
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
 }
 
 /**


### PR DESCRIPTION
Two small, unrelated features. Branched off `main`, independent of #186.

## A lock can drive a door — closes #176

```yaml
openings:
  - { id: front, type: door, x: 300, y: 100, length: 90, angle: 0, entity: lock.front_door }
```

`unlocked` draws the door open, `locked` draws it shut. A door with a smart lock and no contact sensor already knows whether it is shut — and neither of those words is `on` or `open`, so the generic test called every lock closed forever.

The in-between states come from **`entityIsActive`'s domain table** rather than a second list beside it. That table already answers "is this lock doing its active thing" for device badges, and two copies would be two chances for a door and a badge bound to the same lock to disagree about it. So:

| state | drawn |
| --- | --- |
| `unlocked`, `unlocking`, `open`, `opening` | open |
| `locked`, `locking` | shut |
| `jammed`, `unavailable`, `unknown` | shut — fails closed, before `invert` |

A lock publishes no position, so the door is open or shut and never partway. `invert` flips it for a lock wired the other way round.

**A tap opens the lock's dialog; it never turns the lock.** That's the rule the shutter defaults already follow, and unlocking a front door by brushing the plan is the worst version of the accidental-hardware-move it was written for. `tap_action: { action: toggle }` opts in, explicitly.

Per @nicosandller's note on the issue, the entity picker's helper now names locks — nothing else in the UI would suggest one belongs there.

## Rooms answer gestures — closes #181

```yaml
areas:
  - id: kitchen
    points: [ … ]
    entity: light.kitchen_lights
    hold_action: { action: toggle }
```

Tap has a prior claim here: an area has zoomed to itself on tap since zooming existed, and plans rely on it. So `tap_action` **replaces** the zoom rather than joining it, and an unset one keeps it — every plan drawn before this behaves identically.

| You want | Set |
| --- | --- |
| Zoom, and an action | the action on `hold_action` / `double_tap_action` |
| An action instead of the zoom | `tap_action` |
| Neither | `tap_action: { action: none }` |

An action's own `entity` wins, else the area's — so the example toggles `light.kitchen_lights` without naming it twice.

The **hit target stays unconditional**, since every room zooms and there is no affordance to earn (unlike an opening, which earns one by being bound). But the `button` role and the tab stop are still earned by having an action, so a screen reader is not told that an ordinary room is a button.

## Verification

`npm test` (1091, 15 new), `npm run typecheck`, `npm run build` clean.

Checked in a browser against the built bundle:

- five doors bound to locks in each state render open / shut exactly as the table above says;
- a room with no `tap_action` zooms in on tap and back out on a second tap (`scale(1)` → `scale(2.03)` → `scale(1)`);
- the same room's `hold_action` fires `homeassistant.toggle` on the **area's** entity and leaves the zoom untouched;
- a room with `tap_action` acts and does **not** zoom;
- role and tabindex appear only on the room that has an action.

One thing worth recording, since it looked like a bug: a room taller than the canvas once padded reports no zoom at all. That is `areaZoomTransform` behaving as documented — it never zooms *out* — not a regression from this change.

## Note on overlap

#186 restructures the editor panels into groups, including the area's. These new action fields are added to `areaForm` in the flat layout `main` has today, so whichever merges second will need them slotted into the area's **Behavior** group. Small and mechanical, but worth knowing about.