### PR TITLE
Devices: an entity can be bound without being printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ distorted anyway.
 | `hideWhenInactive` | boolean                           | `false`      | Hide on the card while the entity is inactive. Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line. Governs this device's **own** state only — `readings` show regardless. |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
-| `readings`    | `{ entity?, attribute?, showState? }[]` | —           | Everything this device reads beyond its own state. `showState: false` keeps a row bound (the badge can read it) without printing it — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
+| `readings`    | `{ entity?, attribute?, showState? }[]` | —           | Everything this device reads beyond its own state — a sensor's humidity and pressure, a plug's power, link quality and battery. These print whatever the **device's** `showState` says, since that one is about the device's own entity. To hide one of *these*, set its **own** `showState: false`, which keeps it bound (the badge can still read it) without printing it. See [More readings per device](#more-readings-per-device). |
 | `labelPosition` | `below` \| `left` \| `right`         | `below`      | Where the label sits relative to the badge. |
 | `labelSize`   | number                                 | `12`         | Label line font size (px).                             |
 | `tap_action`  | ActionConfig                           | per domain   | Standard Lovelace action. By default `light`, `switch`, `fan` and `input_boolean` toggle and everything else — covers included — opens more-info. |
@@ -1163,7 +1163,7 @@ visible or not, so switching a row off cannot silently repoint the badge at a di
 entity. A device whose every extra row is hidden draws no label at all, and the editor
 stops offering the label's size and position for it.
 
-### Readings ignore "Show state"
+### Readings ignore the device's "Show state"
 
 That is the point of them. A smart plug already says on/off through its badge colour, so
 its label should carry the *other* numbers and not the word "on":
@@ -1180,8 +1180,9 @@ its label should carry the *other* numbers and not the word "on":
       - { attribute: battery }
 ```
 
-→ `Desk plug · 1.2 kW · 84 · 84`. `showState` is about the device's **own state**;
-`readings` are their own statement.
+→ `Desk plug · 1.2 kW · 84 · 84`. The device's `showState` is about its **own** entity;
+the readings are their own statement, and each carries its own `showState` for the times
+you want one bound but not printed (above).
 
 ### One list, not two mechanisms
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ distorted anyway.
 | `hideWhenInactive` | boolean                           | `false`      | Hide on the card while the entity is inactive. Always shown, dimmed, in the editor. |
 | `showState`   | boolean                                | sensors only | Show the entity state in the label line. Governs this device's **own** state only — `readings` show regardless. |
 | `showName`    | boolean                                | `false`      | Show the device's name in the label line (`Name · state` when combined). |
-| `readings`    | `{ entity?, attribute? }[]`            | —            | Everything this device reads beyond its own state — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
+| `readings`    | `{ entity?, attribute?, showState? }[]` | —           | Everything this device reads beyond its own state. `showState: false` keeps a row bound (the badge can read it) without printing it — a sensor's humidity and pressure, a plug's power, link quality and battery. Shown whether or not `showState` is. See [More readings per device](#more-readings-per-device). |
 | `labelPosition` | `below` \| `left` \| `right`         | `below`      | Where the label sits relative to the badge. |
 | `labelSize`   | number                                 | `12`         | Label line font size (px).                             |
 | `tap_action`  | ActionConfig                           | per domain   | Standard Lovelace action. By default `light`, `switch`, `fan` and `input_boolean` toggle and everything else — covers included — opens more-info. |
@@ -1126,8 +1126,8 @@ items:
 
 → `Study · 21.5 °C · 48% · 1013 hPa`, on one line, in the order written.
 
-Each row is `{ entity?, attribute? }`, and between them they say where the number comes
-from:
+Each row is `{ entity?, attribute?, showState? }`. `entity` and `attribute` say where the
+number comes from:
 
 | `entity` | `attribute` | reads |
 | --- | --- | --- |
@@ -1139,6 +1139,29 @@ from:
 The third row is what lets one climate entity show four of its own attributes without
 naming itself four times. The fourth is why the editor's **+ Add entity** can hand you an
 empty row without a `—` appearing on the plan.
+
+### Bound, but not printed
+
+`showState: false` on a row keeps the entity bound to the device without putting its value
+in the label:
+
+```yaml
+  - id: desk_plug
+    entity: switch.desk_plug
+    kind: switch
+    badgeContent: value
+    badgeEntity: 0             # the badge shows the power
+    readings:
+      - { entity: sensor.desk_plug_power, showState: false }
+```
+
+The badge reads `1.2 kW` in its circle and the label does not repeat it. The card still
+watches the entity, so the badge stays live.
+
+**Hiding a row does not renumber the others.** `badgeEntity` indexes the whole list,
+visible or not, so switching a row off cannot silently repoint the badge at a different
+entity. A device whose every extra row is hidden draws no label at all, and the editor
+stops offering the label's size and position for it.
 
 ### Readings ignore "Show state"
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2124,6 +2124,28 @@ export class FloorplanCardEditor extends LitElement {
               <ha-icon icon="mdi:close"></ha-icon>
             </button>
           </div>
+          <!-- Under its own entity, because it is about that entity and not
+               about the device: an entity can be bound for the badge to read
+               and kept out of the label text. -->
+          <div class="row wide reading-show">
+            <label for=${`show-reading-${it.id}-${i}`}>Show on label</label>
+            <input
+              id=${`show-reading-${it.id}-${i}`}
+              type="checkbox"
+              title="Off keeps this entity bound — the badge can still read it — without printing it in the label"
+              .checked=${reading.showState !== false}
+              @change=${(e: Event) =>
+                patch(i, {
+                  // `true` is the default, so it stays out of the YAML.
+                  showState: (e.target as HTMLInputElement).checked ? undefined : false,
+                })}
+            />
+            <span class="hint"
+              >${reading.showState === false
+                ? "Bound but not printed — the badge can still read it."
+                : "Its value joins the label line."}</span
+            >
+          </div>
         `
       )}
       <div class="row wide state-color-add">
