### PR TITLE
Climate, weather and media_player icons never reflected their state

### DIFF
--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -13,7 +13,9 @@
 #                      light.kitchen_lights, light.office_rgbw_lights,
 #                      cover.living_room_window, cover.hall_window,
 #                      cover.garage_door, fan.living_room_fan,
-#                      device_tracker.demo_anne_therese
+#                      device_tracker.demo_anne_therese, climate.hvac,
+#                      weather.demo_weather_south, weather.demo_weather_north,
+#                      media_player.walkman
 #   from configuration.yaml
 #                      sensor.living_area_temperature,
 #                      sensor.living_area_humidity,
@@ -250,6 +252,44 @@ views:
                     x: 300
                     y: 300
                     kind: light
+                  # climate.hvac boots straight into "cool" (issue #206) --
+                  # its own state, never the literal "on" -- which reproduced
+                  # the report on its own: no active highlight, and the spin
+                  # below never played. It is also the one demo climate
+                  # entity whose hvac_modes include fan_only, so switching it
+                  # there from Developer Tools > Actions shows the forced
+                  # spin overriding this very iconAnimation.
+                  - id: i7
+                    entity: climate.hvac
+                    iconAnimation: spin
+                    x: 860
+                    y: 260
+                    kind: climate
+                  # A demo weather entity's condition is fixed for its
+                  # lifetime, so two side by side -- the same pairing
+                  # glow_warm/glow_cool use above -- is the only way to see
+                  # more than one WEATHER_CONDITION_ICONS entry on the plan
+                  # at once (issue #206): south is always sunny, north always
+                  # rainy.
+                  - id: i8
+                    entity: weather.demo_weather_south
+                    x: 260
+                    y: 460
+                    kind: generic
+                  - id: i9
+                    entity: weather.demo_weather_north
+                    x: 340
+                    y: 460
+                    kind: generic
+                  # Boots "playing" (issue #206). Call
+                  # media_player.media_pause from Developer Tools > Actions
+                  # and it reads "paused" and stays lit -- that used to read
+                  # as off.
+                  - id: i10
+                    entity: media_player.walkman
+                    x: 620
+                    y: 460
+                    kind: media_player
 
                 furniture:
                   # Issue #121: click it to go up. The card only makes it a

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -283,8 +283,8 @@ views:
                     kind: generic
                   # Boots "playing" (issue #206). Call
                   # media_player.media_pause from Developer Tools > Actions
-                  # and it reads "paused" and stays lit -- that used to read
-                  # as off.
+                  # and it reads "paused", stays lit, and switches to its own
+                  # pause glyph instead of "off" or the plain play icon.
                   - id: i10
                     entity: media_player.walkman
                     x: 620

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -547,6 +547,21 @@ describe("entityDefaultIcon for domains without a device class", () => {
     expect(entityDefaultIcon("media_player.tv", undefined, false)).toBe("mdi:television-off");
     expect(entityDefaultIcon("camera.doorbell", undefined, true)).toBe("mdi:cctv");
   });
