### PR TITLE
Floors: the switcher can live on the stairs (closes #121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ screen size.
 <img width="444" height="313" alt="night" src="https://github.com/user-attachments/assets/1590b710-d88f-4a34-986b-b08640a45f4c" />
 
 
-- **Multiple floors** — per-floor elements with a switcher in both the editor and the card.
+- **Multiple floors** — per-floor elements with a switcher in both the editor and the card. (${\color{red}NEW!}$) Drag that switcher onto the plan — onto the staircase you drew, as icon buttons — instead of leaving it in the corner.
 - **Background image** — trace over a floor-plan scan, per floor, with adjustable opacity.
 - (${\color{red}NEW!}$) **Skins** — restyle the whole plan from one line of config: `default` follows your Home Assistant theme, `odnetnin` is chunky charcoal on cream, `pastel` is soft and low-contrast, `tron` is neon on near-black. Colors you set on an element yourself always win.
   
@@ -378,6 +378,7 @@ The editor writes this config for you; manual editing is optional.
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
+| `floorSwitcher`| map    | corner             | Where and how the floor switcher is drawn: `{ x?, y?, direction?, width?, height?, hidden? }`. See [Putting the switcher on the stairs](#putting-the-switcher-on-the-stairs). |
 | `walls`      | Wall[]   | `[]`               | Wall segments (single-floor / floor 1).      |
 | `openings`   | Opening[]| `[]`               | Doors and windows (swing or sliding).        |
 | `items`      | Item[]   | `[]`               | Entity devices.                              |
@@ -398,7 +399,9 @@ and remain valid for backward compatibility.
 the editor's **floor** controls; the card shows a switcher when there is more than one.
 
 - **`short`** — abbreviation for the card's switcher button (`GF`, `1st`…), full name as
-  its tooltip. **`color`** accents that button while its floor is active. The top-level
+  its tooltip. **`icon`** replaces that text with a glyph (`mdi:stairs-up`) — what makes a
+  switcher small enough to sit on a drawn staircase; the name stays as the tooltip.
+  **`color`** accents that button while its floor is active. The top-level
   **`defaultFloor`** picks which floor the card opens on.
 - **`haFloor`** — id of a linked Home Assistant floor, set from the floor gear popover.
   Today it auto-names the floor.
@@ -1231,6 +1234,51 @@ label gets no Label group, and an opening with no shutter gets no Shutter group.
 
 Walls and text keep a plain list: a wall is thickness and length, a text is its words, size
 and angle. A heading over one or two fields is chrome rather than structure.
+
+## Putting the switcher on the stairs
+
+A plan with more than one floor gets a switcher in the card's top-right corner. It can go
+somewhere better (issue #121):
+
+```yaml
+floors:
+  - id: ground
+    name: Ground floor
+    icon: mdi:stairs-down
+    # …
+  - id: upstairs
+    name: Upstairs
+    icon: mdi:stairs-up
+    # …
+floorSwitcher:
+  x: 300           # canvas units — on the staircase you drew
+  y: 170
+  direction: row
+  width: 26
+  height: 26
+```
+
+Which answers the original question — *I see an arrow on the stairs and want to tap it to
+see the next floor* — by putting the control there rather than inventing a new kind of
+action for it.
+
+**Unplaced, nothing changes.** Without `x`/`y` the switcher is the fixed corner control it
+has always been: pinned to the card, unaffected by pan or zoom. Give it both coordinates
+and it joins the drawing instead — canvas units like everything else, remapped under
+`rotation`, travelling with the plan, and counter-scaled against zoom-to-room so it stays
+a legible size. One coordinate on its own is not a position, and falls back to the corner.
+
+| Key | What it does |
+| --- | --- |
+| `x`, `y` | Position in canvas units. Both, or neither. |
+| `direction` | `column` (default) or `row`. |
+| `width`, `height` | Button size in canvas units. Unset, each button sizes to its own label. |
+| `hidden` | Draw no switcher at all — for a plan that changes floor its own way. |
+
+**In the editor**, the switcher is previewed on the canvas and you drag it where you want
+it: dashed while it is still standing in for the corner, solid once placed. Its shape and
+the hide toggle are under **Project → Floor switcher**; each floor's icon is in that
+floor's own settings, beside its short label.
 
 ## Doors on locks
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -146,6 +146,14 @@ its own `percentage` attribute, and its label hung to the **left** of the badge,
 so a device that labels itself *without* its own state and a label that is not
 underneath are both on the plan at once.
 
+The plan has **two floors** (issue #121), which is what makes the card draw a
+floor switcher at all — and that switcher is placed on the drawn staircase
+rather than left in the card's corner, with `mdi:stairs-up` / `mdi:stairs-down`
+on its buttons. Tapping the stairs changes floor. Delete the `floorSwitcher`
+block to get the corner back; drag it on the editor canvas to move it. Upstairs
+is deliberately sparse — enough to know you changed floor, not a second plan to
+keep up to date.
+
 The plan also carries one device bound to `light.deleted_by_accident`, which is
 not an entity and never will be. It is what a renamed or deleted binding looks
 like, and the reason it is hard-coded rather than switchable is that no live

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -56,262 +56,304 @@ views:
             # this, and it is working.
             sunDimming: true
 
-            walls:
-              - { id: w1, x1: 100, y1: 100, x2: 900, y2: 100 }
-              - { id: w2, x1: 900, y1: 100, x2: 900, y2: 500 }
-              - { id: w3, x1: 900, y1: 500, x2: 100, y2: 500 }
-              - { id: w4, x1: 100, y1: 500, x2: 100, y2: 100 }
-              # A service shaft boxed into the north-west corner: two partitions
-              # sealing a pocket that no door or window reaches, so `showDeadSpaces`
-              # has something to hatch.
-              - { id: w5, x1: 100, y1: 220, x2: 240, y2: 220 }
-              - { id: w6, x1: 240, y1: 220, x2: 240, y2: 100 }
+            # Issue #121: the floor switcher lives on the staircase rather than
+            # in the card's corner. Delete this block to get the corner back —
+            # that is all "unplaced" means. In the editor it is draggable, so
+            # this is also what you get by dragging it there.
+            floorSwitcher:
+              x: 640
+              y: 300
+              direction: row
+              width: 26
+              height: 26
 
-            openings:
-              # Bound to one of the two demo covers that really report
-              # current_position, so this window sits at partial openings rather
-              # than only fully open or fully shut -- the case a cover replayed as
-              # a boolean gets wrong.
-              - id: o1
-                type: window
-                x: 500
-                y: 100
-                length: 140
-                angle: 0
-                entity: cover.living_room_window
-              - { id: o2, type: door, x: 500, y: 500, length: 90, angle: 0 }
-              # The garage door is open/close only -- no position at all -- which
-              # is the other half of the cover story, and it drives the roll-up
-              # curtain from a real entity rather than a dev-only slider.
-              - id: o3
-                type: door
-                motion: roll
-                x: 900
-                y: 300
-                length: 140
-                angle: 90
-                entity: cover.garage_door
-              # A window whose contact is the door sensor, so there is one opening
-              # driven by a binary_sensor rather than a cover -- the two read
-              # open/closed by different rules.
-              - id: o4
-                type: window
-                x: 300
-                y: 500
-                length: 120
-                angle: 0
-                entity: binary_sensor.front_door
-              # One sensor per leaf (issue #159). All three share the same
-              # pair of contacts, so flipping "Left leaf" on the History view
-              # swings a casement sash, a door leaf and a shutter panel at
-              # once -- three symbols, one rule. Flip only one of the pair to
-              # see the half-open state a single-sensor opening cannot reach.
-              #
-              # A casement window: two sashes, one contact each. `sash` is not
-              # stated because `double` is already the window default.
-              - id: o5
-                type: window
-                x: 740
-                y: 100
-                length: 140
-                angle: 0
-                entity: binary_sensor.left_leaf
-                secondaryEntity: binary_sensor.right_leaf
-              # A double door -- the leaf count a door has to be told, since
-              # `single` is its default.
-              - id: o6
-                type: door
-                sash: double
-                x: 720
-                y: 500
-                length: 140
-                angle: 0
-                entity: binary_sensor.left_leaf
-                secondaryEntity: binary_sensor.right_leaf
-              # A single-sash window behind a pair of hinged shutters, each
-              # panel on its own contact. `shutterSecondaryEntity` is a
-              # separate key from `secondaryEntity` precisely because this
-              # opening could have both -- the shutter is a layer over the
-              # window, not part of it.
-              - id: o7
-                type: window
-                sash: single
-                x: 100
-                y: 380
-                length: 120
-                angle: 90
-                shutterEntity: binary_sensor.left_leaf
-                shutterStyle: swing
-                shutterSecondaryEntity: binary_sensor.right_leaf
+            # Two floors, so the card draws its switcher and issue #121 has
+            # something to place. The ground floor is everything that was
+            # here before; upstairs is deliberately sparse — enough to know
+            # you changed floor, and not a second plan to maintain.
+            floors:
+              - id: ground
+                name: Ground floor
+                short: GF
+                icon: mdi:stairs-down
+                walls:
+                  - { id: w1, x1: 100, y1: 100, x2: 900, y2: 100 }
+                  - { id: w2, x1: 900, y1: 100, x2: 900, y2: 500 }
+                  - { id: w3, x1: 900, y1: 500, x2: 100, y2: 500 }
+                  - { id: w4, x1: 100, y1: 500, x2: 100, y2: 100 }
+                  # A service shaft boxed into the north-west corner: two partitions
+                  # sealing a pocket that no door or window reaches, so `showDeadSpaces`
+                  # has something to hatch.
+                  - { id: w5, x1: 100, y1: 220, x2: 240, y2: 220 }
+                  - { id: w6, x1: 240, y1: 220, x2: 240, y2: 100 }
 
-            items:
-              # Paired temperature/humidity: stored at two decimals, displayed at
-              # one. Should read like "17.9 °C · 49.3%".
-              # Many readings on one device (issue #180): one list, in the
-              # order the label prints them. This one deliberately still uses
-              # the legacy `secondaryEntity` for its second reading, so the
-              # plan proves the compatibility path as well as the new key --
-              # the card reads both as one pool, and opening this device in
-              # the editor rewrites the old spelling into `readings`.
-              - id: i1
-                entity: sensor.living_area_temperature
-                secondaryEntity: sensor.living_area_humidity
-                readings:
-                  - { entity: sensor.ficus_soil_moisture }
-                x: 500
-                y: 300
-                kind: sensor
-              # Cast light. These two sit 200 apart with 200 radii so their pools
-              # overlap in the middle, and both are colour-capable demo lights, so
-              # the band where they mix changes colour as the generator recolours
-              # them.
-              - id: glow_warm
-                entity: light.bed_light
-                x: 400
-                y: 380
-                kind: light
-                glow: true
-                glowRadius: 200
-              - id: glow_cool
-                entity: light.office_rgbw_lights
-                x: 600
-                y: 380
-                kind: light
-                glow: true
-                glowRadius: 200
-              # Brightness but no colour of its own: casts the warm-white default,
-              # dimmed to match.
-              - id: glow_dim
-                entity: light.ceiling_lights
-                x: 780
-                y: 200
-                kind: light
-                glow: true
-                glowRadius: 120
-              - id: glow_plain
-                entity: light.kitchen_lights
-                x: 780
-                y: 430
-                kind: light
-                glow: true
-                glowRadius: 110
-                glowColor: "#b0ffd0"
-              # Two active devices side by side with different active colours.
-              - id: i3
-                entity: cover.living_room_window
-                x: 380
-                y: 180
-                kind: cover
-                activeColor: "#8e24aa"
-              # Readings without the device's own state (issue #180) -- the
-              # smart-plug pattern from discussion #173, with the demo's fan
-              # standing in for the plug. Its badge colour already says on or
-              # off, so the label carries the speed instead of the word "on".
-              # `showState: false` silences the state line; the reading is not
-              # gated on it, which is the whole point.
-              #
-              # Also the one device with its label beside the badge rather than
-              # under it, so both label positions are on the plan at once.
-              - id: i4
-                entity: fan.living_room_fan
-                showState: false
-                readings:
-                  - { attribute: percentage }
-                labelPosition: left
-                x: 220
-                y: 180
-                kind: fan
-              # The one that goes `unavailable` on a timer. Left as a plain value
-              # badge so it is obvious on the plan when it drops out.
-              - id: i5
-                entity: sensor.flaky_sensor
-                x: 620
-                y: 180
-                kind: sensor
-                badgeContent: value
-                showState: true
-              # Offline devices (issue #162), second flavour: an entity id
-              # that is not in Home Assistant at all -- renamed, deleted, or
-              # from an integration that failed to load. Before #162 this drew
-              # an ordinary "off" badge for something that does not exist, and
-              # unlike sensor.flaky_sensor above there is no switch that can
-              # produce it, so it is hard-coded here.
-              - id: i6
-                entity: light.deleted_by_accident
-                name: Missing entity
-                x: 300
-                y: 300
-                kind: light
+                openings:
+                  # Bound to one of the two demo covers that really report
+                  # current_position, so this window sits at partial openings rather
+                  # than only fully open or fully shut -- the case a cover replayed as
+                  # a boolean gets wrong.
+                  - id: o1
+                    type: window
+                    x: 500
+                    y: 100
+                    length: 140
+                    angle: 0
+                    entity: cover.living_room_window
+                  - { id: o2, type: door, x: 500, y: 500, length: 90, angle: 0 }
+                  # The garage door is open/close only -- no position at all -- which
+                  # is the other half of the cover story, and it drives the roll-up
+                  # curtain from a real entity rather than a dev-only slider.
+                  - id: o3
+                    type: door
+                    motion: roll
+                    x: 900
+                    y: 300
+                    length: 140
+                    angle: 90
+                    entity: cover.garage_door
+                  # A window whose contact is the door sensor, so there is one opening
+                  # driven by a binary_sensor rather than a cover -- the two read
+                  # open/closed by different rules.
+                  - id: o4
+                    type: window
+                    x: 300
+                    y: 500
+                    length: 120
+                    angle: 0
+                    entity: binary_sensor.front_door
+                  # One sensor per leaf (issue #159). All three share the same
+                  # pair of contacts, so flipping "Left leaf" on the History view
+                  # swings a casement sash, a door leaf and a shutter panel at
+                  # once -- three symbols, one rule. Flip only one of the pair to
+                  # see the half-open state a single-sensor opening cannot reach.
+                  #
+                  # A casement window: two sashes, one contact each. `sash` is not
+                  # stated because `double` is already the window default.
+                  - id: o5
+                    type: window
+                    x: 740
+                    y: 100
+                    length: 140
+                    angle: 0
+                    entity: binary_sensor.left_leaf
+                    secondaryEntity: binary_sensor.right_leaf
+                  # A double door -- the leaf count a door has to be told, since
+                  # `single` is its default.
+                  - id: o6
+                    type: door
+                    sash: double
+                    x: 720
+                    y: 500
+                    length: 140
+                    angle: 0
+                    entity: binary_sensor.left_leaf
+                    secondaryEntity: binary_sensor.right_leaf
+                  # A single-sash window behind a pair of hinged shutters, each
+                  # panel on its own contact. `shutterSecondaryEntity` is a
+                  # separate key from `secondaryEntity` precisely because this
+                  # opening could have both -- the shutter is a layer over the
+                  # window, not part of it.
+                  - id: o7
+                    type: window
+                    sash: single
+                    x: 100
+                    y: 380
+                    length: 120
+                    angle: 90
+                    shutterEntity: binary_sensor.left_leaf
+                    shutterStyle: swing
+                    shutterSecondaryEntity: binary_sensor.right_leaf
 
-            furniture:
-              - id: fu1
-                type: sofa
-                x: 200
-                y: 380
-                w: 120
-                h: 60
-              # Coloured by threshold off the soil sensor, which the generator
-              # walks down and then "waters", so the thresholds actually cross
-              # while you watch instead of sitting on one colour.
-              - id: fu2
-                type: plant
-                x: 700
-                y: 380
-                w: 60
-                h: 60
-                entity: sensor.ficus_soil_moisture
-                stateColor:
-                  - { above: 80, color: "#2e7d32" }
-                  - { above: 65, color: "#f9a825" }
-                  - { color: "#c62828" }
+                items:
+                  # Paired temperature/humidity: stored at two decimals, displayed at
+                  # one. Should read like "17.9 °C · 49.3%".
+                  # Many readings on one device (issue #180): one list, in the
+                  # order the label prints them. This one deliberately still uses
+                  # the legacy `secondaryEntity` for its second reading, so the
+                  # plan proves the compatibility path as well as the new key --
+                  # the card reads both as one pool, and opening this device in
+                  # the editor rewrites the old spelling into `readings`.
+                  - id: i1
+                    entity: sensor.living_area_temperature
+                    secondaryEntity: sensor.living_area_humidity
+                    readings:
+                      - { entity: sensor.ficus_soil_moisture }
+                    x: 500
+                    y: 300
+                    kind: sensor
+                  # Cast light. These two sit 200 apart with 200 radii so their pools
+                  # overlap in the middle, and both are colour-capable demo lights, so
+                  # the band where they mix changes colour as the generator recolours
+                  # them.
+                  - id: glow_warm
+                    entity: light.bed_light
+                    x: 400
+                    y: 380
+                    kind: light
+                    glow: true
+                    glowRadius: 200
+                  - id: glow_cool
+                    entity: light.office_rgbw_lights
+                    x: 600
+                    y: 380
+                    kind: light
+                    glow: true
+                    glowRadius: 200
+                  # Brightness but no colour of its own: casts the warm-white default,
+                  # dimmed to match.
+                  - id: glow_dim
+                    entity: light.ceiling_lights
+                    x: 780
+                    y: 200
+                    kind: light
+                    glow: true
+                    glowRadius: 120
+                  - id: glow_plain
+                    entity: light.kitchen_lights
+                    x: 780
+                    y: 430
+                    kind: light
+                    glow: true
+                    glowRadius: 110
+                    glowColor: "#b0ffd0"
+                  # Two active devices side by side with different active colours.
+                  - id: i3
+                    entity: cover.living_room_window
+                    x: 380
+                    y: 180
+                    kind: cover
+                    activeColor: "#8e24aa"
+                  # Readings without the device's own state (issue #180) -- the
+                  # smart-plug pattern from discussion #173, with the demo's fan
+                  # standing in for the plug. Its badge colour already says on or
+                  # off, so the label carries the speed instead of the word "on".
+                  # `showState: false` silences the state line; the reading is not
+                  # gated on it, which is the whole point.
+                  #
+                  # Also the one device with its label beside the badge rather than
+                  # under it, so both label positions are on the plan at once.
+                  - id: i4
+                    entity: fan.living_room_fan
+                    showState: false
+                    readings:
+                      - { attribute: percentage }
+                    labelPosition: left
+                    x: 220
+                    y: 180
+                    kind: fan
+                  # The one that goes `unavailable` on a timer. Left as a plain value
+                  # badge so it is obvious on the plan when it drops out.
+                  - id: i5
+                    entity: sensor.flaky_sensor
+                    x: 620
+                    y: 180
+                    kind: sensor
+                    badgeContent: value
+                    showState: true
+                  # Offline devices (issue #162), second flavour: an entity id
+                  # that is not in Home Assistant at all -- renamed, deleted, or
+                  # from an integration that failed to load. Before #162 this drew
+                  # an ordinary "off" badge for something that does not exist, and
+                  # unlike sensor.flaky_sensor above there is no switch that can
+                  # produce it, so it is hard-coded here.
+                  - id: i6
+                    entity: light.deleted_by_accident
+                    name: Missing entity
+                    x: 300
+                    y: 300
+                    kind: light
 
-            trackers:
-              # A tracker is a rectangle plus two distance sensors that map onto
-              # its span -- the mmWave/radar shape, not a device_tracker. The
-              # generator walks the two distance readings around, and gates them
-              # on a presence binary_sensor that goes clear now and then, so the
-              # "hide the marker when the room is empty" path is exercised too.
-              - id: t1
-                x: 120
-                y: 120
-                w: 360
-                h: 360
-                color: "#26c6da"
-                dotSize: 16
-                xSensor:
-                  entity: sensor.tracker_distance_x
-                  min: 0
-                  max: 500
-                  presence:
-                    entity: binary_sensor.living_presence
-                ySensor:
-                  entity: sensor.tracker_distance_y
-                  min: 0
-                  max: 500
-                  presence:
-                    entity: binary_sensor.living_presence
+                furniture:
+                  # The staircase issue #121 is about: the switcher below is
+                  # placed on it, so tapping the stairs changes floor.
+                  - { id: fu3, type: stairs, x: 640, y: 300, w: 80, h: 140 }
+                  - id: fu1
+                    type: sofa
+                    x: 200
+                    y: 380
+                    w: 120
+                    h: 60
+                  # Coloured by threshold off the soil sensor, which the generator
+                  # walks down and then "waters", so the thresholds actually cross
+                  # while you watch instead of sitting on one colour.
+                  - id: fu2
+                    type: plant
+                    x: 700
+                    y: 380
+                    w: 60
+                    h: 60
+                    entity: sensor.ficus_soil_moisture
+                    stateColor:
+                      - { above: 80, color: "#2e7d32" }
+                      - { above: 65, color: "#f9a825" }
+                      - { color: "#c62828" }
 
-            areas:
-              - id: a1
-                name: Living Room
-                showName: true
-                color: "#26c6da"
-                opacity: 0.15
-                points:
-                  - { x: 100, y: 100 }
-                  - { x: 500, y: 100 }
-                  - { x: 500, y: 500 }
-                  - { x: 100, y: 500 }
-              - id: a2
-                name: Kitchen
-                showName: true
-                color: "#ffa726"
-                opacity: 0.15
-                points:
-                  - { x: 500, y: 100 }
-                  - { x: 900, y: 100 }
-                  - { x: 900, y: 500 }
-                  - { x: 500, y: 500 }
+                trackers:
+                  # A tracker is a rectangle plus two distance sensors that map onto
+                  # its span -- the mmWave/radar shape, not a device_tracker. The
+                  # generator walks the two distance readings around, and gates them
+                  # on a presence binary_sensor that goes clear now and then, so the
+                  # "hide the marker when the room is empty" path is exercised too.
+                  - id: t1
+                    x: 120
+                    y: 120
+                    w: 360
+                    h: 360
+                    color: "#26c6da"
+                    dotSize: 16
+                    xSensor:
+                      entity: sensor.tracker_distance_x
+                      min: 0
+                      max: 500
+                      presence:
+                        entity: binary_sensor.living_presence
+                    ySensor:
+                      entity: sensor.tracker_distance_y
+                      min: 0
+                      max: 500
+                      presence:
+                        entity: binary_sensor.living_presence
+
+                areas:
+                  - id: a1
+                    name: Living Room
+                    showName: true
+                    color: "#26c6da"
+                    opacity: 0.15
+                    points:
+                      - { x: 100, y: 100 }
+                      - { x: 500, y: 100 }
+                      - { x: 500, y: 500 }
+                      - { x: 100, y: 500 }
+                  - id: a2
+                    name: Kitchen
+                    showName: true
+                    color: "#ffa726"
+                    opacity: 0.15
+                    points:
+                      - { x: 500, y: 100 }
+                      - { x: 900, y: 100 }
+                      - { x: 900, y: 500 }
+                      - { x: 500, y: 500 }
+              - id: upstairs
+                name: Upstairs
+                short: 1st
+                icon: mdi:stairs-up
+                walls:
+                  - { id: uw1, x1: 200, y1: 150, x2: 800, y2: 150 }
+                  - { id: uw2, x1: 800, y1: 150, x2: 800, y2: 450 }
+                  - { id: uw3, x1: 800, y1: 450, x2: 200, y2: 450 }
+                  - { id: uw4, x1: 200, y1: 450, x2: 200, y2: 150 }
+                openings:
+                  - { id: uo1, type: door, x: 500, y: 450, length: 90, angle: 0 }
+                items:
+                  - { id: ui1, entity: light.bed_light, x: 350, y: 300, kind: light }
+                texts: []
+                furniture:
+                  # The other end of the staircase below.
+                  - { id: ust, type: stairs, x: 640, y: 300, w: 80, h: 140 }
+                trackers: []
+                areas: []
 
   # A plain history view, so when the card disagrees with HA about what
   # happened you can see which one is wrong without leaving the dashboard.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -23,6 +23,7 @@ import {
   projectSunForm,
   projectReliefForm,
   projectDeadSpaceForm,
+  projectFloorSwitcherForm,
   floorImageForm,
   areaForm,
   areaNameForm,
@@ -1816,5 +1817,55 @@ describe("formSlice", () => {
     // renders nothing rather than throwing.
     expect(formSlice(spec, ["shutterStyle", "type"]).fields.map((f) => f.name)).toEqual(["type"]);
     expect(formSlice(spec, []).fields).toEqual([]);
+  });
+});
+
+describe("projectFloorSwitcherForm (issue #121)", () => {
+  const cfg = (floorSwitcher?: Record<string, unknown>) =>
+    ({ type: "t", width: 1000, height: 600, floorSwitcher }) as unknown as FloorplanCardConfig;
+  const names = (c: FloorplanCardConfig) => projectFloorSwitcherForm(c).fields.map((f) => f.name);
+
+  it("offers no position — that is set by dragging it on the canvas", () => {
+    expect(names(cfg())).not.toContain("x");
+    expect(names(cfg())).not.toContain("y");
+  });
+
+  it("offers size only once it is on the plan", () => {
+    // In the corner the buttons size to their labels, which is what a corner
+    // control should do — so there is nothing to set.
+    expect(names(cfg())).toEqual(["hidden", "direction"]);
+    expect(names(cfg({ x: 100, y: 100 }))).toEqual(["hidden", "direction", "width", "height"]);
+  });
+
+  it("hiding it puts every other control away", () => {
+    expect(names(cfg({ hidden: true }))).toEqual(["hidden"]);
+  });
+
+  it("folds every field back into the one nested key", () => {
+    const form = projectFloorSwitcherForm(cfg({ x: 10, y: 20 }));
+    // The position survives an unrelated edit rather than being dropped.
+    expect(form.toPatch({ direction: "row" })).toEqual({
+      floorSwitcher: { x: 10, y: 20, direction: "row" },
+    });
+    expect(form.toPatch({ width: 26 })).toEqual({
+      floorSwitcher: { x: 10, y: 20, width: 26 },
+    });
+  });
+
+  it("keeps defaults out of the YAML, and drops the key when nothing is left", () => {
+    expect(projectFloorSwitcherForm(cfg()).toPatch({ direction: "column" })).toEqual({
+      floorSwitcher: undefined,
+    });
+    expect(projectFloorSwitcherForm(cfg()).toPatch({ hidden: false })).toEqual({
+      floorSwitcher: undefined,
+    });
+    expect(projectFloorSwitcherForm(cfg({ x: 1, y: 2 })).toPatch({ hidden: false })).toEqual({
+      floorSwitcher: { x: 1, y: 2 },
+    });
+  });
+
+  it("reads back what is stored", () => {
+    const d = projectFloorSwitcherForm(cfg({ x: 1, y: 2, direction: "row", width: 26 })).data;
+    expect(d).toMatchObject({ hidden: false, direction: "row", width: 26 });
   });
 });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -55,6 +55,7 @@ import {
   itemReadings,
   badgeEntityIndex,
   offlineStyleOf,
+  floorSwitcherPlaced,
   sliderStyleOf,
   shutterStyleOf,
   DEFAULT_SUN_BEARING,
@@ -1495,6 +1496,72 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       if ("offlineStyle" in out && out.offlineStyle === DEFAULT_OFFLINE_STYLE)
         out = { ...out, offlineStyle: undefined };
       return out;
+    },
+  };
+}
+
+/**
+ * The floor switcher's own settings (issue #121). Only worth showing on a plan
+ * that has more than one floor — on a single-floor plan there is no switcher
+ * to place, and every control here would be inert.
+ *
+ * Position is not here: it is a *place on the drawing*, so it is set by
+ * dragging the switcher on the canvas, the way everything else placed on the
+ * plan is. What is left is the shape of it, and whether it exists at all.
+ */
+export function projectFloorSwitcherForm(c: FloorplanCardConfig): FormSpec {
+  const fs = c.floorSwitcher ?? {};
+  const placed = floorSwitcherPlaced(c);
+  const fields: FormField[] = [
+    {
+      name: "hidden",
+      label: "Hide switcher",
+      helper: "For a plan that changes floor its own way — a device, a dashboard button",
+      selector: { boolean: {} },
+    },
+  ];
+  if (!fs.hidden) {
+    fields.push({
+      name: "direction",
+      label: "Direction",
+      selector: dropdown(opt("column", "Stacked"), opt("row", "Side by side")),
+    });
+    // Size is only worth offering once it is on the plan: in the corner the
+    // buttons size to their labels, which is what a corner control should do.
+    if (placed) {
+      fields.push(
+        {
+          name: "width",
+          label: "Button width",
+          helper: "Canvas units. Empty lets each button size to its own label",
+          selector: { number: { min: 8, max: 200, mode: "box" } },
+        },
+        {
+          name: "height",
+          label: "Button height",
+          selector: { number: { min: 8, max: 200, mode: "box" } },
+        }
+      );
+    }
+  }
+  return {
+    fields,
+    data: {
+      hidden: fs.hidden ?? false,
+      direction: fs.direction ?? "column",
+      width: fs.width,
+      height: fs.height,
+    },
+    // One nested object in the config, so every field here folds back into it
+    // rather than becoming a top-level key.
+    toPatch: (p) => {
+      const next: Record<string, unknown> = { ...c.floorSwitcher };
+      for (const [k, v] of Object.entries(p)) {
+        // Defaults and empties stay out of the YAML.
+        next[k] = v === "" || v === false || (k === "direction" && v === "column") ? undefined : v;
+      }
+      const kept = Object.entries(next).filter(([, v]) => v !== undefined);
+      return { floorSwitcher: kept.length ? Object.fromEntries(kept) : undefined };
     },
   };
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -115,6 +115,9 @@ import {
   labelPositionOf,
   itemReadings,
   itemHasLabel,
+  showsFloorSwitcher,
+  floorSwitcherPlaced,
+  floorSwitcherButton,
   snapToWall,
   collectWatchedEntities,
   hassRenderInputsChanged,
@@ -166,6 +169,7 @@ import {
   openingForm,
   projectForm,
   projectDeadSpaceForm,
+  projectFloorSwitcherForm,
   projectDisplayForm,
   projectPressForm,
   projectSkinForm,
@@ -2991,6 +2995,19 @@ export class FloorplanCardEditor extends LitElement {
                     />
                   </div>
                   <div class="pop-row">
+                    <label>Icon</label>
+                    <input
+                      type="text"
+                      placeholder="mdi:stairs-up"
+                      title="Icon for this floor's switcher button, instead of its short label"
+                      .value=${floor?.icon ?? ""}
+                      @change=${(e: Event) =>
+                        this._commitFloor({
+                          icon: (e.target as HTMLInputElement).value.trim() || undefined,
+                        })}
+                    />
+                  </div>
+                  <div class="pop-row">
                     <label>Color</label>
                     <input
                       type="color"
@@ -3213,6 +3230,7 @@ export class FloorplanCardEditor extends LitElement {
                 .filter((o) => hasOpeningMark(o))
                 .map((o) => this._renderOpeningMarkOverlay(o, c, overlay))}
               ${floor.items.map((it) => this._renderItemOverlay(it, c, overlay))}
+              ${this._renderSwitcherPreview(c, this._config.floors ?? [])}
             </div>
           </div>
         </div>
@@ -3958,6 +3976,96 @@ export class FloorplanCardEditor extends LitElement {
     </div>`;
   }
 
+  /**
+   * The floor switcher, previewed on the editor canvas and draggable (issue
+   * #121) — how you get it off the corner and onto the staircase.
+   *
+   * Drawn wherever the card would draw it: at its placed coordinates, or at
+   * the canvas corner that stands in for the card's corner while it is
+   * unplaced. Dragging from there is what places it, so there is no separate
+   * "enable" step to find.
+   *
+   * Its own pointer handling rather than the shared `_startDrag` path, because
+   * it is not a `Sel`: it is card-level rather than one of the floor's arrays,
+   * so it is never multi-selected, marquee'd, copied or deleted, and threading
+   * it through those switches would add a case to each of them for a control
+   * that can only ever be moved. The drag still snaps like everything else,
+   * and still commits once at the end so it is one undo step.
+   */
+  private _renderSwitcherPreview(c: FloorplanCardConfig, floors: Floor[]): TemplateResult {
+    if (!showsFloorSwitcher(c, floors.length)) return html`${nothing}`;
+    const fs = c.floorSwitcher ?? {};
+    const at = floorSwitcherPlaced(c) ?? this._switcherCorner(c);
+    const active = floors.find((f) => f.id === this._activeFloorId) ?? floors[0];
+    const px = (v: number | undefined) => (Number.isFinite(v as number) ? `${v}px` : "");
+    return html`
+      <div
+        class="switcher-preview ${fs.direction === "row" ? "row" : ""} ${floorSwitcherPlaced(c)
+          ? "placed"
+          : "unplaced"}"
+        style="left:${(at.x / c.width) * 100}%; top:${(at.y / c.height) * 100}%;"
+        title=${floorSwitcherPlaced(c)
+          ? "Drag to move the floor switcher"
+          : "Drag onto the plan to place the floor switcher"}
+        @pointerdown=${(e: PointerEvent) => this._startSwitcherDrag(e)}
+      >
+        ${floors.map((f) => {
+          const { icon, text } = floorSwitcherButton(f);
+          return html`<span
+            class=${f.id === active?.id ? "active" : ""}
+            style=${`${px(fs.width) ? `width:${px(fs.width)};` : ""}${
+              px(fs.height) ? `height:${px(fs.height)};` : ""
+            }`}
+            >${icon ? html`<ha-icon icon=${icon}></ha-icon>` : text}</span
+          >`;
+        })}
+      </div>
+    `;
+  }
+
+  /**
+   * Where an unplaced switcher is previewed: the canvas's own top-right,
+   * inset by roughly the margin the card uses. Not the card's corner — the
+   * editor canvas is not the card — but the same *place*, so dragging it
+   * starts from where you last saw it.
+   */
+  private _switcherCorner(c: FloorplanCardConfig): { x: number; y: number } {
+    const inset = Math.max(c.width, c.height) * 0.04;
+    return { x: c.width - inset, y: inset };
+  }
+
+  private _startSwitcherDrag(ev: PointerEvent): void {
+    if (this._tool !== "select") return;
+    ev.stopPropagation();
+    ev.preventDefault();
+    const el = ev.currentTarget as HTMLElement;
+    const at = floorSwitcherPlaced(this._config) ?? this._switcherCorner(this._config);
+    const from = this._toVirtual(ev, false);
+    const offset = { x: at.x - from.x, y: at.y - from.y };
+    el.setPointerCapture(ev.pointerId);
+    const move = (e: PointerEvent): void => {
+      const p = this._toVirtual(e, false);
+      this._patchConfigLive({
+        floorSwitcher: {
+          ...this._config.floorSwitcher,
+          x: this._snap(p.x + offset.x),
+          y: this._snap(p.y + offset.y),
+        },
+      });
+    };
+    const end = (): void => {
+      el.releasePointerCapture?.(ev.pointerId);
+      el.removeEventListener("pointermove", move);
+      el.removeEventListener("pointerup", end);
+      el.removeEventListener("pointercancel", end);
+      // One commit for the whole drag, so it is one undo step.
+      this._patchConfig({ floorSwitcher: this._config.floorSwitcher });
+    };
+    el.addEventListener("pointermove", move);
+    el.addEventListener("pointerup", end);
+    el.addEventListener("pointercancel", end);
+  }
+
   private _renderItemOverlay(
     it: FloorItem,
     c: FloorplanCardConfig,
@@ -4225,6 +4333,18 @@ export class FloorplanCardEditor extends LitElement {
           this._renderForm(formSlice(display, ["offlineStyle"]), patch),
           this._renderForm(projectPressForm(c), patch)
         )}
+        ${(c.floors ?? []).length > 1
+          ? this._renderGroup(
+              // Only on a plan that has floors to switch between; on a
+              // single-floor plan every control here would be inert.
+              "Floor switcher",
+              this._renderForm(projectFloorSwitcherForm(c), patch),
+              html`<p class="hint rule-note">
+                Drag it on the canvas to place it — on the stairs, say — or leave
+                it in the card's corner.
+              </p>`
+            )
+          : nothing}
         ${this._renderGroup("Symbols", this._renderSymbolsPanel())}
       </div>
     `;
@@ -5941,6 +6061,57 @@ export class FloorplanCardEditor extends LitElement {
       color: var(--fp-skin-text, var(--primary-text-color));
       max-width: none;
       overflow: visible;
+    }
+    /* The floor switcher previewed on the canvas (issue #121). Centred on its
+       point like a device badge, so dropping it puts its middle where the
+       pointer is. Not a real switcher: the buttons are spans, because clicking
+       one here should grab it for dragging rather than change floor. */
+    .switcher-preview {
+      position: absolute;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      cursor: grab;
+      z-index: 3;
+      pointer-events: auto;
+      touch-action: none;
+    }
+    .switcher-preview.row {
+      flex-direction: row;
+    }
+    .switcher-preview:active {
+      cursor: grabbing;
+    }
+    /* Unplaced, it is standing in for the card's corner rather than marking a
+       spot on the plan — dashed, so it reads as "drag me somewhere" instead of
+       as something already positioned here. */
+    .switcher-preview.unplaced span {
+      border-style: dashed;
+      opacity: 0.75;
+    }
+    .switcher-preview span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--divider-color, #ccc);
+      background: var(--card-background-color, #fff);
+      color: var(--primary-text-color);
+      border-radius: 6px;
+      padding: 3px 7px;
+      font-size: 11px;
+      line-height: 1;
+      white-space: nowrap;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+    .switcher-preview span.active {
+      background: var(--primary-color, #03a9f4);
+      color: var(--text-primary-color, #fff);
+      border-color: var(--primary-color, #03a9f4);
+    }
+    .switcher-preview ha-icon {
+      --mdc-icon-size: 14px;
+      display: flex;
     }
     /* An extra-reading row (issue #180): the entity picker takes the space and
        the attribute box stays narrow beside it, the same proportions the

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -86,6 +86,9 @@ import {
   pressEffectOf,
   labelPositionOf,
   offlineStyleOf,
+  showsFloorSwitcher,
+  floorSwitcherPlaced,
+  floorSwitcherButton,
   itemIsOffline,
   itemHiddenWhenInactive,
   itemLabelSize,
@@ -1153,6 +1156,12 @@ export class FloorplanCard extends LitElement {
               (it, i) => it.id || i,
               (it) => this._renderItem(it, c, rot, scale)
             )}
+            ${showsFloorSwitcher(c, floors.length) && floorSwitcherPlaced(c)
+              ? // Placed: part of the drawing, so it belongs in the overlay
+                // with the devices — same rotation remap, same counter-scale
+                // against zoom, same canvas units.
+                this._renderPlacedFloorSwitcher(floors, active, c, rot, scale)
+              : nothing}
           </div>
           </div>
           ${zoom.scale > 1
@@ -1166,40 +1175,99 @@ export class FloorplanCard extends LitElement {
               </button>`
             : nothing}
           ${compactTitle ? html`<div class="plan-title">${c.title}</div>` : nothing}
-          ${floors.length > 1 ? this._renderFloorSwitcher(floors, active, compact) : nothing}
+          ${showsFloorSwitcher(c, floors.length) && !floorSwitcherPlaced(c)
+            ? // Unplaced: the fixed corner control it has always been, outside
+              // the zoom wrapper so it neither pans nor scales.
+              this._renderFloorSwitcher(floors, active, compact)
+            : nothing}
         </div>
       </ha-card>
+    `;
+  }
+
+  /**
+   * Switch to a floor, from wherever the switcher happens to be drawn.
+   *
+   * Shared so the placed and corner switchers cannot drift apart on the two
+   * things that are easy to forget: remembering the choice for the next
+   * preview, and dropping a zoom that belonged to the floor being left.
+   */
+  private _goToFloor(floors: Floor[], id: string): void {
+    this._activeFloorId = id;
+    // Remember it for the next element the editor preview builds.
+    lastViewedFloor.set(floorMemoryKey(floors), id);
+    // A room on the floor just left is meaningless on the new one.
+    this._zoomedAreaId = undefined;
+  }
+
+  /**
+   * The switcher given a place on the plan (issue #121) — canvas coordinates,
+   * inside the overlay, so it travels with the drawing and can sit on the
+   * staircase it changes floors with.
+   *
+   * Its own renderer rather than a flag on the corner one: the corner is
+   * positioned in the card and sized in pixels, this is positioned in canvas
+   * units and remapped through `rotatePlanPoint` like every other overlay
+   * element. Two positioning models, one button.
+   */
+  private _renderPlacedFloorSwitcher(
+    floors: Floor[],
+    active: Floor,
+    c: FloorplanCardConfig,
+    rot: PlanRotation,
+    scale: OverlayScale,
+  ): TemplateResult {
+    const at = floorSwitcherPlaced(c)!;
+    const p = rotatePlanPoint(at.x, at.y, c.width, c.height, rot);
+    const d = rotatedCanvasSize(c.width, c.height, rot);
+    const fs = c.floorSwitcher ?? {};
+    const size = (v: number | undefined) =>
+      Number.isFinite(v as number) ? overlayLength(v as number, scale) : "";
+    return html`
+      <div
+        class="floor-switcher placed ${fs.direction === "row" ? "row" : ""}"
+        style="left:${(p.x / d.w) * 100}%; top:${(p.y / d.h) * 100}%;"
+      >
+        ${floors.map((f) => this._floorButton(f, active, floors, size(fs.width), size(fs.height)))}
+      </div>
+    `;
+  }
+
+  /** One switcher button, wherever the switcher is drawn. */
+  private _floorButton(
+    f: Floor,
+    active: Floor,
+    floors: Floor[],
+    width = "",
+    height = "",
+  ): TemplateResult {
+    // Per-floor accent (issue #67): applied only while active so the
+    // resting buttons stay theme-neutral. cssColor gates the config
+    // string; no custom color falls back to the theme primary.
+    const accent = f.id === active.id ? cssColor(f.color) : undefined;
+    const { icon, text, title } = floorSwitcherButton(f);
+    return html`
+      <button
+        class=${f.id === active.id ? "active" : ""}
+        title=${title}
+        style=${`${accent ? `background:${accent};border-color:${accent};` : ""}${
+          width ? `width:${width};` : ""
+        }${height ? `height:${height};` : ""}`}
+        @click=${() => this._goToFloor(floors, f.id)}
+      >
+        ${icon ? html`<ha-icon icon=${icon}></ha-icon>` : text}
+      </button>
     `;
   }
 
   private _renderFloorSwitcher(floors: Floor[], active: Floor, compact = false): TemplateResult {
     return html`
       <div class="floor-switcher ${compact ? "row" : ""}">
-        ${floors.map((f) => {
-          // Per-floor accent (issue #67): applied only while active so the
-          // resting buttons stay theme-neutral. cssColor gates the config
-          // string; no custom color falls back to the theme primary.
-          const accent = f.id === active.id ? cssColor(f.color) : undefined;
-          return html`
-            <button
-              class=${f.id === active.id ? "active" : ""}
-              title=${f.name}
-              style=${accent ? `background:${accent};border-color:${accent};` : nothing}
-              @click=${() => {
-                this._activeFloorId = f.id;
-                // Remember it for the next element the editor preview builds.
-                lastViewedFloor.set(floorMemoryKey(floors), f.id);
-                // A room on the floor just left is meaningless on the new one.
-                this._zoomedAreaId = undefined;
-              }}
-            >
-              ${f.short || f.name}
-            </button>
-          `;
-        })}
+        ${floors.map((f) => this._floorButton(f, active, floors))}
       </div>
     `;
   }
+
 
   // skinTokens declares every --fp-skin-* default on :host (issue #122), and
   // skinPalettes the chosen skin's values on the same element (issue #155).
@@ -1332,6 +1400,31 @@ export class FloorplanCard extends LitElement {
        wrap the buttons for nothing. */
     .stage.compact-title .floor-switcher.row {
       left: 44%;
+    }
+    /* Placed on the plan (issue #121) rather than pinned to the card's corner.
+       Positioned by the overlay's own left/top percentages, so it is remapped
+       under rotation and travels with the drawing; centred on its point the
+       way a device badge is, so dropping it on a staircase puts its middle
+       where the pointer was. Counter-scaled against zoom-to-room for the same
+       reason a badge is — a control that quadrupled in size on zoom would
+       cover the room it belongs to. */
+    .floor-switcher.placed {
+      top: auto;
+      right: auto;
+      transform: translate(-50%, -50%) scale(var(--fp-inv-zoom, 1));
+      transition: transform 0.4s ease;
+    }
+    /* A button given an explicit size holds it, so a row of icons lines up
+       instead of each button hugging its own glyph. */
+    .floor-switcher.placed button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px;
+    }
+    .floor-switcher.placed ha-icon {
+      --mdc-icon-size: 100%;
+      display: flex;
     }
     .floor-switcher button {
       cursor: pointer;

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -82,6 +82,9 @@ import {
   openingIsActive,
   areaActionForGesture,
   areaHasActions,
+  floorSwitcherPlaced,
+  showsFloorSwitcher,
+  floorSwitcherButton,
   entityStateText,
   itemStateText,
   itemBadgeLabel,
@@ -5136,5 +5139,58 @@ describe("a reading can be bound without being printed", () => {
       ],
     } as unknown as FloorplanCardConfig);
     expect([...got].sort()).toEqual([TEMP, HUMIDITY].sort());
+  });
+});
+
+describe("the floor switcher can be placed (issue #121)", () => {
+  const cfg = (floorSwitcher?: Record<string, unknown>) =>
+    ({ type: "t", width: 1000, height: 600, floorSwitcher }) as unknown as FloorplanCardConfig;
+
+  it("is placed only with both coordinates", () => {
+    expect(floorSwitcherPlaced(cfg())).toBeUndefined();
+    expect(floorSwitcherPlaced(cfg({}))).toBeUndefined();
+    expect(floorSwitcherPlaced(cfg({ x: 100, y: 200 }))).toEqual({ x: 100, y: 200 });
+    // Half a position is not a position — guessing the other axis would drop
+    // it somewhere nobody chose, so it falls back to the corner.
+    expect(floorSwitcherPlaced(cfg({ x: 100 }))).toBeUndefined();
+    expect(floorSwitcherPlaced(cfg({ y: 200 }))).toBeUndefined();
+    // 0 is a real coordinate.
+    expect(floorSwitcherPlaced(cfg({ x: 0, y: 0 }))).toEqual({ x: 0, y: 0 });
+  });
+
+  it("rejects a hand-edited non-position rather than positioning at NaN", () => {
+    for (const bad of [null, "middle", NaN, Infinity, undefined]) {
+      expect(floorSwitcherPlaced(cfg({ x: bad, y: bad }))).toBeUndefined();
+      expect(floorSwitcherPlaced(cfg({ x: 10, y: bad }))).toBeUndefined();
+    }
+  });
+
+  it("is drawn only for more than one floor, and only when not hidden", () => {
+    expect(showsFloorSwitcher(cfg(), 2)).toBe(true);
+    expect(showsFloorSwitcher(cfg(), 1)).toBe(false);
+    expect(showsFloorSwitcher(cfg(), 0)).toBe(false);
+    expect(showsFloorSwitcher(cfg({ hidden: true }), 2)).toBe(false);
+    expect(showsFloorSwitcher(cfg({ hidden: false }), 2)).toBe(true);
+  });
+
+  it("an icon replaces the button's text, and the name becomes its tooltip", () => {
+    // Replaces rather than joins: the button has to be small enough to sit on
+    // a drawn staircase, and a glyph beside a word is not.
+    expect(floorSwitcherButton({ name: "Ground floor", short: "GF" })).toEqual({
+      icon: undefined,
+      text: "GF",
+      title: "Ground floor",
+    });
+    expect(floorSwitcherButton({ name: "Ground floor", short: "GF", icon: "mdi:stairs-up" })).toEqual(
+      { icon: "mdi:stairs-up", text: "GF", title: "Ground floor" },
+    );
+    // No short label falls back to the full name, as it always has.
+    expect(floorSwitcherButton({ name: "Attic" }).text).toBe("Attic");
+  });
+
+  it("gates the icon through the style sink, like every other config glyph", () => {
+    // cssIcon is what keeps a hand-edited config out of the icon attribute.
+    expect(floorSwitcherButton({ name: "F", icon: "not an icon; color:red" }).icon).toBeUndefined();
+    expect(floorSwitcherButton({ name: "F", icon: "mdi:stairs" }).icon).toBe("mdi:stairs");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -30,6 +30,7 @@ import type {
   HassEntity,
   FloorItem,
   OverlayScale,
+  FloorSwitcherConfig,
   ActionConfig,
 } from "./types";
 import {
@@ -1586,6 +1587,53 @@ export function pressEffectOf(c: { pressEffect?: PressEffect }): PressEffect {
   return v === "scale" || v === "ripple" || v === "flash" || v === "none"
     ? v
     : DEFAULT_PRESS_EFFECT;
+}
+
+/**
+ * Whether the floor switcher has been given a place on the plan (issue #121),
+ * as opposed to sitting in the card's corner where it has always been.
+ *
+ * Both coordinates or neither. A switcher carrying only an `x` is a
+ * half-edited config, and guessing the other axis would drop it somewhere
+ * nobody chose — the corner is the honest answer to an incomplete position.
+ * Non-finite values (a hand-edited `x: null`) are not a position either.
+ */
+export function floorSwitcherPlaced(
+  c: { floorSwitcher?: FloorSwitcherConfig },
+): { x: number; y: number } | undefined {
+  const fs = c.floorSwitcher;
+  if (!fs || !Number.isFinite(fs.x as number) || !Number.isFinite(fs.y as number)) return undefined;
+  return { x: fs.x as number, y: fs.y as number };
+}
+
+/**
+ * Whether the card draws a floor switcher at all: more than one floor, and not
+ * switched off. One predicate because the card and the editor preview must
+ * agree — an editor that drew a control the card hides would be inviting you
+ * to place something invisible.
+ */
+export function showsFloorSwitcher(
+  c: { floorSwitcher?: FloorSwitcherConfig },
+  floorCount: number,
+): boolean {
+  return floorCount > 1 && c.floorSwitcher?.hidden !== true;
+}
+
+/**
+ * A floor switcher button's label, and the tooltip that goes with it.
+ *
+ * An icon replaces the text rather than joining it (issue #121): the button is
+ * meant to be small enough to sit on a drawn staircase, and a glyph beside a
+ * word is not. The words are still there as the tooltip, so naming the floor
+ * survives shrinking the button to an icon.
+ */
+export function floorSwitcherButton(f: {
+  name: string;
+  short?: string;
+  icon?: string;
+}): { icon?: string; text: string; title: string } {
+  const text = f.short || f.name;
+  return { icon: cssIcon(f.icon), text, title: f.name };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1100,6 +1100,16 @@ export interface Floor {
    */
   short?: string;
   /**
+   * An mdi icon for this floor's switcher button instead of its text (issue
+   * #121) — `mdi:stairs-up`, `mdi:home-floor-1`. What makes a switcher small
+   * enough to sit on a drawn staircase, which is the whole point of being able
+   * to place it there.
+   *
+   * The text is not lost: it becomes the button's tooltip, so the floor is
+   * still nameable to a pointer and to a screen reader.
+   */
+  icon?: string;
+  /**
    * Accent color for this floor's switcher button while active (issue #67).
    * Passes through the style-injection allowlist (#64). Falls back to the
    * theme primary color.
@@ -1136,6 +1146,43 @@ export interface Floor {
   furniture: Furniture[];
   trackers: Tracker[];
   areas: Area[];
+}
+
+/**
+ * Where and how the card's floor switcher is drawn (issue #121).
+ *
+ * Unplaced — no `x`/`y` — it is the fixed corner control it has always been,
+ * pinned to the top-right of the card and unaffected by pan or zoom. Give it a
+ * position and it becomes part of the drawing instead: canvas coordinates like
+ * everything else, so it sits where you put it and travels with the plan.
+ *
+ * That is what closes issue #121. The ask was to tap the stairs to change
+ * floor; a switcher you can drop *onto* the staircase, shrink, and label with
+ * `mdi:stairs-up` is that, without inventing an action type for it.
+ */
+export interface FloorSwitcherConfig {
+  /**
+   * Position in canvas units. Both or neither — a switcher with one
+   * coordinate is not placed, and falls back to the corner rather than to a
+   * guess about the other axis.
+   */
+  x?: number;
+  y?: number;
+  /** Buttons stacked (default) or side by side. */
+  direction?: "column" | "row";
+  /**
+   * Button size in canvas units. Unset, each button sizes to its own label as
+   * it always has. Set, every button is this size — which is what makes a row
+   * of icon buttons line up.
+   */
+  width?: number;
+  height?: number;
+  /**
+   * Draw no switcher at all. For a plan that changes floor some other way —
+   * its own devices, a dashboard button — and does not want the automatic one
+   * in the corner.
+   */
+  hidden?: boolean;
 }
 
 /** Sizing mode for the HTML overlay layer. See {@link FloorplanCardConfig.overlayScale}. */
@@ -1357,6 +1404,8 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   floors?: Floor[];
   /** Id of the floor shown first. Falls back to the first floor. */
   defaultFloor?: string;
+  /** Where and how the floor switcher is drawn (issue #121). */
+  floorSwitcher?: FloorSwitcherConfig;
   walls?: Wall[];
   openings?: Opening[];
   items?: FloorItem[];


### PR DESCRIPTION
The ask was to tap the stairs and see the next floor. Rather than inventing an action type for it, the control that already changes floor becomes something you can put there — your option **B**.

```yaml
floors:
  - { id: ground,   name: Ground floor, icon: mdi:stairs-down, … }
  - { id: upstairs, name: Upstairs,     icon: mdi:stairs-up,   … }
floorSwitcher:
  x: 300           # canvas units — on the staircase you drew
  y: 170
  direction: row
  width: 26
  height: 26
```

`Floor.icon` replaces a button's text with a glyph, which is what lets it be small enough to sit on a drawn staircase. The floor's name becomes the tooltip, so naming it survives the shrink.

**Unplaced, nothing changes.** Without `x`/`y` it is the fixed corner control it has always been — outside the zoom wrapper, pinned to the card. With both, it joins the drawing: canvas units, remapped under `rotation`, travelling with the plan, counter-scaled against zoom-to-room. One coordinate on its own is not a position and falls back to the corner rather than guessing the other axis.

| Key | What it does |
| --- | --- |
| `x`, `y` | Position in canvas units. Both, or neither. |
| `direction` | `column` (default) or `row`. |
| `width`, `height` | Button size in canvas units. Unset, each button sizes to its own label. |
| `hidden` | Draw no switcher at all. |

## Two things I found while building it

**Why B and not A.** Option A needed a custom action in `tap_action` — but that key is edited by HA's own `ui_action` selector, and the action list is a *closed union* in `custom-card-helpers` (`toggle`, `navigate`, `url`, `more-info`, `call-service`, `fire-dom-event`, `none`, `toggle-menu`) with no extension point. A custom `action: "floor-up"` would sit in a control that cannot represent it: blank at best, and plausibly overwritten the first time someone opens that form. Verifying which needs a logged-in HA, so it wasn't something to ship on a guess.

**The switcher is card-level**, while every draggable element in the editor lives in one of the floor's arrays. So it is deliberately *not* a `Sel`: making it one would add a case to `_applyElementPatch`, `_selectionLabel`, the drag snapshot, the delete and copy/paste paths and the selection panel — for a thing that can only ever be moved. It gets its own pointer handling instead, which still snaps to the grid and still commits once so a drag is one undo step.

## In the editor

The switcher is previewed on the canvas and you drag it where you want it — **dashed** while it stands in for the corner, **solid** once placed. Dragging from there is what places it, so there's no separate "enable" step to find. Its shape and the hide toggle are under **Project → Floor switcher** (only shown on a plan with more than one floor); each floor's icon sits beside its short label in that floor's own settings.

Position is deliberately not a form field: it is a place on the drawing, so it is set the way every other placed thing is.

## Verification

`npm test` (1159, 11 new), `npm run typecheck`, `npm run build` clean.

Checked in a browser against the built bundle:

- an unplaced switcher renders in the corner exactly as before;
- a placed one renders as two icon buttons **on the staircase**, active one accented, floor names as tooltips, and clicking the "up" icon switches floor;
- in the editor, the preview starts dashed in the corner, and a real pointer drag places it — config goes from unset to `{ x: 560, y: 180 }`, snapped to the grid, and the preview turns solid.

Branched off `main`; independent of #187.