### PR TITLE
Overlay scale: a new default belongs in new configs, not in old ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The editor writes this config for you; manual editing is optional.
 | `pressEffect`| string   | `scale`            | Feedback when a device is pressed: `scale`, `ripple`, `flash` or `none`. Only devices that actually do something respond. See [Press feedback](#press-feedback). |
 | `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |
 | `compactHeader`| boolean | `false`           | Draw the title inside the plan and the floor buttons in a row, instead of spending a card header row on them. See [Compact header](#compact-header). |
-| `overlayScale`| string  | `plan`             | How badges, labels, room names and text are sized: `plan` = canvas units so they scale with the drawing, `fixed` = screen pixels. See [Overlay scale](#overlay-scale). |
+| `overlayScale`| string  | `fixed`; `plan` in new plans | How badges, labels, room names and text are sized: `plan` = canvas units so they scale with the drawing, `fixed` = screen pixels. A card added from the picker is created with `plan`; a config that doesn't say renders `fixed`, which is what every plan drawn before the option existed was laid out in. See [Overlay scale](#overlay-scale). |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
@@ -1011,9 +1011,9 @@ the canvas to whatever width the card gets — draw at any size, they always fit
 labels, room names and text are HTML on top of that, so they stay upright under `rotation`
 and can take clicks.
 
-**By default the overlay is sized in canvas units too** (`overlayScale: plan`), so both
-layers shrink together and the card looks the same at every size — a scale drawing rather
-than a drawing with fixed-size furniture on it. Every measure follows: `size` and
+**A new plan is created with the overlay in canvas units too** (`overlayScale: plan`), so
+both layers shrink together and the card looks the same at every size — a scale drawing
+rather than a drawing with fixed-size furniture on it. Every measure follows: `size` and
 `labelSize` on a device, the reading drawn inside a badge, `size` on text, an area's
 `labelSize`, and `rippleSize`. Hairlines deliberately don't — a badge border and a label's
 drop shadow are about a pixel either way, and scaling them down is how you lose them.
@@ -1022,7 +1022,13 @@ Sizes then mean the same thing as everything else in the config: `labelSize: 14`
 units on a `980`-unit-wide canvas, about 1.4 % of the card's width whatever that turns out
 to be.
 
-### `fixed`, and why it isn't the default
+**The editor previews whichever mode the plan uses.** The canvas sizes its badges and
+labels the same way the card will, so the number you type is the number that renders — and
+zooming the canvas previews the card at other widths. (Before this it always drew screen
+pixels, so a plan in canvas units looked right in the editor and small on the dashboard,
+which is what made 1.5's change so hard to place.)
+
+### `fixed`, and when to reach for it
 
 `overlayScale: fixed` pins the overlay to **screen pixels** instead:
 
@@ -1033,8 +1039,9 @@ height: 700
 overlayScale: fixed
 ```
 
-That was the original behaviour, and the original default. It agrees with the drawing only
-while the card renders at roughly its canvas size — which is not something a plan gets to
+That is the original behaviour, and what a config that doesn't mention `overlayScale`
+still renders as. It agrees with the drawing only while the card renders at roughly its
+canvas size — which is not something a plan gets to
 decide, because the dashboard hands it whatever width it has. Below that the two come
 apart: a `980`-wide plan shown `500` wide draws every wall at half size while a 14px room
 name stays 14px, so names spill past their rooms and collide with the badges under them.
@@ -1053,10 +1060,18 @@ there is no relative position left to preserve.)
 Reach for `fixed` when the card renders **larger** than its canvas, or on a wall tablet
 where a px floor under the text is what keeps it readable from across the room.
 
