### PR TITLE
Ripple: offer it on vibration sensors too (closes #202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ distorted anyway.
 | `name`        | string                                 | friendly name| Label / tooltip override.                             |
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
-| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`) and offers it on presence and vibration devices only; in YAML it works on any entity. |
+| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`) and offers it only on devices that detect something where they sit (see [Presence ripples](#presence-ripples)); in YAML it works on any entity. |
 | `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. The editor spells this as the icon options of **Badge shows**, showing `auto` as whatever it resolves to. |
 | `activeColor` | string                                 | theme color  | Badge color while on. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color, falling back to `activeColor` then the primary color. |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ screen size.
 ## Features
 - **Visual editor** — draw walls, drop doors and windows that snap onto them, drag, nudge with arrow keys, multi-select, copy/paste, undo/redo, zoom.
 - **Devices** — bind any entity to an icon: tap to toggle or open more-info, live state or attribute label, custom icon, size, rotation.
-  - **Presence ripples** — presence sensors drawn as animated rings instead of a static icon.
+  - **Presence ripples** — presence and vibration sensors drawn as animated rings instead of a static icon.
   - (${\color{red}NEW!}$) **Cast light** — a light pools its own color and brightness onto the plan; overlapping pools mix, so a warm lamp and a cool one blend between them.
   - (${\color{red}NEW!}$) **Conditional text / icon / coloring** — threshold and state rules restyle an element from what its entity reads: the badge color, the label, and the glyph itself, so blinds swap between open and closed icons and a thermostat reddens as it heats. The same rules drive furniture and rooms.
  
@@ -319,17 +319,18 @@ size** are per tracker.
 
 Turn on a device's **Ripple** toggle and it draws animated concentric rings behind the
 badge — set **Badge shows** to *Nothing* for the rings alone. They pulse outward and fade
-while presence is detected, and collapse to a faint dot when it's clear, so the spot stays
-marked without pulling the eye.
+while the device detects something, and collapse to a faint dot when it's clear, so the
+spot stays marked without pulling the eye.
 
 **Ripple color** and **ripple size** are per device (the color follows **Active color**
 and state rules unless you set one).
 
-The toggle appears only on devices that detect presence — a `binary_sensor` whose device
-class is `motion`, `occupancy` or `presence`, or a `device_tracker` / `person` — the same
-way **Cast light** appears only on lights: a ring claims someone is there, so it's offered
-where that claim can be true. The underlying `display` key still works on any entity in
-YAML.
+The toggle appears only on devices that detect something where they sit — a
+`binary_sensor` whose device class is `motion`, `occupancy`, `presence` or `vibration`, or
+a `device_tracker` / `person` — the same way **Cast light** appears only on lights: a ring
+claims something is happening there, so it's offered where that claim can be true. A
+vibration sensor on a door therefore rings like a motion sensor does. The underlying
+`display` key still works on any entity in YAML.
 
 <img width="540" height="304" alt="ripple_demo_gif" src="https://github.com/user-attachments/assets/e43949cf-13a2-48f8-804d-73738299475f" />
 
@@ -472,7 +473,7 @@ distorted anyway.
 | `name`        | string                                 | friendly name| Label / tooltip override.                             |
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
-| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`) and offers it on presence devices only; in YAML it works on any entity. |
+| `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`) and offers it on presence and vibration devices only; in YAML it works on any entity. |
 | `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. The editor spells this as the icon options of **Badge shows**, showing `auto` as whatever it resolves to. |
 | `activeColor` | string                                 | theme color  | Badge color while on. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color, falling back to `activeColor` then the primary color. |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -462,16 +462,18 @@ describe("itemForm", () => {
     expect(names({ ...item, kind: "sensor", entity: "sensor.temp" } as FloorItem)).not.toContain("glow");
   });
 
-  it("offers Ripple on presence devices only, sized behind the toggle (#127)", () => {
+  it("offers Ripple on detecting devices only, sized behind the toggle (#127, #202)", () => {
     const motion = { ...item, entity: "binary_sensor.hall", kind: "binary_sensor" } as FloorItem;
     const names = (it: FloorItem, dc?: string) => itemForm(it, dc).fields.map((x) => x.name);
-    // A light is not something that detects presence, whatever it can do.
+    // A light is not something that detects anything, whatever it can do.
     expect(names(item)).not.toContain("ripple");
     expect(names(item, "motion")).not.toContain("ripple");
     // Nor is a binary sensor whose class says door / leak / nothing at all.
     expect(names(motion)).not.toContain("ripple");
     expect(names(motion, "door")).not.toContain("ripple");
-    for (const dc of ["motion", "occupancy", "presence"]) {
+    // vibration is offered alongside the presence classes (issue #202): a
+    // vibration sensor on a door marks that spot the way motion marks a room.
+    for (const dc of ["motion", "occupancy", "presence", "vibration"]) {
       expect(names(motion, dc)).toContain("ripple");
     }
     expect(names({ ...item, entity: "device_tracker.phone" } as FloorItem)).toContain("ripple");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -43,7 +43,7 @@ import {
   WALL_THICKNESS,
   badgeContentOf,
   domainIconAnimation,
-  isPresenceEntity,
+  isRippleEntity,
   normalizeOverlayScale,
   normalizePlanRotation,
   openingActionForGesture,
@@ -973,30 +973,32 @@ export function itemBadgeForm(it: FloorItem, badgeSource?: BadgeSourceInfo): For
 
 /**
  * Group 6: the optional visual extras, each offered only where it means
- * something — a ring on a thermostat says "someone is here", which is a lie,
- * and nothing but a light has a colour to cast.
+ * something — a ring on a thermostat says "something is happening here",
+ * which is a lie, and nothing but a light has a colour to cast.
  *
  * Returns `undefined` when this device qualifies for neither, so the editor
  * can leave the whole group out rather than print an empty heading.
  *
  * `deviceClass` is the entity's HA device class, resolved off `hass` at the
  * call site as the openings already do theirs: it is what separates a motion
- * sensor from a door contact, and so decides whether the ring is offered at
- * all (issue #127).
+ * or vibration sensor from a door contact, and so decides whether the ring is
+ * offered at all (issues #127, #202).
  */
 export function itemEffectsForm(it: FloorItem, deviceClass?: string): FormSpec | undefined {
   const ripple = itemHasRipple(it);
-  const presence = isPresenceEntity(it.entity, deviceClass);
+  const canRipple = isRippleEntity(it.entity, deviceClass);
   const lights = it.kind === "light" || it.entity?.startsWith("light.");
-  if (!presence && !lights) return undefined;
+  if (!canRipple && !lights) return undefined;
   const fields: FormField[] = [];
-  if (presence) {
+  if (canRipple) {
     fields.push({
       name: "ripple",
       label: "Ripple",
-      // "Presence detected" rather than "the sensor is on": this is offered to
-      // a device_tracker and a person too, and neither of those is a sensor.
-      helper: "Draws a pulsing ring while presence is detected here",
+      // "Detected" rather than "the sensor is on": this is offered to a
+      // device_tracker and a person too, and neither of those is a sensor.
+      // It stays vague about *what* is detected because a vibration sensor
+      // rings for a knock, not for presence (issue #202).
+      helper: "Draws a pulsing ring while this device detects something",
       selector: { boolean: {} },
     });
     if (ripple) {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -102,7 +102,7 @@ import {
   entityIsActive,
   lightBadgePaint,
   itemRawValue,
-  isPresenceEntity,
+  isRippleEntity,
   badgeContentOf,
   editorItemLabel,
   badgeValue,
@@ -4401,8 +4401,9 @@ export class FloorplanCardEditor extends LitElement {
       const it = this._floor().items.find((x) => x.id === sel.id);
       if (!it) return html`${nothing}`;
       const areaEntities = this._areaEntitiesAt(it.x, it.y);
-      // The entity's device class decides whether this is a presence device,
-      // and so whether the ripple is on offer at all (issue #127).
+      // The entity's device class decides whether this device detects
+      // anything, and so whether the ripple is on offer at all (issues #127,
+      // #202).
       const deviceClass = it.entity
         ? (this.hass?.states[it.entity]?.attributes?.device_class as string | undefined)
         : undefined;
@@ -4482,7 +4483,7 @@ export class FloorplanCardEditor extends LitElement {
               "Effects",
               this._renderForm(effects, apply),
               // The ring's colour belongs with the ring, not with the badge's.
-              isPresenceEntity(it.entity, deviceClass) && itemHasRipple(it)
+              isRippleEntity(it.entity, deviceClass) && itemHasRipple(it)
                 ? this._renderColorRow({
                     label: "Ripple color",
                     value: it.rippleColor,

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -115,7 +115,7 @@ import {
   badgeValueSize,
   resolveIconAnimation,
   domainIconAnimation,
-  isPresenceEntity,
+  isRippleEntity,
   itemIconSize,
   normalizePlanRotation,
   rotatedCanvasSize,
@@ -1692,30 +1692,32 @@ describe("domainIconAnimation (issue #127)", () => {
   });
 });
 
-describe("isPresenceEntity (issue #127)", () => {
-  it("accepts the binary-sensor classes that mean someone is there", () => {
-    for (const dc of ["motion", "occupancy", "presence"]) {
-      expect(isPresenceEntity("binary_sensor.hall", dc)).toBe(true);
+describe("isRippleEntity (issue #127)", () => {
+  it("accepts the binary-sensor classes that mean something happened here", () => {
+    // vibration joins the presence classes: a door sensor that feels a knock
+    // marks a spot the same way a motion sensor does (issue #202).
+    for (const dc of ["motion", "occupancy", "presence", "vibration"]) {
+      expect(isRippleEntity("binary_sensor.hall", dc)).toBe(true);
     }
   });
 
   it("accepts trackers and people on their domain alone", () => {
-    expect(isPresenceEntity("device_tracker.phone", undefined)).toBe(true);
-    expect(isPresenceEntity("person.sam", undefined)).toBe(true);
+    expect(isRippleEntity("device_tracker.phone", undefined)).toBe(true);
+    expect(isRippleEntity("person.sam", undefined)).toBe(true);
   });
 
   it("rejects sensors that detect something else, and an unclassed one", () => {
-    expect(isPresenceEntity("binary_sensor.front_door", "door")).toBe(false);
-    expect(isPresenceEntity("binary_sensor.leak", "moisture")).toBe(false);
+    expect(isRippleEntity("binary_sensor.front_door", "door")).toBe(false);
+    expect(isRippleEntity("binary_sensor.leak", "moisture")).toBe(false);
     // No class at all could be anything — guessing from the name would ring
     // doorbells and smoke alarms.
-    expect(isPresenceEntity("binary_sensor.presence", undefined)).toBe(false);
+    expect(isRippleEntity("binary_sensor.presence", undefined)).toBe(false);
   });
 
   it("rejects other domains, whatever class they carry", () => {
-    expect(isPresenceEntity("light.a", "motion")).toBe(false);
-    expect(isPresenceEntity("sensor.motion", "motion")).toBe(false);
-    expect(isPresenceEntity(undefined, "motion")).toBe(false);
+    expect(isRippleEntity("light.a", "motion")).toBe(false);
+    expect(isRippleEntity("sensor.motion", "motion")).toBe(false);
+    expect(isRippleEntity(undefined, "motion")).toBe(false);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1421,29 +1421,34 @@ export function resolveIconAnimation(
 }
 
 /**
- * Device classes that mean "something is here" — the sensors a ripple ring was
- * drawn for (issue #127). `motion` and `occupancy` are HA's own binary-sensor
- * classes; `presence` is the home/away one.
+ * Device classes a ripple ring is offered for (issue #127). `motion` and
+ * `occupancy` are HA's own binary-sensor classes for someone being there;
+ * `presence` is the home/away one. `vibration` joins them (issue #202,
+ * @GhislainC): a vibration sensor on a door reports the same thing a ring
+ * says — something happened at this spot on the plan — so the ring is as true
+ * of it as of a motion sensor.
  */
-const PRESENCE_DEVICE_CLASSES = new Set(["motion", "occupancy", "presence"]);
+const RIPPLE_DEVICE_CLASSES = new Set(["motion", "occupancy", "presence", "vibration"]);
 
 /**
- * Whether a device detects presence, and so should be offered the ripple ring
- * (issue #127) — the same shape of gate as "Cast light" on a `light`.
+ * Whether a device detects something happening where it sits, and so should be
+ * offered the ripple ring (issue #127) — the same shape of gate as "Cast
+ * light" on a `light`.
  *
  * A `device_tracker` or `person` qualifies on its domain alone; a
  * `binary_sensor` needs the device class to say so, which is what separates a
- * motion sensor from a door contact or a leak detector. A binary sensor with
- * no device class set is therefore *not* presence: it could be anything, and
- * guessing from the entity id would ring doorbells and smoke alarms.
+ * motion or vibration sensor from a door contact or a leak detector. A binary
+ * sensor with no device class set therefore does not qualify: it could be
+ * anything, and guessing from the entity id would ring doorbells and smoke
+ * alarms.
  */
-export function isPresenceEntity(
+export function isRippleEntity(
   entity: string | undefined,
   deviceClass: string | undefined,
 ): boolean {
   const domain = entity?.split(".")[0];
   if (domain === "device_tracker" || domain === "person") return true;
-  return domain === "binary_sensor" && !!deviceClass && PRESENCE_DEVICE_CLASSES.has(deviceClass);
+  return domain === "binary_sensor" && !!deviceClass && RIPPLE_DEVICE_CLASSES.has(deviceClass);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -527,7 +527,8 @@ export interface FloorItem {
    *
    * The ripple modes render on any entity. The editor only *offers* them on a
    * device that detects something where it sits (issues #127, #202) — a
-   * presence sensor, or a vibration one — so a ring on anything else is a
+   * motion, occupancy, presence or vibration sensor, or a `device_tracker` /
+   * `person`, per {@link isRippleEntity} — so a ring on anything else is a
    * YAML-only choice.
    */
   display?: ItemDisplay;

--- a/src/types.ts
+++ b/src/types.ts
@@ -526,8 +526,9 @@ export interface FloorItem {
    * How the device is drawn. Default "badge".
    *
    * The ripple modes render on any entity. The editor only *offers* them on a
-   * presence device (issue #127) — a ring says "someone is there" — so a ring
-   * on anything else is a YAML-only choice.
+   * device that detects something where it sits (issues #127, #202) — a
+   * presence sensor, or a vibration one — so a ring on anything else is a
+   * YAML-only choice.
    */
   display?: ItemDisplay;
   /**


### PR DESCRIPTION
Closes #202 (@GhislainC).

The **Ripple** toggle was gated on presence — a `binary_sensor` classed `motion` / `occupancy` / `presence`, or a `device_tracker` / `person`. A vibration sensor on a front door could get rings only by hand-editing `display:` in YAML, even though the card has always drawn them for any entity.

A vibration sensor makes the same claim the ring does: something happened *here*. So `vibration` joins the set, and the gate stops calling itself presence:

- `isPresenceEntity` → `isRippleEntity`, over `RIPPLE_DEVICE_CLASSES`.
- Helper text now reads "Draws a pulsing ring while this device detects something" — naming presence was already a stretch for a `person` entity and is plainly wrong for a knock on a door.
- README and the `display` docs updated to list `vibration`.

Nothing changes for existing configs: rendering was never gated, so a ring already set on anything keeps working, and the three presence classes still qualify.

Tests: the gate's unit tests and the editor-form test both cover `vibration` now. `npm test` (1148), `npm run typecheck` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)