@@ -5923,6 +5945,17 @@ export class FloorplanCardEditor extends LitElement {
     .item-reading .reading-attr {
       flex: 0 0 130px;
       min-width: 0;
+    }
+    /* The visibility toggle belongs to the entity row above it, so it sits
+       tight under it and the gap goes after the pair instead. */
+    .reading-show {
+      margin-top: -4px;
+      margin-bottom: 12px;
+      padding-left: 4px;
+    }
+    .reading-show label {
+      flex: 0 0 auto;
+      font-size: 12px;
     }
     /* The panel ("Project" config) and the new element-edit area share the
        same boxed look so the two sections below the canvas read as siblings. */

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2128,18 +2128,25 @@ export class FloorplanCardEditor extends LitElement {
                about the device: an entity can be bound for the badge to read
                and kept out of the label text. -->
           <div class="row wide reading-show">
-            <label for=${`show-reading-${it.id}-${i}`}>Show on label</label>
-            <input
-              id=${`show-reading-${it.id}-${i}`}
-              type="checkbox"
-              title="Off keeps this entity bound — the badge can still read it — without printing it in the label"
-              .checked=${reading.showState !== false}
-              @change=${(e: Event) =>
-                patch(i, {
-                  // `true` is the default, so it stays out of the YAML.
-                  showState: (e.target as HTMLInputElement).checked ? undefined : false,
-                })}
-            />
+            <!-- The input is *inside* its label rather than paired to it by
+                 id: the only id available here is the element's own, which
+                 comes from config and can be anything, so a generated "for"
+                 would be invalid or duplicated exactly when someone
+                 hand-writes their YAML. Wrapping needs no id, and clicking
+                 the words toggles the box either way. -->
+            <label>
+              <input
+                type="checkbox"
+                title="Off keeps this entity bound — the badge can still read it — without printing it in the label"
+                .checked=${reading.showState !== false}
+                @change=${(e: Event) =>
+                  patch(i, {
+                    // `true` is the default, so it stays out of the YAML.
+                    showState: (e.target as HTMLInputElement).checked ? undefined : false,
+                  })}
+              />
+              Show on label
+            </label>
             <span class="hint"
               >${reading.showState === false
                 ? "Bound but not printed — the badge can still read it."
@@ -2155,8 +2162,9 @@ export class FloorplanCardEditor extends LitElement {
       </div>
       ${list.length
         ? html`<p class="hint rule-note">
-            Shown whether or not "Show state" is on — that toggle is about this
-            device's own state, so a device can label itself with these alone.
+            These show whether or not the device's own "Show state" above is on
+            — that toggle is about the device's entity, not about these. Use
+            each row's own "Show on label" to keep one bound without printing it.
           </p>`
         : nothing}
     `;
@@ -5956,6 +5964,12 @@ export class FloorplanCardEditor extends LitElement {
     .reading-show label {
       flex: 0 0 auto;
       font-size: 12px;
+      /* Holds the checkbox it wraps, so the pair reads as one control and the
+         whole thing is a click target. */
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
     }
     /* The panel ("Project" config) and the new element-edit area share the
        same boxed look so the two sections below the canvas read as siblings. */

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { html, nothing } from "lit";
-import type { Area, Furniture, FurnitureType, ItemKind } from "./types";
+import type { Area, Furniture, FurnitureType, ItemKind, ItemReading } from "./types";
 import { SKIN_ACCENT, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 import {
   DEFAULT_GLOW_RADIUS,
@@ -5050,5 +5050,91 @@ describe("actions on rooms (issue #181)", () => {
     expect(areaHasActions(area({ tap_action: { action: "none" } }))).toBe(false);
     expect(areaHasActions(area({ tap_action: { action: "toggle" } }))).toBe(true);
     expect(areaHasActions(area({ double_tap_action: { action: "more-info" } }))).toBe(true);
+  });
+});
+
+describe("a reading can be bound without being printed", () => {
+  const named = () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).friendly_name = "Living Temp";
+    return h;
+  };
+  const item = (readings: ItemReading[], extra = {}) =>
+    ({ entity: TEMP, kind: "sensor", readings, ...extra }) as Parameters<typeof itemBadgeLabel>[1];
+
+  it("keeps a hidden reading out of the label", () => {
+    expect(itemBadgeLabel(named(), item([{ entity: HUMIDITY }]))).toBe("17.9 °C · 49.3%");
+    expect(itemBadgeLabel(named(), item([{ entity: HUMIDITY, showState: false }]))).toBe("17.9 °C");
+  });
+
+  it("treats unset and true alike — nothing changes for an existing plan", () => {
+    for (const showState of [undefined, true] as const) {
+      expect(itemBadgeLabel(named(), item([{ entity: HUMIDITY, showState }]))).toBe(
+        "17.9 °C · 49.3%",
+      );
+    }
+  });
+
+  it("hides one without hiding the rest", () => {
+    expect(
+      itemBadgeLabel(
+        named(),
+        item([{ entity: HUMIDITY, showState: false }, { entity: TEMP }]),
+      ),
+    ).toBe("17.9 °C · 17.9 °C");
+  });
+
+  it("does NOT renumber the others — the badge's index must not move", () => {
+    // The trap this exists to avoid: hide reading 0 and, if the badge indexed
+    // only the visible ones, `badgeEntity: 1` would silently start reading a
+    // different entity.
+    const plug = fakeHass([
+      { entity_id: "switch.plug", state: "on" },
+      { entity_id: "sensor.power", state: "1200", unit: "W" },
+      { entity_id: "sensor.lqi", state: "84" },
+    ]);
+    const withHidden = {
+      entity: "switch.plug",
+      readings: [{ entity: "sensor.power", showState: false }, { entity: "sensor.lqi" }],
+      badgeEntity: 0 as const,
+    };
+    // Index 0 is still the power sensor, though it prints nothing.
+    expect(badgeReading(plug, withHidden)?.source).toBe(0);
+    expect(badgeReading(plug, withHidden)?.text).toBe("1.2kW");
+    expect(itemReadings(withHidden)).toHaveLength(2);
+    // …and index 1 is still the one it always was.
+    expect(badgeReading(plug, { ...withHidden, badgeEntity: 1 })?.text).toBe("84");
+  });
+
+  it("a device labelled only by hidden readings draws no label", () => {
+    // So the editor does not offer a label's size and position for a label
+    // that is never on screen.
+    expect(itemHasLabel({ kind: "light", readings: [{ entity: HUMIDITY }] })).toBe(true);
+    expect(
+      itemHasLabel({ kind: "light", readings: [{ entity: HUMIDITY, showState: false }] }),
+    ).toBe(false);
+    // One visible among hidden ones is still a label.
+    expect(
+      itemHasLabel({
+        kind: "light",
+        readings: [{ entity: HUMIDITY, showState: false }, { entity: TEMP }],
+      }),
+    ).toBe(true);
+  });
+
+  it("still watches a hidden reading's entity — the badge reads it live", () => {
+    const got = collectWatchedEntities({
+      items: [
+        {
+          id: "i",
+          kind: "sensor",
+          x: 0,
+          y: 0,
+          entity: TEMP,
+          readings: [{ entity: HUMIDITY, showState: false }],
+        },
+      ],
+    } as unknown as FloorplanCardConfig);
+    expect([...got].sort()).toEqual([TEMP, HUMIDITY].sort());
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1038,6 +1038,11 @@ export function itemBadgeLabel(
   // Each is added only if it resolves to something, so the blank row the
   // editor's "+" creates stays invisible until it is filled in.
   for (const reading of itemReadings(item)) {
+    // `showState: false` binds the entity without printing it — for a device
+    // whose badge shows that number and has no use for it twice. The reading
+    // keeps its place in the list either way, so the badge's index into it
+    // does not move (see ItemReading.showState).
+    if (reading.showState === false) continue;
     const text = itemReadingText(hass, item, reading);
     if (text) parts.push(text);
   }
@@ -1067,7 +1072,10 @@ export function itemHasLabel(item: {
 }): boolean {
   if (item.showName) return true;
   if (item.showState ?? item.kind === "sensor") return true;
-  return itemReadings(item).some((r) => r.entity || r.attribute);
+  // Only the readings that actually print count: a device whose every extra
+  // entity is bound for the badge alone draws no label, and should not be
+  // offered a label's size and position.
+  return itemReadings(item).some((r) => r.showState !== false && (r.entity || r.attribute));
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,7 +460,9 @@ export interface FloorItem {
    * they show. Resolve with `itemReadings`, never by reading either key
    * directly.
    *
-   * **Shown whether or not `showState` is**, which is the point of them. A plug
+   * **Shown whether or not the *device's* {@link FloorItem.showState} is**,
+   * which is the point of them — a row's own {@link ItemReading.showState} is
+   * the switch for hiding one of these. A plug
    * says on/off through its badge colour, so its owner wants Power · LQI ·
    * Battery and *not* the word "on" (I-G-1-1's case in discussion #173).
    * `showState` is about the device's *own state*; these are not it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,20 @@ export interface ItemReading {
   entity?: string;
   /** Attribute to read instead of the state. */
   attribute?: string;
+  /**
+   * Whether this reading's value joins the label line. Default `true`.
+   *
+   * `false` binds the entity to the device without printing it: the badge can
+   * still be pointed at it with {@link FloorItem.badgeEntity}, and the card
+   * still watches it for changes. That is the case this exists for — a smart
+   * plug that badges `1.2 kW` in its circle has no use for the same number
+   * repeated in text underneath.
+   *
+   * Hiding a reading does **not** renumber the others: `badgeEntity` indexes
+   * the whole list, visible or not, so switching this off cannot silently
+   * repoint the badge at a different entity.
+   */
+  showState?: boolean;
 }
 
 /**


### PR DESCRIPTION
Follow-up to the multi-entity work in #186. Each row in **Other entities** gets a **Show on label** toggle beneath its picker.

## Why

The badge created the need. A smart plug pointed at its power sensor shows `1.2 kW` inside the circle — and has no use for the same number repeated in text underneath it. Until now, binding an entity meant printing it, so the only way to have the badge read something was to accept it in the label too.

```yaml
  - id: desk_plug
    entity: switch.desk_plug
    kind: switch
    badgeContent: value
    badgeEntity: 0             # the badge shows the power
    readings:
      - { entity: sensor.desk_plug_power, showState: false }
```

The badge reads `1.2 kW`; the label does not repeat it. The card still watches the entity, so the badge stays live.

Default is `true`, and unset reads as `true` — no existing plan changes.

## Two consequences worth naming

**Hiding a row does not renumber the others.** `badgeEntity` indexes the whole list, visible or not. Filtering hidden rows out before indexing would mean that switching one off silently repoints the badge at a *different* entity — so the list keeps its shape and only the label composer skips. There's a test on exactly that: hide index 0, and index 0 is still the power sensor while index 1 is still what it always was.

**A device labelled only by hidden rows has no label.** `itemHasLabel` counts the rows that actually print, so the editor stops offering a label's size and position for a label that is never on screen.

## The control

It sits *under* its own entity rather than in a column of its own, because it is about that entity and not about the device — which is also how you asked for it. Its hint says which of the two states you're looking at ("Its value joins the label line." / "Bound but not printed — the badge can still read it.") rather than making you infer it from a checkbox.

## Verification

`npm test` (1148, 6 new), `npm run typecheck`, `npm run build` clean.

Checked in a browser against the built bundle, driving the real editor:

- a device with one shown and one hidden row renders `Studio · 21.5 · 48` — the hidden one absent;
- clicking **Show on label** off writes `showState: false` into the config, the canvas label drops to `Studio · 21.5`, and the row's hint switches to the "bound but not printed" wording;
- both rows stay in `readings` after the toggle, so the indices the badge uses are unmoved.

Branched off `main`, independent of #187.