### PR TITLE
Windows let a lamp's glow through, shut or open

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -67,7 +67,7 @@ import {
   resolveOpeningAmount,
   openingIsActive,
   wallsLightPassesThrough,
-  openingClearFraction,
+  glowClearFraction,
   openingHasTwoLeaves,
   secondLeafOf,
   renderGlowMask,
@@ -2836,8 +2836,10 @@ export class FloorplanCardEditor extends LitElement {
       ? wallsLightPassesThrough(floor.walls, floor.openings, (o) => {
           const amt = (id?: string) =>
             resolveOpeningAmount(o, id ? this.hass?.states[id] : undefined);
-          // Same reading as the card, second leaf included (issue #145).
-          return openingClearFraction(
+          // Same reading as the card, second leaf included (issue #145),
+          // glass admitted whole regardless of sash, and a shutter overriding
+          // that — all same as the card.
+          return glowClearFraction(
             o,
             amt(o.entity),
             o.secondaryEntity && openingHasTwoLeaves(o)
@@ -2845,7 +2847,8 @@ export class FloorplanCardEditor extends LitElement {
                   secondLeafOf(o),
                   this.hass?.states[o.secondaryEntity]
                 )
-              : undefined
+              : undefined,
+            o.shutterEntity ? shutterAmount(this.hass?.states[o.shutterEntity], o.shutterInvert) : undefined
           );
         })
       : floor.walls;

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -75,6 +75,7 @@ import {
   renderSunDimMask,
   wallsLightPassesThrough,
   openingClearFraction,
+  glowClearFraction,
   polygonCentroid,
   trackerSensorReading,
   entityIsActive,
@@ -784,8 +785,16 @@ export class FloorplanCard extends LitElement {
       ? wallsLightPassesThrough(active.walls, active.openings, (o) =>
           // Both leaves, and the travel each style actually has (issue #145):
           // asking `entity` alone left a door whose *second* panel was open
-          // still blocking light outright.
-          openingClearFraction(o, this._openingAmount(o), this._openingSecond(o)?.amount)
+          // still blocking light outright. Glass admits it whole regardless
+          // of sash — a closed window is not a hole, but light still gets
+          // through it. A shutter rolled down overrides that, same as it
+          // does for sunlight.
+          glowClearFraction(
+            o,
+            this._openingAmount(o),
+            this._openingSecond(o)?.amount,
+            o.shutterEntity ? shutterAmount(this.hass?.states[o.shutterEntity], o.shutterInvert) : undefined
+          )
         )
       : active.walls;
     // Lit rooms hold back the night (issue #113): without this the flat dim

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -135,6 +135,7 @@ import {
   glowReach,
   wallsLightPassesThrough,
   openingClearFraction,
+  glowClearFraction,
   renderGlowMask,
   renderOpening,
   renderGlow,
@@ -4388,6 +4389,55 @@ describe("openingClearFraction (#145 / #143)", () => {
   });
 });
 
+describe("glowClearFraction — glass admits a lamp's pool shut or open", () => {
+  it("passes an opaque opening straight through to openingClearFraction", () => {
+    expect(glowClearFraction({ type: "door" } as Opening, 0.25)).toBeCloseTo(0.25);
+    expect(glowClearFraction({ type: "door" } as Opening, 1)).toBe(1);
+    expect(glowClearFraction({ type: "door" } as Opening, 0)).toBe(0);
+  });
+
+  it("clears a window's whole gap whatever its sash is doing", () => {
+    expect(glowClearFraction({ type: "window" } as Opening, 0)).toBe(1);
+    expect(glowClearFraction({ type: "window" } as Opening, 0.3)).toBe(1);
+    expect(glowClearFraction({ type: "window" } as Opening, 1)).toBe(1);
+  });
+
+  it("ignores `glazed` — that field is sunlight's, not a lamp's", () => {
+    // A French door is glass to the sun (openingSunFraction), but it is
+    // still a door to a lamp's pool: shut, it blocks like any other door.
+    expect(glowClearFraction({ type: "door", glazed: true } as Opening, 0)).toBe(0);
+    expect(glowClearFraction({ type: "door", glazed: true } as Opening, 0.4)).toBeCloseTo(0.4);
+    // A window stays glass to a lamp even marked `glazed: false` — that flag
+    // only ever meant "block the sun", never "block a lamp's own light".
+    expect(glowClearFraction({ type: "window", glazed: false } as Opening, 0.4)).toBe(1);
+  });
+
+  it("still respects a two-panel slider's travel for a non-glazed opening", () => {
+    const converging = {
+      id: "o", type: "door", motion: "slide", sliderStyle: "converging",
+      x: 300, y: 300, length: 200, angle: 0,
+    } as Opening;
+    expect(glowClearFraction(converging, 1, 1)).toBe(openingClearFraction(converging, 1, 1));
+  });
+
+  it("a shutter rolled down blocks the pool whatever the glass says (issue #185)", () => {
+    // A window's glass is not the whole story: the persiana in front of it can
+    // still be shut, and shut wins.
+    expect(glowClearFraction({ type: "window" } as Opening, 0, undefined, 0)).toBe(0);
+    expect(glowClearFraction({ type: "window" } as Opening, 1, undefined, 0)).toBe(0);
+    // Open, the window's own rule (always clear) still applies.
+    expect(glowClearFraction({ type: "window" } as Opening, 0, undefined, 1)).toBe(1);
+    // Only a fully-down shutter (0) blocks — a crack open is enough to defer
+    // back to the window, same threshold openingSunFraction uses.
+    expect(glowClearFraction({ type: "window" } as Opening, 0, undefined, 0.01)).toBe(1);
+  });
+
+  it("no shutter bound leaves an opening judged on itself alone", () => {
+    expect(glowClearFraction({ type: "window" } as Opening, 0, undefined, undefined)).toBe(1);
+    expect(glowClearFraction({ type: "door" } as Opening, 0.6, undefined, undefined)).toBeCloseTo(0.6);
+  });
+});
+
 describe("wallsLightPassesThrough (#143)", () => {
   const wall = (x1: number, y1: number, x2: number, y2: number, id = "w") => ({ id, x1, y1, x2, y2 });
   // A door centred on a horizontal wall at y=100, spanning x 480..520.
@@ -4565,6 +4615,22 @@ describe("wallsLightPassesThrough (#143)", () => {
     };
     expect(beyond(0)).toBe(false); // shut: the room beyond stays dark
     expect(beyond(1)).toBe(true); // open: light reaches through
+  });
+
+  it("a shut window still cuts a gap when fed glowClearFraction, unlike a shut door", () => {
+    const walls = [wall(0, 100, 1000, 100)];
+    const win = door({ id: "w", type: "window" } as Partial<Opening>);
+    // Fed the plain amount (0, shut): today's door behaviour — wall stays whole.
+    expect(wallsLightPassesThrough(walls, [win], () => 0)).toEqual(walls);
+    // Fed through glowClearFraction: glass admits the pool regardless of sash.
+    const out = wallsLightPassesThrough(walls, [win], (o) => glowClearFraction(o, 0));
+    expect(spans(out)).toEqual([
+      [0, 480],
+      [520, 1000],
+    ]);
+    // A shut door, run through the same helper, still blocks — only glass is exempt.
+    const doorOut = wallsLightPassesThrough(walls, [door()], (o) => glowClearFraction(o, 0));
+    expect(doorOut).toEqual(walls);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -4402,14 +4402,29 @@ describe("glowClearFraction — glass admits a lamp's pool shut or open", () => 
     expect(glowClearFraction({ type: "window" } as Opening, 1)).toBe(1);
   });
 
-  it("ignores `glazed` — that field is sunlight's, not a lamp's", () => {
-    // A French door is glass to the sun (openingSunFraction), but it is
-    // still a door to a lamp's pool: shut, it blocks like any other door.
-    expect(glowClearFraction({ type: "door", glazed: true } as Opening, 0)).toBe(0);
-    expect(glowClearFraction({ type: "door", glazed: true } as Opening, 0.4)).toBeCloseTo(0.4);
-    // A window stays glass to a lamp even marked `glazed: false` — that flag
-    // only ever meant "block the sun", never "block a lamp's own light".
-    expect(glowClearFraction({ type: "window", glazed: false } as Opening, 0.4)).toBe(1);
+  it("reads `glazed` exactly as openingSunFraction does — one field, one fact", () => {
+    // A patio door marked glazed is a wall of glass to a lamp too, not just
+    // to the sun: shut, its own light still gets through.
+    expect(glowClearFraction({ type: "door", glazed: true } as Opening, 0)).toBe(1);
+    // An opaque window — glass-brick, a hatch — marked glazed: false stays
+    // opaque to a lamp same as it does to the sun: shut, it blocks.
+    expect(glowClearFraction({ type: "window", glazed: false } as Opening, 0)).toBe(0);
+    expect(glowClearFraction({ type: "window", glazed: false } as Opening, 0.4)).toBeCloseTo(0.4);
+  });
+
+  it("a roll-motion window is a blind standing in for the glass, not the glass itself", () => {
+    // device_class "shutter"/"blind"/etc. auto-maps to type: "window",
+    // motion: "roll" (openingFromDeviceClass) — reading `glazed`'s default
+    // here would make the blind always-clear no matter how far down it is.
+    const rollUp = { type: "window", motion: "roll" } as Opening;
+    expect(glowClearFraction(rollUp, 0)).toBe(0);
+    expect(glowClearFraction(rollUp, 0.6)).toBeCloseTo(0.6);
+    expect(glowClearFraction(rollUp, 1)).toBe(1);
+    // Categorical, regardless of `glazed` — motion is what says this is a
+    // covering rather than a sash, and an explicit glazed: true on top of it
+    // is the one case openingSunFraction itself doesn't need to consider,
+    // so there is no existing convention this borrows from either way.
+    expect(glowClearFraction({ ...rollUp, glazed: true }, 0)).toBe(0);
   });
 
   it("still respects a two-panel slider's travel for a non-glazed opening", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -643,38 +643,34 @@ export function openingClearFraction(o: Opening, amount: number, secondAmount?: 
 }
 
 /**
- * Whether an opening is a window, for the glow rule above — plain `type`,
- * with none of {@link openingIsGlazed}'s door exception. Sunlight cares
- * whether an opening is *effectively* glass, door included; a lamp's pool
- * cares whether it is drawn as a window.
- */
-export function openingIsWindow(o: Pick<Opening, "type">): boolean {
-  return o.type === "window";
-}
-
-/**
  * How much of an opening's gap a lamp's cast pool passes through — the same
- * question {@link openingClearFraction} answers, except a window admits its
- * whole gap however its sash is sitting. A closed window is not a hole, but
- * it is not a wall either: the glow spills through it same as an open one,
- * since that is what a pane of glass does.
+ * question {@link openingClearFraction} answers, except glass admits its
+ * whole gap however its sash is sitting, the same rule {@link
+ * openingSunFraction} already applies to sunlight and by the same field:
+ * {@link openingIsGlazed}. `glazed` means one thing — is this opening glass —
+ * and a lamp's light passing through glass same as sunlight does is that one
+ * fact read twice, not two different rules that happen to agree.
  *
- * Deliberately its own check ({@link openingIsWindow}) rather than {@link
- * openingIsGlazed} — `glazed` is sunlight's word for "this door is secretly
- * a wall of glass" ({@link openingSunFraction}), and reads a door's `glazed:
- * true` as a yes. A glow pool asks a different question — is this opening a
- * *window* — so a glazed door still blocks a lamp's light exactly as a door
- * does, and this stays true however sunlight's rule evolves.
+ * One exception sunlight doesn't need: a **roll-motion** window is a blind,
+ * shutter, shade, curtain or awning bound as the opening's own entity (an
+ * auto-detected `device_class`, see {@link openingFromDeviceClass}) — a
+ * covering standing in for the glass behind it, not the glass itself. Glazed
+ * by the same default every window gets, it would read as always-clear no
+ * matter how far down it actually is, defeating the one thing binding it was
+ * for. So it keeps {@link openingClearFraction}'s answer regardless of
+ * `glazed` — the roll-up rule {@link openingClearFraction}'s own docs
+ * describe, honoured here too.
  *
- * A shutter overrides the glass, same priority {@link openingSunFraction}
- * gives it: a persiana rolled down stops a lamp's pool same as it stops the
- * sun, whatever the window behind it would otherwise let through. `shutter`
- * is `undefined` where no shutter is bound, so an opening without one is
- * judged on itself alone.
+ * A shutter — the separate `shutterEntity` layered over an opening — overrides
+ * the glass, same priority {@link openingSunFraction} gives it: rolled down,
+ * it blocks a lamp's pool same as it blocks the sun, whatever glass sits
+ * behind it. `shutter` is `undefined` where none is bound, so an opening
+ * without one is judged on itself alone. Unlike the glass rule above, this
+ * one is not window-only — any opening with a `shutterEntity` reads it.
  *
- * Every other opening — doors (glazed or not), roll-ups, an opaque slider —
- * keeps {@link openingClearFraction}'s answer untouched; only a window is
- * pinned to fully clear.
+ * Every other opening — an ordinary door, an opaque slider, a roll-up —
+ * keeps {@link openingClearFraction}'s answer untouched; only real glass,
+ * open or shut, is pinned to fully clear.
  */
 export function glowClearFraction(
   o: Opening,
@@ -683,7 +679,7 @@ export function glowClearFraction(
   shutter?: number,
 ): number {
   if (shutter !== undefined && shutter <= 0) return 0;
-  if (openingIsWindow(o)) return 1;
+  if (openingIsGlazed(o) && openingMotion(o) !== "roll") return 1;
   return openingClearFraction(o, amount, secondAmount);
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -643,6 +643,51 @@ export function openingClearFraction(o: Opening, amount: number, secondAmount?: 
 }
 
 /**
+ * Whether an opening is a window, for the glow rule above — plain `type`,
+ * with none of {@link openingIsGlazed}'s door exception. Sunlight cares
+ * whether an opening is *effectively* glass, door included; a lamp's pool
+ * cares whether it is drawn as a window.
+ */
+export function openingIsWindow(o: Pick<Opening, "type">): boolean {
+  return o.type === "window";
+}
+
+/**
+ * How much of an opening's gap a lamp's cast pool passes through — the same
+ * question {@link openingClearFraction} answers, except a window admits its
+ * whole gap however its sash is sitting. A closed window is not a hole, but
+ * it is not a wall either: the glow spills through it same as an open one,
+ * since that is what a pane of glass does.
+ *
+ * Deliberately its own check ({@link openingIsWindow}) rather than {@link
+ * openingIsGlazed} — `glazed` is sunlight's word for "this door is secretly
+ * a wall of glass" ({@link openingSunFraction}), and reads a door's `glazed:
+ * true` as a yes. A glow pool asks a different question — is this opening a
+ * *window* — so a glazed door still blocks a lamp's light exactly as a door
+ * does, and this stays true however sunlight's rule evolves.
+ *
+ * A shutter overrides the glass, same priority {@link openingSunFraction}
+ * gives it: a persiana rolled down stops a lamp's pool same as it stops the
+ * sun, whatever the window behind it would otherwise let through. `shutter`
+ * is `undefined` where no shutter is bound, so an opening without one is
+ * judged on itself alone.
+ *
+ * Every other opening — doors (glazed or not), roll-ups, an opaque slider —
+ * keeps {@link openingClearFraction}'s answer untouched; only a window is
+ * pinned to fully clear.
+ */
+export function glowClearFraction(
+  o: Opening,
+  amount: number,
+  secondAmount?: number,
+  shutter?: number,
+): number {
+  if (shutter !== undefined && shutter <= 0) return 0;
+  if (openingIsWindow(o)) return 1;
+  return openingClearFraction(o, amount, secondAmount);
+}
+
+/**
  * The walls as **light** meets them (issue #143): the plan's walls with a gap
  * cut wherever an opening is currently open.
  *
@@ -657,12 +702,16 @@ export function openingClearFraction(o: Opening, amount: number, secondAmount?: 
  * drawn from, so a closed door still blocks, a door opening on its sensor lets
  * light through as it swings, and an unbound door — which this card draws open,
  * with its swing arc — lights the room beyond it without anything to configure.
- * A window behaves the same way: shut it blocks, open it spills light outside,
- * which is what an open window does.
+ *
+ * A window is the one exception, and it is the caller's rule rather than this
+ * function's: a lamp's pool admits light however the sash is sitting, so a
+ * caller wanting that reaches for {@link glowClearFraction} instead of {@link
+ * openingClearFraction}. This function itself stays agnostic — it just cuts
+ * the gap it is handed.
  *
  * The caller supplies how much of each opening is clear — see
- * {@link openingClearFraction}, which is where a two-panel slider's two
- * sensors are reconciled into one number.
+ * {@link openingClearFraction} and {@link glowClearFraction}, which is where a
+ * two-panel slider's two sensors are reconciled into one number.
  *
  * The gap is `length * fraction`, **centred**, and that is an approximation
  * worth naming. A half-open slider really clears one side rather than the


### PR DESCRIPTION
Hey! Noticed that a lamp's glow (issue #143's wall-cutting) treats a window the same way it treats a door: shut, it blocks the light, and only counts as "open" when its sensor says so. That felt off for a window, since even a closed one is still glass — the light should still spill through, the same way it already does through an open door.

This PR makes glass let a lamp's own glow through it, open or shut, reusing the same `glazed` field sunlight already reads (`openingSunFraction`) rather than introducing a second name for the same physical fact:

- A window is glass by default, same as it already is to the sun — so it lets a lamp's glow through it regardless of its sash. A patio door marked `glazed: true` now does too. A window explicitly marked `glazed: false` (a glass-brick panel, a hatch) stays opaque to a lamp's light exactly as it already was to the sun.
- One exception sunlight doesn't need: a roll-motion window — a blind, shutter, shade, curtain or awning auto-mapped from its `device_class` — is a covering standing in for the glass, not the glass itself, so it keeps blocking a lamp's glow according to its own position instead of reading as always-clear.
- A shutter still wins if it's rolled down, same priority sunlight already gives it: fully closed, it blocks the light regardless of the glass behind it. This isn't window-only — any opening with a `shutterEntity` bound now reads it, so a door with a shutter rolled down blocks a lamp's pool through it too, where it used to pass while the door itself was open.

Before:
<img width="388" height="353" alt="SCR-20260825-prpq" src="https://github.com/user-attachments/assets/2c3d4587-97ce-41aa-a6ea-c7aedc3c9d8c" />

After:
<img width="383" height="350" alt="SCR-20260825-psos" src="https://github.com/user-attachments/assets/cd2b9894-fbea-46da-86e0-0a5cbbaa55d7" />