### PR TITLE
Choose whether a door or window with no sensor starts open or closed

### DIFF
--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -158,10 +158,16 @@ describe("openingForm", () => {
     });
   });
 
-  it("invert only offered with an entity; the picker takes contacts, covers and locks", () => {
-    expect(openingForm(door).fields.map((x) => x.name)).not.toContain("invert");
+  it("invert is offered whether or not an entity is bound; the picker takes contacts, covers and locks", () => {
+    // Unbound, invert flips the type default (openingDefaultOpen) instead of
+    // a sensor reading — still worth offering, so it carries its own helper
+    // explaining what it does with nothing bound.
+    const unbound = openingForm(door).fields.find((x) => x.name === "invert")!;
+    expect(unbound).toBeDefined();
+    expect(unbound.helper).toContain("No sensor bound");
     const bound = openingForm({ ...door, entity: "cover.x" } as Opening);
     expect(bound.fields.map((x) => x.name)).toContain("invert");
+    expect(bound.fields.find((x) => x.name === "invert")!.helper).toBeUndefined();
     const entity = bound.fields.find((x) => x.name === "entity")!;
     // `lock` joined with issue #176 — a door with a smart lock and no contact.
     expect(entity.selector).toEqual({

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -392,12 +392,22 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
   }
   // Named after what it flips — the opening's own leaf, which is a door or a
   // sash depending on what this is, the same way Leaves / Sashes above.
-  if (o.entity)
-    fields.push({
-      name: "invert",
-      label: o.type === "door" ? "Invert door animation" : "Invert window animation",
-      selector: { boolean: {} },
-    });
+  // Offered whether or not an entity is bound: with one, it flips which
+  // sensor reading counts as open; without one, it flips the type default a
+  // door or window draws with no sensor to ask (openingDefaultOpen) — so an
+  // unbound door can be drawn shut, or an unbound window drawn open.
+  fields.push({
+    name: "invert",
+    label: o.type === "door" ? "Invert door animation" : "Invert window animation",
+    helper: o.entity
+      ? undefined
+      : // Only a swing door draws open with no sensor to ask
+        // (openingDefaultOpen) — everything else, door or window, draws shut.
+        o.type === "door" && openingMotion(o) === "swing"
+        ? "No sensor bound — draws shut instead of open"
+        : "No sensor bound — draws open instead of shut",
+    selector: { boolean: {} },
+  });
   fields.push(angleField());
   // The opening's own badge (issue #154 follow-up). Offered for any bound
   // opening, but sold on the case that needs it: a raised roll-up has nothing

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -240,6 +240,19 @@ describe("openingDefaultOpen", () => {
     expect(openingDefaultOpen({ type: "door", motion: "slide" } as Opening)).toBe(false);
     expect(openingDefaultOpen({ type: "window", motion: "slide" } as Opening)).toBe(false);
   });
+
+  it("invert flips the unbound picture, same as it flips a bound reading", () => {
+    // A swing door normally draws open — inverted, and still unbound, it
+    // draws shut.
+    expect(openingDefaultOpen({ type: "door", invert: true } as Opening)).toBe(false);
+    // A window normally draws shut — inverted, and still unbound, it draws
+    // open, letting someone give an unbound window an "always open" look.
+    expect(openingDefaultOpen({ type: "window", invert: true } as Opening)).toBe(true);
+    // A slider/roll-up normally draws shut too, and inverts the same way.
+    expect(openingDefaultOpen({ type: "door", motion: "slide", invert: true } as Opening)).toBe(true);
+    // invert: false is the same as omitting it — no flip.
+    expect(openingDefaultOpen({ type: "door", invert: false } as Opening)).toBe(true);
+  });
 });
 
 describe("openingMotion", () => {
@@ -455,6 +468,11 @@ describe("resolveOpeningOpen", () => {
     expect(resolveOpeningOpen(slider, undefined)).toBe(false);
   });
 
+  it("invert flips that fallback too, for an opening with no entity at all", () => {
+    expect(resolveOpeningOpen({ type: "door", invert: true } as Opening, undefined)).toBe(false);
+    expect(resolveOpeningOpen({ type: "window", invert: true } as Opening, undefined)).toBe(true);
+  });
+
   it("a slider bound to a cover resolves like a door", () => {
     expect(resolveOpeningOpen(slider, "open")).toBe(true);
     expect(resolveOpeningOpen(slider, "closed")).toBe(false);
@@ -485,6 +503,11 @@ describe("resolveOpeningAmount", () => {
   it("uses the type default when there is no entity/state", () => {
     expect(resolveOpeningAmount({ type: "door" } as Opening, undefined)).toBe(1);
     expect(resolveOpeningAmount({ type: "door", motion: "slide" } as Opening, undefined)).toBe(0);
+  });
+
+  it("invert flips that default too, for an opening with no entity at all", () => {
+    expect(resolveOpeningAmount({ type: "door", invert: true } as Opening, undefined)).toBe(0);
+    expect(resolveOpeningAmount({ type: "window", invert: true } as Opening, undefined)).toBe(1);
   });
 
   it("fails closed (0) on a sensor outage, ignoring any stale position", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -2005,9 +2005,16 @@ export function openingMotion(o: Opening): "swing" | "slide" | "roll" {
  * openings are drawn closed (intact glass / panels filling the gap). This
  * preserves the look of a static floor plan — a slider drawn open would read as
  * a hole rather than a door.
+ *
+ * `invert` flips this picture same as it flips a bound entity's reading
+ * ({@link resolveOpeningOpen}) — an unbound opening has no sensor to invert,
+ * but the intent is the same either way: "the opposite of what this would
+ * otherwise draw." A swing door marked `invert: true` and left unbound draws
+ * shut; an unbound window marked the same way draws open.
  */
 export function openingDefaultOpen(o: Opening): boolean {
-  return o.type === "door" && openingMotion(o) === "swing";
+  const natural = o.type === "door" && openingMotion(o) === "swing";
+  return o.invert ? !natural : natural;
 }
 
 /**


### PR DESCRIPTION
A door with no entity always draws open (its familiar swing arc); a window with no entity always draws shut — openingDefaultOpen's rule, with nothing to configure it by. There was no way to ask for the other picture without binding a sensor just to get a fixed reading.

`invert` already exists for exactly this — flipping which way an opening reads — but only ever looked at a bound entity's state. openingDefaultOpen now applies it too: an unbound door marked `invert: true` draws shut, and an unbound window marked the same way draws open. resolveOpeningOpen and resolveOpeningAmount both already fall through to openingDefaultOpen with no entity, so both pick this up without their own changes.

The editor's Invert toggle was only offered once an entity was bound, since flipping a reading needs a reading to flip. It's offered unconditionally now, with a helper explaining what it does with nothing bound.