### PR TITLE
Editor: an Apply button that saves without closing (closes #198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ screen size.
 
 ## Features
 - **Visual editor** — draw walls, drop doors and windows that snap onto them, drag, nudge with arrow keys, multi-select, copy/paste, undo/redo, zoom.
+  - (${\color{red}NEW!}$) **Apply** — save the plan to the dashboard *without* closing the editor, so you can judge a change on the real card (in a second tab, or by collapsing the editor) instead of in the small preview beside it, then carry straight on. Needs Home Assistant 2025.3 or newer; on anything older the button says so and Save still works.
 - **Devices** — bind any entity to an icon: tap to toggle or open more-info, live state or attribute label, custom icon, size, rotation.
   - **Presence ripples** — presence sensors drawn as animated rings instead of a static icon.
   - (${\color{red}NEW!}$) **Cast light** — a light pools its own color and brightness onto the plan; overlapping pools mix, so a warm lamp and a cool one blend between them.

--- a/src/editor-save.test.ts
+++ b/src/editor-save.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyCardConfig,
+  findCardEditDialog,
+  APPLY_NEW_CARD,
+  APPLY_UNAVAILABLE,
+  type AncestorNode,
+  type CardEditDialog,
+} from "./editor-save";
+
+/** A stand-in for HA's edit dialog, with the internals Apply reaches for. */
+const makeDialog = (over: Partial<CardEditDialog> = {}): CardEditDialog & {
+  saved: unknown[];
+} => {
+  const saved: unknown[] = [];
+  return {
+    saved,
+    _cardConfig: { type: "custom:easy-floorplan-card", floors: [] },
+    _params: {
+      saveCardConfig: (config: unknown) => {
+        saved.push(config);
+      },
+    },
+    ...over,
+  };
+};
+
+/** Chain `nodes` child-to-parent, shadow roots included (`{ host }` hops). */
+const chain = (...nodes: AncestorNode[]): AncestorNode => {
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const node = nodes[i] as { parentNode?: AncestorNode; host?: AncestorNode };
+    if ("host" in node) node.host = nodes[i + 1];
+    else node.parentNode = nodes[i + 1];
+  }
+  return nodes[0];
+};
+
+describe("findCardEditDialog", () => {
+  it("walks out of shadow roots to the dialog", () => {
+    const dialog = makeDialog();
+    const editor = {};
+    chain(editor, { host: null }, {}, { host: null }, dialog);
+    expect(findCardEditDialog(editor)).toBe(dialog);
+  });
+
+  it("stops at the nearest dialog", () => {
+    const inner = makeDialog();
+    const outer = makeDialog();
+    const editor = {};
+    chain(editor, inner, outer);
+    expect(findCardEditDialog(editor)).toBe(inner);
+  });
+
+  it("ignores ancestors whose saveCardConfig isn't callable", () => {
+    // An older dialog: params, but no hook — as good as no dialog at all.
+    const legacy = { _params: { path: [0], cardIndex: 1 } };
+    const editor = {};
+    chain(editor, legacy as AncestorNode);
+    expect(findCardEditDialog(editor)).toBeNull();
+  });
+
+  it("returns null for a detached editor", () => {
+    expect(findCardEditDialog({})).toBeNull();
+    expect(findCardEditDialog(null)).toBeNull();
+  });
+
+  it("gives up rather than looping on a cyclic chain", () => {
+    const a: { parentNode?: AncestorNode } = {};
+    const b: { parentNode?: AncestorNode } = {};
+    a.parentNode = b;
+    b.parentNode = a;
+    expect(findCardEditDialog(a)).toBeNull();
+  });
+});
+
+describe("applyCardConfig", () => {
+  it("saves the config the dialog holds", async () => {
+    const dialog = makeDialog();
+    const editor = chain({}, { host: null }, dialog);
+    await expect(applyCardConfig(editor)).resolves.toEqual({ ok: true });
+    expect(dialog.saved).toEqual([dialog._cardConfig]);
+  });
+
+  it("saves the whole stack when the floorplan is nested in one", async () => {
+    // What the view must be handed back is the outer card, not ours.
+    const stack = { type: "vertical-stack", cards: [{ type: "custom:easy-floorplan-card" }] };
+    const dialog = makeDialog({ _cardConfig: stack });
+    await expect(applyCardConfig(chain({}, dialog))).resolves.toEqual({ ok: true });
+    expect(dialog.saved).toEqual([stack]);
+  });
+
+  it("waits for an async save", async () => {
+    let resolveSave: () => void = () => {};
+    const done = new Promise<void>((r) => {
+      resolveSave = r;
+    });
+    const dialog = makeDialog({ _params: { saveCardConfig: () => done } });
+    let settled = false;
+    const applying = applyCardConfig(chain({}, dialog)).then((r) => {
+      settled = true;
+      return r;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    resolveSave();
+    await expect(applying).resolves.toEqual({ ok: true });
+  });
+
+  it("reports a failed dashboard write instead of claiming a save", async () => {
+    const dialog = makeDialog({
+      _params: {
+        saveCardConfig: () => Promise.reject(new Error("Config not found")),
+      },
+      _markDirtyStateClean: vi.fn(),
+    });
+    const result = await applyCardConfig(chain({}, dialog));
+    expect(result).toEqual({ ok: false, error: "Could not save — Config not found" });
+    // A failed save leaves unsaved changes: closing must still warn.
+    expect(dialog._markDirtyStateClean).not.toHaveBeenCalled();
+  });
+
+  it("clears the dialog's dirty state so closing doesn't warn", async () => {
+    const dialog = makeDialog({ _markDirtyStateClean: vi.fn() });
+    await applyCardConfig(chain({}, dialog));
+    expect(dialog._markDirtyStateClean).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the older dirty flag", async () => {
+    const dialog = makeDialog({ _dirty: true });
+    await applyCardConfig(chain({}, dialog));
+    expect(dialog._dirty).toBe(false);
+  });
+
+  it("refuses while the card is new, which would add a second copy", async () => {
+    const dialog = makeDialog({
+      _params: { saveCardConfig: () => {}, isNew: true },
+    });
+    await expect(applyCardConfig(chain({}, dialog))).resolves.toEqual({
+      ok: false,
+      error: APPLY_NEW_CARD,
+    });
+    expect(dialog.saved).toEqual([]);
+  });
+
+  it("reports unavailable when there is no dialog to save through", async () => {
+    await expect(applyCardConfig({})).resolves.toEqual({
+      ok: false,
+      error: APPLY_UNAVAILABLE,
+    });
+  });
+
+  it("reports unavailable rather than saving a config the dialog hasn't got", async () => {
+    const dialog = makeDialog({ _cardConfig: undefined });
+    await expect(applyCardConfig(chain({}, dialog))).resolves.toEqual({
+      ok: false,
+      error: APPLY_UNAVAILABLE,
+    });
+    expect(dialog.saved).toEqual([]);
+  });
+});

--- a/src/editor-save.ts
+++ b/src/editor-save.ts
@@ -1,0 +1,115 @@
+/**
+ * "Apply" — write the card to the dashboard without closing the editor
+ * (issue #198).
+ *
+ * Home Assistant's Save closes the edit dialog. The preview beside the editor
+ * is a fraction of the size of the real card, so it can't settle where an icon
+ * actually lands on the plan; checking that meant saving, losing the editor,
+ * looking at the dashboard, then reopening and expanding it again for the next
+ * nudge. Apply does what Save does, minus the close.
+ *
+ * There is no public API for that, so this reaches into the dialog HA opened
+ * around us: `hui-dialog-edit-card` keeps the params it was shown with —
+ * including `saveCardConfig`, the callback that writes the card back into the
+ * view — plus the config it currently holds. Those are internals, so nothing
+ * here assumes they exist: every hop is duck-typed and a miss becomes a "use
+ * Save" message rather than an exception. HA has had this shape since 2025.3;
+ * before that the dialog built the new dashboard config itself, and the button
+ * degrades to that message.
+ *
+ * The config that gets saved is the *dialog's*, never our own. A floorplan
+ * nested in a vertical-stack is edited through the stack's editor, and what
+ * the view must be handed back is the whole stack — our own config would
+ * replace the stack with the bare floorplan.
+ */
+
+/**
+ * A node in the composed ancestor chain: an element (`parentNode`) or a shadow
+ * root (`host`). Structural rather than `Node`, so the walk is testable
+ * without a DOM.
+ */
+export interface AncestorNode {
+  readonly parentNode?: AncestorNode | null;
+  readonly host?: AncestorNode | null;
+}
+
+/** The parts of `hui-dialog-edit-card` Apply uses. All internals, all optional. */
+export interface CardEditDialog extends AncestorNode {
+  _params?: {
+    /** Writes the card back into the view (and saves the dashboard). */
+    saveCardConfig?: (config: unknown) => unknown;
+    /** True while the card is still being added — see `applyCardConfig`. */
+    isNew?: boolean;
+  };
+  /** The card config the dialog holds right now, ours included. */
+  _cardConfig?: unknown;
+  /** Current HA: re-baselines the dirty tracking after a save. */
+  _markDirtyStateClean?: () => void;
+  /** Older HA: the same thing as a plain flag. */
+  _dirty?: boolean;
+}
+
+export type ApplyResult = { ok: true } | { ok: false; error: string };
+
+/** Shown when the dialog above us isn't one we know how to save through. */
+export const APPLY_UNAVAILABLE =
+  "Apply needs Home Assistant's card editor — use Save instead.";
+
+/**
+ * Shown while the card is new. The dialog's callback *adds* a card until the
+ * first save, so applying twice would leave two floorplans on the dashboard.
+ */
+export const APPLY_NEW_CARD =
+  "Save this card once first — it isn't on the dashboard yet.";
+
+/** A cycle in the chain (or a pathological one) must not hang the click. */
+const MAX_DEPTH = 200;
+
+/** The nearest ancestor that can save the card, or null. */
+export function findCardEditDialog(
+  start: AncestorNode | null | undefined
+): CardEditDialog | null {
+  let node: AncestorNode | null | undefined = start;
+  for (let depth = 0; node && depth < MAX_DEPTH; depth++) {
+    const dialog = node as CardEditDialog;
+    if (typeof dialog._params?.saveCardConfig === "function") return dialog;
+    // A shadow root has no parent; step through its host instead.
+    node = node.parentNode ?? node.host ?? null;
+  }
+  return null;
+}
+
+/**
+ * Save whatever the surrounding edit dialog currently holds, leaving it open.
+ *
+ * `start` is the editor element: the dialog is found by walking out through
+ * the shadow roots between us. Failures are returned, not thrown — the button
+ * reports them in place and HA's own Save still works.
+ */
+export async function applyCardConfig(
+  start: AncestorNode | null | undefined
+): Promise<ApplyResult> {
+  const dialog = findCardEditDialog(start);
+  if (!dialog) return { ok: false, error: APPLY_UNAVAILABLE };
+  if (dialog._params?.isNew) return { ok: false, error: APPLY_NEW_CARD };
+  const config = dialog._cardConfig;
+  if (!config || typeof config !== "object") {
+    return { ok: false, error: APPLY_UNAVAILABLE };
+  }
+  try {
+    // The callback is async in every HA that has it; await it so a failed
+    // dashboard write is reported instead of read as a save.
+    await dialog._params!.saveCardConfig!(config);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Could not save — ${message}` };
+  }
+  // What the dialog holds is now what's on the dashboard, so closing it must
+  // not warn about unsaved changes.
+  if (typeof dialog._markDirtyStateClean === "function") {
+    dialog._markDirtyStateClean();
+  } else if (typeof dialog._dirty === "boolean") {
+    dialog._dirty = false;
+  }
+  return { ok: true };
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -143,6 +143,7 @@ import {
   type Sel,
   type SelKind,
 } from "./editor-geometry";
+import { applyCardConfig } from "./editor-save";
 import type { AreaEntityScope } from "./editor-forms";
 import {
   furnitureChoices,
@@ -258,6 +259,8 @@ const WALL_SNAP = 35;
  */
 const PICK_EPS_PX = 8;
 const HISTORY_MAX = 60;
+/** How long Apply stays on "Saved" before returning to its idle label. */
+const APPLY_SAVED_MS = 2000;
 /** Angle (degrees) within which a drawn wall is snapped flat to horizontal/vertical. */
 const WALL_AXIS_SNAP_DEG = 10;
 
@@ -336,6 +339,15 @@ export class FloorplanCardEditor extends LitElement {
    * gets real room and the element/project sections dock beside it.
    */
   @state() private _fullscreen = false;
+  /**
+   * Apply (issue #198): "saving" while the dashboard write is in flight,
+   * "saved" for a moment after, so the click has a visible answer — the card
+   * that changed is on another tab, or behind the fullscreen workspace.
+   */
+  @state() private _applyState: "idle" | "saving" | "saved" = "idle";
+  /** Why the last Apply didn't go through, shown beside the button. */
+  @state() private _applyError = "";
+  private _applyResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   @query(".editor") private _editorEl?: HTMLElement;
   @query("svg") private _svg?: SVGSVGElement;
@@ -400,6 +412,7 @@ export class FloorplanCardEditor extends LitElement {
     window.removeEventListener("keydown", this._onKeyDown, true);
     this.removeEventListener("keydown", this._onHostKeyDown);
     window.removeEventListener("focusin", this._onFocusIn);
+    if (this._applyResetTimer !== null) clearTimeout(this._applyResetTimer);
     this._resetPinch();
     super.disconnectedCallback();
   }
@@ -2853,6 +2866,30 @@ export class FloorplanCardEditor extends LitElement {
             ${this._fullscreen ? "Exit" : "Expand"}
           </button>
 
+          <!-- Apply: save the plan to the dashboard and keep editing (issue
+               #198). HA's own Save closes the dialog, and the preview beside
+               the editor is too small to judge where an icon really lands, so
+               checking one nudge cost a save, a close, a look, then reopening
+               and re-expanding the editor. Next to Expand because that is
+               where the need bites hardest: the fullscreen workspace covers
+               HA's footer, Save included. -->
+          <button
+            class="apply-btn"
+            ?disabled=${this._applyState === "saving"}
+            title="Save to the dashboard without closing the editor — the card behind updates"
+            @click=${this._apply}
+          >
+            <ha-icon
+              icon=${this._applyState === "saved" ? "mdi:check" : "mdi:content-save-outline"}
+            ></ha-icon>
+            ${this._applyState === "saved"
+              ? "Saved"
+              : this._applyState === "saving"
+                ? "Saving…"
+                : "Apply"}
+          </button>
+          ${this._applyError ? html`<span class="apply-error">${this._applyError}</span>` : nothing}
+
           <!-- Labels: declutter a dense plan while editing (issue #52). -->
           <button
             class="icon-btn"
@@ -3548,6 +3585,36 @@ export class FloorplanCardEditor extends LitElement {
     this._addMenuOpen = false;
     this._addQuery = "";
   }
+
+  /**
+   * Save the card to the dashboard and stay in the editor (issue #198).
+   *
+   * The heavy lifting is in `editor-save.ts`; what belongs here is the wait
+   * before it. Our edits reach HA through `config-changed`, which the element
+   * editor between us and the dialog re-fires only after its own render — and
+   * a field committed by the blur *this very click* caused is still in flight
+   * at this point. Letting the microtasks drain first is the difference
+   * between applying the plan and applying it one edit ago.
+   */
+  private _apply = async (): Promise<void> => {
+    if (this._applyState === "saving") return;
+    if (this._applyResetTimer !== null) clearTimeout(this._applyResetTimer);
+    this._applyState = "saving";
+    this._applyError = "";
+    await this.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const result = await applyCardConfig(this);
+    if (!result.ok) {
+      this._applyState = "idle";
+      this._applyError = result.error;
+      return;
+    }
+    this._applyState = "saved";
+    this._applyResetTimer = setTimeout(() => {
+      this._applyResetTimer = null;
+      this._applyState = "idle";
+    }, APPLY_SAVED_MS);
+  };
 
   /**
    * The "+ Add" popover: device, text, then every symbol as its real glyph.
@@ -4880,12 +4947,25 @@ export class FloorplanCardEditor extends LitElement {
       background: var(--card-background-color, #fff);
       overflow: hidden;
     }
-    /* Toolbar-icon button (Expand/Exit) — match the gear button's icon+label
-       alignment so it reads as part of the toolbar. */
-    .expand-toggle {
+    /* Toolbar-icon buttons (Expand/Exit, Apply) — match the gear button's
+       icon+label alignment so they read as part of the toolbar. */
+    .expand-toggle,
+    .apply-btn {
       display: inline-flex;
       align-items: center;
       gap: 5px;
+    }
+    /* Apply writes to the dashboard, unlike everything else in the toolbar —
+       accented so it reads as the one committing action. */
+    .apply-btn {
+      color: var(--primary-color, #03a9f4);
+      border-color: var(--primary-color, #03a9f4);
+    }
+    /* Why the last Apply didn't go through; sits in the toolbar so it is
+       visible in the fullscreen workspace too, where nothing else is. */
+    .apply-error {
+      font-size: 12px;
+      color: var(--error-color, #c62828);
     }
     /* Below the two toolbars: the canvas and the element/project sections.
        Stacked at dialog width; split into canvas + docked side panel when


### PR DESCRIPTION
Closes #198.

## The problem

HA's **Save** closes the edit dialog. The preview beside the editor is a fraction of the size of the real card, so it can't settle where an icon actually lands on the plan — checking that meant exiting full screen, saving, switching to the dashboard tab, then coming back through *edit → pick the card → expand* for the next nudge.

## What this adds

An **Apply** button in the editor toolbar, next to Expand — the fullscreen workspace covers HA's own footer, Save included, so that is where the need bites hardest. It writes the card to the dashboard and leaves the editor exactly as it was: the card behind updates, in a second tab as well, and you carry on editing. The button answers the click (`Saving…` → `Saved` for two seconds), because the thing that changed is somewhere you can't see from here.

## How

There is no public API for "save but stay open", so `src/editor-save.ts` walks out through the shadow roots to the dialog HA opened around us and uses its own hook: the `saveCardConfig` callback `hui-dialog-edit-card` was shown with, plus the config it currently holds. Those are internals, so every hop is duck-typed and any miss becomes an inline "use Save" message rather than an exception. HA has had this shape since 2025.3; older ones get the message and Save still works.

Three things the shortest version of this would get wrong, and which the tests pin:

- **The config saved is the dialog's, not ours.** A floorplan nested in a `vertical-stack` is edited through the stack's editor; handing the view our own config would replace the stack with a bare floorplan.
- **A card that isn't on the dashboard yet is refused.** Until the first save the dialog's callback *adds* rather than replaces, so applying twice would leave two floorplans behind. The button says to save once first.
- **The click waits for the edit it caused.** Our `config-changed` reaches the dialog via the element editor, which re-fires it only after its own render — a field committed by the blur from this very click is still in flight. Without the wait, Apply saves the plan as of one edit ago.

After a successful apply the dialog's dirty tracking is re-baselined (`_markDirtyStateClean`, falling back to the older `_dirty` flag), so closing afterwards doesn't warn about changes that are already on disk. A failed write is reported and leaves it dirty.

## Verified

- `npm run typecheck`, `npm test` (1162 pass, 14 new), `npm run build`.
- Driven in a browser against the built bundle inside a stand-in dialog with two shadow-root hops, both docked and fullscreen: one save per click carrying the dialog's own config object, `Saving… → Saved → Apply`, dirty flag cleared, all three failure messages rendering in the toolbar, and the in-flight-edit case above saving the *latest* config.

Not run against a live Home Assistant — the container harness needs onboarding — so a click on a real dashboard before merging is worth it.