-> **Upgrading?** The default changed, so a plan that never set `overlayScale` now scales
-> its overlay with the drawing. If your card renders at about its canvas width you will
-> barely see it; if it renders much smaller, labels get smaller (which is the point) and if
-> much larger, bigger. Setting `overlayScale: fixed` restores the old behaviour exactly.
+> **Upgrading from 1.5.x?** 1.5.0 changed what a *missing* `overlayScale` meant, which
+> resized the overlay of every plan that had never set one — including plans whose author
+> had deliberately chosen the pixels, since that was the default at the time and the editor
+> wrote nothing down for it. On a card narrower than its canvas the badges came out a
+> fraction of their size (issue #192). That is undone: **a config with no `overlayScale`
+> renders in pixels, as it always did.** Canvas units are what a plan wants, so a card
+> added from the picker is created with `overlayScale: plan` written into it — a new
+> default belongs in new configs, not in a changed reading of old ones.
+>
+> If you liked what 1.5 did, add `overlayScale: plan` and keep it. Opening **Display** in
+> the editor also pins whichever mode your plan is already using, so a later default can
+> never move it again.
 
 ### Where it helps, and where it costs
 

--- a/README.md
+++ b/README.md
@@ -640,11 +640,12 @@ animated inside a rectangular tracked area:
 - `points` — `{ x, y }` vertices in drawing order, implicitly closed last-to-first.
 - `name` / `showName` — label centered on the polygon (`showName` defaults `true`).
   Mirrors the linked HA area's name when `haArea` is set.
-- `labelSize` — that label's size, `8`–`40`, default `14`. Canvas units under the default
-  `overlayScale: plan`, px under `fixed`,
-  canvas units under `plan`. Small rooms want a smaller number than the big ones beside them.
-  Left unset on a `fixed` card the size stays in the stylesheet, so a card-mod rule on
-  `.area-label` still wins; set it, or switch to `plan`, and it moves inline and takes over.
+- `labelSize` — that label's size, `8`–`40`, default `14`. Px under `overlayScale: fixed`,
+  which is what a plan renders as unless it says otherwise; canvas units under `plan`,
+  which is what a new plan is created with. Small rooms want a smaller number than the big
+  ones beside them. Left unset on a `fixed` card the size stays in the stylesheet, so a
+  card-mod rule on `.area-label` still wins; set it, or switch to `plan`, and it moves
+  inline and takes over.
 - `color` / `opacity` — the room's fill; theme primary and `0.25` by default.
 - `haArea` — id of a linked Home Assistant area, set by the editor when `name` matches one.
 - `filterEntities` — with `haArea` set, scopes the entity picker for devices inside this
@@ -1069,9 +1070,10 @@ where a px floor under the text is what keeps it readable from across the room.
 > added from the picker is created with `overlayScale: plan` written into it — a new
 > default belongs in new configs, not in a changed reading of old ones.
 >
-> If you liked what 1.5 did, add `overlayScale: plan` and keep it. Opening **Display** in
-> the editor also pins whichever mode your plan is already using, so a later default can
-> never move it again.
+> If you liked what 1.5 did, add `overlayScale: plan` and keep it — or pick **Canvas
+> units** under **Display** in the editor, which now writes your choice down instead of
+> omitting it for being the default. Merely opening that panel changes nothing: a plan's
+> YAML gains the key when you choose a mode, not because you looked at the setting.
 
 ### Where it helps, and where it costs
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1105,6 +1105,27 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(opts).toEqual(["plan", "fixed"]);
   });
 
