### PR TITLE
fix(sunlight): the falloff was never being drawn — CSS was overriding the gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,10 +950,13 @@ gap moved the same way. So:
   throws a narrow patch, not the one it would throw standing wide open. Sliding styles
   count the gap they actually clear rather than the distance a leaf travels, so a
   converging pair reads the same here as it draws;
-- a patch **fades out radially from its opening**, the way a lamp's pool does, and its
-  edges soften with distance: sharp at the glass, feathered by the time it lands. It
-  reaches `sunReach` of the plan's shorter side and is gone by the end of it, instead of
-  crossing the whole house at the brightness it started with;
+- a patch **fades out radially from its opening**, the way a lamp's pool does, over the
+  distance the light actually travels before a wall stops it — so it is always faint by
+  the time it ends, whatever size the room is. `sunReach` is the ceiling on that
+  distance, not a fixed span;
+- its **long edges are feathered** rather than cut, so a patch reads as light rather than
+  as tape. The softness is drawn inside the beam, so no light falls outside the gap the
+  sun came through;
 - while the plan follows the real sun, that reach **shortens as the sun climbs** — a patch
   is about as deep as the opening is tall over the tangent of the sun's angle, so a midday
   sun lays a short patch at your feet and an evening one rakes across the room. A pinned

--- a/README.md
+++ b/README.md
@@ -950,10 +950,11 @@ gap moved the same way. So:
   throws a narrow patch, not the one it would throw standing wide open. Sliding styles
   count the gap they actually clear rather than the distance a leaf travels, so a
   converging pair reads the same here as it draws;
-- a patch **fades out radially from its opening**, the way a lamp's pool does, over the
-  distance the light actually travels before a wall stops it — so it is always faint by
-  the time it ends, whatever size the room is. `sunReach` is the ceiling on that
-  distance, not a fixed span;
+- a patch **fades out from its opening** over the distance the light actually travels
+  before a wall stops it, so it is always faint by the time it ends, whatever size the
+  room is. `sunReach` is the ceiling on that distance, not a fixed span. The falloff is
+  an ellipse fitted to the patch — long along the light, narrow across it — so the tip
+  rounds off and the flanks dim, instead of the light stopping at an edge;
   What ends a patch is that circle, not the edge of any shape: the beam's outline always
   extends past the point the light has faded to nothing, so you see the arc and never a
   straight cut across the room;

--- a/README.md
+++ b/README.md
@@ -954,9 +954,9 @@ gap moved the same way. So:
   distance the light actually travels before a wall stops it — so it is always faint by
   the time it ends, whatever size the room is. `sunReach` is the ceiling on that
   distance, not a fixed span;
-- its **long edges are feathered** rather than cut, so a patch reads as light rather than
-  as tape. The softness is drawn inside the beam, so no light falls outside the gap the
-  sun came through;
+  What ends a patch is that circle, not the edge of any shape: the beam's outline always
+  extends past the point the light has faded to nothing, so you see the arc and never a
+  straight cut across the room;
 - while the plan follows the real sun, that reach **shortens as the sun climbs** — a patch
   is about as deep as the opening is tall over the tangent of the sun's angle, so a midday
   sun lays a short patch at your feet and an evening one rakes across the room. A pinned

--- a/README.md
+++ b/README.md
@@ -950,10 +950,10 @@ gap moved the same way. So:
   throws a narrow patch, not the one it would throw standing wide open. Sliding styles
   count the gap they actually clear rather than the distance a leaf travels, so a
   converging pair reads the same here as it draws;
-- a patch **fades out as it travels**, and fans a little as it goes: light scatters, and a
-  beam drawn as a hard-edged stripe at flat brightness reads as a cut-out rather than as
-  light. It reaches `sunReach` of the plan's shorter side and is gone by the end of it,
-  instead of crossing the whole house at the brightness it started with;
+- a patch **fades out radially from its opening**, the way a lamp's pool does, and its
+  edges soften with distance: sharp at the glass, feathered by the time it lands. It
+  reaches `sunReach` of the plan's shorter side and is gone by the end of it, instead of
+  crossing the whole house at the brightness it started with;
 - while the plan follows the real sun, that reach **shortens as the sun climbs** — a patch
   is about as deep as the opening is tall over the tangent of the sun's angle, so a midday
   sun lays a short patch at your feet and an evening one rakes across the room. A pinned

--- a/docker/README.md
+++ b/docker/README.md
@@ -234,3 +234,34 @@ image: ghcr.io/home-assistant/home-assistant:2026.7
 
 Then `npm run ha:reset` first — a config directory written by a newer Home
 Assistant is not always readable by an older one.
+
+## Moving the sun
+
+Sunlight is only visible while the sun is up, which makes it awkward to work
+on in the evening — and impossible to compare morning against afternoon
+without waiting half a day.
+
+`sun.sun` is computed from the instance's own coordinates and the real clock.
+The clock is not ours to move (the recorder writes against it, and jumping it
+backwards confuses it), but the coordinates are: solar time runs four minutes
+per degree of longitude, so moving the instance east or west is exactly
+equivalent to moving the sun.
+
+```bash
+node docker/sun-at.mjs --show   # where the sun is now
+node docker/sun-at.mjs 9        # mid-morning, long raking patches
+node docker/sun-at.mjs 12       # overhead: short patches at your feet
+node docker/sun-at.mjs 17.5     # low evening sun
+node docker/sun-at.mjs 2        # below the horizon: nothing drawn
+docker restart easy-floorplan-ha
+```
+
+It edits `latitude`/`longitude` in `config/.storage/core.config`, so it changes
+where the instance thinks it is — worth putting back if you care, and harmless
+if you don't, since nothing else here reads the location.
+
+The alternative, when the angle matters more than the hour, is to turn
+**Follow the real sun** off in the card editor and set **Sun from** yourself.
+A stated bearing keeps the light on around the clock by design, so it needs no
+container changes at all — but it pins the elevation at full, so it will not
+show you the dusk ramp or the way reach shortens as the sun climbs.

--- a/docker/sun-at.mjs
+++ b/docker/sun-at.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Put the container's sun wherever you need it, so sunlight can be worked on
+ * at any hour — including at night, when there is otherwise nothing to look at.
+ *
+ * Home Assistant's `sun.sun` is computed from the instance's own coordinates
+ * and the real clock. The clock is not ours to move (the recorder writes
+ * against it, and a jump backwards confuses it), but the coordinates are:
+ * solar time runs 4 minutes per degree of longitude, so moving the instance
+ * east or west is exactly equivalent to moving the sun. Latitude sets how
+ * high it climbs, which is what the reach scales with.
+ *
+ *   node docker/sun-at.mjs 9       # sun as it is at 09:00 solar time
+ *   node docker/sun-at.mjs 12      # overhead: short patches
+ *   node docker/sun-at.mjs 17.5    # low and raking, long patches
+ *   node docker/sun-at.mjs 2       # below the horizon: nothing drawn
+ *   node docker/sun-at.mjs --show  # what the sun is doing right now
+ *
+ * Restart the container afterwards for HA to pick the new location up.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const store = resolve(here, "config", ".storage", "core.config");
+
+const rad = (d) => (d * Math.PI) / 180;
+const deg = (r) => (r * 180) / Math.PI;
+
+/** Equation of time, minutes, for a day of the year. */
+function eot(day) {
+  const g = rad((360 / 365.25) * (day - 81));
+  return 9.87 * Math.sin(2 * g) - 7.53 * Math.cos(g) - 1.5 * Math.sin(g);
+}
+function declination(day) {
+  return rad(23.44) * Math.sin(rad((360 / 365.25) * (day - 81)));
+}
+function solarPosition(date, lat, lon) {
+  const day = Math.floor((date - new Date(Date.UTC(date.getUTCFullYear(), 0, 0))) / 864e5);
+  const utc = date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
+  const solar = utc + (4 * lon + eot(day)) / 60;
+  const H = rad(15 * (solar - 12));
+  const d = declination(day);
+  const la = rad(lat);
+  const elevation = deg(Math.asin(Math.sin(la) * Math.sin(d) + Math.cos(la) * Math.cos(d) * Math.cos(H)));
+  const azimuth =
+    (deg(Math.atan2(-Math.sin(H), Math.tan(d) * Math.cos(la) - Math.sin(la) * Math.cos(H))) + 360) % 360;
+  return { elevation, azimuth, solarTime: ((solar % 24) + 24) % 24 };
+}
+
+const cfg = JSON.parse(readFileSync(store, "utf8"));
+const data = cfg.data;
+const now = new Date();
+const arg = process.argv[2];
+
+if (!arg || arg === "--show") {
+  const p = solarPosition(now, data.latitude, data.longitude);
+  console.log(`  location   ${data.latitude.toFixed(4)}, ${data.longitude.toFixed(4)}`);
+  console.log(`  solar time ${p.solarTime.toFixed(2)}h`);
+  console.log(`  elevation  ${p.elevation.toFixed(1)}°  ${p.elevation <= 0 ? "(below the horizon — nothing is drawn)" : ""}`);
+  console.log(`  azimuth    ${p.azimuth.toFixed(1)}°`);
+  process.exit(0);
+}
+
+const target = Number(arg);
+if (!Number.isFinite(target) || target < 0 || target >= 24) {
+  console.error("Give an hour between 0 and 24, e.g. `node docker/sun-at.mjs 15.5`.");
+  process.exit(1);
+}
+
+const day = Math.floor((now - new Date(Date.UTC(now.getUTCFullYear(), 0, 0))) / 864e5);
+const utc = now.getUTCHours() + now.getUTCMinutes() / 60 + now.getUTCSeconds() / 3600;
+// solarTime = utc + (4*lon + eot)/60  =>  lon = ((target - utc)*60 - eot) / 4
+let lon = ((target - utc) * 60 - eot(day)) / 4;
+while (lon > 180) lon -= 360;
+while (lon < -180) lon += 360;
+
+const before = solarPosition(now, data.latitude, data.longitude);
+data.longitude = Number(lon.toFixed(4));
+writeFileSync(store, JSON.stringify(cfg, null, 2));
+const after = solarPosition(now, data.latitude, data.longitude);
+
+console.log(`  solar time  ${before.solarTime.toFixed(2)}h -> ${after.solarTime.toFixed(2)}h`);
+console.log(`  elevation   ${before.elevation.toFixed(1)}° -> ${after.elevation.toFixed(1)}°`);
+console.log(`  azimuth     ${before.azimuth.toFixed(1)}° -> ${after.azimuth.toFixed(1)}°`);
+console.log(`  longitude   -> ${data.longitude}`);
+console.log(`\n  Restart for HA to read it:  docker restart easy-floorplan-ha`);

--- a/docker/sun-at.mjs
+++ b/docker/sun-at.mjs
@@ -23,7 +23,19 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const store = resolve(here, "config", ".storage", "core.config");
+// configuration.yaml, NOT .storage/core.config. A `homeassistant:` block in
+// YAML wins over the stored core config, and this instance has one — editing
+// the store looks like it works (the file changes, the UI even shows the new
+// place) and moves the sun not at all. That cost an afternoon: the card was
+// correctly drawing nothing, because sun.sun was still reading below_horizon
+// from coordinates half a world from where the store claimed to be.
+const store = resolve(here, "config", "configuration.yaml");
+const LAT = /^(\s*latitude:\s*)(-?[\d.]+)/m;
+const LON = /^(\s*longitude:\s*)(-?[\d.]+)/m;
+const readLoc = (text) => ({
+  latitude: Number(text.match(LAT)?.[2]),
+  longitude: Number(text.match(LON)?.[2]),
+});
 
 const rad = (d) => (d * Math.PI) / 180;
 const deg = (r) => (r * 180) / Math.PI;
@@ -49,8 +61,12 @@ function solarPosition(date, lat, lon) {
   return { elevation, azimuth, solarTime: ((solar % 24) + 24) % 24 };
 }
 
