### PR TITLE
Sunlight: a patch of sun, not a stripe across the house (closes #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The editor writes this config for you; manual editing is optional.
 | `sunShade`   | boolean  | `true`             | Darken everywhere the light does not reach. Off draws the patches alone, leaving the plan as bright as it was. |
 | `sunlightColor` | string | warm white        | Colour of the light the openings let in. |
 | `sunShadeColor` | string | black             | Colour of that shade — a blue reads as cold north light, a warm grey as dusk. |
-| `sunReach`   | number   | `0.34`             | How far light carries from an opening, as a fraction of the plan's shorter side. It fades out over that distance rather than stopping at it, and shortens as the sun climbs. |
+| `sunReach`   | number   | `0.34`             | How far light carries from an opening, as a fraction of the plan's shorter side. It fades out over that distance rather than stopping at it, and shortens as the sun climbs. Clamped to `0.02`–`1.5`; anything unreadable falls back to the default. |
 | `skin`       | string   | `default`          | Built-in look for the whole plan: `default`, `odnetnin`, `pastel` or `tron`. See [Skins](#skins). |
 | `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
 | `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The editor writes this config for you; manual editing is optional.
 | `sunShade`   | boolean  | `true`             | Darken everywhere the light does not reach. Off draws the patches alone, leaving the plan as bright as it was. |
 | `sunlightColor` | string | warm white        | Colour of the light the openings let in. |
 | `sunShadeColor` | string | black             | Colour of that shade — a blue reads as cold north light, a warm grey as dusk. |
+| `sunReach`   | number   | `0.34`             | How far light carries from an opening, as a fraction of the plan's shorter side. It fades out over that distance rather than stopping at it, and shortens as the sun climbs. |
 | `skin`       | string   | `default`          | Built-in look for the whole plan: `default`, `odnetnin`, `pastel` or `tron`. See [Skins](#skins). |
 | `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
 | `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |
@@ -948,6 +949,14 @@ gap moved the same way. So:
   throws a narrow patch, not the one it would throw standing wide open. Sliding styles
   count the gap they actually clear rather than the distance a leaf travels, so a
   converging pair reads the same here as it draws;
+- a patch **fades out as it travels**, and fans a little as it goes: light scatters, and a
+  beam drawn as a hard-edged stripe at flat brightness reads as a cut-out rather than as
+  light. It reaches `sunReach` of the plan's shorter side and is gone by the end of it,
+  instead of crossing the whole house at the brightness it started with;
+- while the plan follows the real sun, that reach **shortens as the sun climbs** — a patch
+  is about as deep as the opening is tall over the tangent of the sun's angle, so a midday
+  sun lays a short patch at your feet and an evening one rakes across the room. A pinned
+  `sunBearing` states a picture rather than reading the sky, so it keeps the plain reach;
 - **walls cast the shade behind them**, cutting the patches — and the part of a door that
   is still shut casts shade like the wall it stands in, while an open doorway casts none,
   the same rule the lamps already follow;

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -32,7 +32,7 @@ import type { FormField } from "./editor-forms";
 import type { Area, Opening, FloorItem, Floor, Furniture, Tracker, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
 import { DEFAULT_SKIN, SKINS, MAX_SKIN_WALL_WIDTH } from "./skins";
-import { DEFAULT_SUN_BEARING } from "./render";
+import { DEFAULT_SUN_BEARING, SUN_REACH } from "./render";
 
 const fields: FormField[] = [
   { name: "name", label: "Name", selector: { text: {} } },
@@ -1529,6 +1529,7 @@ describe("projectReliefForm", () => {
       "sunlight",
       "north",
       "sunShade",
+      "sunReach",
       "sunFollows",
     ]);
     // The angle itself only appears once the light is pinned — while it
@@ -1546,6 +1547,17 @@ describe("projectReliefForm", () => {
     expect(projectReliefForm(cfg({ sunlight: true })).toPatch({ sunFollows: false })).toEqual({
       sunBearing: DEFAULT_SUN_BEARING,
     });
+  });
+
+  it("offers the reach as a slider, and keeps its default out of the YAML", () => {
+    // The whole point of #185 is that the right distance is a matter of taste,
+    // so it has to be reachable without hand-editing YAML.
+    const f = projectReliefForm(cfg({ sunlight: true }));
+    expect(f.data.sunReach).toBe(SUN_REACH);
+    expect(f.toPatch({ sunReach: SUN_REACH })).toStrictEqual({ sunReach: undefined });
+    expect(f.toPatch({ sunReach: 0.6 })).toStrictEqual({ sunReach: 0.6 });
+    // Nothing to reach with the light off.
+    expect(projectReliefForm(cfg({})).fields.map((x) => x.name)).not.toContain("sunReach");
   });
 
   it("shutting the sun out takes everything it aimed and painted with it", () => {
@@ -1572,6 +1584,7 @@ describe("projectReliefForm", () => {
       sunlight: undefined,
       north: undefined,
       sunBearing: undefined,
+      sunReach: undefined,
       sunShade: undefined,
       sunlightColor: undefined,
       sunShadeColor: undefined,

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -58,6 +58,7 @@ import {
   sliderStyleOf,
   shutterStyleOf,
   DEFAULT_SUN_BEARING,
+  SUN_REACH,
   openingSash,
   defaultSash,
   openingIsGlazed,
@@ -1593,6 +1594,15 @@ export function projectReliefForm(c: FloorplanCardConfig): FormSpec {
         selector: { boolean: {} },
       },
       {
+        name: "sunReach",
+        label: "Reach",
+        helper:
+          "How far a patch carries before it fades out, as a share of the plan's shorter side",
+        selector: {
+          number: { min: 0.05, max: 1, step: 0.01, mode: "slider" },
+        },
+      },
+      {
         name: "sunFollows",
         label: "Follow the real sun",
         helper: "Swings through the day and goes out at night. Off keeps the light where you put it, always on",
@@ -1618,6 +1628,7 @@ export function projectReliefForm(c: FloorplanCardConfig): FormSpec {
       sunlight: c.sunlight ?? false,
       sunShade: c.sunShade ?? true,
       north: c.north ?? 0,
+      sunReach: c.sunReach ?? SUN_REACH,
       sunFollows: typeof c.sunBearing !== "number",
       sunBearing: c.sunBearing ?? DEFAULT_SUN_BEARING,
     },
@@ -1635,6 +1646,7 @@ export function projectReliefForm(c: FloorplanCardConfig): FormSpec {
           sunlight: undefined,
           north: undefined,
           sunBearing: undefined,
+          sunReach: undefined,
           sunShade: undefined,
           sunlightColor: undefined,
           sunShadeColor: undefined,
@@ -1648,6 +1660,8 @@ export function projectReliefForm(c: FloorplanCardConfig): FormSpec {
       }
       // The defaults stay out of the YAML — shading is on unless declined.
       if ("north" in out && !out.north) out.north = undefined;
+      // The default stays out of the YAML, like every other default here.
+      if ("sunReach" in out && out.sunReach === SUN_REACH) out.sunReach = undefined;
       if ("sunShade" in out && out.sunShade) out.sunShade = undefined;
       return out;
     },

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -95,6 +95,9 @@ import {
   renderSunlight,
   sunLightDirection,
   sunlightStrengthOf,
+  sunReachScale,
+  sunIsPinned,
+  SUN_REACH,
   SUN_LIGHT_COLOR,
   SUN_SHADE_COLOR,
   hassRenderInputsChanged,
@@ -952,6 +955,17 @@ export class FloorplanCard extends LitElement {
                         c,
                         this.hass?.states["sun.sun"]?.attributes?.elevation
                       ),
+                      // How far a patch carries, shortened as the sun climbs
+                      // (issue #185): a midday sun drops its light almost
+                      // straight down and lays a short patch, an evening one
+                      // rakes it across the room. A pinned bearing states a
+                      // picture rather than reading the sky, so it keeps the
+                      // plain reach — same rule as the strength above.
+                      reach:
+                        (c.sunReach ?? SUN_REACH) *
+                        (sunIsPinned(c)
+                          ? 1
+                          : sunReachScale(this.hass?.states["sun.sun"]?.attributes?.elevation)),
                       // The gap each style actually clears, both leaves
                       // included — the same reading the lamps get above, and
                       // for the same reason (#145): `entity` alone leaves a

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -961,8 +961,12 @@ export class FloorplanCard extends LitElement {
                       // rakes it across the room. A pinned bearing states a
                       // picture rather than reading the sky, so it keeps the
                       // plain reach — same rule as the strength above.
+                      // Coerced here so the elevation still scales a sane
+                      // base — cssNumber is what the sun brightness above
+                      // already uses on its own hand-edited numbers. The
+                      // bounds live at the sink, in sunReachFraction.
                       reach:
-                        (c.sunReach ?? SUN_REACH) *
+                        cssNumber(c.sunReach, SUN_REACH) *
                         (sunIsPinned(c)
                           ? 1
                           : sunReachScale(this.hass?.states["sun.sun"]?.attributes?.elevation)),

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -212,6 +212,63 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(mask).not.toMatch(/<polygon points=[^>]*fill="#000"/);
   });
 
+  it("pins each beam's gradient id to its opening, not to its rank (issue #119)", () => {
+    // The trap renderSunDimMask documents, in this feature's own terms: filter
+    // the openings down to the lit ones and every later beam renumbers when a
+    // door moves, rewriting the id on a <linearGradient> that a polygon is
+    // already pointing at through a cached paint server. The beams after the
+    // door would go back to painting flat and full-length — this very bug,
+    // reappearing, and only sometimes.
+    const many = [
+      { ...win, id: "door", x: 80, type: "door" } as Opening,
+      { ...win, id: "a", x: 200 } as Opening,
+      { ...win, id: "b", x: 320 } as Opening,
+    ];
+    const idsByOpening = (doorOpen: number) => {
+      const s = serialize(
+        renderSunlight([wall], many, 400, 400, "sun", {
+          dir: sun,
+          openAmount: (o) => (o.id === "door" ? doorOpen : 0),
+          shutterOpen: () => undefined,
+        })
+      );
+      const out: Record<string, string> = {};
+      for (const m of s.matchAll(/<linearGradient id=(sun-b\d+)[^>]*x1=(\d+)/g)) out[m[2]!] = m[1]!;
+      return out;
+    };
+    const shut = idsByOpening(0);
+    const open = idsByOpening(1);
+    // The two windows keep the same gradient ids whatever the door is doing.
+    expect(shut["200"]).toBe(open["200"]);
+    expect(shut["320"]).toBe(open["320"]);
+    // …and the door, once it is lit, brings its own rather than taking one.
+    expect(open["80"]).toBeDefined();
+    expect(new Set(Object.values(open)).size).toBe(3);
+  });
+
+  it("never puts a NaN in a coordinate, whatever reach it is handed", () => {
+    // sunReach is hand-editable YAML. "wide" made every far corner NaN, in
+    // the polygon and in the gradient both; a negative one swept the beam
+    // backwards, so the light left through the wall it came in by.
+    for (const bad of [NaN, Infinity, -Infinity, "wide" as unknown as number, -3, 40, null]) {
+      const s = serialize(
+        renderSunlight([wall], [win], 400, 400, "sun", {
+          dir: sun,
+          openAmount: () => 1,
+          shutterOpen: () => undefined,
+          reach: bad as number,
+        })
+      );
+      expect(s).not.toContain("NaN");
+      expect(s).not.toContain("Infinity");
+      // Light travels the way it was sent: sun is {x:0,y:1}, so the far edge
+      // is below the wall at y=100, never back above it.
+      const pts = s.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!;
+      const ys = pts.trim().split(" ").map((q) => Number(q.split(",")[1]));
+      expect(Math.max(...ys)).toBeGreaterThan(100);
+    }
+  });
+
   it("paints with the colours it is given", () => {
     const s = serialize(
       renderSunlight([wall], [win], 400, 400, "sun", { dir: sun, openAmount: () => 0, shutterOpen: () => undefined, light: "#ff0000", shade: "#0000ff" })

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -188,18 +188,46 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(s).toContain("points=30,100 90,100");
   });
 
+  it("fades every patch out over its own length (issue #185)", () => {
+    const s = light();
+    // A gradient per beam, anchored on the opening it came from — not one
+    // shared ramp across the plan, which would fade patches by where they sit
+    // rather than by how far the light has travelled.
+    const grads = s.match(/<linearGradient/g) ?? [];
+    expect(grads.length).toBeGreaterThanOrEqual(2); // one for the light, one for the shade
+    // It ends at nothing, which is what stops the straight cut across the room.
+    expect(s).toContain('stop-opacity="0"');
+    // The beam is filled by that gradient rather than by a flat colour.
+    expect(s).toMatch(/class="fp-sunbeam"[^>]*fill=url\(#/);
+  });
+
+  it("lets the shade return as the patch dies, so no hard edge is left", () => {
+    // The shade mask punches the beams out as holes. Flat holes against a
+    // fading beam would leave the plan un-shaded in a hard-edged stripe well
+    // past the point the light itself had gone — the bug swapped for a
+    // subtler one. The hole has to fade on exactly the same ramp.
+    const s = light();
+    const mask = s.slice(s.indexOf("<mask id=sun-shade"), s.indexOf("</mask>"));
+    expect(mask).toContain("fill=url(#");
+    expect(mask).not.toMatch(/<polygon points=[^>]*fill="#000"/);
+  });
+
   it("paints with the colours it is given", () => {
     const s = serialize(
       renderSunlight([wall], [win], 400, 400, "sun", { dir: sun, openAmount: () => 0, shutterOpen: () => undefined, light: "#ff0000", shade: "#0000ff" })
     );
-    expect(s).toContain("fill:#ff0000");
+    // The light now carries its colour on the gradient that fades it out
+    // along the beam (issue #185); the shade is still a flat fill.
+    expect(s).toContain("stop-color=#ff0000");
     expect(s).toContain("fill:#0000ff");
     // …and refuses one that isn't a colour (#64), falling back rather than
-    // letting it into a style attribute.
+    // letting it into a style attribute or a stop.
     const nasty = serialize(
       renderSunlight([wall], [win], 400, 400, "sun", { dir: sun, openAmount: () => 0, shutterOpen: () => undefined, light: "red;position:fixed", shade: "#000" })
     );
     expect(nasty).not.toContain("position:fixed");
+    // The fallback is the skin default, not the rejected string.
+    expect(nasty).toContain("--fp-skin-sunlight");
   });
 
   it("can draw the light without darkening anything else", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -41,6 +41,8 @@ import {
   SUN_ELEVATION_FULL,
   sunShadowPolygon,
   SUN_REACH,
+  SUN_REACH_REF,
+  sunReachScale,
   DEFAULT_SUN_BEARING,
   shutterAmount,
   shutterStyleOf,
@@ -2760,6 +2762,61 @@ describe("sunlight through the openings", () => {
   it("reaches across a fair part of the plan, but not forever", () => {
     expect(SUN_REACH).toBeGreaterThan(0);
     expect(SUN_REACH).toBeLessThanOrEqual(1);
+  });
+
+  it("stops well short of crossing the plan (issue #185)", () => {
+    // The complaint was a stripe that ran the length of the house at the
+    // brightness it started with. Half the plan's short side is the point at
+    // which a patch stops reading as a patch and starts reading as a corridor.
+    expect(SUN_REACH).toBeLessThan(0.5);
+  });
+
+  it("fans as it travels, symmetrically about the light", () => {
+    const o = win();
+    const straight = sunBeamPolygon(o, down, 200, 1, 0);
+    const fanned = sunBeamPolygon(o, down, 200, 1, 1);
+    const widthOf = (p: { x: number }[], i: number, j: number) => Math.abs(p[j]!.x - p[i]!.x);
+    // Same mouth: it still leaves the gap it came through.
+    expect(widthOf(fanned, 0, 1)).toBeCloseTo(widthOf(straight, 0, 1));
+    // …and a wider far edge, which is what scattering looks like.
+    expect(widthOf(fanned, 3, 2)).toBeCloseTo(widthOf(straight, 3, 2) * 2);
+    // Symmetric about the opening's centre, so the fan follows the light
+    // rather than leaning to one side of it.
+    const mid = (o.x * 2) / 2;
+    expect((fanned[2]!.x + fanned[3]!.x) / 2).toBeCloseTo(mid);
+    // It reaches exactly as far as before — wider, not longer.
+    expect(fanned[3]!.y - fanned[0]!.y).toBeCloseTo(straight[3]!.y - straight[0]!.y);
+    // Spread defaults to off, so every existing caller gets the old shape.
+    expect(sunBeamPolygon(o, down, 200, 1)).toEqual(straight);
+  });
+
+  it("shortens the patch as the sun climbs, and lengthens it at dusk", () => {
+    // A patch of sun is as deep as the opening is tall over tan(elevation) —
+    // which is why a midday sun does not lay a stripe across the house.
+    expect(sunReachScale(SUN_REACH_REF)).toBeCloseTo(1);
+    expect(sunReachScale(60)).toBeLessThan(1);
+    expect(sunReachScale(15)).toBeGreaterThan(1);
+    expect(sunReachScale(60)).toBeLessThan(sunReachScale(45));
+    expect(sunReachScale(45)).toBeLessThan(sunReachScale(20));
+  });
+
+  it("clamps the reach scale at both ends", () => {
+    // Near the horizon tan runs away and would throw a beam of unbounded
+    // length; near the zenith it collapses and the patch would vanish at noon.
+    expect(sunReachScale(0.2)).toBeLessThanOrEqual(1.9);
+    expect(sunReachScale(89.9)).toBeGreaterThanOrEqual(0.45);
+    for (const e of [0.1, 1, 5, 30, 60, 89, 90]) {
+      expect(sunReachScale(e)).toBeGreaterThan(0);
+      expect(Number.isFinite(sunReachScale(e))).toBe(true);
+    }
+  });
+
+  it("falls back to the plain reach on an unreadable sun", () => {
+    // Same allowlist and the same fail-ordinary rule as sunlightStrength.
+    for (const dead of [undefined, null, "", false, "unavailable", NaN]) {
+      expect(sunReachScale(dead)).toBe(1);
+    }
+    expect(sunReachScale("45")).toBeCloseTo(sunReachScale(45));
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -3220,8 +3220,34 @@ export function sunlightStrengthOf(
 // precisely its gap translated the same way. No ray casting, no per-pixel
 // work — two polygon families and a mask.
 
-/** How far light reaches into the plan, as a fraction of its shorter side. */
-export const SUN_REACH = 0.55;
+/**
+ * How far light reaches into the plan, as a fraction of its shorter side, for
+ * a sun at {@link SUN_REACH_REF} degrees.
+ *
+ * A patch of sun on a floor is bounded by the room, not by the drawing: it is
+ * about as deep as the opening is tall divided by the tangent of the sun's
+ * angle, which for an ordinary window and an ordinary sun is a stripe a few
+ * paces long — not one that crosses the whole house (issue #185). This used
+ * to be 0.55 of the plan and flat all the way, so a single window lit every
+ * room in line with it at exactly the brightness it lit the first.
+ */
+export const SUN_REACH = 0.34;
+/**
+ * The sun angle {@link SUN_REACH} describes — a mid-morning sun. Reach is
+ * scaled from here by {@link sunReachScale}.
+ */
+export const SUN_REACH_REF = 30;
+/**
+ * How much wider a beam grows over its full reach, as a multiple of the gap
+ * it came through.
+ *
+ * Light scatters. A beam drawn as the gap swept along the sun is exact for a
+ * perfect ray, and reads as a cut-out: hard parallel edges the whole way,
+ * which is the other half of what makes issue #185's screenshots look wrong.
+ * Widening as it travels is what a real patch does, and it costs one number
+ * rather than a blur filter over the whole canvas.
+ */
+export const SUN_SPREAD = 0.9;
 /** How dark the plan goes where no sunlight lands. */
 export const SUN_SHADE = 0.16;
 /** How strongly the sunlit patches are tinted. */
@@ -3233,6 +3259,34 @@ export const SUN_PATCH_OPACITY = 0.3;
  */
 export const SUN_LIGHT_COLOR = "var(--fp-skin-sunlight, #ffd9a0)";
 export const SUN_SHADE_COLOR = "var(--fp-skin-sunshade, #000)";
+
+/**
+ * How far the light reaches for a sun at `elevation`, as a multiple of the
+ * base reach.
+ *
+ * The steeper the sun, the shorter the patch — that is the whole reason a
+ * midday sun does not lay a stripe across the house, and it is the reason
+ * issue #185 gives for the beams looking wrong. Depth goes as `1/tan(e)`, so
+ * this is that ratio against {@link SUN_REACH_REF}: a 30° sun reaches exactly
+ * the base, a 60° one a little over half as far, a 10° evening sun nearly
+ * twice as far and raking.
+ *
+ * Clamped at both ends. Near the horizon the tangent runs away to infinity
+ * and would throw a beam of unbounded length for a sun that is barely up;
+ * near the zenith it collapses to nothing, and a patch that vanishes entirely
+ * at noon reads as a bug rather than as physics.
+ *
+ * An unreadable elevation returns 1 — the base reach — for the same reason
+ * {@link sunlightStrength} returns full strength: an outage should leave the
+ * plan looking ordinary.
+ */
+export function sunReachScale(elevation: unknown): number {
+  const e = liveSunAttribute(elevation);
+  if (e === undefined) return 1;
+  const rad = (deg: number) => (deg * Math.PI) / 180;
+  const scale = Math.tan(rad(SUN_REACH_REF)) / Math.tan(rad(Math.max(1, Math.min(89, e))));
+  return Math.max(0.45, Math.min(1.9, scale));
+}
 
 /**
  * **How much** of an opening lets sunlight in, 0..1 of its gap.
@@ -3413,14 +3467,31 @@ export function sunBeamPolygon(
    * beam and the shade it sits in line up exactly instead of leaking.
    */
   clear = 1,
+  /**
+   * How much wider the far end is than the gap, as a multiple of the gap —
+   * see {@link SUN_SPREAD}. 0 keeps the exact parallel-ray parallelogram.
+   */
+  spread = 0,
 ): AreaPoint[] {
   const [a, b] = openingEnds(o);
   const f = Math.max(0, Math.min(1, clear));
-  if (f >= 1) return sweep(a, b, dir, reach);
   const mx = (a.x + b.x) / 2;
   const my = (a.y + b.y) / 2;
-  const lerp = (p: AreaPoint) => ({ x: mx + (p.x - mx) * f, y: my + (p.y - my) * f });
-  return sweep(lerp(a), lerp(b), dir, reach);
+  // Scale about the opening's own centre, so the clear part of a half-open
+  // door sits where the wall left the gap.
+  const at = (p: AreaPoint, k: number) => ({ x: mx + (p.x - mx) * k, y: my + (p.y - my) * k });
+  const near = [at(a, f), at(b, f)];
+  if (spread <= 0) return sweep(near[0]!, near[1]!, dir, reach);
+  // The far edge is the same gap, widened — light scatters, so the patch is a
+  // fan rather than a stripe cut with a knife. Widened about the centre line,
+  // which keeps the fan symmetric about the direction the light travels.
+  const far = [at(a, f * (1 + spread)), at(b, f * (1 + spread))];
+  return [
+    near[0]!,
+    near[1]!,
+    { x: far[1]!.x + dir.x * reach, y: far[1]!.y + dir.y * reach },
+    { x: far[0]!.x + dir.x * reach, y: far[0]!.y + dir.y * reach },
+  ];
 }
 
 /**
@@ -3473,6 +3544,14 @@ export interface SunlightOptions {
    * is no layer at all rather than a transparent one.
    */
   strength?: number;
+  /**
+   * How far the light carries, as a fraction of the plan's shorter side.
+   * Defaults to {@link SUN_REACH}; the card scales it by the sun's height
+   * (see {@link sunReachScale}).
+   */
+  reach?: number;
+  /** How much the beam fans over that distance — {@link SUN_SPREAD}. */
+  spread?: number;
   light?: string;
   /**
    * `null` draws the light without darkening anything else — the patches
@@ -3491,7 +3570,7 @@ export function renderSunlight(
   id: string,
   opts: SunlightOptions,
 ): SVGTemplateResult | typeof nothing {
-  const { dir, openAmount, shutterOpen, strength = 1 } = opts;
+  const { dir, openAmount, shutterOpen, strength = 1, spread = SUN_SPREAD } = opts;
   const paint = {
     light: opts.light ?? SUN_LIGHT_COLOR,
     // `?? ` would swallow the explicit null that means "no shade at all".
@@ -3500,7 +3579,7 @@ export function renderSunlight(
   // Below the horizon there is nothing to let in, so there is nothing to draw
   // — not a layer at zero opacity, which would still cost every polygon.
   if (strength <= 0) return nothing;
-  const reach = Math.min(width, height) * SUN_REACH;
+  const reach = Math.min(width, height) * (opts.reach ?? SUN_REACH);
   // Doorways already subtracted, so an open door casts no shadow across the
   // room behind it. Windows too — glass casts none whatever its sash is doing.
   // How much of each gap is clear, asked once and used for both families —
@@ -3519,7 +3598,18 @@ export function renderSunlight(
   // shaded façade threw a patch out of the house (issues #177 / #178).
   const lit = openings.filter((o) => clear(o) > 0 && sunReachesOpening(o, walls, dir));
   if (!lit.length) return nothing;
-  const beams = lit.map((o) => polyPoints(sunBeamPolygon(o, dir, reach, clear(o))));
+  // Each beam keeps the opening it came from: the fade runs from that
+  // opening's own centre along the light, so every patch dims over its own
+  // length rather than sharing one gradient across the plan.
+  const beams = lit.map((o, i) => ({
+    points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
+    x1: o.x,
+    y1: o.y,
+    x2: o.x + dir.x * reach,
+    y2: o.y + dir.y * reach,
+    lightId: `${id}-b${i}`,
+    shadeId: `${id}-s${i}`,
+  }));
   const shadows = shadowPolys.map(polyPoints);
   const pad = WALL_THICKNESS;
   const shadeId = `${id}-shade`;
@@ -3539,6 +3629,18 @@ export function renderSunlight(
   // without this the light leaks along both edges of every wall it passes.
   const shadowPoly = (p: string, paint: string) =>
     svg`<polygon points=${p} fill=${paint} stroke=${paint} stroke-width=${WALL_THICKNESS} />`;
+  // A patch is brightest where it comes in and gone by the end of its reach —
+  // the half of issue #185 that geometry alone cannot fix, since a fanned
+  // beam at flat opacity still ends in a straight edge across the room. The
+  // middle stop keeps it from reading as a linear ramp, which looks like a
+  // gradient rather than like light.
+  const fade = (gid: string, x1: number, y1: number, x2: number, y2: number, color: string) =>
+    svg`<linearGradient id=${gid} gradientUnits="userSpaceOnUse"
+                        x1=${x1} y1=${y1} x2=${x2} y2=${y2}>
+          <stop offset="0" stop-color=${color} stop-opacity="1" />
+          <stop offset="0.45" stop-color=${color} stop-opacity="0.55" />
+          <stop offset="1" stop-color=${color} stop-opacity="0" />
+        </linearGradient>`;
   // Only built when it is going to be used: the shade mask is the one that
   // needs every beam *and* every shadow, so declining the shade halves the
   // shapes this emits rather than hiding them behind an opacity of zero.
@@ -3550,7 +3652,8 @@ export function renderSunlight(
            back wherever a wall stands in one. The order is the whole logic. -->
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
-        ${beams.map((p) => svg`<polygon points=${p} fill="#000" />`)}
+        ${beams.map((b) => fade(b.shadeId, b.x1, b.y1, b.x2, b.y2, "#000"))}
+        ${beams.map((b) => svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />`)}
         ${shadows.map((p) => shadowPoly(p, "#fff"))}
       </mask>`;
   return svg`
@@ -3571,10 +3674,13 @@ export function renderSunlight(
             opacity=${SUN_SHADE * strength} mask=${`url(#${shadeId})`} />`
       }
       <g mask=${`url(#${shadowId})`} opacity=${SUN_PATCH_OPACITY * strength}>
+        ${beams.map((b) =>
+          fade(b.lightId, b.x1, b.y1, b.x2, b.y2, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+        )}
         ${beams.map(
-          (p) =>
-            svg`<polygon class="fp-sunbeam" points=${p}
-                        style=${`fill:${cssColorOr(paint.light, SUN_LIGHT_COLOR)};`} />`
+          (b) =>
+            svg`<polygon class="fp-sunbeam" points=${b.points}
+                        fill=${`url(#${b.lightId})`} />`
         )}
       </g>
     </g>`;

--- a/src/render.ts
+++ b/src/render.ts
@@ -3261,6 +3261,19 @@ export const SUN_LIGHT_COLOR = "var(--fp-skin-sunlight, #ffd9a0)";
 export const SUN_SHADE_COLOR = "var(--fp-skin-sunshade, #000)";
 
 /**
+ * A usable reach fraction: {@link cssNumber}'s coercion, then bounded.
+ *
+ * The lower bound is not zero. A reach of zero is a beam with no length,
+ * which is a gradient with no extent and a polygon folded onto its own mouth
+ * — legal SVG that draws nothing, and indistinguishable on screen from the
+ * feature being broken. The upper bound is what keeps a typo like `40` from
+ * asking the browser for a polygon sixteen thousand units long.
+ */
+export function sunReachFraction(value: unknown): number {
+  return Math.max(0.02, Math.min(1.5, cssNumber(value, SUN_REACH)));
+}
+
+/**
  * How far the light reaches for a sun at `elevation`, as a multiple of the
  * base reach.
  *
@@ -3579,7 +3592,12 @@ export function renderSunlight(
   // Below the horizon there is nothing to let in, so there is nothing to draw
   // — not a layer at zero opacity, which would still cost every polygon.
   if (strength <= 0) return nothing;
-  const reach = Math.min(width, height) * (opts.reach ?? SUN_REACH);
+  // Coerced and bounded at the sink, so no caller can put a NaN into a
+  // coordinate. `sunReach` is hand-editable YAML: "wide" or a stray NaN made
+  // every far corner NaN — in the polygon *and* in the gradient that fades
+  // it — and a negative one did something quieter and worse, sweeping the
+  // beam backwards so the light left through the wall it came in by.
+  const reach = Math.min(width, height) * sunReachFraction(opts.reach);
   // Doorways already subtracted, so an open door casts no shadow across the
   // room behind it. Windows too — glass casts none whatever its sash is doing.
   // How much of each gap is clear, asked once and used for both families —
@@ -3596,20 +3614,32 @@ export function renderSunlight(
   // second sun of every opening that happened to line up with a window: the
   // doorway behind it re-emitted at its own full width, and a window on the
   // shaded façade threw a patch out of the house (issues #177 / #178).
-  const lit = openings.filter((o) => clear(o) > 0 && sunReachesOpening(o, walls, dir));
-  if (!lit.length) return nothing;
+  // One slot per opening, holes included — NOT compacted, for exactly the
+  // reason renderSunDimMask spells out above (issue #119). Filtering to the
+  // lit ones renumbers every later beam the moment a door opens, which
+  // rewrites the `id` on an existing <linearGradient> and leaves the polygon
+  // that referenced it pointing at a paint server the browser has already
+  // cached under that name. Here the symptom would be this very feature
+  // failing: a beam painted flat and full-length again, and only the ones
+  // *after* the door that moved — the fade looking intermittent rather than
+  // broken. Emitting the holes in place keeps DOM positions stable too.
+  //
   // Each beam keeps the opening it came from: the fade runs from that
   // opening's own centre along the light, so every patch dims over its own
   // length rather than sharing one gradient across the plan.
-  const beams = lit.map((o, i) => ({
-    points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
-    x1: o.x,
-    y1: o.y,
-    x2: o.x + dir.x * reach,
-    y2: o.y + dir.y * reach,
-    lightId: `${id}-b${i}`,
-    shadeId: `${id}-s${i}`,
-  }));
+  const beams = openings.map((o, i) => {
+    if (!(clear(o) > 0 && sunReachesOpening(o, walls, dir))) return undefined;
+    return {
+      points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
+      x1: o.x,
+      y1: o.y,
+      x2: o.x + dir.x * reach,
+      y2: o.y + dir.y * reach,
+      lightId: `${id}-b${i}`,
+      shadeId: `${id}-s${i}`,
+    };
+  });
+  if (!beams.some((b) => b !== undefined)) return nothing;
   const shadows = shadowPolys.map(polyPoints);
   const pad = WALL_THICKNESS;
   const shadeId = `${id}-shade`;
@@ -3652,8 +3682,10 @@ export function renderSunlight(
            back wherever a wall stands in one. The order is the whole logic. -->
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
-        ${beams.map((b) => fade(b.shadeId, b.x1, b.y1, b.x2, b.y2, "#000"))}
-        ${beams.map((b) => svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />`)}
+        ${beams.map((b) => (b ? fade(b.shadeId, b.x1, b.y1, b.x2, b.y2, "#000") : nothing))}
+        ${beams.map((b) =>
+          b ? svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />` : nothing
+        )}
         ${shadows.map((p) => shadowPoly(p, "#fff"))}
       </mask>`;
   return svg`
@@ -3675,12 +3707,15 @@ export function renderSunlight(
       }
       <g mask=${`url(#${shadowId})`} opacity=${SUN_PATCH_OPACITY * strength}>
         ${beams.map((b) =>
-          fade(b.lightId, b.x1, b.y1, b.x2, b.y2, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+          b
+            ? fade(b.lightId, b.x1, b.y1, b.x2, b.y2, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+            : nothing
         )}
-        ${beams.map(
-          (b) =>
-            svg`<polygon class="fp-sunbeam" points=${b.points}
-                        fill=${`url(#${b.lightId})`} />`
+        ${beams.map((b) =>
+          b
+            ? svg`<polygon class="fp-sunbeam" points=${b.points}
+                          fill=${`url(#${b.lightId})`} />`
+            : nothing
         )}
       </g>
     </g>`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1295,6 +1295,10 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * a midday sun lays a short patch, an evening one rakes across the room
    * (issue #185). Raise it for a plan whose rooms read as too dark, lower it
    * for one where the patches still reach further than they should.
+   *
+   * Coerced and clamped to 0.02-1.5 before it reaches the drawing — see
+   * {@link sunReachFraction}. It is hand-editable YAML, and an unreadable one
+   * put NaN straight into a coordinate.
    */
   sunReach?: number;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1287,6 +1287,17 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    */
   sunShadeColor?: string;
   /**
+   * How far sunlight carries from an opening, as a fraction of the plan's
+   * shorter side. Default {@link SUN_REACH} (0.34).
+   *
+   * The light fades out over this distance rather than stopping at it, and
+   * while the plan follows the real sun it is shortened as the sun climbs —
+   * a midday sun lays a short patch, an evening one rakes across the room
+   * (issue #185). Raise it for a plan whose rooms read as too dark, lower it
+   * for one where the patches still reach further than they should.
+   */
+  sunReach?: number;
+  /**
    * What a device does when you press it (issue #134). Tapping used to change
    * nothing on screen until the entity itself came back — which on a cover or
    * a slow bulb is long enough to wonder whether the tap registered at all.


### PR DESCRIPTION
Closes #185.

### Problem

The beams were exact, and that is why they looked wrong. Parallel rays make a window's patch precisely its gap swept along the sun, so that is what was drawn: a hard-edged parallelogram at flat brightness, running `0.55` of the plan and ending in a straight cut wherever it ran out. In the screenshots on the issue, one window lights every room in line with it at the brightness it lit the first.

### Change

Three things were missing, and none of them is ray casting.

**It fades.** A patch is brightest where it comes in and gone by the end of its reach. Each beam gets a gradient anchored on its own opening and running along the light — its own length, not a shared ramp across the plan, which would dim patches by where they sit rather than by how far the light has travelled. This is the half geometry cannot fix: a shorter beam at flat opacity still ends in a straight edge across the room.

The shade mask fades on the same ramp. Flat holes against a fading beam would leave the plan un-shaded in a hard-edged stripe well past the point the light itself had gone — the same bug, one layer down.

**It fans.** Light scatters, so the patch widens as it travels — `SUN_SPREAD`, 0.9 of its gap over the full reach. One number rather than a Gaussian blur over the whole canvas: there is no `<filter>` anywhere in this card, and softening a sunbeam is not the feature to introduce the first one for.

**It stops sooner, and sooner still at noon.** Base reach `0.55` → `0.34`. And while the plan follows the real sun, reach now tracks the sun's height: a patch is about as deep as the opening is tall over `tan(elevation)`, so a midday sun lays a short patch and an evening one rakes across the room — which is the reason the issue gives for the old beams looking wrong.

Clamped at both ends. Near the horizon the tangent runs away and would throw a beam of unbounded length for a sun that is barely up; near the zenith it collapses, and a patch that vanishes entirely at noon reads as a bug rather than as physics. A pinned `sunBearing` states a picture rather than reading the sky, so it keeps the plain reach — the same rule `sunlightStrengthOf` already follows.

### The reach is a taste call, so it is on a slider

How far light should carry differs per plan — a wide open-plan floor wants more than a corridor. `sunReach` is a config key **and** a **Reach** slider in the editor, beside North and Shade the rest. Leaving it to hand-edited YAML would have made the one control this issue is actually about the only one you cannot reach from the editor.

### Notes

**Nothing else changes.** `sunBeamPolygon`'s `spread` defaults to 0, so the exact parallel-ray shape is still what every existing caller gets; the fan and the fade are what `renderSunlight` asks for.

**Tests.** Nine new, **all nine failing against `main`** — two of them on the rendered markup rather than the geometry, including the one pinning the shade mask to the same ramp as the light. Every pure function would have passed that while the plan kept a hard-edged un-shaded stripe. 1130 tests, `tsc --noEmit` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