+  it("does not invent an overlayScale for a plan that never set one", () => {
+    // The whole editing lifecycle, because the claim "opening Display pins the
+    // mode" turned out to be wrong and worth pinning down as a test rather than
+    // as prose (review of #193). ha-form re-emits its whole data object; the
+    // editor diffs that against `data` and patches only what changed. `data`
+    // already carries the *normalized* mode, so an untouched dropdown never
+    // differs from itself and nothing about the overlay reaches the config.
+    const legacy = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    const form = projectDisplayForm(legacy);
+    const emitted = { ...form.data, rotation: "90" };
+    const diff = diffFormValue(form.data, emitted, form.fields);
+    expect(diff).toEqual({ rotation: "90" });
+    expect(form.toPatch(diff)).toEqual({ rotation: 90 });
+    // Opening and closing it, changing nothing, is a no-op all the way down.
+    expect(diffFormValue(form.data, { ...form.data }, form.fields)).toEqual({});
+    // Which is the behaviour to want: a plan's YAML gains a key when someone
+    // chooses one, not because they looked at the panel. Choosing is what
+    // records it — including choosing the mode the plan is already in.
+    expect(form.toPatch({ overlayScale: "fixed" })).toEqual({ overlayScale: "fixed" });
+  });
+
   it("image opacity appears only when an image is set", () => {
     expect(floorImageForm({ image: "x.png" } as Floor).fields.map((x) => x.name)).toContain(
       "imageOpacity"

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1078,12 +1078,14 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(form.fields[0].helper).toBe(tron.description);
   });
 
-  it("overlay scale shares that form, defaults to plan, and stays out of the YAML when default", () => {
+  it("overlay scale shares that form, and records whichever value is chosen", () => {
     const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
-    expect(form.data.overlayScale).toBe("plan");
-    // Canvas units are the default, so they are what stays unwritten; "fixed"
-    // is the choice that has to be recorded.
-    expect(form.toPatch({ overlayScale: "plan" })).toEqual({ overlayScale: undefined });
+    // A config with no key is an older plan, and shows the pixels it is drawn in.
+    expect(form.data.overlayScale).toBe("fixed");
+    // Neither value is omitted as "the default" — that habit is what let a
+    // changed default restyle every plan in the field (issue #192). A plan says
+    // how it renders, so opening this panel pins whatever it is already doing.
+    expect(form.toPatch({ overlayScale: "plan" })).toEqual({ overlayScale: "plan" });
     expect(form.toPatch({ overlayScale: "fixed" })).toEqual({ overlayScale: "fixed" });
     // Patching one field must not invent a value for the other.
     expect(form.toPatch({ rotation: "90" })).toEqual({ rotation: 90 });
@@ -1091,10 +1093,11 @@ describe("wallForm / projectForm / floorImageForm", () => {
       type: "t",
       width: 1000,
       height: 600,
-      overlayScale: "fixed",
+      overlayScale: "plan",
     } as FloorplanCardConfig);
-    expect(pinned.data.overlayScale).toBe("fixed");
-    // The default leads the dropdown, so the list opens on what a plan wants.
+    expect(pinned.data.overlayScale).toBe("plan");
+    // Canvas units still lead the dropdown: they are what a new plan is made
+    // with and what a plan generally wants.
     const field = form.fields.find((x) => x.name === "overlayScale")!;
     const opts = (field.selector as { select: { options: { value: string }[] } }).select.options.map(
       (o) => o.value

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1442,10 +1442,11 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       {
         name: "overlayScale",
         label: "Badge & label size",
-        // The default first, and the helper describes the *exception* now:
-        // canvas units are what a plan wants unless it is being shown bigger
-        // than it was drawn.
-        helper: `Canvas units scale badges and labels with the drawing. Fixed pixels suit a card rendered larger than its ${c.width}-wide canvas, or a wall tablet`,
+        // Canvas units lead because they are what a plan wants and what a new
+        // plan is created with; fixed pixels are what an older plan is still
+        // laid out in, and the right answer for a card shown bigger than its
+        // canvas or a wall tablet that wants a px floor under its text.
+        helper: `Canvas units scale badges and labels with the drawing. Fixed pixels keep their size whatever width the card gets — suits a card rendered larger than its ${c.width}-wide canvas, or a wall tablet`,
         selector: dropdown(opt("plan", "Canvas units"), opt("fixed", "Fixed pixels")),
       },
       {
@@ -1479,10 +1480,13 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       if ("rotation" in out)
         // Stored as a number; 0 means "not rotated", so keep it out of the YAML.
         out = { ...out, rotation: out.rotation === "0" ? undefined : Number(out.rotation) };
-      // Canvas units are the default now, so they are what stays out of the
-      // YAML — and "fixed" is what has to be written down.
-      if ("overlayScale" in out && out.overlayScale === "plan")
-        out = { ...out, overlayScale: undefined };
+      // Both values are written down, which is the one field here that breaks
+      // the "defaults stay out of the YAML" habit — deliberately. Omitting the
+      // default is what let 1.5.0 restyle every existing plan by changing its
+      // mind about what silence meant (issue #192): a plan that had *chosen*
+      // fixed pixels stored nothing, so it could not be told from one that had
+      // never been asked. Recording the answer makes a plan say how it renders,
+      // whatever any future default decides.
       // As are the ordinary header and the dimmed offline device — every
       // default here stays out of the YAML, so a config only ever records the
       // choices someone actually made.

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -20,6 +20,7 @@ import type {
   AreaPoint,
   HaAreaInfo,
   StateColorRule,
+  OverlayScale,
 } from "./types";
 import {
   normalizeSymbol,
@@ -84,6 +85,7 @@ import {
   hasOpeningMark,
   SHUTTER_MARK_PIXEL_OFFSET,
   SHUTTER_MARK_SIZE,
+  SHUTTER_MARK_ICON_SIZE,
   hasShutterMark,
   openingFromDeviceClass,
   renderRipple,
@@ -117,6 +119,8 @@ import {
   collectWatchedEntities,
   hassRenderInputsChanged,
   wallStrokeStyle,
+  normalizeOverlayScale,
+  overlayLength,
 } from "./render";
 import { deadSpacesCached } from "./dead-space";
 import { cssColor, cssColorOr, cssNumber, contrastText } from "./css-safe";
@@ -2723,6 +2727,11 @@ export class FloorplanCardEditor extends LitElement {
     const c = this._config;
     const floor = this._floor();
     const floors = c.floors ?? [];
+    // How the card will size this plan's badges and labels. The canvas honours
+    // it so the editor previews the drawing rather than a version of it with
+    // fixed-size furniture on top (issue #192): set a badge to 34 on a plan
+    // 1200 wide and the number you see here is the one the card renders.
+    const overlay = normalizeOverlayScale(c.overlayScale);
     // Which room, if any, is currently narrowing the selected element's
     // entity picker — animated on the canvas so the scoping is never a
     // mystery (see _scopingAreaId).
@@ -3017,8 +3026,15 @@ export class FloorplanCardEditor extends LitElement {
             : `aspect-ratio:${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(c.height, DEFAULT_HEIGHT)};`}
           @wheel=${this._onCanvasWheel}
         >
-          <div class="stage" style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
-            c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;${skinStyle(c.skin)}">
+          <!-- The stage doubles as the card's .plan box for overlay sizing: same
+               container query, same --fp-u, so a badge measured in canvas units
+               previews here at the size a card of this width would draw it
+               (issue #192). The editor never rotates the plan, so the canvas
+               width is what 100cqw measures against. -->
+          <div class="stage ${overlay === "plan" ? "scale-plan" : ""}"
+               style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
+            c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;
+                   --fp-plan-w: ${cssNumber(c.width, DEFAULT_WIDTH)};${skinStyle(c.skin)}">
             <!-- Keyed on the skin, for the repaint reason documented on the
                  card's SVG (issue #122): a var() inside a presentation
                  attribute does not repaint when the custom property changes,
@@ -3159,14 +3175,14 @@ export class FloorplanCardEditor extends LitElement {
             </svg>`
             )}
             <div class="items">
-              ${floor.texts.map((t) => this._renderTextOverlay(t, c))}
+              ${floor.texts.map((t) => this._renderTextOverlay(t, c, overlay))}
               ${floor.openings
                 .filter((o) => hasShutterMark(o))
-                .map((o) => this._renderShutterMarkOverlay(o, c))}
+                .map((o) => this._renderShutterMarkOverlay(o, c, overlay))}
               ${floor.openings
                 .filter((o) => hasOpeningMark(o))
-                .map((o) => this._renderOpeningMarkOverlay(o, c))}
-              ${floor.items.map((it) => this._renderItemOverlay(it, c))}
+                .map((o) => this._renderOpeningMarkOverlay(o, c, overlay))}
+              ${floor.items.map((it) => this._renderItemOverlay(it, c, overlay))}
             </div>
           </div>
         </div>
@@ -3842,7 +3858,11 @@ export class FloorplanCardEditor extends LitElement {
    * badge that swallowed those clicks would make the opening under it awkward
    * to grab. On the card it is a control; here it is a picture of one.
    */
-  private _renderShutterMarkOverlay(o: Opening, c: FloorplanCardConfig): TemplateResult {
+  private _renderShutterMarkOverlay(
+    o: Opening,
+    c: FloorplanCardConfig,
+    scale: OverlayScale
+  ): TemplateResult {
     const id = o.shutterEntity!;
     const st = this.hass?.states[id];
     const open = shutterAmount(st, o.shutterInvert) > 0;
@@ -3852,20 +3872,24 @@ export class FloorplanCardEditor extends LitElement {
     // Same two-part offset as the card (canvas units + screen pixels), so the
     // preview shows where the badge will actually sit. The editor never
     // rotates the plan, hence no rotation argument.
-    // Always the fixed-pixel form here: the editor canvas is zoomed by the
-    // user rather than sized by the card, so `overlayScale: plan` has no
-    // meaning on it — the badges it draws for devices are fixed too.
+    // In the plan's own units when that is how the card measures them, so the
+    // badge previews at the size it will actually be drawn (issue #192).
     const n = shutterMarkNormal(o);
+    const box = overlayLength(SHUTTER_MARK_SIZE, scale);
+    const step = overlayLength(SHUTTER_MARK_PIXEL_OFFSET, scale);
     return html`<div
       class="shutter-mark ${shutterActive(st, o.shutterInvert) ? "on" : "off"}"
       style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;
-             width:${SHUTTER_MARK_SIZE}px;height:${SHUTTER_MARK_SIZE}px;
-             transform:translate(-50%,-50%) translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
-               n.y * SHUTTER_MARK_PIXEL_OFFSET
-             }px);--fp-active:${accent};"
+             width:${box};height:${box};
+             transform:translate(-50%,-50%)
+                       translate(calc(${n.x} * ${step}), calc(${n.y} * ${step}));
+             --fp-active:${accent};"
       title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open the shutter`}
     >
-      <ha-icon icon=${icon}></ha-icon>
+      <ha-icon icon=${icon} style="--mdc-icon-size:${overlayLength(
+        SHUTTER_MARK_ICON_SIZE,
+        scale
+      )};"></ha-icon>
     </div>`;
   }
 
@@ -3874,7 +3898,11 @@ export class FloorplanCardEditor extends LitElement {
    * the shutter's preview above: turning **Show icon** on and finding out where
    * the badge lands is the whole point of having a canvas. Inert here too.
    */
-  private _renderOpeningMarkOverlay(o: Opening, c: FloorplanCardConfig): TemplateResult {
+  private _renderOpeningMarkOverlay(
+    o: Opening,
+    c: FloorplanCardConfig,
+    scale: OverlayScale
+  ): TemplateResult {
     const id = o.entity!;
     const st = this.hass?.states[id];
     const open = resolveOpeningAmount(o, st) > 0;
@@ -3882,20 +3910,29 @@ export class FloorplanCardEditor extends LitElement {
     const accent = cssColor(o.activeColor) ?? SKIN_ACCENT;
     const at = openingMarkPoint(o);
     const n = openingMarkNormal(o);
+    const box = overlayLength(SHUTTER_MARK_SIZE, scale);
+    const step = overlayLength(SHUTTER_MARK_PIXEL_OFFSET, scale);
     return html`<div
       class="shutter-mark ${openingIsActive(o, st) ? "on" : "off"}"
       style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;
-             width:${SHUTTER_MARK_SIZE}px;height:${SHUTTER_MARK_SIZE}px;
-             transform:translate(-50%,-50%) translate(${n.x * SHUTTER_MARK_PIXEL_OFFSET}px, ${
-               n.y * SHUTTER_MARK_PIXEL_OFFSET
-             }px);--fp-active:${accent};"
+             width:${box};height:${box};
+             transform:translate(-50%,-50%)
+                       translate(calc(${n.x} * ${step}), calc(${n.y} * ${step}));
+             --fp-active:${accent};"
       title=${`${(st?.attributes?.friendly_name as string | undefined) ?? id} — shown on the card, tap it there to open its dialog`}
     >
-      <ha-icon icon=${icon}></ha-icon>
+      <ha-icon icon=${icon} style="--mdc-icon-size:${overlayLength(
+        SHUTTER_MARK_ICON_SIZE,
+        scale
+      )};"></ha-icon>
     </div>`;
   }
 
-  private _renderItemOverlay(it: FloorItem, c: FloorplanCardConfig): TemplateResult {
+  private _renderItemOverlay(
+    it: FloorItem,
+    c: FloorplanCardConfig,
+    scale: OverlayScale
+  ): TemplateResult {
     const selected = this._isSel("item", it.id);
     const st = it.entity ? this.hass?.states[it.entity] : undefined;
     // Pass the registry icon here too, so the editor preview matches the card.
@@ -3929,36 +3966,42 @@ export class FloorplanCardEditor extends LitElement {
     // (entity currently active), so the "Badge shows" dropdown shows its
     // effect without leaving the editor.
     const anim = resolveIconAnimation(it, st?.state);
+    // Every measure the card expresses in canvas units, expressed the same way
+    // here (issue #192) — the badge box, the value inside it, the glyph, the
+    // ripple and the label below.
+    const box = overlayLength(size, scale);
     const badge = html`<div
       class="badge ${showIcon ? "" : "ghost"} ${stateColor
         ? "state-colored"
         : active
           ? "active-colored"
           : ""}"
-      style="width:${size}px;height:${size}px;transform:rotate(${cssNumber(it.angle, 0)}deg);${
+      style="width:${box};height:${box};transform:rotate(${cssNumber(it.angle, 0)}deg);${
         stateColor ? `--fp-state:${stateColor};` : ""
       }${activeColor ? `--fp-active:${activeColor};` : ""}${
         badgeInk ? `--fp-ink:${badgeInk};` : ""
       }"
     >
       ${value
-        ? html`<span class="badge-value" style="font-size:${badgeValueSize(size, value)}px;"
+        ? html`<span
+            class="badge-value"
+            style="font-size:${overlayLength(badgeValueSize(size, value), scale)};"
             >${value}</span
           >`
         : html`<ha-icon
             class=${anim ? `anim-${anim}` : ""}
             icon=${icon}
-            style="--mdc-icon-size:${itemIconSize(size)}px;"
+            style="--mdc-icon-size:${overlayLength(itemIconSize(size), scale)};"
           ></ha-icon>`}
     </div>`;
 
     // Editor always previews the ripple animated so its effect is visible.
     let visual: TemplateResult;
     if (display === "ripple") {
-      visual = renderRipple(true, rippleColor, rippleSize);
+      visual = renderRipple(true, rippleColor, rippleSize, 3, scale);
     } else if (display === "iconRipple") {
       visual = html`<div class="stack">
-        ${renderRipple(true, rippleColor, rippleSize)}
+        ${renderRipple(true, rippleColor, rippleSize, 3, scale)}
         <div class="stack-icon">${badge}</div>
       </div>`;
     } else {
@@ -3988,22 +4031,27 @@ export class FloorplanCardEditor extends LitElement {
           ? nothing
           : html`<span
               class="ilabel ${cardLabel ? "live" : ""} ilabel-${labelPositionOf(it)}"
-              style="font-size:${cardLabel || it.labelSize != null
-                ? itemLabelSize(it.labelSize)
-                : 11}px;${cardLabel && stateColor ? `color:${stateColor};` : ""}"
+              style="font-size:${overlayLength(
+                cardLabel || it.labelSize != null ? itemLabelSize(it.labelSize) : 11,
+                scale
+              )};${cardLabel && stateColor ? `color:${stateColor};` : ""}"
               >${label}</span
             >`}
       </div>
     `;
   }
 
-  private _renderTextOverlay(t: FloorText, c: FloorplanCardConfig): TemplateResult {
+  private _renderTextOverlay(
+    t: FloorText,
+    c: FloorplanCardConfig,
+    scale: OverlayScale
+  ): TemplateResult {
     const selected = this._isSel("text", t.id);
     return html`
       <div
         class="edit-text ${selected ? "selected" : ""}"
         style="left:${(t.x / c.width) * 100}%; top:${(t.y / c.height) * 100}%;
-               font-size:${cssNumber(t.size, DEFAULT_TEXT_SIZE)}px;
+               font-size:${overlayLength(cssNumber(t.size, DEFAULT_TEXT_SIZE), scale)};
                color:${cssColorOr(t.color, SKIN_TEXT)};
                transform:translate(-50%,-50%) rotate(${cssNumber(t.angle, 0)}deg);"
         @pointerdown=${(e: PointerEvent) => this._onOverlayDown(e, { kind: "text", id: t.id })}
@@ -5355,6 +5403,45 @@ export class FloorplanCardEditor extends LitElement {
       position: absolute;
       inset: 0;
       pointer-events: none;
+    }
+    /*
+     * overlayScale: plan, previewed (issue #192). The same two lines the card
+     * uses, on the box that plays the same part: the stage carries the canvas
+     * ratio, so 100cqw is the plan's own width on screen and --fp-u is one
+     * canvas unit. Declared on .items rather than .stage for the reason the
+     * card documents — an unregistered custom property substitutes as a token
+     * stream, so the cqw resolves where it is used, which stays correct if
+     * --fp-u is ever registered with @property.
+     *
+     * Zoom falls out of it rather than needing a term of its own: the stage's
+     * width is a percentage of the zoom, so zooming in widens the container and
+     * every canvas-unit measure grows with the drawing — which is the mode.
+     */
+    .stage.scale-plan {
+      container-type: inline-size;
+    }
+    .stage.scale-plan .items {
+      --fp-u: calc(100cqw / var(--fp-plan-w));
+    }
+    /* Label padding and offsets go to em so they track the text with the plan,
+       exactly as the card's own scale-plan rules do. Hairlines stay px on
+       purpose there and here: below a pixel they disappear on the small cards
+       this mode is for. */
+    .stage.scale-plan .ilabel {
+      padding: 0.08em 0.33em;
+      border-radius: 0.33em;
+      top: calc(100% + 0.17em);
+      max-width: none;
+    }
+    .stage.scale-plan .ilabel-left,
+    .stage.scale-plan .ilabel-right {
+      top: 50%;
+    }
+    .stage.scale-plan .ilabel-left {
+      right: calc(100% + 0.33em);
+    }
+    .stage.scale-plan .ilabel-right {
+      left: calc(100% + 0.33em);
     }
     /* Preview of the card's shutter badge. Inherits .items' pointer-events:
        none — the opening underneath stays clickable for selection and drag. */

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -27,6 +27,7 @@ import {
   PRESS_OUT_MS,
   getFloors,
   trackerPresenceDetected,
+  newPlanConfig,
 } from "./types";
 import {
   WALL_THICKNESS,
@@ -238,7 +239,12 @@ export class FloorplanCard extends LitElement {
   public static getStubConfig(): Partial<FloorplanCardConfig> {
     // Minimal on purpose: the editor migrates to the floors model on first
     // edit, and defaults (width/height/grid) backfill in setConfig.
-    return {};
+    //
+    // …except what a *new* plan is deliberately made with, which is
+    // {@link newPlanConfig}'s to state: written into the config rather than
+    // inferred from a missing key, so it reaches new plans and only new plans
+    // (issue #192).
+    return newPlanConfig();
   }
 
   /**

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1052,16 +1052,18 @@ describe("editorItemLabel (#135)", () => {
 });
 
 describe("overlay scaling", () => {
-  it("normalizes the mode, defaulting anything unrecognized to plan", () => {
-    // The default is canvas units: a plan is shown at whatever width the
-    // dashboard has, so pinning the overlay to px only agrees with the drawing
-    // by luck. `fixed` is now the value you have to ask for by name.
-    expect(normalizeOverlayScale("fixed")).toBe("fixed");
+  it("reads a missing mode as the pixels every older plan was laid out in", () => {
+    // Canvas units are the better answer and new plans are *created* with them
+    // (getStubConfig writes the key). Inferring them from silence is a
+    // different thing entirely: it restyles every plan already in the field on
+    // upgrade, which is what 1.5.0 did (issue #192). Silence means what it has
+    // always meant.
     expect(normalizeOverlayScale("plan")).toBe("plan");
-    expect(normalizeOverlayScale(undefined)).toBe("plan");
-    expect(normalizeOverlayScale("FIXED")).toBe("plan");
-    expect(normalizeOverlayScale(1)).toBe("plan");
-    expect(normalizeOverlayScale("")).toBe("plan");
+    expect(normalizeOverlayScale("fixed")).toBe("fixed");
+    expect(normalizeOverlayScale(undefined)).toBe("fixed");
+    expect(normalizeOverlayScale("PLAN")).toBe("fixed");
+    expect(normalizeOverlayScale(1)).toBe("fixed");
+    expect(normalizeOverlayScale("")).toBe("fixed");
   });
 
   it("emits screen pixels under fixed and canvas units under plan", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -1171,24 +1171,28 @@ export function wallStrokeStyle(thickness: unknown): string {
 // `calc(14 * var(--fp-u))` is 14 canvas units however large the card ends up.
 
 /**
- * Coerce a config `overlayScale`; anything unrecognised means the default,
- * which is `plan`.
+ * Coerce a config `overlayScale`. An **absent** value means `fixed`, which is
+ * how every plan drawn before the option existed was laid out.
  *
- * The default flipped here, and it is the one change in this file that every
- * existing plan sees. `fixed` was the historic behaviour and the wrong default:
- * it only agrees with the drawing when the card renders at roughly its canvas
- * size, and a plan is shown at whatever width the dashboard gives it. Sizing
- * the overlay in canvas units is what makes a plan a *drawing* — it looks the
- * same at every width, and a cluster of badges keeps the spacing it was given
- * (issue #179).
+ * Canvas units are the better default and new plans get them — but they get
+ * them *written down* ({@link FloorplanCard.getStubConfig}), not inferred from
+ * silence. 1.5.0 changed this function's answer for the missing key instead,
+ * and that is not a default for new plans: it is a restyle of every plan in
+ * the field, applied on upgrade with nothing on screen to say so. It landed
+ * hardest where nobody could have opted out — the editor wrote no key at all
+ * for `fixed`, being the default at the time, so *choosing* the old behaviour
+ * and never touching the setting left identical YAML, and both flipped
+ * together. Badges came out at a third of their size on a card narrower than
+ * its canvas, and the number in the editor no longer matched the drawing
+ * (issue #192).
  *
- * `fixed` remains a real choice, and the one to make for a card rendered much
- * *larger* than its canvas, or a wall tablet where a fixed px floor is what
- * keeps text readable from across the room. See the README's "Where it helps,
- * and where it costs".
+ * The rule that follows, and the reason {@link projectDisplayForm} now records
+ * whichever value is chosen rather than omitting the default: **a config says
+ * what it renders as.** A stored `overlayScale` is immune to whatever this
+ * function is ever made to answer for silence.
  */
 export function normalizeOverlayScale(v: unknown): OverlayScale {
-  return v === "fixed" ? "fixed" : "plan";
+  return v === "plan" ? "plan" : "fixed";
 }
 
 /**

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { normalizeOverlayScale } from "./render";
 import {
   emptyConfig,
+  newPlanConfig,
   makeFloor,
   getFloors,
   resolveSnap,
@@ -78,6 +80,31 @@ describe("emptyConfig", () => {
     expect(c.openings).toEqual([]);
     expect(c.items).toEqual([]);
     expect(c.trackers).toEqual([]);
+  });
+
+  it("backfills nothing about how the plan is laid out", () => {
+    // It runs over *every* config the editor is handed, existing plans
+    // included, so anything stated here is stated about all of them. The
+    // overlay mode in particular: put it here and every plan ever drawn
+    // acquires the new default the next time its author opened the editor,
+    // which is the shape of issue #192.
+    expect(emptyConfig("t").overlayScale).toBeUndefined();
+  });
+});
+
+describe("newPlanConfig (issue #192)", () => {
+  it("states the new default rather than leaving it to be inferred", () => {
+    // Canvas units are what a plan wants (#179), so a new plan is created with
+    // them — written down, so the choice belongs to that plan.
+    expect(newPlanConfig().overlayScale).toBe("plan");
+  });
+
+  it("reaches new plans and only new plans", () => {
+    // The pair that has to hold: a created plan renders in canvas units, and a
+    // config that predates the option renders in the pixels it was drawn in.
+    // 1.5.0 had one lever for both and moved everybody.
+    expect(normalizeOverlayScale(newPlanConfig().overlayScale)).toBe("plan");
+    expect(normalizeOverlayScale(emptyConfig("t").overlayScale)).toBe("fixed");
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1165,25 +1165,32 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /**
    * How the HTML overlay (badges, labels, room names, text) is sized.
    *
-   * - **`plan`** (default) — canvas units, so the overlay scales with the
-   *   drawing exactly as the SVG does.
-   * - **`fixed`** — screen pixels, whatever size the card renders at.
+   * - **`plan`** — canvas units, so the overlay scales with the drawing
+   *   exactly as the SVG does. What {@link newPlanConfig} creates a card with.
+   * - **`fixed`** — screen pixels, whatever size the card renders at. What an
+   *   **absent** key means, and so what every plan drawn before this option
+   *   existed keeps rendering as.
    *
-   * `fixed` was the historic behaviour and the historic default, and it is
-   * right only when the card renders at roughly its canvas size — which is not
-   * something a plan gets to decide, since the dashboard hands it whatever
-   * width it has. Below that it comes apart: a plan drawn at 980 wide and
-   * rendered 510 wide draws every wall at half size while a 14px room name
-   * stays 14px, so labels collide with the badges and each other, and a
-   * carefully spaced cluster of badges overlaps (issue #179).
+   * The split is deliberate and is the whole shape of issue #192. `plan` is
+   * the better way to lay a plan out: `fixed` agrees with the drawing only
+   * while the card renders at roughly its canvas size, which is not something
+   * a plan gets to decide, since the dashboard hands it whatever width it has.
+   * Below that the two layers come apart — a plan drawn 980 wide and rendered
+   * 510 wide draws every wall at half size while a 14px room name stays 14px,
+   * so labels collide with the badges and each other and a carefully spaced
+   * cluster of badges overlaps (issue #179).
    *
-   * `plan` makes the two layers shrink together, which is what makes the thing
-   * a drawing rather than a drawing with fixed-size furniture on it. It is now
-   * the default, and that **does** change how an existing card looks: an
-   * overlay that was pinned to px now tracks the plan. The trade runs the other
-   * way at the extremes — see the README's "Where it helps, and where it
-   * costs" — so `fixed` stays a real choice for a card rendered much larger
-   * than its canvas, or a wall tablet that wants a px floor under its text.
+   * None of which makes it safe to *infer*. 1.5.0 made `plan` the answer for a
+   * missing key and resized the overlay of every plan in the field, badges
+   * landing at a third of their size on a card narrower than its canvas — and
+   * nobody could have opted out, because the editor omitted `fixed` as the
+   * default of the day, so a plan that had chosen pixels stored exactly what a
+   * plan that had never been asked stored. A new default belongs in new
+   * configs: see {@link newPlanConfig} and {@link normalizeOverlayScale}.
+   *
+   * `fixed` is also a real choice on its own merits, for a card rendered much
+   * larger than its canvas or a wall tablet that wants a px floor under its
+   * text. See the README's "Where it helps, and where it costs".
    */
   overlayScale?: OverlayScale;
   /** Canvas background color (CSS / hex). Falls back to the skin's paper, then the card background. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1533,6 +1533,27 @@ export function emptyConfig(type: string): FloorplanCardConfig {
   };
 }
 
+/**
+ * What a **newly created** card starts as — the config HA's card picker gets
+ * back from `getStubConfig`.
+ *
+ * Deliberately not the same thing as {@link emptyConfig}, which backfills
+ * missing keys on *any* config the editor is handed, existing plans included.
+ * Anything stated here is stated about new plans only; putting it in
+ * `emptyConfig` would apply it to every plan ever drawn, the moment its author
+ * next opened the editor.
+ *
+ * That distinction is the whole point of this function. `overlayScale: plan`
+ * is the better way to lay a plan out (issue #179) and so it is what a new
+ * plan is made with — but it is written into the config rather than inferred
+ * from a missing key, because inference reaches backwards: 1.5.0 changed what
+ * an absent `overlayScale` meant and resized the overlay of every plan in the
+ * field (issue #192). A new default belongs in new configs.
+ */
+export function newPlanConfig(): Partial<FloorplanCardConfig> {
+  return { overlayScale: "plan" };
+}
+
 export function uid(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
 }


### PR DESCRIPTION
Closes #192.

## What happened

1.5.0 meant to give **new** plans canvas units. What it changed was the meaning of a **missing** `overlayScale`, and that reaches backwards — every plan already in the field was resized on upgrade.

Measured on a 1200-wide canvas in a 460px dashboard column, which is roughly the reporter's ratio:

| `size:` | 1.4 | 1.5 |
| --- | --- | --- |
| 34 | 37px | **16px** |
| 60 | 63px | **26px** |

It could not be opted out of, either. The editor omitted `fixed` from the YAML precisely *because* it was the default at the time — so a plan whose author had deliberately chosen pixels stored byte-identical config to one that had never been asked, and the flip took both.

## The fix

**A config with no `overlayScale` renders `fixed`**, as it always did. `getStubConfig` writes `plan` into cards created from the picker. That is the difference between a default for new plans and a restyle of old ones.

`newPlanConfig()` is deliberately its own function rather than a line in `emptyConfig()` — that one backfills *every* config the editor is handed, existing plans included, so stating the new default there would be the same mistake wearing a hat. There's a test for exactly that.

**The Display panel now records whichever mode is chosen** instead of omitting the default. Breaking the "defaults stay out of the YAML" habit is the point: a config that says how it renders cannot be moved by a later change of mind. It records on a choice, not on a look — opening the panel writes nothing, which a test now walks end to end.

## And the editor previews it

The second half of the report — "the configured icon size is no longer applied" rather than "everything got smaller" — is because the editor canvas always drew screen pixels regardless of `overlayScale`. Under the old default that matched the card, so it was an honest preview. After the flip the user typed 34, saw 34px in the editor, and got 13px on the dashboard.

The stage now doubles as the card's `.plan` box — same container query, same `--fp-u` — and every overlay measure goes through `overlayLength`: badge box, badge value, glyph, ripple, label, text, and the shutter/opening marks. Zoom falls out of it for free, so zooming the canvas previews the card at other widths.

Verified in a browser with the editor and the card side by side at the same width, which is how the issue was reported:

| | editor | card |
| --- | --- | --- |
| `overlayScale: plan` | 16 / 16 / 16 / 26px, text 8.6px | 16 / 16 / 16 / 26px, text 8.6px |
| absent (the upgrade path) | 37 / 37 / 37 / 63px, text 22px | 37 / 37 / 37 / 63px, text 22px |

Before this they disagreed by 2.3× in the first row. Zooming the editor to 200% doubles the stage and grows the badge with it, so the overlay tracks the drawing rather than floating over it.

## Verification

- 1135 unit tests pass, `tsc --noEmit` clean. New tests cover the missing-key reading, `newPlanConfig` reaching new plans and only new plans, `emptyConfig` staying silent about layout, and the Display panel recording both values.
- README: the config table, the section intro, and a rewritten upgrade note aimed at people coming from 1.5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
