### PR TITLE
Stairs: click them to change floor (closes #121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,6 @@ This does not replace the floor switcher in the card's corner; the stairs are a 
 up. Set `floors` and you get both.
 
 ## Offline devices
-## Offline devices
 
 An entity that has dropped out no longer looks like one that is simply switched off.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ screen size.
 <img width="444" height="313" alt="night" src="https://github.com/user-attachments/assets/1590b710-d88f-4a34-986b-b08640a45f4c" />
 
 
-- **Multiple floors** — per-floor elements with a switcher in both the editor and the card.
+- **Multiple floors** — per-floor elements with a switcher in both the editor and the card. (${\color{red}NEW!}$) Give a staircase `goToFloor: up` and clicking it takes you there.
 - **Background image** — trace over a floor-plan scan, per floor, with adjustable opacity.
 - (${\color{red}NEW!}$) **Skins** — restyle the whole plan from one line of config: `default` follows your Home Assistant theme, `odnetnin` is chunky charcoal on cream, `pastel` is soft and low-contrast, `tron` is neon on near-black. Colors you set on an element yourself always win.
   
@@ -559,7 +559,7 @@ without turning into the color of the light. Pools never intercept clicks.
 
 ### Furniture
 
-`{ id, type, x, y, w, h, angle?, hand?, color?, entity?, activeColor?, stateColor? }`
+`{ id, type, x, y, w, h, angle?, hand?, color?, entity?, activeColor?, stateColor?, goToFloor? }`
 
 `type` names a **symbol** — one of the ~26 the card ships with (`table`, `sofa`, `bed`,
 `fridge`, `stairs`, …; the full set is [`furniture/`](furniture/), a file each), or one you
@@ -574,6 +574,9 @@ The editor's **+ Add** picker draws every symbol at its real size and is searcha
 Bind an **entity** and `stateColor` / `activeColor` recolor the whole diagram — a plant
 goes red when its soil sensor says it needs watering, a cabinet highlights while its
 contact sensor is open.
+
+**`goToFloor`** (`up` / `down`) makes clicking the piece change floor — written for the
+`stairs` symbol. See [Stairs that change floor](#stairs-that-change-floor).
 
 ```yaml
 { id: plant1, type: plant, x: 300, y: 220, w: 40, h: 40,
@@ -1294,6 +1297,39 @@ anything.
 A room with an action bound announces itself as a button and takes a tab stop; a room that
 only zooms does not, exactly as before.
 
+## Stairs that change floor
+
+A staircase already draws an arrow saying which way it goes. `goToFloor` makes that a
+promise the card keeps (issue #121):
+
+```yaml
+floors:
+  - id: ground
+    name: Ground floor
+    furniture:
+      - { id: stairs_up, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: up }
+  - id: upstairs
+    name: Upstairs
+    furniture:
+      - { id: stairs_down, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: down }
+```
+
+Click the stairs, change floor. `up` is the next entry in `floors`, `down` the previous —
+the list is read bottom-to-top — and the button's tooltip names the floor it leads to.
+
+**At the end of the list it leads nowhere, and stops being a button.** An `up` staircase
+on the top floor still draws as a staircase; it just takes no clicks, gets no pointer
+cursor and no tab stop. A control that does nothing is worse than no control. It does not
+wrap either: the loft is not above the cellar.
+
+The option is on **furniture generally**, not just the built-in `stairs` symbol — a plan
+can [draw its own](#drawing-your-own) staircase, and a rule keyed on one symbol id would
+leave those out. It sits under **Behavior** in the furniture panel.
+
+This does not replace the floor switcher in the card's corner; the stairs are a second way
+up. Set `floors` and you get both.
+
+## Offline devices
 ## Offline devices
 
 An entity that has dropped out no longer looks like one that is simply switched off.

--- a/docker/README.md
+++ b/docker/README.md
@@ -146,6 +146,15 @@ its own `percentage` attribute, and its label hung to the **left** of the badge,
 so a device that labels itself *without* its own state and a label that is not
 underneath are both on the plan at once.
 
+The plan has **two floors**, and a staircase on each that you can click to
+change floor (issue #121): the ground floor's is `goToFloor: up`, the one
+upstairs is `goToFloor: down`. The corner switcher is still there — the stairs
+are a second way up, not a replacement for it. Upstairs is deliberately sparse:
+enough to know you changed floor, not a second plan to keep up to date.
+
+Worth trying: move the ground floor's staircase to the top floor in the editor
+and it stops being a button, because there is no floor above it.
+
 The plan also carries one device bound to `light.deleted_by_accident`, which is
 not an entity and never will be. It is what a renamed or deleted binding looks
 like, and the reason it is hard-coded rather than switchable is that no live

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -56,262 +56,292 @@ views:
             # this, and it is working.
             sunDimming: true
 
-            walls:
-              - { id: w1, x1: 100, y1: 100, x2: 900, y2: 100 }
-              - { id: w2, x1: 900, y1: 100, x2: 900, y2: 500 }
-              - { id: w3, x1: 900, y1: 500, x2: 100, y2: 500 }
-              - { id: w4, x1: 100, y1: 500, x2: 100, y2: 100 }
-              # A service shaft boxed into the north-west corner: two partitions
-              # sealing a pocket that no door or window reaches, so `showDeadSpaces`
-              # has something to hatch.
-              - { id: w5, x1: 100, y1: 220, x2: 240, y2: 220 }
-              - { id: w6, x1: 240, y1: 220, x2: 240, y2: 100 }
+            # Two floors, so the card draws its switcher and issue #121 has
+            # something to place. The ground floor is everything that was
+            # here before; upstairs is deliberately sparse — enough to know
+            # you changed floor, and not a second plan to maintain.
+            floors:
+              - id: ground
+                name: Ground floor
+                short: GF
+                walls:
+                  - { id: w1, x1: 100, y1: 100, x2: 900, y2: 100 }
+                  - { id: w2, x1: 900, y1: 100, x2: 900, y2: 500 }
+                  - { id: w3, x1: 900, y1: 500, x2: 100, y2: 500 }
+                  - { id: w4, x1: 100, y1: 500, x2: 100, y2: 100 }
+                  # A service shaft boxed into the north-west corner: two partitions
+                  # sealing a pocket that no door or window reaches, so `showDeadSpaces`
+                  # has something to hatch.
+                  - { id: w5, x1: 100, y1: 220, x2: 240, y2: 220 }
+                  - { id: w6, x1: 240, y1: 220, x2: 240, y2: 100 }
 
-            openings:
-              # Bound to one of the two demo covers that really report
-              # current_position, so this window sits at partial openings rather
-              # than only fully open or fully shut -- the case a cover replayed as
-              # a boolean gets wrong.
-              - id: o1
-                type: window
-                x: 500
-                y: 100
-                length: 140
-                angle: 0
-                entity: cover.living_room_window
-              - { id: o2, type: door, x: 500, y: 500, length: 90, angle: 0 }
-              # The garage door is open/close only -- no position at all -- which
-              # is the other half of the cover story, and it drives the roll-up
-              # curtain from a real entity rather than a dev-only slider.
-              - id: o3
-                type: door
-                motion: roll
-                x: 900
-                y: 300
-                length: 140
-                angle: 90
-                entity: cover.garage_door
-              # A window whose contact is the door sensor, so there is one opening
-              # driven by a binary_sensor rather than a cover -- the two read
-              # open/closed by different rules.
-              - id: o4
-                type: window
-                x: 300
-                y: 500
-                length: 120
-                angle: 0
-                entity: binary_sensor.front_door
-              # One sensor per leaf (issue #159). All three share the same
-              # pair of contacts, so flipping "Left leaf" on the History view
-              # swings a casement sash, a door leaf and a shutter panel at
-              # once -- three symbols, one rule. Flip only one of the pair to
-              # see the half-open state a single-sensor opening cannot reach.
-              #
-              # A casement window: two sashes, one contact each. `sash` is not
-              # stated because `double` is already the window default.
-              - id: o5
-                type: window
-                x: 740
-                y: 100
-                length: 140
-                angle: 0
-                entity: binary_sensor.left_leaf
-                secondaryEntity: binary_sensor.right_leaf
-              # A double door -- the leaf count a door has to be told, since
-              # `single` is its default.
-              - id: o6
-                type: door
-                sash: double
-                x: 720
-                y: 500
-                length: 140
-                angle: 0
-                entity: binary_sensor.left_leaf
-                secondaryEntity: binary_sensor.right_leaf
-              # A single-sash window behind a pair of hinged shutters, each
-              # panel on its own contact. `shutterSecondaryEntity` is a
-              # separate key from `secondaryEntity` precisely because this
-              # opening could have both -- the shutter is a layer over the
-              # window, not part of it.
-              - id: o7
-                type: window
-                sash: single
-                x: 100
-                y: 380
-                length: 120
-                angle: 90
-                shutterEntity: binary_sensor.left_leaf
-                shutterStyle: swing
-                shutterSecondaryEntity: binary_sensor.right_leaf
+                openings:
+                  # Bound to one of the two demo covers that really report
+                  # current_position, so this window sits at partial openings rather
+                  # than only fully open or fully shut -- the case a cover replayed as
+                  # a boolean gets wrong.
+                  - id: o1
+                    type: window
+                    x: 500
+                    y: 100
+                    length: 140
+                    angle: 0
+                    entity: cover.living_room_window
+                  - { id: o2, type: door, x: 500, y: 500, length: 90, angle: 0 }
+                  # The garage door is open/close only -- no position at all -- which
+                  # is the other half of the cover story, and it drives the roll-up
+                  # curtain from a real entity rather than a dev-only slider.
+                  - id: o3
+                    type: door
+                    motion: roll
+                    x: 900
+                    y: 300
+                    length: 140
+                    angle: 90
+                    entity: cover.garage_door
+                  # A window whose contact is the door sensor, so there is one opening
+                  # driven by a binary_sensor rather than a cover -- the two read
+                  # open/closed by different rules.
+                  - id: o4
+                    type: window
+                    x: 300
+                    y: 500
+                    length: 120
+                    angle: 0
+                    entity: binary_sensor.front_door
+                  # One sensor per leaf (issue #159). All three share the same
+                  # pair of contacts, so flipping "Left leaf" on the History view
+                  # swings a casement sash, a door leaf and a shutter panel at
+                  # once -- three symbols, one rule. Flip only one of the pair to
+                  # see the half-open state a single-sensor opening cannot reach.
+                  #
+                  # A casement window: two sashes, one contact each. `sash` is not
+                  # stated because `double` is already the window default.
+                  - id: o5
+                    type: window
+                    x: 740
+                    y: 100
+                    length: 140
+                    angle: 0
+                    entity: binary_sensor.left_leaf
+                    secondaryEntity: binary_sensor.right_leaf
+                  # A double door -- the leaf count a door has to be told, since
+                  # `single` is its default.
+                  - id: o6
+                    type: door
+                    sash: double
+                    x: 720
+                    y: 500
+                    length: 140
+                    angle: 0
+                    entity: binary_sensor.left_leaf
+                    secondaryEntity: binary_sensor.right_leaf
+                  # A single-sash window behind a pair of hinged shutters, each
+                  # panel on its own contact. `shutterSecondaryEntity` is a
+                  # separate key from `secondaryEntity` precisely because this
+                  # opening could have both -- the shutter is a layer over the
+                  # window, not part of it.
+                  - id: o7
+                    type: window
+                    sash: single
+                    x: 100
+                    y: 380
+                    length: 120
+                    angle: 90
+                    shutterEntity: binary_sensor.left_leaf
+                    shutterStyle: swing
+                    shutterSecondaryEntity: binary_sensor.right_leaf
 
-            items:
-              # Paired temperature/humidity: stored at two decimals, displayed at
-              # one. Should read like "17.9 °C · 49.3%".
-              # Many readings on one device (issue #180): one list, in the
-              # order the label prints them. This one deliberately still uses
-              # the legacy `secondaryEntity` for its second reading, so the
-              # plan proves the compatibility path as well as the new key --
-              # the card reads both as one pool, and opening this device in
-              # the editor rewrites the old spelling into `readings`.
-              - id: i1
-                entity: sensor.living_area_temperature
-                secondaryEntity: sensor.living_area_humidity
-                readings:
-                  - { entity: sensor.ficus_soil_moisture }
-                x: 500
-                y: 300
-                kind: sensor
-              # Cast light. These two sit 200 apart with 200 radii so their pools
-              # overlap in the middle, and both are colour-capable demo lights, so
-              # the band where they mix changes colour as the generator recolours
-              # them.
-              - id: glow_warm
-                entity: light.bed_light
-                x: 400
-                y: 380
-                kind: light
-                glow: true
-                glowRadius: 200
-              - id: glow_cool
-                entity: light.office_rgbw_lights
-                x: 600
-                y: 380
-                kind: light
-                glow: true
-                glowRadius: 200
-              # Brightness but no colour of its own: casts the warm-white default,
-              # dimmed to match.
-              - id: glow_dim
-                entity: light.ceiling_lights
-                x: 780
-                y: 200
-                kind: light
-                glow: true
-                glowRadius: 120
-              - id: glow_plain
-                entity: light.kitchen_lights
-                x: 780
-                y: 430
-                kind: light
-                glow: true
-                glowRadius: 110
-                glowColor: "#b0ffd0"
-              # Two active devices side by side with different active colours.
-              - id: i3
-                entity: cover.living_room_window
-                x: 380
-                y: 180
-                kind: cover
-                activeColor: "#8e24aa"
-              # Readings without the device's own state (issue #180) -- the
-              # smart-plug pattern from discussion #173, with the demo's fan
-              # standing in for the plug. Its badge colour already says on or
-              # off, so the label carries the speed instead of the word "on".
-              # `showState: false` silences the state line; the reading is not
-              # gated on it, which is the whole point.
-              #
-              # Also the one device with its label beside the badge rather than
-              # under it, so both label positions are on the plan at once.
-              - id: i4
-                entity: fan.living_room_fan
-                showState: false
-                readings:
-                  - { attribute: percentage }
-                labelPosition: left
-                x: 220
-                y: 180
-                kind: fan
-              # The one that goes `unavailable` on a timer. Left as a plain value
-              # badge so it is obvious on the plan when it drops out.
-              - id: i5
-                entity: sensor.flaky_sensor
-                x: 620
-                y: 180
-                kind: sensor
-                badgeContent: value
-                showState: true
-              # Offline devices (issue #162), second flavour: an entity id
-              # that is not in Home Assistant at all -- renamed, deleted, or
-              # from an integration that failed to load. Before #162 this drew
-              # an ordinary "off" badge for something that does not exist, and
-              # unlike sensor.flaky_sensor above there is no switch that can
-              # produce it, so it is hard-coded here.
-              - id: i6
-                entity: light.deleted_by_accident
-                name: Missing entity
-                x: 300
-                y: 300
-                kind: light
+                items:
+                  # Paired temperature/humidity: stored at two decimals, displayed at
+                  # one. Should read like "17.9 °C · 49.3%".
+                  # Many readings on one device (issue #180): one list, in the
+                  # order the label prints them. This one deliberately still uses
+                  # the legacy `secondaryEntity` for its second reading, so the
+                  # plan proves the compatibility path as well as the new key --
+                  # the card reads both as one pool, and opening this device in
+                  # the editor rewrites the old spelling into `readings`.
+                  - id: i1
+                    entity: sensor.living_area_temperature
+                    secondaryEntity: sensor.living_area_humidity
+                    readings:
+                      - { entity: sensor.ficus_soil_moisture }
+                    x: 500
+                    y: 300
+                    kind: sensor
+                  # Cast light. These two sit 200 apart with 200 radii so their pools
+                  # overlap in the middle, and both are colour-capable demo lights, so
+                  # the band where they mix changes colour as the generator recolours
+                  # them.
+                  - id: glow_warm
+                    entity: light.bed_light
+                    x: 400
+                    y: 380
+                    kind: light
+                    glow: true
+                    glowRadius: 200
+                  - id: glow_cool
+                    entity: light.office_rgbw_lights
+                    x: 600
+                    y: 380
+                    kind: light
+                    glow: true
+                    glowRadius: 200
+                  # Brightness but no colour of its own: casts the warm-white default,
+                  # dimmed to match.
+                  - id: glow_dim
+                    entity: light.ceiling_lights
+                    x: 780
+                    y: 200
+                    kind: light
+                    glow: true
+                    glowRadius: 120
+                  - id: glow_plain
+                    entity: light.kitchen_lights
+                    x: 780
+                    y: 430
+                    kind: light
+                    glow: true
+                    glowRadius: 110
+                    glowColor: "#b0ffd0"
+                  # Two active devices side by side with different active colours.
+                  - id: i3
+                    entity: cover.living_room_window
+                    x: 380
+                    y: 180
+                    kind: cover
+                    activeColor: "#8e24aa"
+                  # Readings without the device's own state (issue #180) -- the
+                  # smart-plug pattern from discussion #173, with the demo's fan
+                  # standing in for the plug. Its badge colour already says on or
+                  # off, so the label carries the speed instead of the word "on".
+                  # `showState: false` silences the state line; the reading is not
+                  # gated on it, which is the whole point.
+                  #
+                  # Also the one device with its label beside the badge rather than
+                  # under it, so both label positions are on the plan at once.
+                  - id: i4
+                    entity: fan.living_room_fan
+                    showState: false
+                    readings:
+                      - { attribute: percentage }
+                    labelPosition: left
+                    x: 220
+                    y: 180
+                    kind: fan
+                  # The one that goes `unavailable` on a timer. Left as a plain value
+                  # badge so it is obvious on the plan when it drops out.
+                  - id: i5
+                    entity: sensor.flaky_sensor
+                    x: 620
+                    y: 180
+                    kind: sensor
+                    badgeContent: value
+                    showState: true
+                  # Offline devices (issue #162), second flavour: an entity id
+                  # that is not in Home Assistant at all -- renamed, deleted, or
+                  # from an integration that failed to load. Before #162 this drew
+                  # an ordinary "off" badge for something that does not exist, and
+                  # unlike sensor.flaky_sensor above there is no switch that can
+                  # produce it, so it is hard-coded here.
+                  - id: i6
+                    entity: light.deleted_by_accident
+                    name: Missing entity
+                    x: 300
+                    y: 300
+                    kind: light
 
-            furniture:
-              - id: fu1
-                type: sofa
-                x: 200
-                y: 380
-                w: 120
-                h: 60
-              # Coloured by threshold off the soil sensor, which the generator
-              # walks down and then "waters", so the thresholds actually cross
-              # while you watch instead of sitting on one colour.
-              - id: fu2
-                type: plant
-                x: 700
-                y: 380
-                w: 60
-                h: 60
-                entity: sensor.ficus_soil_moisture
-                stateColor:
-                  - { above: 80, color: "#2e7d32" }
-                  - { above: 65, color: "#f9a825" }
-                  - { color: "#c62828" }
+                furniture:
+                  # Issue #121: click it to go up. The card only makes it a
+                  # button when there is a floor that way, so the same piece on
+                  # the top floor would draw as ordinary stairs.
+                  - { id: fu3, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: up }
+                  - id: fu1
+                    type: sofa
+                    x: 200
+                    y: 380
+                    w: 120
+                    h: 60
+                  # Coloured by threshold off the soil sensor, which the generator
+                  # walks down and then "waters", so the thresholds actually cross
+                  # while you watch instead of sitting on one colour.
+                  - id: fu2
+                    type: plant
+                    x: 700
+                    y: 380
+                    w: 60
+                    h: 60
+                    entity: sensor.ficus_soil_moisture
+                    stateColor:
+                      - { above: 80, color: "#2e7d32" }
+                      - { above: 65, color: "#f9a825" }
+                      - { color: "#c62828" }
 
-            trackers:
-              # A tracker is a rectangle plus two distance sensors that map onto
-              # its span -- the mmWave/radar shape, not a device_tracker. The
-              # generator walks the two distance readings around, and gates them
-              # on a presence binary_sensor that goes clear now and then, so the
-              # "hide the marker when the room is empty" path is exercised too.
-              - id: t1
-                x: 120
-                y: 120
-                w: 360
-                h: 360
-                color: "#26c6da"
-                dotSize: 16
-                xSensor:
-                  entity: sensor.tracker_distance_x
-                  min: 0
-                  max: 500
-                  presence:
-                    entity: binary_sensor.living_presence
-                ySensor:
-                  entity: sensor.tracker_distance_y
-                  min: 0
-                  max: 500
-                  presence:
-                    entity: binary_sensor.living_presence
+                trackers:
+                  # A tracker is a rectangle plus two distance sensors that map onto
+                  # its span -- the mmWave/radar shape, not a device_tracker. The
+                  # generator walks the two distance readings around, and gates them
+                  # on a presence binary_sensor that goes clear now and then, so the
+                  # "hide the marker when the room is empty" path is exercised too.
+                  - id: t1
+                    x: 120
+                    y: 120
+                    w: 360
+                    h: 360
+                    color: "#26c6da"
+                    dotSize: 16
+                    xSensor:
+                      entity: sensor.tracker_distance_x
+                      min: 0
+                      max: 500
+                      presence:
+                        entity: binary_sensor.living_presence
+                    ySensor:
+                      entity: sensor.tracker_distance_y
+                      min: 0
+                      max: 500
+                      presence:
+                        entity: binary_sensor.living_presence
 
-            areas:
-              - id: a1
-                name: Living Room
-                showName: true
-                color: "#26c6da"
-                opacity: 0.15
-                points:
-                  - { x: 100, y: 100 }
-                  - { x: 500, y: 100 }
-                  - { x: 500, y: 500 }
-                  - { x: 100, y: 500 }
-              - id: a2
-                name: Kitchen
-                showName: true
-                color: "#ffa726"
-                opacity: 0.15
-                points:
-                  - { x: 500, y: 100 }
-                  - { x: 900, y: 100 }
-                  - { x: 900, y: 500 }
-                  - { x: 500, y: 500 }
+                areas:
+                  - id: a1
+                    name: Living Room
+                    showName: true
+                    color: "#26c6da"
+                    opacity: 0.15
+                    points:
+                      - { x: 100, y: 100 }
+                      - { x: 500, y: 100 }
+                      - { x: 500, y: 500 }
+                      - { x: 100, y: 500 }
+                  - id: a2
+                    name: Kitchen
+                    showName: true
+                    color: "#ffa726"
+                    opacity: 0.15
+                    points:
+                      - { x: 500, y: 100 }
+                      - { x: 900, y: 100 }
+                      - { x: 900, y: 500 }
+                      - { x: 500, y: 500 }
+              - id: upstairs
+                name: Upstairs
+                short: 1st
+                walls:
+                  - { id: uw1, x1: 200, y1: 150, x2: 800, y2: 150 }
+                  - { id: uw2, x1: 800, y1: 150, x2: 800, y2: 450 }
+                  - { id: uw3, x1: 800, y1: 450, x2: 200, y2: 450 }
+                  - { id: uw4, x1: 200, y1: 450, x2: 200, y2: 150 }
+                openings:
+                  - { id: uo1, type: door, x: 500, y: 450, length: 90, angle: 0 }
+                items:
+                  - { id: ui1, entity: light.bed_light, x: 350, y: 300, kind: light }
+                texts: []
+                furniture:
+                  # The other end of the staircase below — and the way back.
+                  - { id: ust, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: down }
+                trackers: []
+                areas: []
 
   # A plain history view, so when the card disagrees with HA about what
   # happened you can see which one is wrong without leaving the dashboard.

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1730,7 +1730,7 @@ describe("every field lands in exactly one panel group", () => {
     ["showIcon", "icon"],
     ["tapTarget", "tap_action", "hold_action", "double_tap_action"],
   ];
-  const FURNITURE_GROUPS = [["type", "hand", "w", "h", "angle"], ["entity"]];
+  const FURNITURE_GROUPS = [["type", "hand", "w", "h", "angle"], ["entity"], ["goToFloor"]];
   const TRACKER_GROUPS = [["w", "h", "x", "y", "angle"], ["dotSize"]];
   const AREA_GROUPS = [
     ["showName", "labelSize"],

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1151,6 +1151,16 @@ export function furnitureForm(
         helper: areaScopeHelper(areaScope, "Optional — lets the drawing change color with a sensor"),
         selector: areaScopedEntity(areaScope, f.entity),
       },
+      // Clicking it changes floor (issue #121). Offered on any piece rather
+      // than only on the built-in `stairs`, because a plan can draw its own
+      // staircase and a rule keyed on one symbol id would leave those out.
+      // Empty on everything by default, so it is a row and not a nag.
+      {
+        name: "goToFloor",
+        label: "Go to floor",
+        helper: "Clicking this piece changes floor — for a staircase",
+        selector: dropdown(opt("", "Nothing"), opt("up", "Up one floor"), opt("down", "Down one floor")),
+      },
     ],
     data: {
       type: f.type,
@@ -1159,8 +1169,10 @@ export function furnitureForm(
       h: f.h,
       angle: f.angle ?? 0,
       entity: f.entity ?? "",
+      goToFloor: f.goToFloor ?? "",
     },
-    toPatch: identity,
+    // "" is the empty option, and means the piece is ordinary furniture.
+    toPatch: (p) => ("goToFloor" in p && !p.goToFloor ? { ...p, goToFloor: undefined } : p),
   };
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2058,6 +2058,8 @@ export class FloorplanCardEditor extends LitElement {
   private static readonly FURNITURE_GROUPS = [
     ["Shape", ["type", "hand", "w", "h", "angle"]],
     ["What it reads", ["entity"]],
+    // What clicking it does — a staircase that changes floor (issue #121).
+    ["Behavior", ["goToFloor"]],
   ] as const;
 
   private static readonly TRACKER_GROUPS = [

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -61,6 +61,7 @@ import {
   renderRipple,
   renderFurniture,
   furnitureColor,
+  furnitureFloorTarget,
   renderTracker,
   renderArea,
   renderAreaBorder,
@@ -473,6 +474,19 @@ export class FloorplanCard extends LitElement {
         ></ha-icon>
       </div>
     `;
+  }
+
+  /**
+   * Switch to a floor, from the switcher or from a staircase (issue #121).
+   *
+   * Shared so the two cannot drift apart on the things that are easy to
+   * forget: remembering the choice for the next preview the editor builds, and
+   * dropping a zoom that belonged to the floor being left.
+   */
+  private _goToFloor(floors: readonly Floor[], id: string): void {
+    this._activeFloorId = id;
+    lastViewedFloor.set(floorMemoryKey(floors), id);
+    this._zoomedAreaId = undefined;
   }
 
   /** Tapping a room zooms the plan in to it; tapping the same room again zooms back out. */
@@ -927,13 +941,27 @@ export class FloorplanCard extends LitElement {
                   : nothing;
               })}
             </g>