+  it("draws a paused media_player with its own glyph, not the playing one (issue #206 follow-up)", () => {
+    // "paused" is active (entityIsActive says so too), so this is not the
+    // off icon — but it should not be the same icon "playing" gets either.
+    expect(entityDefaultIcon("media_player.tv", undefined, true, "paused")).toBe(
+      "mdi:television-pause",
+    );
+    // Every other active state keeps the plain play glyph — only "paused"
+    // gets its own.
+    expect(entityDefaultIcon("media_player.tv", undefined, true, "playing")).toBe(
+      "mdi:television-play",
+    );
+    expect(entityDefaultIcon("media_player.tv", undefined, true, "idle")).toBe(
+      "mdi:television-play",
+    );
+  });
   it("shows a lock as open when it is unlocked", () => {
     expect(entityDefaultIcon("lock.front", undefined, true)).toBe("mdi:lock-open-variant");
     expect(entityDefaultIcon("lock.front", undefined, false)).toBe("mdi:lock");

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -553,12 +553,14 @@ describe("entityDefaultIcon for domains without a device class", () => {
     expect(entityDefaultIcon("media_player.tv", undefined, true, "paused")).toBe(
       "mdi:television-pause",
     );
-    // Every other active state keeps the plain play glyph — only "paused"
-    // gets its own.
+    // "idle" is on with nothing loaded at all — its own glyph too, not
+    // "playing" and not "paused".
+    expect(entityDefaultIcon("media_player.tv", undefined, true, "idle")).toBe("mdi:television");
+    // Every other active state keeps the plain play glyph.
     expect(entityDefaultIcon("media_player.tv", undefined, true, "playing")).toBe(
       "mdi:television-play",
     );
-    expect(entityDefaultIcon("media_player.tv", undefined, true, "idle")).toBe(
+    expect(entityDefaultIcon("media_player.tv", undefined, true, "buffering")).toBe(
       "mdi:television-play",
     );
   });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -557,6 +557,54 @@ describe("entityDefaultIcon for domains without a device class", () => {
   });
 });
 
+describe("entityDefaultIcon for climate and weather (issue #206)", () => {
+  it("reads the HVAC mode, not just on/off — a running unit says which mode", () => {
+    // Before: every mode fell through to the bare thermostat icon, since
+    // climate had no entry in DOMAIN_STATE_ICONS at all.
+    expect(entityDefaultIcon("climate.ac", undefined, true, "cool")).toBe("mdi:snowflake");
+    expect(entityDefaultIcon("climate.ac", undefined, true, "heat")).toBe("mdi:fire");
+    expect(entityDefaultIcon("climate.ac", undefined, true, "dry")).toBe("mdi:water-percent");
+    expect(entityDefaultIcon("climate.ac", undefined, true, "fan_only")).toBe("mdi:fan");
+    expect(entityDefaultIcon("climate.ac", undefined, true, "auto")).toBe("mdi:thermostat-auto");
+    expect(entityDefaultIcon("climate.ac", undefined, true, "heat_cool")).toBe(
+      "mdi:sun-snowflake-variant"
+    );
+    expect(entityDefaultIcon("climate.ac", undefined, false, "off")).toBe("mdi:power");
+  });
+
+  it("falls back to a plain on/off thermostat for a mode it doesn't recognise", () => {
+    expect(entityDefaultIcon("climate.ac", undefined, true, "some_custom_mode")).toBe(
+      "mdi:thermostat"
+    );
+    expect(entityDefaultIcon("climate.ac", undefined, false, "some_custom_mode")).toBe(
+      "mdi:power"
+    );
+    // No state passed at all — same fallback, not a crash.
+    expect(entityDefaultIcon("climate.ac", undefined, true)).toBe("mdi:thermostat");
+  });
+
+  it("reads the weather condition — before, a weather item drew a bare circle", () => {
+    expect(entityDefaultIcon("weather.home", undefined, true, "sunny")).toBe("mdi:weather-sunny");
+    expect(entityDefaultIcon("weather.home", undefined, true, "rainy")).toBe("mdi:weather-rainy");
+    expect(entityDefaultIcon("weather.home", undefined, true, "partlycloudy")).toBe(
+      "mdi:weather-partly-cloudy"
+    );
+    expect(entityDefaultIcon("weather.home", undefined, true, "clear-night")).toBe(
+      "mdi:weather-night"
+    );
+    expect(entityDefaultIcon("weather.home", undefined, true, "lightning-rainy")).toBe(
+      "mdi:weather-lightning-rainy"
+    );
+  });
+
+  it("falls back to a generic cloud for a weather condition it doesn't recognise", () => {
+    expect(entityDefaultIcon("weather.home", undefined, true, "a_new_condition")).toBe(
+      "mdi:weather-cloudy"
+    );
+    expect(entityDefaultIcon("weather.home", undefined, true)).toBe("mdi:weather-cloudy");
+  });
+});
+
 describe("trackerSensorReading", () => {
   const states = {
     "sensor.x": { state: "2.5" },
@@ -1303,8 +1351,11 @@ describe("isEntityOn / resolveItemIcon", () => {
       expect(resolveItemIcon(climate, { state: "heat", attributes: { hvac_action: "heating" } })).toBe(
         "mdi:fire"
       );
+      // No rule matches (hvac_action is "idle", not "heating"): falls to the
+      // entity's own default icon, which since issue #206 is heat's own icon
+      // rather than the bare climate fallback.
       expect(resolveItemIcon(climate, { state: "heat", attributes: { hvac_action: "idle" } })).toBe(
-        defaultIcon("climate")
+        entityDefaultIcon("climate.hall", undefined, true, "heat")
       );
     });
 
@@ -1606,6 +1657,23 @@ describe("entityIsActive — domains that never say \"on\"", () => {
     expect(entityIsActive("camera.door", "idle")).toBe(false);
   });
 
+  it("a climate entity is active in any HVAC mode but off (issue #206)", () => {
+    // Its state *is* the mode — "cool", "heat", … — never the literal "on"
+    // the generic test looks for, so every one of these used to read as off.
+    for (const mode of ["auto", "cool", "dry", "fan_only", "heat", "heat_cool"]) {
+      expect(entityIsActive("climate.ac", mode), mode).toBe(true);
+    }
+    expect(entityIsActive("climate.ac", "off")).toBe(false);
+  });
+
+  it("a media player is active whenever it isn't off, not only while playing (issue #206)", () => {
+    // A paused or idle player is still switched on, just not mid-playback.
+    for (const s of ["on", "idle", "playing", "paused", "buffering"]) {
+      expect(entityIsActive("media_player.tv", s), s).toBe(true);
+    }
+    expect(entityIsActive("media_player.tv", "off")).toBe(false);
+  });
+
   it("falls back to the generic on/off test for every other domain", () => {
     expect(entityIsActive("light.a", "on")).toBe(true);
     expect(entityIsActive("binary_sensor.a", "off")).toBe(false);
@@ -1648,13 +1716,54 @@ describe("resolveIconAnimation (issue #48)", () => {
     expect(resolveIconAnimation({ entity: "switch.a" }, "on")).toBeUndefined();
   });
 
+  it("a climate entity in fan_only always spins, whatever iconAnimation says (issue #206 follow-up)", () => {
+    // Auto: no other climate mode gets a default animation, but fan_only
+    // does — its own fan is what's running.
+    expect(resolveIconAnimation({ entity: "climate.ac" }, "fan_only")).toBe("spin");
+    expect(resolveIconAnimation({ entity: "climate.ac" }, "cool")).toBeUndefined();
+    // Forced pulse: every other active mode pulses, but fan_only still spins
+    // — the fan_only spin overrides the config rather than the other way
+    // round.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "pulse" }, "fan_only"),
+    ).toBe("spin");
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "pulse" }, "cool"),
+    ).toBe("pulse");
+    // Forced spin: no conflict, still spins.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "fan_only"),
+    ).toBe("spin");
+    // none is a decision to show no animation at all, and wins over even
+    // fan_only's own spin.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "none" }, "fan_only"),
+    ).toBeUndefined();
+    // Off never animates, fan_only override or not.
+    expect(resolveIconAnimation({ entity: "climate.ac" }, "off")).toBeUndefined();
+  });
+
+  it("a forced spin plays for a climate entity running in any mode (issue #206)", () => {
+    // The reported bug exactly: an AC in "cool" with iconAnimation: "spin"
+    // read as off (entityIsActive didn't know "cool" from "off") and never
+    // animated at all.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "cool"),
+    ).toBe("spin");
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "off"),
+    ).toBeUndefined();
+  });
+
   it("never animates an inactive entity — including forced spin/pulse", () => {
     expect(resolveIconAnimation({ entity: "fan.ceiling" }, "off")).toBeUndefined();
     expect(
       resolveIconAnimation({ entity: "light.a", iconAnimation: "spin" }, "off"),
     ).toBeUndefined();
+    // "paused" is active (issue #206) — a paused player is switched on, just
+    // not mid-playback — so "off" is what proves this rather than "paused".
     expect(
-      resolveIconAnimation({ entity: "media_player.tv", iconAnimation: "pulse" }, "paused"),
+      resolveIconAnimation({ entity: "media_player.tv", iconAnimation: "pulse" }, "off"),
     ).toBeUndefined();
   });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1417,6 +1417,17 @@ const DOMAIN_STATE_ICONS: Record<string, { on: string; off: string }> = {
 };
 
 /**
+ * Two media_player states differ from its plain on/off pair above (issue
+ * #206 follow-up): "paused" is on but not mid-playback, and "idle" is on
+ * with nothing loaded at all. mdi:television-play used to claim both, which
+ * reads as "playing" for a device doing neither.
+ */
+const MEDIA_PLAYER_STATE_ICONS: Record<string, string> = {
+  paused: "mdi:television-pause",
+  idle: "mdi:television",
+};
+
+/**
  * A climate entity's icon per HVAC mode (issue #206) — its state carries the
  * mode directly, unlike the on/off domains {@link DOMAIN_STATE_ICONS} covers,
  * so a single on/off pair cannot say "cool" from "heat". Every mode HA's own
@@ -1673,12 +1684,15 @@ export function entityDefaultIcon(
   if (domain === "climate")
     return CLIMATE_MODE_ICONS[state ?? ""] ?? (on ? "mdi:thermostat" : "mdi:power");
   if (domain === "weather") return WEATHER_CONDITION_ICONS[state ?? ""] ?? "mdi:weather-cloudy";
-  // A paused player is still "on" by entityIsActive's own rule (issue #206
-  // follow-up) — it stays lit, correctly — but the play glyph that fact
-  // shares with "playing" reads as a stall nobody noticed, not what
-  // actually happened. One state differs from the domain's on/off pair, so
-  // one override rather than a whole table for it.
-  if (domain === "media_player" && state === "paused") return "mdi:television-pause";
+  // paused and idle are both "on" by entityIsActive's own rule (issue #206
+  // follow-up) — correctly so — but the play glyph the on/off pair below
+  // would give both reads as "playing" for a device doing neither. Checked
+  // ahead of that pair; every other active state (playing, buffering, the
+  // literal "on") still falls through to it.
+  if (domain === "media_player" && state) {
+    const stateIcon = MEDIA_PLAYER_STATE_ICONS[state];
+    if (stateIcon) return stateIcon;
+  }
   // These domains carry their meaning in the domain, not a device class, so the
   // device-class guard below would skip them entirely.
   const byDomain = DOMAIN_STATE_ICONS[domain];

--- a/src/render.ts
+++ b/src/render.ts
@@ -1673,6 +1673,12 @@ export function entityDefaultIcon(
   if (domain === "climate")
     return CLIMATE_MODE_ICONS[state ?? ""] ?? (on ? "mdi:thermostat" : "mdi:power");
   if (domain === "weather") return WEATHER_CONDITION_ICONS[state ?? ""] ?? "mdi:weather-cloudy";
+  // A paused player is still "on" by entityIsActive's own rule (issue #206
+  // follow-up) — it stays lit, correctly — but the play glyph that fact
+  // shares with "playing" reads as a stall nobody noticed, not what
+  // actually happened. One state differs from the domain's on/off pair, so
+  // one override rather than a whole table for it.
+  if (domain === "media_player" && state === "paused") return "mdi:television-pause";
   // These domains carry their meaning in the domain, not a device class, so the
   // device-class guard below would skip them entirely.
   const byDomain = DOMAIN_STATE_ICONS[domain];

--- a/src/render.ts
+++ b/src/render.ts
@@ -1326,6 +1326,47 @@ const DOMAIN_STATE_ICONS: Record<string, { on: string; off: string }> = {
 };
 
 /**
+ * A climate entity's icon per HVAC mode (issue #206) — its state carries the
+ * mode directly, unlike the on/off domains {@link DOMAIN_STATE_ICONS} covers,
+ * so a single on/off pair cannot say "cool" from "heat". Every mode HA's own
+ * climate.HVACMode enum defines.
+ */
+const CLIMATE_MODE_ICONS: Record<string, string> = {
+  off: "mdi:power",
+  heat: "mdi:fire",
+  cool: "mdi:snowflake",
+  heat_cool: "mdi:sun-snowflake-variant",
+  auto: "mdi:thermostat-auto",
+  dry: "mdi:water-percent",
+  fan_only: "mdi:fan",
+};
+
+/**
+ * A weather entity's icon per condition (issue #206) — again a state that
+ * carries more than on/off, and one this card had no mapping for at all: a
+ * weather item drew the bare `defaultIcon` fallback (a plain circle)
+ * whatever the sky was doing. Every condition HA's own weather integrations
+ * report (`ATTR_CONDITION_*`).
+ */
+const WEATHER_CONDITION_ICONS: Record<string, string> = {
+  "clear-night": "mdi:weather-night",
+  cloudy: "mdi:weather-cloudy",
+  exceptional: "mdi:alert-circle-outline",
+  fog: "mdi:weather-fog",
+  hail: "mdi:weather-hail",
+  lightning: "mdi:weather-lightning",
+  "lightning-rainy": "mdi:weather-lightning-rainy",
+  partlycloudy: "mdi:weather-partly-cloudy",
+  pouring: "mdi:weather-pouring",
+  rainy: "mdi:weather-rainy",
+  snowy: "mdi:weather-snowy",
+  "snowy-rainy": "mdi:weather-snowy-rainy",
+  sunny: "mdi:weather-sunny",
+  windy: "mdi:weather-windy",
+  "windy-variant": "mdi:weather-windy-variant",
+};
+
+/**
  * State-aware icons per `binary_sensor` device class ("show as" in the HA UI),
  * mirroring Home Assistant's own device-class icon set. `on` is the
  * device-class's active state (open / detected / unlocked / …).
@@ -1407,6 +1448,18 @@ const ACTIVE_STATES: Record<string, ReadonlySet<string>> = {
   lock: new Set(["unlocked", "unlocking", "open", "opening"]),
   vacuum: new Set(["cleaning", "returning"]),
   camera: new Set(["recording", "streaming"]),
+  // A climate entity's state *is* its HVAC mode (issue #206) — "cool",
+  // "heat", "dry"… never the generic "on" the fallback test looks for, so
+  // every mode but the literal "off" read as off forever: the active
+  // highlight never lit, and a configured iconAnimation never played on a
+  // unit that was very much running. Every mode HA's own climate.HVACMode
+  // enum defines, off excluded.
+  climate: new Set(["auto", "cool", "dry", "fan_only", "heat", "heat_cool"]),
+  // Same trap, one domain over: a paused or idle player is still switched
+  // on, just not mid-playback, and "playing" alone left everything else
+  // reading as off. "standby" is the one state that means the device itself
+  // dropped to low power, so it stays out.
+  media_player: new Set(["on", "idle", "playing", "paused", "buffering"]),
 };
 
 /**
@@ -1453,6 +1506,13 @@ export function domainIconAnimation(entity: string | undefined): "spin" | "pulse
  * unavailable) entity — including when the config forces "spin"/"pulse": a
  * spinning fan icon is a claim that the fan is running, so it obeys the same
  * fail-closed rule as the active highlight ({@link entityIsActive}).
+ *
+ * A climate entity in `fan_only` spins regardless of `iconAnimation`
+ * (issue #206 follow-up) — its own fan is what's actually running, the same
+ * physical fact that makes a `fan` domain entity spin by default, just
+ * decided from this entity's *state* rather than its domain. `none` still
+ * wins over it: that is a decision to show no animation at all, not a
+ * preference between spin and pulse for this one to override.
  */
 export function resolveIconAnimation(
   item: { entity?: string; iconAnimation?: IconAnimation },
@@ -1461,6 +1521,7 @@ export function resolveIconAnimation(
   const mode = item.iconAnimation ?? "auto";
   if (mode === "none") return undefined;
   if (!entityIsActive(item.entity, state)) return undefined;
+  if (item.entity?.split(".")[0] === "climate" && state === "fan_only") return "spin";
   if (mode === "spin" || mode === "pulse") return mode;
   return domainIconAnimation(item.entity);
 }
@@ -1508,8 +1569,19 @@ export function entityDefaultIcon(
   entityId: string,
   deviceClass: string | undefined,
   on: boolean,
+  state?: string,
 ): string | undefined {
   const domain = entityId.split(".")[0];
+  // Climate and weather carry more than on/off in their state (issue #206):
+  // a climate's state is its HVAC mode, and a weather entity's is its
+  // condition, so a single on/off pair — even a correct one — can only ever
+  // say two things about a domain with five or fifteen. Checked ahead of
+  // the plain on/off table below, and falling back to it (or, for weather,
+  // to state === undefined too) covers a state this card doesn't recognise
+  // rather than drawing nothing.
+  if (domain === "climate")
+    return CLIMATE_MODE_ICONS[state ?? ""] ?? (on ? "mdi:thermostat" : "mdi:power");
+  if (domain === "weather") return WEATHER_CONDITION_ICONS[state ?? ""] ?? "mdi:weather-cloudy";
   // These domains carry their meaning in the domain, not a device class, so the
   // device-class guard below would skip them entirely.
   const byDomain = DOMAIN_STATE_ICONS[domain];
@@ -1589,6 +1661,7 @@ export function resolveItemIcon(
       item.entity,
       st?.attributes?.device_class as string | undefined,
       entityIsActive(item.entity, st?.state),
+      st?.state,
     ) ?? defaultIcon(item.kind)
   );
 }