-const cfg = JSON.parse(readFileSync(store, "utf8"));
-const data = cfg.data;
+const text = readFileSync(store, "utf8");
+const data = readLoc(text);
+if (!Number.isFinite(data.latitude) || !Number.isFinite(data.longitude)) {
+  console.error("Could not find latitude/longitude in docker/config/configuration.yaml.");
+  process.exit(1);
+}
 const now = new Date();
 const arg = process.argv[2];
 
@@ -77,8 +93,9 @@ while (lon > 180) lon -= 360;
 while (lon < -180) lon += 360;
 
 const before = solarPosition(now, data.latitude, data.longitude);
-data.longitude = Number(lon.toFixed(4));
-writeFileSync(store, JSON.stringify(cfg, null, 2));
+const next = Number(lon.toFixed(4));
+writeFileSync(store, text.replace(LON, `$1${next}`));
+data.longitude = next;
 const after = solarPosition(now, data.latitude, data.longitude);
 
 console.log(`  solar time  ${before.solarTime.toFixed(2)}h -> ${after.solarTime.toFixed(2)}h`);

--- a/src/card-styles.test.ts
+++ b/src/card-styles.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+/**
+ * The card's stylesheet, as source. Read as text rather than imported,
+ * because importing the card pulls in Lit's whole element machinery — and
+ * registers a custom element — for a question the CSS itself answers.
+ */
+import cardSourceRaw from "./floorplan-card.ts?raw";
+const cardSource = cardSourceRaw as string;
+
+describe("the stylesheet does not overwrite paint the renderer computes", () => {
+  /**
+   * CSS beats the SVG presentation attribute. Anything the renderer paints
+   * with a per-element `url(#...)` — a gradient it builds, a mask it sizes —
+   * is therefore silently discarded by a flat declaration of the same
+   * property in here.
+   *
+   * This is not hypothetical. `.fp-sunbeam { fill: var(--fp-skin-sunlight) }`
+   * shipped in the sunlight feature (#169) and threw away every falloff the
+   * renderer produced: the markup kept saying url(#...), the computed style
+   * said rgb(...), and sunlight came out as a flat hard-edged slab. Issue
+   * #185 was reopened three times against it, and four separate rewrites of
+   * the falloff — a fan, a penumbra, a circle, an ellipse — were each correct
+   * and none of them was ever rendered. The tests all passed throughout,
+   * because they asserted on markup, and the markup was right.
+   *
+   * The skin still reaches these: the colour is read into the gradient's own
+   * stops, which is where a per-element paint has to be set from.
+   */
+  const gradientPainted = [
+    { selector: ".fp-sunbeam", property: "fill" },
+    { selector: ".fp-glow", property: "fill" },
+  ];
+
+  for (const { selector, property } of gradientPainted) {
+    it(`${selector} declares no ${property}`, () => {
+      const at = cardSource.indexOf(`${selector} {`);
+      if (at === -1) return; // the class is gone; nothing to guard
+      const block = cardSource.slice(at, cardSource.indexOf("}", at));
+      expect(block).not.toMatch(new RegExp(`(^|[;\\s])${property}\\s*:`));
+    });
+  }
+
+  it("says why, so the next person does not add it back", () => {
+    // A rule this easy to re-add needs its reason written next to it.
+    const at = cardSource.indexOf(".fp-sunlight {");
+    expect(at).toBeGreaterThan(-1);
+    const nearby = cardSource.slice(at, at + 1400);
+    expect(nearby).toMatch(/CSS beats the presentation attribute/i);
+  });
+});

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1434,9 +1434,17 @@ export class FloorplanCard extends LitElement {
     .fp-sunlight {
       pointer-events: none;
     }
-    .fp-sunbeam {
-      fill: var(--fp-skin-sunlight, #ffd9a0);
-    }
+    /* No fill declaration here, deliberately. CSS beats the presentation attribute — the same rule the
+       wall below relies on — and a patch of sunlight is filled with a
+       *gradient* the renderer builds per opening. A flat colour declared here
+       silently discards it: the markup keeps saying url(#…), the computed
+       style says rgb(…), and the light comes out as a hard slab no matter
+       what shape the falloff is given. That is issue #185, and it survived
+       four rewrites of the falloff because every one of them was correct and
+       none of them was ever used.
+
+       The skin still applies: --fp-skin-sunlight is read by SUN_LIGHT_COLOR
+       and lands on the gradient's own stops. */
     .wall {
       stroke: var(--fp-skin-wall, var(--primary-text-color));
       /* CSS beats the presentation attribute, so the skin sets the wall's

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { renderOpening, renderSunlight } from "./render";
+import { renderOpening, renderSunlight, SUN_REACH } from "./render";
 import type { OpeningStyle } from "./render";
-import type { Opening } from "./types";
+import type { Opening, Wall } from "./types";
 import { nothing } from "lit";
 
 /**
@@ -48,7 +48,8 @@ describe("renderSunlight — the markup, not just the geometry", () => {
 
   it("gives both masks a ground to subtract from, in one piece", () => {
     const s = light();
-    expect(s.match(/<mask /g)?.length).toBe(2);
+    // shade + wall-shadow, plus one edge mask per beam (the soft long edges).
+    expect(s.match(/<mask /g)?.length).toBe(3);
     // Three rects — a ground in each mask, and the shade itself — and every
     // one of them closes. That count is the whole point: a `<rect` with no `>`
     // is exactly the bug this describe exists for, and it leaves the masks
@@ -62,40 +63,95 @@ describe("renderSunlight — the markup, not just the geometry", () => {
   it("draws a patch per opening that admits light, and a shadow per wall piece", () => {
     const s = light();
     // The window splits its wall in two, so two shadow pieces, appearing in
-    // both masks (4). The beam is three penumbra bands — the nested fans that
-    // soften its sides (issue #185) — drawn once as holes in the shade mask
-    // and once as the warm patch itself (6). 4 + 6 = 10.
-    expect(s.match(/<polygon/g)?.length).toBe(10);
-    expect(s.match(/fp-sunbeam/g)?.length).toBe(3);
-    // Two windows in the same wall: a three-band patch each.
+    // both masks (4). The beam is drawn three times: once inside its own edge
+    // mask, once as a hole in the shade mask, once as the warm patch (3).
+    expect(s.match(/<polygon/g)?.length).toBe(7);
+    expect(s.match(/fp-sunbeam/g)?.length).toBe(1);
+    // Two windows in the same wall: a patch each.
     const two = light([win, { ...win, id: "o2", x: 320 } as Opening]);
-    expect(two.match(/fp-sunbeam/g)?.length).toBe(6);
+    expect(two.match(/fp-sunbeam/g)?.length).toBe(2);
   });
 
-  it("softens its sides with distance: three bands off one mouth (issue #185)", () => {
-    // The first fix faded the beam along its length and left the sides as
-    // knife-cuts at full brightness — rendered side by side with v1.5.1 the
-    // two were nearly indistinguishable, which is what reopened the issue.
-    // The penumbra is geometric: three fans sharing the mouth, diverging as
-    // they travel, each fainter than the last.
+  it("feathers its long edges from inside the beam (issue #185)", () => {
+    // The fan this replaces was clipped away by the wall the beam came
+    // through — its shadow runs exactly parallel to the beam, so the spread
+    // went straight into it. Measured on a real card the penumbra was
+    // invisible while every test still passed, because they asserted the
+    // bands were emitted, never that they survived compositing.
+    //
+    // Fading inward cannot be clipped: it lives inside the beam's own
+    // polygon, and no light is drawn outside the gap the sun came through.
     const s = light();
-    const bands = [...s.matchAll(/class="fp-sunbeam" points=([-\d., ]+)\s+fill=url\(#[^)]+\) fill-opacity=([\d.]+)/g)]
-      .map((m) => {
-        const xs = m[1]!.trim().split(" ").map((q) => Number(q.split(",")[0]));
-        return { mouth: Math.abs(xs[1]! - xs[0]!), far: Math.abs(xs[2]! - xs[3]!), opacity: Number(m[2]) };
-      });
-    expect(bands.length).toBe(3);
-    // Same mouth: at the glass the edge of a sun patch really is sharp.
-    for (const b of bands) expect(b.mouth).toBeCloseTo(bands[0]!.mouth);
-    // Diverging far ends, and the wider the band the fainter it is.
-    const byFar = [...bands].sort((a, b) => a.far - b.far);
-    expect(byFar[0]!.far).toBeLessThan(byFar[1]!.far);
-    expect(byFar[1]!.far).toBeLessThan(byFar[2]!.far);
-    expect(byFar[0]!.opacity).toBeGreaterThan(byFar[1]!.opacity);
-    expect(byFar[1]!.opacity).toBeGreaterThan(byFar[2]!.opacity);
-    // The straight core still spans exactly the gap — the penumbra widens
-    // outward from the true patch, it does not shrink the light.
-    expect(byFar[0]!.far).toBeCloseTo(byFar[0]!.mouth);
+    const grad = s.match(/<linearGradient id=[^ ]+ [^>]*x1=([-\d.]+) y1=([-\d.]+) x2=([-\d.]+) y2=([-\d.]+)/);
+    expect(grad).not.toBeNull();
+    // Its axis is the gap itself — end to end — so its iso-lines lie along
+    // the beam's long edges and both sides feather at once.
+    const [ , x1, y1, x2, y2 ] = grad!.map(Number);
+    expect(Math.min(x1, x2)).toBeCloseTo(win.x - win.length / 2);
+    expect(Math.max(x1, x2)).toBeCloseTo(win.x + win.length / 2);
+    expect(y1).toBeCloseTo(win.y);
+    expect(y2).toBeCloseTo(win.y);
+    // Dark at both rims, clear through the middle.
+    // Quotes are optional here: the serializer quotes literal attributes and
+    // leaves interpolated ones bare.
+    const grads = s.slice(s.indexOf("<linearGradient"), s.indexOf("</linearGradient>"));
+    const stops = [...grads.matchAll(/<stop offset="?([\d.]+)"? stop-color="?(#[0-9a-f]{3,6})"?/g)]
+      .map((m) => ({ at: Number(m[1]), color: m[2] }));
+    expect(stops.length).toBe(4);
+    expect(stops[0]).toEqual({ at: 0, color: "#000" });
+    expect(stops[3]).toEqual({ at: 1, color: "#000" });
+    // …clear through the middle, and symmetric about it.
+    expect(stops[1]!.color).toBe("#fff");
+    expect(stops[2]!.color).toBe("#fff");
+    expect(stops[1]!.at).toBeCloseTo(1 - stops[2]!.at);
+    expect(stops[1]!.at).toBeGreaterThan(0);
+    // And the beam is drawn through that mask rather than raw.
+    expect(s).toMatch(/<g mask=url\(#[^)]*em0\)>\s*<polygon class="fp-sunbeam"/);
+  });
+
+  it("the softness survives the wall it came through, not just the markup", () => {
+    // The lesson from the fan: it WAS emitted, three bands of it, and every
+    // test passed — and on a real card it was invisible, because the wall
+    // segments beside the gap cast shadows parallel to the beam and clipped
+    // it off. So this asserts containment rather than existence: everything
+    // that softens the beam has to live inside the beam's own polygon, where
+    // no shadow can reach it.
+    const s = light();
+    const beamPts = s.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim();
+    // The edge mask is built from exactly the beam polygon — same points, so
+    // it cannot extend past it and cannot be trimmed by a shadow.
+    const maskBlock = s.slice(s.indexOf("<mask id=sun-em0"), s.indexOf("</mask>", s.indexOf("<mask id=sun-em0")));
+    expect(maskBlock).toContain(beamPts);
+    // And no drawn geometry reaches outside the gap the sun came through:
+    // every x in the beam lies within the window's own span.
+    const xs = beamPts.split(" ").map((q) => Number(q.split(",")[0]));
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(win.x - win.length / 2 - 0.01);
+    expect(Math.max(...xs)).toBeLessThanOrEqual(win.x + win.length / 2 + 0.01);
+  });
+
+  it("fades over the distance the light really travels, not a share of the plan", () => {
+    // A room shallower than the reach used to get a patch still at full
+    // brightness when the far wall cut it — a hard bar across the floor.
+    // The falloff radius is the ray's own travel, so it is faint by the end
+    // whatever size the room is.
+    const near = { id: "near", x1: 0, y1: 160, x2: 400, y2: 160 };  // 60 away
+    const far = { id: "far", x1: 0, y1: 340, x2: 400, y2: 340 };    // 240 away
+    const radiusWith = (blocker: Wall) => {
+      const out = serialize(
+        renderSunlight([wall, blocker], [win], 400, 400, "sun", {
+          dir: sun, openAmount: () => 0, shutterOpen: () => undefined,
+        })
+      );
+      return Number(out.match(/<radialGradient id=sun-b0[^>]*r=([\d.]+)/)![1]);
+    };
+    const shallow = radiusWith(near);
+    const deep = radiusWith(far);
+    // A wall closer than the reach pulls the falloff in to meet it.
+    expect(shallow).toBeCloseTo(60, 0);
+    // A wall further away does not push it out: sunReach stays the ceiling,
+    // so this is 0.34 x 400 = 136, not the 240 to the wall.
+    expect(deep).toBeCloseTo(SUN_REACH * 400, 0);
+    expect(shallow).toBeLessThan(deep);
   });
 
   it("a door ajar throws a narrower patch than one standing open", () => {
@@ -159,7 +215,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     ] as Opening[];
     const s = light(facing, [north, south]);
     const beams = s.match(/class="fp-sunbeam"/g) ?? [];
-    expect(beams.length).toBe(3); // one lit opening = its three penumbra bands
+    expect(beams.length).toBe(1); // exactly one lit opening
     // …and it is the one on the sunlit side: the patch starts at y=0.
     expect(s).toContain('points=170,0 230,0');
     expect(s).not.toContain("230,300");
@@ -181,7 +237,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         shutterOpen: () => undefined,
       })
     );
-    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(3); // one lit opening, three bands
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1); // exactly one lit opening
     // The one beam is the window's, 20 across — not the door's 120.
     expect(s).toContain("points=190,100 210,100");
     // The light still gets *through* the doorway: the interior wall is cut
@@ -211,7 +267,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         shutterOpen: () => undefined,
       })
     );
-    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(3); // one lit opening, three bands
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1); // exactly one lit opening
     expect(s).toContain("points=30,100 90,100");
   });
 
@@ -231,7 +287,9 @@ describe("renderSunlight — the markup, not just the geometry", () => {
       // and no straight cut survives.
       expect(Number(g[3])).toBeGreaterThan(0);
     }
-    expect(s).not.toContain("<linearGradient");
+    // A linearGradient is present too — it is the edge feather, which runs
+    // across the beam rather than along it.
+    expect(s.match(/<linearGradient/g)?.length).toBeGreaterThanOrEqual(1);
     expect(s).toContain('stop-opacity="0"');
     // The beam is filled by that gradient rather than by a flat colour.
     expect(s).toMatch(/class="fp-sunbeam"[^>]*fill=url\(#/);

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -48,8 +48,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
 
   it("gives both masks a ground to subtract from, in one piece", () => {
     const s = light();
-    // shade + wall-shadow, plus one edge mask per beam (the soft long edges).
-    expect(s.match(/<mask /g)?.length).toBe(3);
+    expect(s.match(/<mask /g)?.length).toBe(2);
     // Three rects — a ground in each mask, and the shade itself — and every
     // one of them closes. That count is the whole point: a `<rect` with no `>`
     // is exactly the bug this describe exists for, and it leaves the masks
@@ -62,71 +61,13 @@ describe("renderSunlight — the markup, not just the geometry", () => {
 
   it("draws a patch per opening that admits light, and a shadow per wall piece", () => {
     const s = light();
-    // The window splits its wall in two, so two shadow pieces, appearing in
-    // both masks (4). The beam is drawn three times: once inside its own edge
-    // mask, once as a hole in the shade mask, once as the warm patch (3).
-    expect(s.match(/<polygon/g)?.length).toBe(7);
+    // The window splits its wall in two, so two shadow pieces, in both masks
+    // (4). The beam is a hole in the shade mask and the warm patch itself (2).
+    expect(s.match(/<polygon/g)?.length).toBe(6);
     expect(s.match(/fp-sunbeam/g)?.length).toBe(1);
     // Two windows in the same wall: a patch each.
     const two = light([win, { ...win, id: "o2", x: 320 } as Opening]);
     expect(two.match(/fp-sunbeam/g)?.length).toBe(2);
-  });
-
-  it("feathers its long edges from inside the beam (issue #185)", () => {
-    // The fan this replaces was clipped away by the wall the beam came
-    // through — its shadow runs exactly parallel to the beam, so the spread
-    // went straight into it. Measured on a real card the penumbra was
-    // invisible while every test still passed, because they asserted the
-    // bands were emitted, never that they survived compositing.
-    //
-    // Fading inward cannot be clipped: it lives inside the beam's own
-    // polygon, and no light is drawn outside the gap the sun came through.
-    const s = light();
-    const grad = s.match(/<linearGradient id=[^ ]+ [^>]*x1=([-\d.]+) y1=([-\d.]+) x2=([-\d.]+) y2=([-\d.]+)/);
-    expect(grad).not.toBeNull();
-    // Its axis is the gap itself — end to end — so its iso-lines lie along
-    // the beam's long edges and both sides feather at once.
-    const [ , x1, y1, x2, y2 ] = grad!.map(Number);
-    expect(Math.min(x1, x2)).toBeCloseTo(win.x - win.length / 2);
-    expect(Math.max(x1, x2)).toBeCloseTo(win.x + win.length / 2);
-    expect(y1).toBeCloseTo(win.y);
-    expect(y2).toBeCloseTo(win.y);
-    // Dark at both rims, clear through the middle.
-    // Quotes are optional here: the serializer quotes literal attributes and
-    // leaves interpolated ones bare.
-    const grads = s.slice(s.indexOf("<linearGradient"), s.indexOf("</linearGradient>"));
-    const stops = [...grads.matchAll(/<stop offset="?([\d.]+)"? stop-color="?(#[0-9a-f]{3,6})"?/g)]
-      .map((m) => ({ at: Number(m[1]), color: m[2] }));
-    expect(stops.length).toBe(4);
-    expect(stops[0]).toEqual({ at: 0, color: "#000" });
-    expect(stops[3]).toEqual({ at: 1, color: "#000" });
-    // …clear through the middle, and symmetric about it.
-    expect(stops[1]!.color).toBe("#fff");
-    expect(stops[2]!.color).toBe("#fff");
-    expect(stops[1]!.at).toBeCloseTo(1 - stops[2]!.at);
-    expect(stops[1]!.at).toBeGreaterThan(0);
-    // And the beam is drawn through that mask rather than raw.
-    expect(s).toMatch(/<g mask=url\(#[^)]*em0\)>\s*<polygon class="fp-sunbeam"/);
-  });
-
-  it("the softness survives the wall it came through, not just the markup", () => {
-    // The lesson from the fan: it WAS emitted, three bands of it, and every
-    // test passed — and on a real card it was invisible, because the wall
-    // segments beside the gap cast shadows parallel to the beam and clipped
-    // it off. So this asserts containment rather than existence: everything
-    // that softens the beam has to live inside the beam's own polygon, where
-    // no shadow can reach it.
-    const s = light();
-    const beamPts = s.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim();
-    // The edge mask is built from exactly the beam polygon — same points, so
-    // it cannot extend past it and cannot be trimmed by a shadow.
-    const maskBlock = s.slice(s.indexOf("<mask id=sun-em0"), s.indexOf("</mask>", s.indexOf("<mask id=sun-em0")));
-    expect(maskBlock).toContain(beamPts);
-    // And no drawn geometry reaches outside the gap the sun came through:
-    // every x in the beam lies within the window's own span.
-    const xs = beamPts.split(" ").map((q) => Number(q.split(",")[0]));
-    expect(Math.min(...xs)).toBeGreaterThanOrEqual(win.x - win.length / 2 - 0.01);
-    expect(Math.max(...xs)).toBeLessThanOrEqual(win.x + win.length / 2 + 0.01);
   });
 
   it("fades over the distance the light really travels, not a share of the plan", () => {
@@ -178,6 +119,32 @@ describe("renderSunlight — the markup, not just the geometry", () => {
       const dangling = referenced.filter((id) => !defined.has(id));
       expect(dangling).toEqual([]);
     }
+  });
+
+  it("ends in the gradient's circle, never in the polygon's straight edge", () => {
+    // What #185 asked for in the first place: "limit the reach of that
+    // sunlight, maybe radially, like we do for light bulbs". The falloff has
+    // to reach zero strictly INSIDE the beam's outline, so what terminates
+    // the visible patch is the gradient's circular arc and not the flat far
+    // edge of the polygon. Two earlier attempts failed here — a fan that the
+    // wall clipped, then a lateral feather whose gradient ran along the gap
+    // and so cut diagonally across obliquely-lit beams, fading one side and
+    // not the other.
+    const s = light();
+    const g = s.match(/<radialGradient id=sun-b0[^>]*cx=([\d.]+) cy=([\d.]+) r=([\d.]+)/)!;
+    const [cx, cy, r] = [Number(g[1]), Number(g[2]), Number(g[3])];
+    // It dies at zero, not at some residual value that would leave an edge.
+    const stops = s.slice(s.indexOf("<radialGradient id=sun-b0"));
+    expect(stops.slice(0, stops.indexOf("</radialGradient>"))).toContain('stop-opacity="0"');
+    // Every corner of the polygon is at or beyond that radius, so the light
+    // has already gone to nothing before the outline is reached.
+    const pts = s.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim().split(" ")
+      .map((q) => q.split(",").map(Number));
+    const far = pts.map(([x, y]) => Math.hypot(x! - cx, y! - cy)).sort((a, b) => b - a);
+    expect(far[0]).toBeGreaterThanOrEqual(r);
+    expect(far[1]).toBeGreaterThanOrEqual(r);
+    // …and the two long edges are untouched, so neither side is favoured.
+    expect(s).not.toContain("<linearGradient");
   });
 
   it("a door ajar throws a narrower patch than one standing open", () => {
@@ -313,9 +280,8 @@ describe("renderSunlight — the markup, not just the geometry", () => {
       // and no straight cut survives.
       expect(Number(g[3])).toBeGreaterThan(0);
     }
-    // A linearGradient is present too — it is the edge feather, which runs
-    // across the beam rather than along it.
-    expect(s.match(/<linearGradient/g)?.length).toBeGreaterThanOrEqual(1);
+    // Nothing linear left: the falloff is radial and it is the whole effect.
+    expect(s).not.toContain("<linearGradient");
     expect(s).toContain('stop-opacity="0"');
     // The beam is filled by that gradient rather than by a flat colour.
     expect(s).toMatch(/class="fp-sunbeam"[^>]*fill=url\(#/);
@@ -414,10 +380,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     // The patches stay; the shade rect and the mask it needed are simply not
     // built, rather than emitted at zero opacity.
     expect(s).toContain("fp-sunbeam");
-    // The wall-shadow mask and one edge mask per beam survive — the shade's
-    // own mask is the only one that goes. Declining the shade must not take
-    // the softness with it, which is exactly what it used to do.
-    expect(s.match(/<mask /g)?.length).toBe(2);
+    expect(s.match(/<mask /g)?.length).toBe(1);
     expect(s.match(/<rect /g)?.length).toBe(1); // the surviving mask's ground
   });
 

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -61,14 +61,41 @@ describe("renderSunlight — the markup, not just the geometry", () => {
 
   it("draws a patch per opening that admits light, and a shadow per wall piece", () => {
     const s = light();
-    // The window splits its wall in two, so two shadow pieces — and they
-    // appear in both masks, while the one beam appears in the shade mask and
-    // again as the warm patch itself.
-    expect(s.match(/<polygon/g)?.length).toBe(6);
-    expect(s).toContain("fp-sunbeam");
-    // Two windows in the same wall: a patch each.
+    // The window splits its wall in two, so two shadow pieces, appearing in
+    // both masks (4). The beam is three penumbra bands — the nested fans that
+    // soften its sides (issue #185) — drawn once as holes in the shade mask
+    // and once as the warm patch itself (6). 4 + 6 = 10.
+    expect(s.match(/<polygon/g)?.length).toBe(10);
+    expect(s.match(/fp-sunbeam/g)?.length).toBe(3);
+    // Two windows in the same wall: a three-band patch each.
     const two = light([win, { ...win, id: "o2", x: 320 } as Opening]);
-    expect(two.match(/fp-sunbeam/g)?.length).toBe(2);
+    expect(two.match(/fp-sunbeam/g)?.length).toBe(6);
+  });
+
+  it("softens its sides with distance: three bands off one mouth (issue #185)", () => {
+    // The first fix faded the beam along its length and left the sides as
+    // knife-cuts at full brightness — rendered side by side with v1.5.1 the
+    // two were nearly indistinguishable, which is what reopened the issue.
+    // The penumbra is geometric: three fans sharing the mouth, diverging as
+    // they travel, each fainter than the last.
+    const s = light();
+    const bands = [...s.matchAll(/class="fp-sunbeam" points=([-\d., ]+)\s+fill=url\(#[^)]+\) fill-opacity=([\d.]+)/g)]
+      .map((m) => {
+        const xs = m[1]!.trim().split(" ").map((q) => Number(q.split(",")[0]));
+        return { mouth: Math.abs(xs[1]! - xs[0]!), far: Math.abs(xs[2]! - xs[3]!), opacity: Number(m[2]) };
+      });
+    expect(bands.length).toBe(3);
+    // Same mouth: at the glass the edge of a sun patch really is sharp.
+    for (const b of bands) expect(b.mouth).toBeCloseTo(bands[0]!.mouth);
+    // Diverging far ends, and the wider the band the fainter it is.
+    const byFar = [...bands].sort((a, b) => a.far - b.far);
+    expect(byFar[0]!.far).toBeLessThan(byFar[1]!.far);
+    expect(byFar[1]!.far).toBeLessThan(byFar[2]!.far);
+    expect(byFar[0]!.opacity).toBeGreaterThan(byFar[1]!.opacity);
+    expect(byFar[1]!.opacity).toBeGreaterThan(byFar[2]!.opacity);
+    // The straight core still spans exactly the gap — the penumbra widens
+    // outward from the true patch, it does not shrink the light.
+    expect(byFar[0]!.far).toBeCloseTo(byFar[0]!.mouth);
   });
 
   it("a door ajar throws a narrower patch than one standing open", () => {
@@ -132,7 +159,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     ] as Opening[];
     const s = light(facing, [north, south]);
     const beams = s.match(/class="fp-sunbeam"/g) ?? [];
-    expect(beams.length).toBe(1);
+    expect(beams.length).toBe(3); // one lit opening = its three penumbra bands
     // …and it is the one on the sunlit side: the patch starts at y=0.
     expect(s).toContain('points=170,0 230,0');
     expect(s).not.toContain("230,300");
@@ -154,7 +181,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         shutterOpen: () => undefined,
       })
     );
-    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1);
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(3); // one lit opening, three bands
     // The one beam is the window's, 20 across — not the door's 120.
     expect(s).toContain("points=190,100 210,100");
     // The light still gets *through* the doorway: the interior wall is cut
@@ -184,18 +211,27 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         shutterOpen: () => undefined,
       })
     );
-    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1);
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(3); // one lit opening, three bands
     expect(s).toContain("points=30,100 90,100");
   });
 
-  it("fades every patch out over its own length (issue #185)", () => {
+  it("fades every patch out radially from its opening (issue #185)", () => {
     const s = light();
-    // A gradient per beam, anchored on the opening it came from — not one
-    // shared ramp across the plan, which would fade patches by where they sit
-    // rather than by how far the light has travelled.
-    const grads = s.match(/<linearGradient/g) ?? [];
+    // A RADIAL gradient per beam, centred on the opening it came from — the
+    // lamp-pool construction the issue asks for by name. The first fix faded
+    // along the beam's length only, and the sides stayed knife-cuts at full
+    // brightness from mouth to tip: still a stripe, just a shorter one.
+    const grads = [...s.matchAll(/<radialGradient id=[^ ]+ [^>]*cx=(\d+) cy=(\d+) r=([\d.]+)/g)];
     expect(grads.length).toBeGreaterThanOrEqual(2); // one for the light, one for the shade
-    // It ends at nothing, which is what stops the straight cut across the room.
+    for (const g of grads) {
+      // Centred on the window, not on some shared anchor.
+      expect(Number(g[1])).toBe(win.x);
+      expect(Number(g[2])).toBe(win.y);
+      // Dying exactly at the reach, so the polygon's far edge is already dark
+      // and no straight cut survives.
+      expect(Number(g[3])).toBeGreaterThan(0);
+    }
+    expect(s).not.toContain("<linearGradient");
     expect(s).toContain('stop-opacity="0"');
     // The beam is filled by that gradient rather than by a flat colour.
     expect(s).toMatch(/class="fp-sunbeam"[^>]*fill=url\(#/);
@@ -233,7 +269,7 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         })
       );
       const out: Record<string, string> = {};
-      for (const m of s.matchAll(/<linearGradient id=(sun-b\d+)[^>]*x1=(\d+)/g)) out[m[2]!] = m[1]!;
+      for (const m of s.matchAll(/<radialGradient id=(sun-b\d+)[^>]*cx=(\d+)/g)) out[m[2]!] = m[1]!;
       return out;
     };
     const shut = idsByOpening(0);
@@ -325,7 +361,9 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         shutterOpen: () => undefined,
       })
     );
-    const op = (s: string) => Number(s.match(/opacity=([0-9.]+)/)![1]);
+    // The strength lives on the beam group's own opacity; the penumbra bands
+    // carry fill-opacity, which this must not match instead.
+    const op = (s: string) => Number(s.match(/<g mask=[^>]*? opacity=([0-9.]+)/)![1]);
     expect(op(dusk)).toBeLessThan(op(noon));
   });
 

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -70,31 +70,6 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(two.match(/fp-sunbeam/g)?.length).toBe(2);
   });
 
-  it("fades over the distance the light really travels, not a share of the plan", () => {
-    // A room shallower than the reach used to get a patch still at full
-    // brightness when the far wall cut it — a hard bar across the floor.
-    // The falloff radius is the ray's own travel, so it is faint by the end
-    // whatever size the room is.
-    const near = { id: "near", x1: 0, y1: 160, x2: 400, y2: 160 };  // 60 away
-    const far = { id: "far", x1: 0, y1: 340, x2: 400, y2: 340 };    // 240 away
-    const radiusWith = (blocker: Wall) => {
-      const out = serialize(
-        renderSunlight([wall, blocker], [win], 400, 400, "sun", {
-          dir: sun, openAmount: () => 0, shutterOpen: () => undefined,
-        })
-      );
-      return Number(out.match(/<radialGradient id=sun-b0[^>]*r=([\d.]+)/)![1]);
-    };
-    const shallow = radiusWith(near);
-    const deep = radiusWith(far);
-    // A wall closer than the reach pulls the falloff in to meet it.
-    expect(shallow).toBeCloseTo(60, 0);
-    // A wall further away does not push it out: sunReach stays the ceiling,
-    // so this is 0.34 x 400 = 136, not the 240 to the wall.
-    expect(deep).toBeCloseTo(SUN_REACH * 400, 0);
-    expect(shallow).toBeLessThan(deep);
-  });
-
   it("every id a beam references is actually defined, shade or no shade", () => {
     // The bug this exists for: the edge masks were emitted INSIDE the shade
     // mask, so turning the shade off deleted them while the beams went on
@@ -121,52 +96,49 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     }
   });
 
-  it("ends in the gradient's circle, never in the polygon's straight edge", () => {
-    // What #185 asked for in the first place: "limit the reach of that
-    // sunlight, maybe radially, like we do for light bulbs". The falloff has
-    // to reach zero strictly INSIDE the beam's outline, so what terminates
-    // the visible patch is the gradient's circular arc and not the flat far
-    // edge of the polygon. Two earlier attempts failed here — a fan that the
-    // wall clipped, then a lateral feather whose gradient ran along the gap
-    // and so cut diagonally across obliquely-lit beams, fading one side and
-    // not the other.
-    const s = light();
-    // It dies at zero, not at some residual value that would leave an edge.
-    const stops = s.slice(s.indexOf("<radialGradient id=sun-b0"));
-    expect(stops.slice(0, stops.indexOf("</radialGradient>"))).toContain('stop-opacity="0"');
-    // Both FAR corners are at or beyond that radius, so the light has already
-    // gone to nothing before the outline is reached and what bounds the patch
-    // is the circle.
-    const farCorners = (markup: string) => {
-      const g2 = markup.match(/<radialGradient id=sun-b0[^>]*cx=([\d.]+) cy=([\d.]+) r=([\d.]+)/)!;
-      const [gx, gy, gr] = [Number(g2[1]), Number(g2[2]), Number(g2[3])];
-      const q = markup.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim().split(" ")
-        .map((t) => t.split(",").map(Number));
-      // points 0,1 are the mouth (at the gap, correctly full strength);
-      // 2,3 are the far edge.
-      return { r: gr, far: [2, 3].map((i) => Math.hypot(q[i]![0]! - gx, q[i]![1]! - gy)) };
-    };
-    const straight = farCorners(s);
-    expect(Math.min(...straight.far)).toBeGreaterThanOrEqual(straight.r);
+  it("fades over the distance the light really travels, not a share of the plan", () => {
+    // A room shallower than the reach used to keep the patch at full strength
+    // until a wall cut it — a hard bar across the floor.
+    const near = { id: "near", x1: 0, y1: 160, x2: 400, y2: 160 };
+    const far = { id: "far", x1: 0, y1: 340, x2: 400, y2: 340 };
+    const alongWith = (blocker: Wall) =>
+      falloff(
+        serialize(
+          renderSunlight([wall, blocker], [win], 400, 400, "sun", {
+            dir: sun,
+            openAmount: () => 0,
+            shutterOpen: () => undefined,
+          })
+        )
+      )!.along;
+    expect(alongWith(near)).toBeCloseTo(60, 0);
+    // A wall further off does not push it out: sunReach stays the ceiling.
+    expect(alongWith(far)).toBeCloseTo(SUN_REACH * 400, 0);
+  });
 
-    // …and the same for light arriving OBLIQUELY, which is the case that
-    // matters. The falloff ends on a circle; the outline ends on a straight
-    // edge at a constant distance along the beam. They cross, and when the
-    // sun is square-on to the wall they happen to agree — so a fixture using
-    // perpendicular light passes while a real plan shows a hard bright edge
-    // where the near corner stops dead. That is exactly what shipped.
-    const oblique = farCorners(
-      serialize(
+  it("runs its outline past the falloff, so the ellipse is what bounds it", () => {
+    for (const dir of [sun, { x: 0.72, y: 0.69 }]) {
+      const markup = serialize(
         renderSunlight([wall], [win], 400, 400, "sun", {
-          dir: { x: 0.72, y: 0.69 },
+          dir,
           openAmount: () => 0,
           shutterOpen: () => undefined,
         })
-      )
-    );
-    expect(Math.min(...oblique.far)).toBeGreaterThanOrEqual(oblique.r);
-    // …and the two long edges are untouched, so neither side is favoured.
-    expect(s).not.toContain("<linearGradient");
+      );
+      const f = falloff(markup)!;
+      const pts = markup.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim().split(" ")
+        .map((q) => q.split(",").map(Number));
+      // Distance from the opening to each FAR corner, measured in the
+      // ellipse's own units: at or beyond 1 means the light is already gone.
+      const rad = (-f.angle * Math.PI) / 180;
+      for (const i of [2, 3]) {
+        const dx = pts[i]![0]! - f.cx;
+        const dy = pts[i]![1]! - f.cy;
+        const u = (dx * Math.cos(rad) - dy * Math.sin(rad)) / f.along;
+        const v = (dx * Math.sin(rad) + dy * Math.cos(rad)) / f.across;
+        expect(Math.hypot(u, v)).toBeGreaterThanOrEqual(1);
+      }
+    }
   });
 
   it("a door ajar throws a narrower patch than one standing open", () => {
@@ -286,26 +258,22 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(s).toContain("points=30,100 90,100");
   });
 
-  it("fades every patch out radially from its opening (issue #185)", () => {
+  it("fades every patch out with an ellipse fitted to it (issue #185)", () => {
     const s = light();
-    // A RADIAL gradient per beam, centred on the opening it came from — the
-    // lamp-pool construction the issue asks for by name. The first fix faded
-    // along the beam's length only, and the sides stayed knife-cuts at full
-    // brightness from mouth to tip: still a stripe, just a shorter one.
-    const grads = [...s.matchAll(/<radialGradient id=[^ ]+ [^>]*cx=(\d+) cy=(\d+) r=([\d.]+)/g)];
-    expect(grads.length).toBeGreaterThanOrEqual(2); // one for the light, one for the shade
-    for (const g of grads) {
-      // Centred on the window, not on some shared anchor.
-      expect(Number(g[1])).toBe(win.x);
-      expect(Number(g[2])).toBe(win.y);
-      // Dying exactly at the reach, so the polygon's far edge is already dark
-      // and no straight cut survives.
-      expect(Number(g[3])).toBeGreaterThan(0);
-    }
-    // Nothing linear left: the falloff is radial and it is the whole effect.
-    expect(s).not.toContain("<linearGradient");
+    // An ELLIPSE, not a circle. A circle centred on the opening is nearly a
+    // straight edge by the time it has travelled far enough to matter — on
+    // the plan that reopened #185 it bowed 13px across a 129-wide window —
+    // so the tip read as a hard stop however the stops were tuned. Squashed
+    // to the beam's own proportions it curves on the scale of the WIDTH.
+    const f = falloff(s)!;
+    expect(f).toBeDefined();
+    expect(f.cx).toBe(win.x);
+    expect(f.cy).toBe(win.y);
+    expect(f.across).toBeLessThan(f.along); // squashed across the light
+    // Tip curvature is across^2/along; it has to be small next to the beam's
+    // own width or the end is flat again.
+    expect((f.across * f.across) / f.along).toBeLessThan(win.length);
     expect(s).toContain('stop-opacity="0"');
-    // The beam is filled by that gradient rather than by a flat colour.
     expect(s).toMatch(/class="fp-sunbeam"[^>]*fill=url\(#/);
   });
 
@@ -341,7 +309,10 @@ describe("renderSunlight — the markup, not just the geometry", () => {
         })
       );
       const out: Record<string, string> = {};
-      for (const m of s.matchAll(/<radialGradient id=(sun-b\d+)[^>]*cx=(\d+)/g)) out[m[2]!] = m[1]!;
+      for (const m of s.matchAll(
+        /<radialGradient id=(sun-b\d+)[^>]*gradientTransform=translate\((\d+)/g
+      ))
+        out[m[2]!] = m[1]!;
       return out;
     };
     const shut = idsByOpening(0);
@@ -444,6 +415,16 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(light()).toContain("fp-sunlight");
   });
 });
+
+
+/** The falloff ellipse a beam is painted with: where it sits and how big. */
+function falloff(markup: string, id = "sun-b0") {
+  const m = markup.match(
+    new RegExp(`<radialGradient id=${id}[^>]*gradientTransform=translate\\(([-\\d.]+) ([-\\d.]+)\\) rotate\\(([-\\d.]+)\\) scale\\(([\\d.]+) ([\\d.]+)\\)`)
+  );
+  if (!m) return undefined;
+  return { cx: +m[1]!, cy: +m[2]!, angle: +m[3]!, along: +m[4]!, across: +m[5]! };
+}
 
 describe("renderOpening — orientation mirror", () => {
   it("wraps the body in an identity scale by default (unchanged output)", () => {

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -154,6 +154,32 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(shallow).toBeLessThan(deep);
   });
 
+  it("every id a beam references is actually defined, shade or no shade", () => {
+    // The bug this exists for: the edge masks were emitted INSIDE the shade
+    // mask, so turning the shade off deleted them while the beams went on
+    // pointing at them. An undefined mask is not an error in SVG — it simply
+    // does not apply — so the patches came back at full strength with knife
+    // edges and nothing looked broken enough to suspect. It shipped, and it
+    // was the one configuration the reporter was running.
+    //
+    // So this checks the graph rather than any one feature: whatever a beam
+    // points at has to exist, in both configurations.
+    for (const shade of [undefined, null]) {
+      const s = serialize(
+        renderSunlight([wall], [win], 400, 400, "sun", {
+          dir: sun, openAmount: () => 0, shutterOpen: () => undefined, shade,
+        })
+      );
+      const referenced = [...s.matchAll(/url\(#([^)]+)\)/g)].map((m) => m[1]!);
+      expect(referenced.length).toBeGreaterThan(0);
+      const defined = new Set(
+        [...s.matchAll(/<(?:mask|linearGradient|radialGradient|clipPath) id=([^\s>]+)/g)].map((m) => m[1]!)
+      );
+      const dangling = referenced.filter((id) => !defined.has(id));
+      expect(dangling).toEqual([]);
+    }
+  });
+
   it("a door ajar throws a narrower patch than one standing open", () => {
     // The end of the boolean, seen in the markup: the width of the polygon is
     // the width of the gap that is actually clear, and the wall keeps the
@@ -388,7 +414,10 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     // The patches stay; the shade rect and the mask it needed are simply not
     // built, rather than emitted at zero opacity.
     expect(s).toContain("fp-sunbeam");
-    expect(s.match(/<mask /g)?.length).toBe(1);
+    // The wall-shadow mask and one edge mask per beam survive — the shade's
+    // own mask is the only one that goes. Declining the shade must not take
+    // the softness with it, which is exactly what it used to do.
+    expect(s.match(/<mask /g)?.length).toBe(2);
     expect(s.match(/<rect /g)?.length).toBe(1); // the surviving mask's ground
   });
 

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -131,18 +131,40 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     // and so cut diagonally across obliquely-lit beams, fading one side and
     // not the other.
     const s = light();
-    const g = s.match(/<radialGradient id=sun-b0[^>]*cx=([\d.]+) cy=([\d.]+) r=([\d.]+)/)!;
-    const [cx, cy, r] = [Number(g[1]), Number(g[2]), Number(g[3])];
     // It dies at zero, not at some residual value that would leave an edge.
     const stops = s.slice(s.indexOf("<radialGradient id=sun-b0"));
     expect(stops.slice(0, stops.indexOf("</radialGradient>"))).toContain('stop-opacity="0"');
-    // Every corner of the polygon is at or beyond that radius, so the light
-    // has already gone to nothing before the outline is reached.
-    const pts = s.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim().split(" ")
-      .map((q) => q.split(",").map(Number));
-    const far = pts.map(([x, y]) => Math.hypot(x! - cx, y! - cy)).sort((a, b) => b - a);
-    expect(far[0]).toBeGreaterThanOrEqual(r);
-    expect(far[1]).toBeGreaterThanOrEqual(r);
+    // Both FAR corners are at or beyond that radius, so the light has already
+    // gone to nothing before the outline is reached and what bounds the patch
+    // is the circle.
+    const farCorners = (markup: string) => {
+      const g2 = markup.match(/<radialGradient id=sun-b0[^>]*cx=([\d.]+) cy=([\d.]+) r=([\d.]+)/)!;
+      const [gx, gy, gr] = [Number(g2[1]), Number(g2[2]), Number(g2[3])];
+      const q = markup.match(/class="fp-sunbeam" points=([-\d., ]+)/)![1]!.trim().split(" ")
+        .map((t) => t.split(",").map(Number));
+      // points 0,1 are the mouth (at the gap, correctly full strength);
+      // 2,3 are the far edge.
+      return { r: gr, far: [2, 3].map((i) => Math.hypot(q[i]![0]! - gx, q[i]![1]! - gy)) };
+    };
+    const straight = farCorners(s);
+    expect(Math.min(...straight.far)).toBeGreaterThanOrEqual(straight.r);
+
+    // …and the same for light arriving OBLIQUELY, which is the case that
+    // matters. The falloff ends on a circle; the outline ends on a straight
+    // edge at a constant distance along the beam. They cross, and when the
+    // sun is square-on to the wall they happen to agree — so a fixture using
+    // perpendicular light passes while a real plan shows a hard bright edge
+    // where the near corner stops dead. That is exactly what shipped.
+    const oblique = farCorners(
+      serialize(
+        renderSunlight([wall], [win], 400, 400, "sun", {
+          dir: { x: 0.72, y: 0.69 },
+          openAmount: () => 0,
+          shutterOpen: () => undefined,
+        })
+      )
+    );
+    expect(Math.min(...oblique.far)).toBeGreaterThanOrEqual(oblique.r);
     // …and the two long edges are untouched, so neither side is favoured.
     expect(s).not.toContain("<linearGradient");
   });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2773,23 +2773,16 @@ describe("sunlight through the openings", () => {
     expect(SUN_REACH).toBeLessThan(0.5);
   });
 
-  it("fans as it travels, symmetrically about the light", () => {
+  it("sweeps the gap straight along the light, at the gap's own width", () => {
+    // No fan. An earlier attempt widened the beam as it travelled, to imitate
+    // scattering; the wall segments either side of the gap cast shadows
+    // exactly parallel to the beam, so the extra width was clipped away every
+    // time. Softness comes from the falloff now, which nothing can clip.
     const o = win();
-    const straight = sunBeamPolygon(o, down, 200, 1, 0);
-    const fanned = sunBeamPolygon(o, down, 200, 1, 1);
-    const widthOf = (p: { x: number }[], i: number, j: number) => Math.abs(p[j]!.x - p[i]!.x);
-    // Same mouth: it still leaves the gap it came through.
-    expect(widthOf(fanned, 0, 1)).toBeCloseTo(widthOf(straight, 0, 1));
-    // …and a wider far edge, which is what scattering looks like.
-    expect(widthOf(fanned, 3, 2)).toBeCloseTo(widthOf(straight, 3, 2) * 2);
-    // Symmetric about the opening's centre, so the fan follows the light
-    // rather than leaning to one side of it.
-    const mid = (o.x * 2) / 2;
-    expect((fanned[2]!.x + fanned[3]!.x) / 2).toBeCloseTo(mid);
-    // It reaches exactly as far as before — wider, not longer.
-    expect(fanned[3]!.y - fanned[0]!.y).toBeCloseTo(straight[3]!.y - straight[0]!.y);
-    // Spread defaults to off, so every existing caller gets the old shape.
-    expect(sunBeamPolygon(o, down, 200, 1)).toEqual(straight);
+    const p = sunBeamPolygon(o, down, 200, 1);
+    const width = (i: number, j: number) => Math.abs(p[j]!.x - p[i]!.x);
+    expect(width(0, 1)).toBeCloseTo(width(3, 2));
+    expect(width(0, 1)).toBeCloseTo(o.length);
   });
 
   it("shortens the patch as the sun climbs, and lengthens it at dusk", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -3242,16 +3242,21 @@ export const SUN_REACH = 0.34;
  */
 export const SUN_REACH_REF = 30;
 /**
- * How much wider a beam grows over its full reach, as a multiple of the gap
- * it came through.
+ * How far the falloff spreads ACROSS the beam, as a multiple of the gap's
+ * width — the other half of the ellipse the light dies into.
  *
- * Light scatters. A beam drawn as the gap swept along the sun is exact for a
- * perfect ray, and reads as a cut-out: hard parallel edges the whole way,
- * which is the other half of what makes issue #185's screenshots look wrong.
- * Widening as it travels is what a real patch does, and it costs one number
- * rather than a blur filter over the whole canvas.
+ * The falloff is an ellipse fitted to the beam, not a circle. That is the
+ * whole difference between a rounded tip and a flat one, and it took four
+ * attempts to find because a circle centred on the opening is nearly a
+ * straight edge by the time it has travelled far enough to matter: on the
+ * plan that reopened issue #185, a radius of 163 bowed 13px across a 129-wide
+ * window, 10% of the width. An ellipse squashed to the beam's own proportions
+ * curves on the scale of its WIDTH instead, which is what reads as round.
+ *
+ * A shade under 1 means the light is already dimming at the gap's own edges,
+ * so the patch has soft flanks as well as a soft tip.
  */
-export const SUN_SPREAD = 0;
+export const SUN_ACROSS = 0.95;
 /** How dark the plan goes where no sunlight lands. */
 export const SUN_SHADE = 0.16;
 /** How strongly the sunlit patches are tinted. */
@@ -3511,35 +3516,16 @@ export function sunBeamPolygon(
   /**
    * How much of the gap is clear, 0..1 — see {@link openingSunFraction}. The
    * patch narrows about the opening's centre, matching the gap {@link
-   * wallsLightPassesThrough} leaves in the wall for the same fraction, so the
-   * beam and the shade it sits in line up exactly instead of leaking.
+   * wallsLightPassesThrough} leaves in the wall for the same fraction.
    */
   clear = 1,
-  /**
-   * How much wider the far end is than the gap, as a multiple of the gap —
-   * see {@link SUN_SPREAD}. 0 keeps the exact parallel-ray parallelogram.
-   */
-  spread = 0,
 ): AreaPoint[] {
   const [a, b] = openingEnds(o);
   const f = Math.max(0, Math.min(1, clear));
   const mx = (a.x + b.x) / 2;
   const my = (a.y + b.y) / 2;
-  // Scale about the opening's own centre, so the clear part of a half-open
-  // door sits where the wall left the gap.
-  const at = (p: AreaPoint, k: number) => ({ x: mx + (p.x - mx) * k, y: my + (p.y - my) * k });
-  const near = [at(a, f), at(b, f)];
-  if (spread <= 0) return sweep(near[0]!, near[1]!, dir, reach);
-  // The far edge is the same gap, widened — light scatters, so the patch is a
-  // fan rather than a stripe cut with a knife. Widened about the centre line,
-  // which keeps the fan symmetric about the direction the light travels.
-  const far = [at(a, f * (1 + spread)), at(b, f * (1 + spread))];
-  return [
-    near[0]!,
-    near[1]!,
-    { x: far[1]!.x + dir.x * reach, y: far[1]!.y + dir.y * reach },
-    { x: far[0]!.x + dir.x * reach, y: far[0]!.y + dir.y * reach },
-  ];
+  const at = (p: AreaPoint) => ({ x: mx + (p.x - mx) * f, y: my + (p.y - my) * f });
+  return sweep(at(a), at(b), dir, reach);
 }
 
 /**
@@ -3598,8 +3584,6 @@ export interface SunlightOptions {
    * (see {@link sunReachScale}).
    */
   reach?: number;
-  /** How much the beam fans over that distance — {@link SUN_SPREAD}. */
-  spread?: number;
   light?: string;
   /**
    * `null` draws the light without darkening anything else — the patches
@@ -3618,7 +3602,7 @@ export function renderSunlight(
   id: string,
   opts: SunlightOptions,
 ): SVGTemplateResult | typeof nothing {
-  const { dir, openAmount, shutterOpen, strength = 1, spread = SUN_SPREAD } = opts;
+  const { dir, openAmount, shutterOpen, strength = 1 } = opts;
   const paint = {
     light: opts.light ?? SUN_LIGHT_COLOR,
     // `?? ` would swallow the explicit null that means "no shade at all".
@@ -3664,30 +3648,28 @@ export function renderSunlight(
   // length rather than sharing one gradient across the plan.
   const beams = openings.map((o, i) => {
     if (!(clear(o) > 0 && sunReachesOpening(o, walls, dir))) return undefined;
-    // How far this beam actually gets. The falloff is measured against this,
-    // so a patch is faint by the time a wall ends it however deep the room is.
-    const travel = sunTravelDistance(o, dir, walls, reach);
-    // The outline runs PAST that, by the width of the gap it came through.
-    //
-    // The two shapes disagree about what "the end" means: the falloff ends on
-    // a circle centred on the opening, the outline ends on a straight edge at
-    // a constant distance *along* the beam. They cross. Cut both at the same
-    // number and the near corner of that edge is still lit — measured on the
-    // reporter's own card, a corner 131 units out against a falloff reaching
-    // 163, so about a third of full strength, stopping dead. That was the
-    // sharp end; the fade was working the whole time behind it.
-    //
-    // Overshooting puts the entire far edge outside the circle, where the
-    // light has already gone. What bounds the patch is then the falloff
-    // alone, and a falloff bounded by nothing else is round.
-    const span = travel + o.length;
+    // How far the light gets before a wall stops it. The falloff is measured
+    // against this, so a patch is faint by the time it ends however deep or
+    // shallow the room is.
+    const along = sunTravelDistance(o, dir, walls, reach);
+    // …and how wide it is, measured across the light rather than along the
+    // wall: a gap seen obliquely admits a narrower beam than its own length.
+    const [ga, gb] = openingEnds(o);
+    const gx = gb.x - ga.x;
+    const gy = gb.y - ga.y;
+    const width = Math.abs(gx * dir.y - gy * dir.x) * clear(o);
     return {
-      points: polyPoints(sunBeamPolygon(o, dir, span, clear(o), spread)),
+      // The outline runs past the falloff, so the ellipse is what bounds the
+      // patch and never the polygon's flat far edge.
+      points: polyPoints(sunBeamPolygon(o, dir, along + o.length, clear(o))),
       cx: o.x,
       cy: o.y,
-      travel,
+      along,
+      across: Math.max(1, width * SUN_ACROSS),
+      angle: (Math.atan2(dir.y, dir.x) * 180) / Math.PI,
       lightId: `${id}-b${i}`,
       shadeId: `${id}-s${i}`,
+      fadeId: `${id}-f${i}`,
     };
   });
   if (!beams.some((b) => b !== undefined)) return nothing;
@@ -3710,22 +3692,23 @@ export function renderSunlight(
   // without this the light leaks along both edges of every wall it passes.
   const shadowPoly = (p: string, paint: string) =>
     svg`<polygon points=${p} fill=${paint} stroke=${paint} stroke-width=${WALL_THICKNESS} />`;
-  // A patch is brightest at the opening and dies out in EVERY direction from
-  // it — radially, the way a lamp's pool does, which is what issue #185
-  // asked for by name. The first cut at this faded along the beam's length
-  // only, and it was not enough: the sides stayed knife-cuts at full
-  // brightness from mouth to tip, so a beam still read as a stripe laid on
-  // the floor, and wherever a wall's shadow cut one short the end was a hard
-  // diagonal. A radial falloff centred on the opening fixes all three at
-  // once — the far end rounds off before the polygon runs out, the sides dim
-  // with distance, and a shadow cut lands where the light is already faint.
-  // The polygon's job shrinks to bounding the light (the fan, the walls);
-  // the gradient is what says how bright it is. Same construction as
-  // renderGlow, and the same middle stop as before so it does not read as a
-  // textbook radial ramp.
-  const fade = (gid: string, cx: number, cy: number, r: number, color: string) =>
-    svg`<radialGradient id=${gid} gradientUnits="userSpaceOnUse"
-                        cx=${cx} cy=${cy} r=${r}>
+  // The falloff, as an ellipse fitted to the beam rather than a circle.
+  //
+  // A unit circle is mapped onto the beam's own frame — rotated to point down
+  // the light, stretched to its reach along, squashed to the gap's width
+  // across. So its iso-lines curve on the scale of the beam's WIDTH, which is
+  // what makes the tip read as round; a true circle centred on the opening is
+  // nearly a straight edge by the time it gets there, which is what every
+  // earlier attempt drew and what kept reading as a hard stop.
+  //
+  // It reaches zero at the far end, so nothing bounds the patch except the
+  // light giving out — and the flanks dim too, because SUN_ACROSS is under 1.
+  const fade = (
+    b: { fadeId: string; cx: number; cy: number; along: number; across: number; angle: number },
+    gid: string,
+    color: string,
+  ) => svg`<radialGradient id=${gid} gradientUnits="userSpaceOnUse" cx="0" cy="0" r="1"
+              gradientTransform=${`translate(${b.cx} ${b.cy}) rotate(${b.angle}) scale(${b.along} ${b.across})`}>
           <stop offset="0" stop-color=${color} stop-opacity="1" />
           <stop offset="0.45" stop-color=${color} stop-opacity="0.55" />
           <stop offset="1" stop-color=${color} stop-opacity="0" />
@@ -3741,7 +3724,7 @@ export function renderSunlight(
            back wherever a wall stands in one. The order is the whole logic. -->
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
-        ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, b.travel, "#000") : nothing))}
+        ${beams.map((b) => (b ? fade(b, b.shadeId, "#000") : nothing))}
         ${beams.map((b) =>
           b
             ? svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />`
@@ -3769,7 +3752,7 @@ export function renderSunlight(
       <g mask=${`url(#${shadowId})`} opacity=${SUN_PATCH_OPACITY * strength}>
         ${beams.map((b) =>
           b
-            ? fade(b.lightId, b.cx, b.cy, b.travel, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+            ? fade(b, b.lightId, cssColorOr(paint.light, SUN_LIGHT_COLOR))
             : nothing
         )}
         ${beams.map((b) =>

--- a/src/render.ts
+++ b/src/render.ts
@@ -3252,10 +3252,25 @@ export const SUN_REACH_REF = 30;
  * rather than a blur filter over the whole canvas.
  */
 export const SUN_SPREAD = 0.9;
+/**
+ * The penumbra, as nested fans. All three share the beam's mouth — at the
+ * glass the edge of a sun patch really is sharp — and diverge as they
+ * travel, so the edge softens with distance the way a real patch's does.
+ * Layered same-colour fills compose, so the centre (all three) is brightest
+ * and the rim (the widest alone) faintest: a three-step lateral falloff with
+ * no blur filter, which this card has none of and is not getting one for
+ * cosmetics. Three steps at these opacities read as smooth; the gradient
+ * along the beam's length is doing the rest of the work.
+ */
+export const SUN_PENUMBRA: readonly { spread: number; opacity: number }[] = [
+  { spread: 0, opacity: 0.5 }, // the gap swept straight: the bright core
+  { spread: 0.45, opacity: 0.4 },
+  { spread: SUN_SPREAD, opacity: 0.35 }, // the full fan, faintest
+];
 /** How dark the plan goes where no sunlight lands. */
 export const SUN_SHADE = 0.16;
 /** How strongly the sunlit patches are tinted. */
-export const SUN_PATCH_OPACITY = 0.3;
+export const SUN_PATCH_OPACITY = 0.37;
 /**
  * Default colours: the same warm white a lamp with no colour of its own casts
  * (issue #6), and a plain black for the shade so it darkens whatever is under
@@ -3634,11 +3649,17 @@ export function renderSunlight(
   const beams = openings.map((o, i) => {
     if (!(clear(o) > 0 && sunReachesOpening(o, walls, dir))) return undefined;
     return {
-      points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
-      x1: o.x,
-      y1: o.y,
-      x2: o.x + dir.x * reach,
-      y2: o.y + dir.y * reach,
+      // One polygon per penumbra band, sharing the mouth and fanning apart.
+      // `spread` (the option) scales the whole family, so a plan that asks
+      // for a narrower fan narrows its penumbra with it.
+      bands: SUN_PENUMBRA.map((band) => ({
+        points: polyPoints(
+          sunBeamPolygon(o, dir, reach, clear(o), band.spread * (spread / SUN_SPREAD))
+        ),
+        opacity: band.opacity,
+      })),
+      cx: o.x,
+      cy: o.y,
       lightId: `${id}-b${i}`,
       shadeId: `${id}-s${i}`,
     };
@@ -3663,18 +3684,26 @@ export function renderSunlight(
   // without this the light leaks along both edges of every wall it passes.
   const shadowPoly = (p: string, paint: string) =>
     svg`<polygon points=${p} fill=${paint} stroke=${paint} stroke-width=${WALL_THICKNESS} />`;
-  // A patch is brightest where it comes in and gone by the end of its reach —
-  // the half of issue #185 that geometry alone cannot fix, since a fanned
-  // beam at flat opacity still ends in a straight edge across the room. The
-  // middle stop keeps it from reading as a linear ramp, which looks like a
-  // gradient rather than like light.
-  const fade = (gid: string, x1: number, y1: number, x2: number, y2: number, color: string) =>
-    svg`<linearGradient id=${gid} gradientUnits="userSpaceOnUse"
-                        x1=${x1} y1=${y1} x2=${x2} y2=${y2}>
+  // A patch is brightest at the opening and dies out in EVERY direction from
+  // it — radially, the way a lamp's pool does, which is what issue #185
+  // asked for by name. The first cut at this faded along the beam's length
+  // only, and it was not enough: the sides stayed knife-cuts at full
+  // brightness from mouth to tip, so a beam still read as a stripe laid on
+  // the floor, and wherever a wall's shadow cut one short the end was a hard
+  // diagonal. A radial falloff centred on the opening fixes all three at
+  // once — the far end rounds off before the polygon runs out, the sides dim
+  // with distance, and a shadow cut lands where the light is already faint.
+  // The polygon's job shrinks to bounding the light (the fan, the walls);
+  // the gradient is what says how bright it is. Same construction as
+  // renderGlow, and the same middle stop as before so it does not read as a
+  // textbook radial ramp.
+  const fade = (gid: string, cx: number, cy: number, r: number, color: string) =>
+    svg`<radialGradient id=${gid} gradientUnits="userSpaceOnUse"
+                        cx=${cx} cy=${cy} r=${r}>
           <stop offset="0" stop-color=${color} stop-opacity="1" />
           <stop offset="0.45" stop-color=${color} stop-opacity="0.55" />
           <stop offset="1" stop-color=${color} stop-opacity="0" />
-        </linearGradient>`;
+        </radialGradient>`;
   // Only built when it is going to be used: the shade mask is the one that
   // needs every beam *and* every shadow, so declining the shade halves the
   // shapes this emits rather than hiding them behind an opacity of zero.
@@ -3686,9 +3715,14 @@ export function renderSunlight(
            back wherever a wall stands in one. The order is the whole logic. -->
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
-        ${beams.map((b) => (b ? fade(b.shadeId, b.x1, b.y1, b.x2, b.y2, "#000") : nothing))}
+        ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, reach, "#000") : nothing))}
         ${beams.map((b) =>
-          b ? svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />` : nothing
+          b
+            ? b.bands.map(
+                (band) => svg`<polygon points=${band.points}
+                  fill=${`url(#${b.shadeId})`} fill-opacity=${band.opacity} />`
+              )
+            : nothing
         )}
         ${shadows.map((p) => shadowPoly(p, "#fff"))}
       </mask>`;
@@ -3712,13 +3746,15 @@ export function renderSunlight(
       <g mask=${`url(#${shadowId})`} opacity=${SUN_PATCH_OPACITY * strength}>
         ${beams.map((b) =>
           b
-            ? fade(b.lightId, b.x1, b.y1, b.x2, b.y2, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+            ? fade(b.lightId, b.cx, b.cy, reach, cssColorOr(paint.light, SUN_LIGHT_COLOR))
             : nothing
         )}
         ${beams.map((b) =>
           b
-            ? svg`<polygon class="fp-sunbeam" points=${b.points}
-                          fill=${`url(#${b.lightId})`} />`
+            ? b.bands.map(
+                (band) => svg`<polygon class="fp-sunbeam" points=${band.points}
+                    fill=${`url(#${b.lightId})`} fill-opacity=${band.opacity} />`
+              )
             : nothing
         )}
       </g>

--- a/src/render.ts
+++ b/src/render.ts
@@ -3771,7 +3771,6 @@ export function renderSunlight(
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
         ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, b.travel, "#000") : nothing))}
-        ${beams.map((b) => (b ? edgeMask(b) : nothing))}
         ${beams.map((b) =>
           b
             ? svg`<g mask=${`url(#${b.edgeMaskId})`}>
@@ -3784,6 +3783,14 @@ export function renderSunlight(
   return svg`
     <defs>
       ${shade}
+      <!-- The soft long edges, defined out here rather than inside the shade
+           mask above. That mask is only built when a shade is wanted, and
+           when it was not (sunShade: false) these definitions vanished with
+           it while the beams went on referencing them — an undefined mask is
+           not an error in SVG, it simply does not apply, so the patches came
+           out at full strength with knife edges and nothing looked broken
+           enough to suspect. -->
+      ${beams.map((b) => (b ? edgeMask(b) : nothing))}
       <!-- The wall shadows again, for the warm patches themselves. -->
       <mask id=${shadowId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}

--- a/src/render.ts
+++ b/src/render.ts
@@ -3667,8 +3667,22 @@ export function renderSunlight(
     // How far this beam actually gets. The falloff is measured against this,
     // so a patch is faint by the time a wall ends it however deep the room is.
     const travel = sunTravelDistance(o, dir, walls, reach);
+    // The outline runs PAST that, by the width of the gap it came through.
+    //
+    // The two shapes disagree about what "the end" means: the falloff ends on
+    // a circle centred on the opening, the outline ends on a straight edge at
+    // a constant distance *along* the beam. They cross. Cut both at the same
+    // number and the near corner of that edge is still lit — measured on the
+    // reporter's own card, a corner 131 units out against a falloff reaching
+    // 163, so about a third of full strength, stopping dead. That was the
+    // sharp end; the fade was working the whole time behind it.
+    //
+    // Overshooting puts the entire far edge outside the circle, where the
+    // light has already gone. What bounds the patch is then the falloff
+    // alone, and a falloff bounded by nothing else is round.
+    const span = travel + o.length;
     return {
-      points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
+      points: polyPoints(sunBeamPolygon(o, dir, span, clear(o), spread)),
       cx: o.x,
       cy: o.y,
       travel,

--- a/src/render.ts
+++ b/src/render.ts
@@ -3251,22 +3251,25 @@ export const SUN_REACH_REF = 30;
  * Widening as it travels is what a real patch does, and it costs one number
  * rather than a blur filter over the whole canvas.
  */
-export const SUN_SPREAD = 0.9;
+export const SUN_SPREAD = 0;
 /**
- * The penumbra, as nested fans. All three share the beam's mouth — at the
- * glass the edge of a sun patch really is sharp — and diverge as they
- * travel, so the edge softens with distance the way a real patch's does.
- * Layered same-colour fills compose, so the centre (all three) is brightest
- * and the rim (the widest alone) faintest: a three-step lateral falloff with
- * no blur filter, which this card has none of and is not getting one for
- * cosmetics. Three steps at these opacities read as smooth; the gradient
- * along the beam's length is doing the rest of the work.
+ * How much of a beam's width each long edge fades over, as a share of the
+ * gap. 0.28 each side leaves a bright core a little under half the gap wide.
+ *
+ * Fading *inward* rather than fanning outward, which is the correction that
+ * finally made this visible. A fan widens the beam past its gap — and the
+ * wall segments either side of that gap cast shadows running exactly parallel
+ * to the beam, so the fan spread straight into them and was clipped off at a
+ * hard line. Not bad luck with one plan: for any window in any wall the
+ * penumbra was guaranteed to be cut away precisely where it was supposed to
+ * soften the edge. Measured on a real card it was invisible, while every test
+ * still passed, because the tests asserted the bands were emitted and never
+ * that they survived compositing.
+ *
+ * Inside the beam nothing can clip it, and it stays honest: no light is drawn
+ * outside the gap the sun actually came through.
  */
-export const SUN_PENUMBRA: readonly { spread: number; opacity: number }[] = [
-  { spread: 0, opacity: 0.5 }, // the gap swept straight: the bright core
-  { spread: 0.45, opacity: 0.4 },
-  { spread: SUN_SPREAD, opacity: 0.35 }, // the full fan, faintest
-];
+export const SUN_EDGE_FEATHER = 0.28;
 /** How dark the plan goes where no sunlight lands. */
 export const SUN_SHADE = 0.16;
 /** How strongly the sunlit patches are tinted. */
@@ -3290,6 +3293,37 @@ export const SUN_SHADE_COLOR = "var(--fp-skin-sunshade, #000)";
  */
 export function sunReachFraction(value: unknown): number {
   return Math.max(0.02, Math.min(1.5, cssNumber(value, SUN_REACH)));
+}
+
+/**
+ * How far the light from `o` actually travels before a wall stops it, capped
+ * at `max`.
+ *
+ * The falloff has to be measured against this rather than against a fraction
+ * of the plan, or a room shallower than the reach gets a patch that is still
+ * at full brightness when the far wall cuts it — a hard bar across the floor,
+ * which is the thing issue #185 keeps being reopened about. Fading over the
+ * distance the light has to cross means the patch is always faint by the time
+ * it ends, whatever size the room is.
+ *
+ * The same idea as {@link glowReach} for a lamp, but a single ray rather than
+ * a visibility polygon: the beam is already bounded sideways by the wall
+ * shadows, so the only unknown is how far down the middle it gets.
+ */
+export function sunTravelDistance(
+  o: Opening,
+  dir: { x: number; y: number },
+  walls: readonly Wall[],
+  max: number,
+): number {
+  let nearest = max;
+  for (const w of walls) {
+    const t = rayWallHit(o.x, o.y, dir.x, dir.y, w);
+    // A wall the opening itself sits in reports a hit at ~0; the epsilon in
+    // rayWallHit already drops those, but a gap's own wall can still graze.
+    if (t !== undefined && t > 1 && t < nearest) nearest = t;
+  }
+  return nearest;
 }
 
 /**
@@ -3648,20 +3682,25 @@ export function renderSunlight(
   // length rather than sharing one gradient across the plan.
   const beams = openings.map((o, i) => {
     if (!(clear(o) > 0 && sunReachesOpening(o, walls, dir))) return undefined;
+    // How far this beam actually gets. The falloff is measured against this,
+    // so a patch is faint by the time a wall ends it however deep the room is.
+    const travel = sunTravelDistance(o, dir, walls, reach);
+    const [ga, gb] = openingEnds(o);
     return {
-      // One polygon per penumbra band, sharing the mouth and fanning apart.
-      // `spread` (the option) scales the whole family, so a plan that asks
-      // for a narrower fan narrows its penumbra with it.
-      bands: SUN_PENUMBRA.map((band) => ({
-        points: polyPoints(
-          sunBeamPolygon(o, dir, reach, clear(o), band.spread * (spread / SUN_SPREAD))
-        ),
-        opacity: band.opacity,
-      })),
+      points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
       cx: o.x,
       cy: o.y,
+      travel,
+      // The gap's own ends: the edge fade runs across the beam from one to
+      // the other, so its iso-lines lie along the beam's long edges.
+      ax: ga.x,
+      ay: ga.y,
+      bx: gb.x,
+      by: gb.y,
       lightId: `${id}-b${i}`,
       shadeId: `${id}-s${i}`,
+      edgeId: `${id}-e${i}`,
+      edgeMaskId: `${id}-em${i}`,
     };
   });
   if (!beams.some((b) => b !== undefined)) return nothing;
@@ -3697,6 +3736,22 @@ export function renderSunlight(
   // the gradient is what says how bright it is. Same construction as
   // renderGlow, and the same middle stop as before so it does not read as a
   // textbook radial ramp.
+  // Soft long edges, drawn INSIDE the beam so no wall shadow can clip them.
+  // A gradient from one end of the gap to the other has its iso-lines along
+  // the beam's own edges, so this feathers both sides at once. Used as a
+  // mask, it multiplies the radial falloff rather than replacing it.
+  const edgeMask = (b: { edgeId: string; edgeMaskId: string; points: string;
+                         ax: number; ay: number; bx: number; by: number }) => svg`
+      <linearGradient id=${b.edgeId} gradientUnits="userSpaceOnUse"
+                      x1=${b.ax} y1=${b.ay} x2=${b.bx} y2=${b.by}>
+        <stop offset="0" stop-color="#000" />
+        <stop offset=${SUN_EDGE_FEATHER} stop-color="#fff" />
+        <stop offset=${1 - SUN_EDGE_FEATHER} stop-color="#fff" />
+        <stop offset="1" stop-color="#000" />
+      </linearGradient>
+      <mask id=${b.edgeMaskId} maskUnits="userSpaceOnUse">
+        <polygon points=${b.points} fill=${`url(#${b.edgeId})`} />
+      </mask>`;
   const fade = (gid: string, cx: number, cy: number, r: number, color: string) =>
     svg`<radialGradient id=${gid} gradientUnits="userSpaceOnUse"
                         cx=${cx} cy=${cy} r=${r}>
@@ -3715,13 +3770,13 @@ export function renderSunlight(
            back wherever a wall stands in one. The order is the whole logic. -->
       <mask id=${shadeId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
-        ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, reach, "#000") : nothing))}
+        ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, b.travel, "#000") : nothing))}
+        ${beams.map((b) => (b ? edgeMask(b) : nothing))}
         ${beams.map((b) =>
           b
-            ? b.bands.map(
-                (band) => svg`<polygon points=${band.points}
-                  fill=${`url(#${b.shadeId})`} fill-opacity=${band.opacity} />`
-              )
+            ? svg`<g mask=${`url(#${b.edgeMaskId})`}>
+                    <polygon points=${b.points} fill=${`url(#${b.shadeId})`} />
+                  </g>`
             : nothing
         )}
         ${shadows.map((p) => shadowPoly(p, "#fff"))}
@@ -3746,15 +3801,15 @@ export function renderSunlight(
       <g mask=${`url(#${shadowId})`} opacity=${SUN_PATCH_OPACITY * strength}>
         ${beams.map((b) =>
           b
-            ? fade(b.lightId, b.cx, b.cy, reach, cssColorOr(paint.light, SUN_LIGHT_COLOR))
+            ? fade(b.lightId, b.cx, b.cy, b.travel, cssColorOr(paint.light, SUN_LIGHT_COLOR))
             : nothing
         )}
         ${beams.map((b) =>
           b
-            ? b.bands.map(
-                (band) => svg`<polygon class="fp-sunbeam" points=${band.points}
-                    fill=${`url(#${b.lightId})`} fill-opacity=${band.opacity} />`
-              )
+            ? svg`<g mask=${`url(#${b.edgeMaskId})`}>
+                    <polygon class="fp-sunbeam" points=${b.points}
+                             fill=${`url(#${b.lightId})`} />
+                  </g>`
             : nothing
         )}
       </g>

--- a/src/render.ts
+++ b/src/render.ts
@@ -3252,24 +3252,6 @@ export const SUN_REACH_REF = 30;
  * rather than a blur filter over the whole canvas.
  */
 export const SUN_SPREAD = 0;
-/**
- * How much of a beam's width each long edge fades over, as a share of the
- * gap. 0.28 each side leaves a bright core a little under half the gap wide.
- *
- * Fading *inward* rather than fanning outward, which is the correction that
- * finally made this visible. A fan widens the beam past its gap — and the
- * wall segments either side of that gap cast shadows running exactly parallel
- * to the beam, so the fan spread straight into them and was clipped off at a
- * hard line. Not bad luck with one plan: for any window in any wall the
- * penumbra was guaranteed to be cut away precisely where it was supposed to
- * soften the edge. Measured on a real card it was invisible, while every test
- * still passed, because the tests asserted the bands were emitted and never
- * that they survived compositing.
- *
- * Inside the beam nothing can clip it, and it stays honest: no light is drawn
- * outside the gap the sun actually came through.
- */
-export const SUN_EDGE_FEATHER = 0.28;
 /** How dark the plan goes where no sunlight lands. */
 export const SUN_SHADE = 0.16;
 /** How strongly the sunlit patches are tinted. */
@@ -3685,22 +3667,13 @@ export function renderSunlight(
     // How far this beam actually gets. The falloff is measured against this,
     // so a patch is faint by the time a wall ends it however deep the room is.
     const travel = sunTravelDistance(o, dir, walls, reach);
-    const [ga, gb] = openingEnds(o);
     return {
       points: polyPoints(sunBeamPolygon(o, dir, reach, clear(o), spread)),
       cx: o.x,
       cy: o.y,
       travel,
-      // The gap's own ends: the edge fade runs across the beam from one to
-      // the other, so its iso-lines lie along the beam's long edges.
-      ax: ga.x,
-      ay: ga.y,
-      bx: gb.x,
-      by: gb.y,
       lightId: `${id}-b${i}`,
       shadeId: `${id}-s${i}`,
-      edgeId: `${id}-e${i}`,
-      edgeMaskId: `${id}-em${i}`,
     };
   });
   if (!beams.some((b) => b !== undefined)) return nothing;
@@ -3736,22 +3709,6 @@ export function renderSunlight(
   // the gradient is what says how bright it is. Same construction as
   // renderGlow, and the same middle stop as before so it does not read as a
   // textbook radial ramp.
-  // Soft long edges, drawn INSIDE the beam so no wall shadow can clip them.
-  // A gradient from one end of the gap to the other has its iso-lines along
-  // the beam's own edges, so this feathers both sides at once. Used as a
-  // mask, it multiplies the radial falloff rather than replacing it.
-  const edgeMask = (b: { edgeId: string; edgeMaskId: string; points: string;
-                         ax: number; ay: number; bx: number; by: number }) => svg`
-      <linearGradient id=${b.edgeId} gradientUnits="userSpaceOnUse"
-                      x1=${b.ax} y1=${b.ay} x2=${b.bx} y2=${b.by}>
-        <stop offset="0" stop-color="#000" />
-        <stop offset=${SUN_EDGE_FEATHER} stop-color="#fff" />
-        <stop offset=${1 - SUN_EDGE_FEATHER} stop-color="#fff" />
-        <stop offset="1" stop-color="#000" />
-      </linearGradient>
-      <mask id=${b.edgeMaskId} maskUnits="userSpaceOnUse">
-        <polygon points=${b.points} fill=${`url(#${b.edgeId})`} />
-      </mask>`;
   const fade = (gid: string, cx: number, cy: number, r: number, color: string) =>
     svg`<radialGradient id=${gid} gradientUnits="userSpaceOnUse"
                         cx=${cx} cy=${cy} r=${r}>
@@ -3773,9 +3730,7 @@ export function renderSunlight(
         ${beams.map((b) => (b ? fade(b.shadeId, b.cx, b.cy, b.travel, "#000") : nothing))}
         ${beams.map((b) =>
           b
-            ? svg`<g mask=${`url(#${b.edgeMaskId})`}>
-                    <polygon points=${b.points} fill=${`url(#${b.shadeId})`} />
-                  </g>`
+            ? svg`<polygon points=${b.points} fill=${`url(#${b.shadeId})`} />`
             : nothing
         )}
         ${shadows.map((p) => shadowPoly(p, "#fff"))}
@@ -3783,14 +3738,6 @@ export function renderSunlight(
   return svg`
     <defs>
       ${shade}
-      <!-- The soft long edges, defined out here rather than inside the shade
-           mask above. That mask is only built when a shade is wanted, and
-           when it was not (sunShade: false) these definitions vanished with
-           it while the beams went on referencing them — an undefined mask is
-           not an error in SVG, it simply does not apply, so the patches came
-           out at full strength with knife edges and nothing looked broken
-           enough to suspect. -->
-      ${beams.map((b) => (b ? edgeMask(b) : nothing))}
       <!-- The wall shadows again, for the warm patches themselves. -->
       <mask id=${shadowId} maskUnits="userSpaceOnUse" x=${x} y=${y} width=${w} height=${h}>
         ${cover("#fff")}
@@ -3813,10 +3760,8 @@ export function renderSunlight(
         )}
         ${beams.map((b) =>
           b
-            ? svg`<g mask=${`url(#${b.edgeMaskId})`}>
-                    <polygon class="fp-sunbeam" points=${b.points}
-                             fill=${`url(#${b.lightId})`} />
-                  </g>`
+            ? svg`<polygon class="fp-sunbeam" points=${b.points}
+                            fill=${`url(#${b.lightId})`} />`
             : nothing
         )}
       </g>


### PR DESCRIPTION
Fixes #185, which had been reopened three times. The seven commits are the search; this describes where it landed.

### The bug

One line in the card's own stylesheet, shipped with the original sunlight feature (#169):

```css
.fp-sunbeam { fill: var(--fp-skin-sunlight, #ffd9a0); }
```

CSS beats the SVG presentation attribute. The renderer paints each patch with `fill="url(#gradient)"`; that rule overwrote it with a flat colour. **Every falloff this feature has ever produced was discarded before it reached the screen.** Confirmed in the browser against the reporter's own plan:

```
polygon attribute : fill="url(#…-sun-b2)"
computed style    : rgb(255, 217, 160)
after removing it : url("#…-sun-b2")
```

Sunlight therefore rendered as a hard-edged slab no matter what shape the falloff was given. Four rewrites of that shape across this PR — a fan, a three-band penumbra, a circle, an ellipse — were each correct, and none of them was ever drawn.

### Why it survived so long

Every test passed throughout, because they asserted on **markup**, and the markup was right. Every render produced to check the work looked correct, because both methods rendered the SVG **without the card's stylesheet**: calling `renderSunlight` in isolation, and sampling pixels from a serialised copy of the live SVG. Both drop the CSS, so both showed the gradient the browser was throwing away.

The bug was invisible to every instrument pointed at it and visible only in the live card — placed side by side with that same serialised copy on one page, where the two rendered visibly differently from identical markup.

### The falloff

Now an **ellipse fitted to the patch** — long along the light, narrow across it — so it curves on the scale of the beam's *width*. A true circle centred on the opening bows only 13px across a 129-wide window on the reporter's plan, which is why the tip read as a hard stop even in the versions where the gradient did apply.

Also in here, from the same investigation:

- reach is measured against the distance the light **actually travels** before a wall stops it, so a patch is faint by its end in a small room and a large one alike; `sunReach` is the ceiling on that, not a fixed span;
- reach shortens as the sun climbs — a midday sun lays a short patch, an evening one rakes;
- `sunReach` is coerced and bounded at the render sink (a hand-edited `"wide"` put NaN into a coordinate; a negative one swept the beam *backwards*, out through the wall it came in by);
- per-beam gradient ids are pinned to the opening, not to its rank (#119's rule);
- `docker/sun-at.mjs`, so sunlight can be worked on at night — it edits `configuration.yaml`, because a `homeassistant:` block there overrides `.storage/core.config` and editing the store moves the sun not at all.

### The guard

Deliberately not about sunlight. It reads the stylesheet and asserts that no selector the renderer paints per-element declares that property flat, with the reason written beside the rule it protects. It fails against the shipped CSS on exactly `.fp-sunbeam`.

**1142 tests**, typecheck and build clean. Verified in the dev container against the reporter's own card, not a fixture.