-            ${active.furniture.map((f) =>
-              renderFurniture(
+            ${active.furniture.map((f) => {
+              const drawn = renderFurniture(
                 f,
                 furnitureColor(f, f.entity ? this.hass?.states[f.entity]?.state : undefined),
                 symbolCatalog(c.symbols)
-              )
-            )}
+              );
+              // Stairs that go somewhere (issue #121). Only when there is a
+              // floor that way: at the top of the building an "up" staircase
+              // is still a staircase, but it takes no clicks rather than
+              // offering a control that does nothing.
+              const to = furnitureFloorTarget(f, floors, active.id);
+              if (!to) return drawn;
+              return svg`<g class="fp-furniture-link" role="button" tabindex="0"
+                    title=${`Go to ${floors.find((x) => x.id === to)?.name ?? "the next floor"}`}
+                    @click=${() => this._goToFloor(floors, to)}
+                    @keydown=${(e: KeyboardEvent) => {
+                      if (e.key !== "Enter" && e.key !== " ") return;
+                      e.preventDefault();
+                      this._goToFloor(floors, to);
+                    }}>${drawn}</g>`;
+            })}
             <!-- Sunlight through the openings. Under the walls on purpose:
                  light lands on the floor, and the walls stay crisp lines over
                  it rather than being tinted by the patches they let in. The