### PR DESCRIPTION
entityIsActive only ever recognised the literal state "on" (or a small per-domain set for lock/vacuum/camera) as active. A climate entity's state *is* its HVAC mode — "cool", "heat", "dry" — never "on", so a running unit always read as off: no active highlight, and a configured iconAnimation never played however it was actually running. A media player reporting "paused"/"idle"/"buffering" instead of "playing" had the same problem — still switched on, read as off.

climate and media_player each get their own active-state set now, mirroring lock/vacuum/camera: every HVAC mode but "off", and every media_player state but "off".

Separately, climate and weather had no state-aware icon at all — DOMAIN_STATE_ICONS only ever expressed a two-way on/off choice, and neither domain's meaning is binary. A climate item always drew the bare thermostat glyph regardless of mode, and a weather item — with no device class and no domain entry — drew entityDefaultIcon's plain fallback circle whatever the sky was doing.

Adds CLIMATE_MODE_ICONS (one icon per HVAC mode, HA's own climate.HVACMode enum) and WEATHER_CONDITION_ICONS (one per condition, HA's own ATTR_CONDITION_* set), and threads the entity's raw state into entityDefaultIcon so it can pick from them. A climate entity in fan_only always spins regardless of iconAnimation — its own fan is what's running, the same physical fact that makes a `fan` domain entity spin by default, just decided from this entity's state rather than its domain; `none` still wins over it.