### PR TITLE
Keep the wall neon outside the doorway mask

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3267,10 +3267,10 @@ export class FloorplanCardEditor extends LitElement {
               }
               ${
                 this._draft
-                  ? svg`<line x1=${this._draft.x1} y1=${this._draft.y1}
+                  ? svg`<g class="fp-wall-neon"><line x1=${this._draft.x1} y1=${this._draft.y1}
                               x2=${this._draft.x2} y2=${this._draft.y2}
                               class="wall draft" mask=${`url(#${this._wallMaskId})`}
-                              stroke-width=${WALL_THICKNESS} />`
+                              stroke-width=${WALL_THICKNESS} /></g>`
                   : nothing
               }
               ${this._renderAreaDraft()}
@@ -3810,10 +3810,10 @@ export class FloorplanCardEditor extends LitElement {
         <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
               class="wall-hit"
               @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "wall", id: w.id })} />
-        <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
+        <g class="fp-wall-neon"><line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
               class="wall ${selected ? "selected" : ""}"
               mask=${`url(#${this._wallMaskId})`}
-              style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />
+              style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" /></g>
         ${
           selected
             ? svg`
@@ -5262,13 +5262,20 @@ export class FloorplanCardEditor extends LitElement {
     line.wall {
       stroke: var(--fp-skin-wall, var(--primary-text-color));
       /* Same skin hooks as the card's .wall, so the canvas draws the weight
-         and glow the plan will actually have. */
+         and glow the plan will actually have. The glow itself is on
+         .fp-wall-neon, outside the doorway mask — see the note there. */
       stroke-width: var(--fp-skin-wall-width, 8);
-      filter: var(--fp-skin-wall-filter, none);
       /* The wide transparent .wall-hit line beneath handles selection/drag.
          Without this, the visible line (painted on top) swallows clicks on the
          wall body, so you could only grab it just *outside* the body. */
       pointer-events: none;
+    }
+    /* Neon, matching the card. Must stay on a group *outside* the doorway
+       mask: CSS applies filter before mask, so a filter on the wall itself is
+       computed from the uncut wall and its halo then survives the cut,
+       leaving a fringe that runs through every opening (#203). */
+    .fp-wall-neon {
+      filter: var(--fp-skin-wall-filter, none);
     }
     line.wall.selected {
       stroke: var(--primary-color, #03a9f4);

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1038,13 +1038,15 @@ export class FloorplanCard extends LitElement {
                 : nothing
             }
             ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
-            <g mask=${`url(#${this._wallMaskId})`}>
-              ${active.walls.map(
-                (w) => svg`
-                <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
-                      class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
-                      style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />`
-              )}
+            <g class="fp-wall-neon">
+              <g mask=${`url(#${this._wallMaskId})`}>
+                ${active.walls.map(
+                  (w) => svg`
+                  <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
+                        class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
+                        style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />`
+                )}
+              </g>
             </g>
             <!-- Room outlines, above the walls they trace. An area polygon runs
                  down the centerline of the room's walls, so an outline drawn
@@ -1491,8 +1493,20 @@ export class FloorplanCard extends LitElement {
          mask and the opening symbols are cut from. Capped at 10 for that
          reason — see MAX_SKIN_WALL_WIDTH. */
       stroke-width: var(--fp-skin-wall-width, 8);
-      /* Neon, for the skins that want it. Everyone else gets none, which
-         costs nothing. */
+    }
+    /* Neon, for the skins that want it. Everyone else gets none, which costs
+       nothing.
+
+       This lives on a group *outside* the doorway mask, and must stay there.
+       CSS applies filter before mask, so a filter on the wall itself is
+       computed from the uncut wall: the mask then removes the wall body but
+       not the outer halo, and the leftover fringe runs straight through every
+       opening. The doorway cut clears WALL_THICKNESS + 4 (12 units, so +-6
+       from the centreline) while a drop-shadow of blur 4 reaches about +-8.5,
+       and that difference is exactly what leaked. Measured on a Tron render:
+       35.6 luminance inside an opening against a 7.8 background, versus 7.8
+       with the filter out here. See issue #203. */
+    .fp-wall-neon {
       filter: var(--fp-skin-wall-filter, none);
     }
     /* Dead-space hatching (issue #88). It spans whole regions of the plan, so

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1038,16 +1038,13 @@ export class FloorplanCard extends LitElement {
                 : nothing
             }
             ${renderWallMask(active.openings, c.width, c.height, this._wallMaskId)}
-            <g class="fp-wall-neon">
-              <g mask=${`url(#${this._wallMaskId})`}>
-                ${active.walls.map(
-                  (w) => svg`
-                  <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
-                        class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
-                        style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" />`
-                )}
-              </g>
-            </g>
+            ${active.walls.map(
+                (w) => svg`
+                <g class="fp-wall-neon"><line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
+                      class="wall fp-wall" data-id=${cssIdent(w.id) ?? nothing}
+                      mask=${`url(#${this._wallMaskId})`}
+                      style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" /></g>`
+              )}
             <!-- Room outlines, above the walls they trace. An area polygon runs
                  down the centerline of the room's walls, so an outline drawn
                  with the fill is buried under the wall and never seen. Drawn
@@ -1497,15 +1494,23 @@ export class FloorplanCard extends LitElement {
     /* Neon, for the skins that want it. Everyone else gets none, which costs
        nothing.
 
-       This lives on a group *outside* the doorway mask, and must stay there.
-       CSS applies filter before mask, so a filter on the wall itself is
-       computed from the uncut wall: the mask then removes the wall body but
-       not the outer halo, and the leftover fringe runs straight through every
-       opening. The doorway cut clears WALL_THICKNESS + 4 (12 units, so +-6
-       from the centreline) while a drop-shadow of blur 4 reaches about +-8.5,
-       and that difference is exactly what leaked. Measured on a Tron render:
-       35.6 luminance inside an opening against a 7.8 background, versus 7.8
-       with the filter out here. See issue #203. */
+       Two things about where this sits, and both matter.
+
+       It is *outside* the doorway mask. CSS applies filter before mask, so a
+       filter on the wall itself is computed from the uncut wall: the mask then
+       removes the wall body but not the outer halo, and the leftover fringe
+       runs straight through every opening. The doorway cut clears
+       WALL_THICKNESS + 4 (12 units, so +-6 from the centreline) while a
+       drop-shadow of blur 4 reaches about +-8.5, and that difference is
+       exactly what leaked. Measured on a Tron render: 35.6 luminance inside an
+       opening against a 7.8 background, versus 7.8 with the filter out here.
+
+       It is also *per wall*, not one group around the whole collection.
+       Wrapping them all together would composite the strokes before filtering,
+       so two walls meeting at a corner glow once instead of twice and every
+       joint quietly dims. Per-wall keeps the accumulation the card has always
+       had, and keeps the editor honest, since _renderWall wraps each wall the
+       same way. See issue #203. */
     .fp-wall-neon {
       filter: var(--fp-skin-wall-filter, none);
     }

--- a/src/wall-neon-mask.test.ts
+++ b/src/wall-neon-mask.test.ts
@@ -57,34 +57,48 @@ describe("the wall neon sits outside the doorway mask (#203)", () => {
     });
   }
 
-  it("the card nests the mask INSIDE the neon group, not the other way round", () => {
-    const open = cardSource.indexOf(`<g class="fp-wall-neon">`);
-    expect(open, "neon group not found in the card template").toBeGreaterThan(-1);
-    const wallLine = cardSource.indexOf("class=\"wall fp-wall\"", open);
-    expect(wallLine).toBeGreaterThan(open);
-    // between the neon group opening and the wall itself there must be a mask
-    expect(cardSource.slice(open, wallLine)).toMatch(/mask=\$\{`url\(#\$\{this\._wallMaskId\}\)`\}/);
-  });
+  for (const [name, source] of [
+    ["card", cardSource],
+    ["editor", editorSource],
+  ] as const) {
+    it(`${name}: every masked wall opens its own neon group immediately before it`, () => {
+      // Per wall, not one group around the collection. Wrapping them together
+      // composites the strokes before filtering, so walls meeting at a corner
+      // glow once instead of twice and every joint dims — a silent change to
+      // how a plan looks, on top of the fix this is actually for.
+      const masked = [...source.matchAll(/<line[^>]*class="wall[^"]*"[^>]*mask=/gs)];
+      expect(masked.length, `no masked wall lines found in the ${name}`).toBeGreaterThan(0);
+      for (const m of masked) {
+        const before = source.slice(Math.max(0, m.index! - 160), m.index!);
+        expect(before, `unwrapped masked wall in the ${name} at index ${m.index}`).toMatch(
+          /<g class="fp-wall-neon">\s*$/,
+        );
+      }
+    });
+  }
 
-  it("every masked wall in the editor is wrapped by the neon group", () => {
-    // each editor wall <line class="wall ..."> carrying the doorway mask must
-    // have the neon group opened immediately before it
-    const masked = [...editorSource.matchAll(/<line[^>]*class="wall[^"]*"[^>]*mask=/g)];
-    expect(masked.length, "no masked wall lines found in the editor").toBeGreaterThan(0);
-    for (const m of masked) {
-      const before = editorSource.slice(Math.max(0, m.index! - 120), m.index!);
-      expect(before, `unwrapped masked wall near index ${m.index}`).toMatch(
-        /<g class="fp-wall-neon">\s*$/,
-      );
+  it("no neon group wraps the whole wall collection", () => {
+    // the shape that regressed joints: a neon group whose body is a .map(...)
+    for (const [name, source] of [["card", cardSource], ["editor", editorSource]] as const) {
+      const collectionWrap = /<g class="fp-wall-neon">\s*(<g mask|\$\{[a-zA-Z.?]*walls)/;
+      expect(collectionWrap.test(source), `${name} wraps the collection, not each wall`).toBe(false);
     }
   });
 
   it("says why, so the next person does not move it back onto the wall", () => {
     for (const source of [cardSource, editorSource]) {
       const at = source.indexOf(".fp-wall-neon {");
-      const nearby = source.slice(Math.max(0, at - 900), at);
+      const nearby = source.slice(Math.max(0, at - 2000), at);
       expect(nearby).toMatch(/filter before mask/i);
       expect(nearby).toMatch(/#203/);
+    }
+    // and the card must say why it is per wall, since that is the part a
+    // future tidy-up would most plausibly "simplify" back into one group
+    {
+      const at = cardSource.indexOf(".fp-wall-neon {");
+      const nearby = cardSource.slice(Math.max(0, at - 2000), at);
+      expect(nearby).toMatch(/per wall/i);
+      expect(nearby).toMatch(/joint/i);
     }
   });
 });

--- a/src/wall-neon-mask.test.ts
+++ b/src/wall-neon-mask.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+/**
+ * Read as source text rather than imported, for the same reason as
+ * card-styles.test.ts: importing either module drags in Lit's element
+ * machinery for a question the source itself answers.
+ */
+import cardSourceRaw from "./floorplan-card.ts?raw";
+import editorSourceRaw from "./editor.ts?raw";
+
+const cardSource = cardSourceRaw as string;
+const editorSource = editorSourceRaw as string;
+
+/**
+ * Issue #203 — "Neon Glow Ignores Wall Openings".
+ *
+ * CSS applies `filter` before `mask`. A skin filter set on the wall element
+ * itself is therefore computed from the *uncut* wall, and the doorway mask
+ * then removes the wall body but not the halo around it. The cut clears
+ * `WALL_THICKNESS + 4` (12 units, so ±6 from the centreline); a
+ * `drop-shadow` of blur 4 reaches roughly ±8.5. The ~2.5 units of halo on
+ * each side that the mask never touches run straight through every opening.
+ *
+ * Measured on a Tron render before the fix: 35.6 peak luminance inside an
+ * opening against a 7.8 background — 4.6x — falling to exactly 7.8 once the
+ * filter moved outside the mask.
+ *
+ * The invariant is structural, so it is guarded structurally: the filter
+ * belongs to a group that *wraps* the masked group, never to the wall.
+ */
+describe("the wall neon sits outside the doorway mask (#203)", () => {
+  const blockAfter = (source: string, selector: string): string | undefined => {
+    const at = source.indexOf(selector);
+    if (at === -1) return undefined;
+    return source.slice(at, source.indexOf("}", at));
+  };
+
+  it("the card's .wall declares no filter of its own", () => {
+    const block = blockAfter(cardSource, "\n    .wall {");
+    expect(block, ".wall rule not found").toBeDefined();
+    expect(block).not.toMatch(/(^|[;\s])filter\s*:/);
+  });
+
+  it("the editor's line.wall declares no filter of its own", () => {
+    const block = blockAfter(editorSource, "line.wall {");
+    expect(block, "line.wall rule not found").toBeDefined();
+    expect(block).not.toMatch(/(^|[;\s])filter\s*:/);
+  });
+
+  for (const [name, source] of [
+    ["card", cardSource],
+    ["editor", editorSource],
+  ] as const) {
+    it(`${name}: .fp-wall-neon is what carries the skin filter`, () => {
+      const block = blockAfter(source, ".fp-wall-neon {");
+      expect(block, ".fp-wall-neon rule not found").toBeDefined();
+      expect(block).toMatch(/filter\s*:\s*var\(--fp-skin-wall-filter/);
+    });
+  }
+
+  it("the card nests the mask INSIDE the neon group, not the other way round", () => {
+    const open = cardSource.indexOf(`<g class="fp-wall-neon">`);
+    expect(open, "neon group not found in the card template").toBeGreaterThan(-1);
+    const wallLine = cardSource.indexOf("class=\"wall fp-wall\"", open);
+    expect(wallLine).toBeGreaterThan(open);
+    // between the neon group opening and the wall itself there must be a mask
+    expect(cardSource.slice(open, wallLine)).toMatch(/mask=\$\{`url\(#\$\{this\._wallMaskId\}\)`\}/);
+  });
+
+  it("every masked wall in the editor is wrapped by the neon group", () => {
+    // each editor wall <line class="wall ..."> carrying the doorway mask must
+    // have the neon group opened immediately before it
+    const masked = [...editorSource.matchAll(/<line[^>]*class="wall[^"]*"[^>]*mask=/g)];
+    expect(masked.length, "no masked wall lines found in the editor").toBeGreaterThan(0);
+    for (const m of masked) {
+      const before = editorSource.slice(Math.max(0, m.index! - 120), m.index!);
+      expect(before, `unwrapped masked wall near index ${m.index}`).toMatch(
+        /<g class="fp-wall-neon">\s*$/,
+      );
+    }
+  });
+
+  it("says why, so the next person does not move it back onto the wall", () => {
+    for (const source of [cardSource, editorSource]) {
+      const at = source.indexOf(".fp-wall-neon {");
+      const nearby = source.slice(Math.max(0, at - 900), at);
+      expect(nearby).toMatch(/filter before mask/i);
+      expect(nearby).toMatch(/#203/);
+    }
+  });
+});


### PR DESCRIPTION
Addresses #203.

On a skin that sets `--fp-skin-wall-filter`, the wall neon carried straight through doors and
windows, so a plan read as one unbroken glowing outline instead of a room with openings in it.

### Cause

CSS applies `filter` before `mask`. The filter sat on the wall element itself, inside the group that
punches the doorway holes:

```
<g mask="url(#fp-wall-mask-0)">
  <line class="wall fp-wall" ... />   <-- filter here
</g>
```

So each wall was rendered *with its full glow*, and only then was the opening cut out of the result.
The cut clears `WALL_THICKNESS + 4` — 12 units, so ±6 from the centreline — while
`drop-shadow(0 0 4px …)` reaches roughly ±8.5. The couple of units of halo on each side that the mask
never touches ran through every opening.

On a Tron render with a wall at x=150 and a door across it, the mask rect and the wall geometry read
straight off the DOM: the mask clears `x ∈ [144, 156]` and the 5px wall occupies
`x ∈ [147.5, 152.5]`, so the wall body *is* cut correctly. The halo figure is derived rather than
measured — a blur radius of 4 is a Gaussian of sigma 2, which fades out around 6 units, giving
roughly `x ∈ [141.5, 158.5]`. The luminance numbers below are what actually pins it down.

### Measured

Peak luminance sampled inside an opening, against a 7.8 background, on the same plan and skin:

| | peak | above background |
|---|---|---|
| solid wall (reference) | 211.0 | 203.2 |
| before | **35.6** | **27.8** |
| after | **7.8** | **0.0** |

About 17% of full wall brightness — plainly visible against a near-black ground. Skins without a
wall filter never showed it at all, since there is no halo to leak.

### Fix

The filter moves to `.fp-wall-neon`, a group that wraps the masked group, so the hole is punched
first and the glow is computed from the shape that survives.

`editor.ts` has the same defect in a sharper form — `mask` and the filter on the *same* element — at
both the committed-walls site and the wall-being-drawn site, so both are wrapped too. The editor is
meant to preview the glow the plan will actually have, and would otherwise disagree with the card.

Both were checked in a running Home Assistant, on a 37-wall plan with the Tron skin. In the editor
the numbers come out as intended: 37 wall lines, all 37 carrying the doorway mask, all 37 wrapped in
the neon group, computed `filter` on the wall itself `none`, and `drop-shadow(rgb(34, 211, 238) 0px
0px 4px)` on the group above it. Doorways read as real gaps on the canvas.

Only skins that set a wall filter were ever affected. Default and the others set `none` and render
identically before and after.

### What this does not do

#203 also asks that door and window outlines themselves glow. **This PR does not do that** — opening
symbols render outside the filtered group and are untouched here. Left deliberately, as it is a
design decision about how openings should look rather than a rendering defect. That is why this says
*Addresses* rather than *Closes*.

### Testing

`wall-neon-mask.test.ts` pins the structure rather than the pixels: the wall carries no filter of its
own, `.fp-wall-neon` carries it, the mask is nested inside that group, every masked wall in the
editor is wrapped, and the reason is written beside the rule so it does not get moved back. All seven
guards fail against the unfixed source — checked by reverting the fix and re-running, so they cannot
quietly pass forever.

`npx tsc --noEmit` clean. **1175 tests pass** (1168 before, plus the 7 added here).

Both sides are exercised against a real render of the built bundle: the card through the images and
luminance numbers above, the editor in a live Home Assistant as described.

### Screenshots

<!-- ATTACH: notes/assets/issue203-before-after.png -->

Same room, same three openings (one window, two doors), same skin per row. Top row Tron before/after;
bottom row the Default skin before/after, which is pixel-identical either way.