@@ -1185,13 +1213,7 @@ export class FloorplanCard extends LitElement {
               class=${f.id === active.id ? "active" : ""}
               title=${f.name}
               style=${accent ? `background:${accent};border-color:${accent};` : nothing}
-              @click=${() => {
-                this._activeFloorId = f.id;
-                // Remember it for the next element the editor preview builds.
-                lastViewedFloor.set(floorMemoryKey(floors), f.id);
-                // A room on the floor just left is meaningless on the new one.
-                this._zoomedAreaId = undefined;
-              }}
+              @click=${() => this._goToFloor(floors, f.id)}
             >
               ${f.short || f.name}
             </button>
@@ -1421,6 +1443,16 @@ export class FloorplanCard extends LitElement {
     }
     .area-tap-target {
       cursor: pointer;
+    }
+    /* A staircase that changes floor (issue #121). The pointer is the whole
+       affordance — the symbol already draws an arrow saying which way it
+       goes — and it only exists on a piece that has somewhere to lead. */
+    .fp-furniture-link {
+      cursor: pointer;
+    }
+    .fp-furniture-link:focus-visible {
+      outline: 2px solid var(--fp-skin-accent, var(--primary-color, #03a9f4));
+      outline-offset: 2px;
     }
     svg {
       position: absolute;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -953,14 +953,21 @@ export class FloorplanCard extends LitElement {
               // offering a control that does nothing.
               const to = furnitureFloorTarget(f, floors, active.id);
               if (!to) return drawn;
+              const name = floors.find((x) => x.id === to)?.name;
               return svg`<g class="fp-furniture-link" role="button" tabindex="0"
-                    title=${`Go to ${floors.find((x) => x.id === to)?.name ?? "the next floor"}`}
-                    @click=${() => this._goToFloor(floors, to)}
-                    @keydown=${(e: KeyboardEvent) => {
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      this._goToFloor(floors, to);
-                    }}>${drawn}</g>`;
+                    @action=${() => this._goToFloor(floors, to)}
+                    .actionHandler=${actionHandler({
+                      // A staircase has one gesture. Saying so keeps a tap from
+                      // sitting out the hold and double-tap timers before it
+                      // does anything.
+                      hasHold: false,
+                      hasDoubleClick: false,
+                    })}>
+                  <!-- An SVG tooltip is a <title> child, not a title=
+                       attribute: the attribute does nothing here. -->
+                  <title>${name ? `Go to ${name}` : "Go to the next floor"}</title>
+                  ${drawn}
+                </g>`;
             })}
             <!-- Sunlight through the openings. Under the walls on purpose:
                  light lands on the floor, and the walls stay crisp lines over

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -76,6 +76,7 @@ import {
   defaultIcon,
   renderFurniture,
   furnitureColor,
+  furnitureFloorTarget,
   entityDefaultIcon,
   trackerSensorReading,
   openingInMotion,
@@ -5138,5 +5139,46 @@ describe("a reading can be bound without being printed", () => {
       ],
     } as unknown as FloorplanCardConfig);
     expect([...got].sort()).toEqual([TEMP, HUMIDITY].sort());
+  });
+});
+
+describe("stairs that change floor (issue #121)", () => {
+  const floors = [{ id: "cellar" }, { id: "ground" }, { id: "loft" }];
+  const stairs = (goToFloor?: "up" | "down") => ({ goToFloor }) as Pick<Furniture, "goToFloor">;
+
+  it("reads the floor list bottom-to-top", () => {
+    expect(furnitureFloorTarget(stairs("up"), floors, "ground")).toBe("loft");
+    expect(furnitureFloorTarget(stairs("down"), floors, "ground")).toBe("cellar");
+  });
+
+  it("leads nowhere at the end of the list, so the card draws no button", () => {
+    expect(furnitureFloorTarget(stairs("up"), floors, "loft")).toBeUndefined();
+    expect(furnitureFloorTarget(stairs("down"), floors, "cellar")).toBeUndefined();
+  });
+
+  it("does not wrap — the loft is not above the cellar", () => {
+    // A stair click that teleported you from the top of the building to the
+    // bottom would be a bug report, not a feature.
+    expect(furnitureFloorTarget(stairs("up"), floors, "loft")).not.toBe("cellar");
+    expect(furnitureFloorTarget(stairs("down"), floors, "cellar")).not.toBe("loft");
+  });
+
+  it("is inert on ordinary furniture", () => {
+    expect(furnitureFloorTarget(stairs(), floors, "ground")).toBeUndefined();
+    expect(furnitureFloorTarget({ goToFloor: "sideways" } as never, floors, "ground")).toBeUndefined();
+  });
+
+  it("leads nowhere when the active floor is not in the list", () => {
+    // A stale `_activeFloorId` must not resolve to floors[0] by accident.
+    expect(furnitureFloorTarget(stairs("up"), floors, "gone")).toBeUndefined();
+    expect(furnitureFloorTarget(stairs("up"), floors, undefined)).toBeUndefined();
+    expect(furnitureFloorTarget(stairs("up"), [], "ground")).toBeUndefined();
+  });
+
+  it("works on a two-floor plan, which is the ordinary case", () => {
+    const two = [{ id: "g" }, { id: "up" }];
+    expect(furnitureFloorTarget(stairs("up"), two, "g")).toBe("up");
+    expect(furnitureFloorTarget(stairs("down"), two, "up")).toBe("g");
+    expect(furnitureFloorTarget(stairs("down"), two, "g")).toBeUndefined();
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1594,6 +1594,32 @@ export function pressEffectOf(c: { pressEffect?: PressEffect }): PressEffect {
 }
 
 /**
+ * Which floor a piece of furniture's click leads to (issue #121), or
+ * `undefined` when it leads nowhere.
+ *
+ * `floors` is bottom-to-top, so `up` is the next entry and `down` the
+ * previous. Nothing at that end of the list means no target, and the card
+ * draws the piece as ordinary furniture: a staircase on the top floor is still
+ * a staircase, but it is not a button, because a button that does nothing is
+ * worse than no button.
+ *
+ * Deliberately not wrapping. A plan's floors are a building, and the top of a
+ * building is not above the basement — a stair click that teleported you from
+ * the loft to the cellar would be a bug report, not a feature.
+ */
+export function furnitureFloorTarget(
+  f: Pick<Furniture, "goToFloor">,
+  floors: readonly { id: string }[],
+  activeFloorId: string | undefined,
+): string | undefined {
+  if (f.goToFloor !== "up" && f.goToFloor !== "down") return undefined;
+  const i = floors.findIndex((x) => x.id === activeFloorId);
+  if (i < 0) return undefined;
+  const next = floors[i + (f.goToFloor === "up" ? 1 : -1)];
+  return next?.id;
+}
+
+/**
  * Which offline treatment a plan uses (issue #162), resolving anything
  * unrecognised to the default — the value becomes a class name, exactly as
  * {@link pressEffectOf}'s does, so an unchecked string would silently mean

--- a/src/types.ts
+++ b/src/types.ts
@@ -732,6 +732,23 @@ export interface Furniture {
   /** Stroke/fill color. Defaults to gray so it reads differently from walls. */
   color?: string;
   /**
+   * Clicking this changes floor (issue #121) — `up` for the next floor in
+   * `floors`, `down` for the previous one.
+   *
+   * Written for the **stairs** symbol, which is where a plan already draws the
+   * thing people expect to click: the arrow on a staircase is a promise that
+   * it goes somewhere. It is not restricted to that symbol, because a plan can
+   * define its own staircase (see "Drawing your own") and a rule keyed on one
+   * built-in id would leave those out.
+   *
+   * `floors` is read bottom-to-top, so `up` is the next entry and `down` the
+   * previous. At the end of the list the direction has nowhere to go: the
+   * piece draws as ordinary furniture and takes no clicks, rather than
+   * offering a control that does nothing. It does not wrap — a staircase on
+   * the top floor does not lead to the basement.
+   */
+  goToFloor?: "up" | "down";
+  /**
    * Optional entity that makes the drawing live (issue #82) — a soil sensor on
    * a plant, a water temperature sensor on a fish tank, a contact sensor on a
    * cabinet. Drives {@link stateColor} and {@link activeColor}; furniture has


### PR DESCRIPTION
Replaces #210, which solved the wrong problem — placing the switcher on the stairs still made you *pick a floor*, where the issue asks to *move up or down*.

This is much smaller. A staircase already draws an arrow saying which way it goes; `goToFloor` makes that a promise the card keeps.

```yaml
floors:
  - id: ground
    furniture:
      - { id: stairs_up, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: up }
  - id: upstairs
    furniture:
      - { id: stairs_down, type: stairs, x: 640, y: 300, w: 80, h: 140, goToFloor: down }
```

Click the stairs, change floor. `floors` is read bottom-to-top, so `up` is the next entry and `down` the previous, and the button's tooltip names the floor it leads to.

## Two decisions worth reviewing

**At the end of the list it leads nowhere, and stops being a button.** An `up` staircase on the top floor still *draws* as a staircase — it just takes no clicks, no pointer cursor, no `button` role and no tab stop. That's the rule an unbound device and an unbound opening already follow: a control that does nothing is worse than no control. It doesn't wrap, either — a plan's floors are a building, and the loft is not above the cellar.

**The option is on furniture generally**, not on the built-in `stairs` symbol alone. The symbol library is explicitly extensible, so a plan can draw its own staircase, and a rule keyed on one symbol id would leave those out. The default is empty, so it's a row in the furniture panel's **Behavior** group rather than a nag.

It does not replace the corner switcher — the stairs are a second way up. Both routes go through one `_goToFloor`, so they can't drift apart on the easy-to-forget parts: remembering the choice for the next editor preview, and dropping a zoom that belonged to the floor you left.

## Dev container

The demo plan was **single-floor**, so nothing could exercise this — or any multi-floor path. It now has two: everything that was there becomes Ground floor (unchanged apart from the indent), plus a deliberately sparse Upstairs, and a staircase on each — `goToFloor: up` below, `down` above. This part is carried over from #210, which is the only piece of it worth keeping.

## Verification

`npm test` (1168, 6 new), `npm run typecheck`, `npm run build` clean.

Driven in a browser against the **real demo config**, not a fixture:

- ground floor shows one clickable staircase titled "Go to Upstairs"; clicking it lands on `upstairs`;
- upstairs shows one titled "Go to Ground floor"; clicking it lands back on `ground`;
- the corner switcher is still present throughout;
- an `up` staircase placed on the top floor renders as stairs with **zero** clickable links.

The editor's furniture panel gains "Go to floor" under Behavior; the group-coverage test caught the new field before I did, which is what it is there for.