### PR TITLE
Text labels can show an entity's value (closes #225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ screen size.
   - (${\color{red}NEW!}$) **A sensor per leaf** — anything with two leaves takes a second contact and draws them independently: a casement window with one sash open and one shut, a double door ajar on one side, a pair of shutters with one folded back.
 - (${\color{red}NEW!}$) **Offline devices read as offline** — an entity that is unavailable, unknown, or gone from Home Assistant is dimmed (or crossed out), instead of looking exactly like a device someone switched off.
 - (${\color{red}NEW!}$) **Furniture** — 26 gray line-art diagrams (table, sofa, bed, stove, stairs, tv…), each bindable to an entity, in a searchable picker. Every one is a plain JSON file of numbers you can copy: draw your own in the editor's paste box, use it straight away, and open a PR when it's good. No SVG, so nothing you paste can run anything.
+- (${\color{red}NEW!}$) **Live text labels** — bind a text to an entity and it shows the reading: a power figure in the corner, a temperature over a room. Type words in front of it, or leave them out for the number alone.
 - **Areas** — trace room polygons that color live from an entity, and link them to Home Assistant areas to scope entity pickers and bulk-add devices.
 - **Live position trackers** — map one or two distance sensors (mmWave / radar) onto a marker that moves across the plan in real time.
 - (${\color{red}NEW!}$) **Dead spaces** — hatch the spaces your walls seal off that no door or window reaches: a service shaft, the void behind a boxed-in stairwell. Nothing to draw — the regions come from the walls and openings themselves, so cutting a doorway into one stops it being dead the moment you place the door.
@@ -556,8 +557,27 @@ without turning into the color of the light. Pools never intercept clicks.
 
 ### Text
 
-`{ id, x, y, text, size?, color?, angle? }` — `size` px (default 16), `color` CSS/hex,
-`angle` degrees.
+`{ id, x, y, text, entity?, attribute?, size?, color?, angle? }` — `size` px (default 16),
+`color` CSS/hex, `angle` degrees.
+
+Bind an **`entity`** and the label shows its current value (issue #225) — a power reading
+in the corner of the plan, a temperature over a room:
+
+```yaml
+texts:
+  # The reading on its own.
+  - { id: pv, x: 300, y: 80, text: "", entity: sensor.pv_output, size: 28 }
+  # Words in front of it: "Grid 0.4 kW".
+  - { id: grid, x: 300, y: 130, text: Grid, entity: sensor.grid_power }
+  # An attribute rather than the state: "Hall 21.5".
+  - { id: hall, x: 300, y: 180, text: Hall, entity: climate.hall, attribute: current_temperature }
+```
+
+`text` becomes a **prefix** when an entity is bound, and the value stands alone when you
+leave it empty. Values are formatted the way Home Assistant formats them anywhere else,
+units and display precision included — so rounding a reading is that entity's own
+**display precision** setting rather than anything to configure here. An entity that isn't
+there reads `—`, the same as a device's label.
 
 ### Furniture
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./editor-forms";
 import { itemHasLabel } from "./render";
 import type { FormField } from "./editor-forms";
-import type { Area, Opening, FloorItem, Floor, Furniture, Tracker, FloorplanCardConfig } from "./types";
+import type { Area, FloorText, Opening, FloorItem, Floor, Furniture, Tracker, FloorplanCardConfig } from "./types";
 import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
 import { DEFAULT_SKIN, SKINS, MAX_SKIN_WALL_WIDTH } from "./skins";
 import { DEFAULT_SUN_BEARING, SUN_REACH } from "./render";
@@ -882,9 +882,15 @@ describe("areaForm", () => {
 });
 
 describe("textForm / furnitureForm / trackerForm", () => {
-  it("text field is required (empty stays empty, not undefined)", () => {
-    const form = textForm({ id: "t", x: 0, y: 0, text: "hi" });
-    expect(form.fields.find((x) => x.name === "text")!.required).toBe(true);
+  it("text is required while nothing else fills the label (issue #225)", () => {
+    const req = (t: Partial<FloorText>) =>
+      textForm({ id: "t", x: 0, y: 0, text: "hi", ...t } as FloorText).fields.find(
+        (x) => x.name === "text"
+      )!.required;
+    // No entity: words are the only thing that can be on screen.
+    expect(req({})).toBe(true);
+    // A bound reading fills it, so the words become an optional prefix.
+    expect(req({ entity: "sensor.pv" })).toBe(false);
   });
 
   it("furniture type options carry human labels", () => {

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1096,19 +1096,64 @@ export function itemBehaviourForm(it: FloorItem): FormSpec {
 }
 
 
-export function textForm(t: FloorText): FormSpec {
+/**
+ * `areaScope` narrows the entity picker to the room the label sits in, exactly
+ * as it does for a device or a piece of furniture — a reading placed in the
+ * kitchen is usually a kitchen entity.
+ */
+export function textForm(t: FloorText, areaScope?: AreaEntityScope): FormSpec {
+  const fields: FormField[] = [
+    {
+      name: "text",
+      label: "Text",
+      // Required only while nothing else fills the label. A text with no words
+      // and no entity is an invisible element, which is what this guarded
+      // against; with a reading bound the words are optional, and demanding
+      // them for a label that is only ever a number would be asking for a
+      // placeholder to delete.
+      required: !t.entity,
+      helper: t.entity ? "Shown in front of the reading — leave empty for the value alone" : undefined,
+      selector: { text: {} },
+    },
+    {
+      name: "entity",
+      label: "Entity",
+      helper: areaScopeHelper(areaScope, "Shows this entity's value, formatted as HA formats it"),
+      selector: areaScopedEntity(areaScope, t.entity),
+    },
+  ];
+  // Only once there is an entity to take an attribute from.
+  if (t.entity) {
+    fields.push({
+      name: "attribute",
+      label: "Attribute",
+      helper: "Show this attribute instead of the state (e.g. current_temperature)",
+      selector: { attribute: { entity_id: t.entity } },
+    });
+  }
+  fields.push(
+    {
+      name: "size",
+      label: "Size",
+      selector: { number: { min: 8, max: 200, mode: "slider", unit_of_measurement: "px" } },
+    },
+    angleField()
+  );
   return {
-    fields: [
-      { name: "text", label: "Text", required: true, selector: { text: {} } },
-      {
-        name: "size",
-        label: "Size",
-        selector: { number: { min: 8, max: 200, mode: "slider", unit_of_measurement: "px" } },
-      },
-      angleField(),
-    ],
-    data: { text: t.text, size: t.size ?? DEFAULT_TEXT_SIZE, angle: t.angle ?? 0 },
-    toPatch: identity,
+    fields,
+    data: {
+      text: t.text,
+      entity: t.entity ?? "",
+      attribute: t.attribute ?? "",
+      size: t.size ?? DEFAULT_TEXT_SIZE,
+      angle: t.angle ?? 0,
+    },
+    toPatch: (p) => {
+      // Unbinding the entity takes the attribute with it: left behind, it would
+      // silently reapply to whatever gets bound here next.
+      if ("entity" in p && !p.entity) return { ...p, attribute: undefined };
+      return p;
+    },
   };
 }
 

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -13,7 +13,7 @@ import {
   cyclePick,
 } from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
-import type { Area, Floor, Wall } from "./types";
+import type { Area, Floor, RenderHass, Wall } from "./types";
 
 const walls = [{ x1: 0, y1: 0, x2: 100, y2: 0 }];
 
@@ -212,6 +212,30 @@ describe("elementsAtPoint / cyclePick (issue #52)", () => {
     expect(elementsAtPoint(rotated, 100, 120, opts).map((s) => s.id)).toEqual(["fu"]);
     // …while the same distance horizontally misses.
     expect(elementsAtPoint(rotated, 180, 200, opts)).toEqual([]);
+  });
+
+  it("a bound text is pickable across the value it draws (issue #225)", () => {
+    // A bare reading over a room: no words typed, so the only thing on screen
+    // is the value — and the room polygon is underneath the whole of it.
+    const hass = {
+      states: { "sensor.pv": { state: "1.234", attributes: {} } },
+      formatEntityState: () => "1.234 kW",
+    } as unknown as RenderHass;
+    const withText = {
+      ...floor,
+      items: [], walls: [], openings: [], furniture: [], trackers: [],
+      texts: [{ id: "t", x: 100, y: 100, text: "", entity: "sensor.pv", size: 20 }],
+      areas: [{ id: "a", points: [
+        { x: 0, y: 0 }, { x: 400, y: 0 }, { x: 400, y: 400 }, { x: 0, y: 400 },
+      ] }],
+    } as unknown as Floor;
+    // 40 units off centre is well inside "1.234 kW" at 20px, and would have
+    // been outside a box measured against the empty typed string.
+    expect(elementsAtPoint(withText, 140, 100, opts).map((s) => s.kind)).toEqual(["area"]);
+    expect(elementsAtPoint(withText, 140, 100, { ...opts, hass }).map((s) => s.kind)).toEqual([
+      "text",
+      "area",
+    ]);
   });
 
   it("cyclePick steps down the stack on repeat clicks and wraps", () => {

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -1,5 +1,5 @@
-import type { Area, AreaPoint, Floor, Wall } from "./types";
-import { polygonCentroid, pointInPolygon } from "./render";
+import type { Area, AreaPoint, Floor, RenderHass, Wall } from "./types";
+import { polygonCentroid, pointInPolygon, textLabel } from "./render";
 
 /** Element kinds addressable by the editor's selection model. */
 export type SelKind = "wall" | "opening" | "item" | "text" | "furniture" | "tracker" | "area";
@@ -363,13 +363,14 @@ function distToSegment(x: number, y: number, w: WallSegment): number {
  * unit-testable and agrees with what the user sees.
  *
  * `itemSize` / `textSize` supply the per-element defaults the caller renders
- * with, since those live in the card's config layer.
+ * with, since those live in the card's config layer, and `hass` is what lets a
+ * text's box be measured against the value it draws (issue #225).
  */
 export function elementsAtPoint(
   f: Floor,
   x: number,
   y: number,
-  opts: { itemSize: number; textSize: number; wallThickness: number }
+  opts: { itemSize: number; textSize: number; wallThickness: number; hass?: RenderHass }
 ): Sel[] {
   const hits: { sel: Sel; rank: number; order: number }[] = [];
   const push = (kind: SelKind, id: string, order: number) =>
@@ -381,8 +382,14 @@ export function elementsAtPoint(
   });
   f.texts.forEach((t, i) => {
     // Rough box: text is centered on (x, y); width scales with the string.
+    // The string *drawn*, not the one typed (issue #225): a label bound to an
+    // entity shows its reading, and the case the feature exists for — a bare
+    // number with no words at all — types nothing. Measured against `t.text`
+    // that label is pickable only through a sliver at its centre, and a click
+    // anywhere else on it falls through to whatever is underneath, which for a
+    // temperature written over a room is the room.
     const size = t.size ?? opts.textSize;
-    const hw = (size * 0.6 * Math.max(1, t.text?.length ?? 1)) / 2 + HIT.pad;
+    const hw = (size * 0.6 * Math.max(1, textLabel(opts.hass, t).length)) / 2 + HIT.pad;
     const hh = size / 2 + HIT.pad;
     const p = toLocal(x, y, t.x, t.y, t.angle ?? 0);
     if (Math.abs(p.x) <= hw && Math.abs(p.y) <= hh) push("text", t.id, i);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1307,6 +1307,7 @@ export class FloorplanCardEditor extends LitElement {
       itemSize: DEFAULT_ITEM_SIZE,
       textSize: DEFAULT_TEXT_SIZE,
       wallThickness: WALL_THICKNESS,
+      hass: this.hass,
     });
     const sameSpot =
       !!this._pickAnchor &&

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -112,6 +112,7 @@ import {
   resolveIconAnimation,
   itemIconSize,
   itemLabelSize,
+  textLabel,
   labelPositionOf,
   itemReadings,
   itemHasLabel,
@@ -4203,7 +4204,7 @@ export class FloorplanCardEditor extends LitElement {
         @pointerup=${this._onOverlayUp}
         @pointercancel=${this._onPointerCancel}
       >
-        ${t.text || "…"}
+        ${textLabel(this.hass, t) || "…"}
       </div>
     `;
   }
@@ -4617,7 +4618,7 @@ export class FloorplanCardEditor extends LitElement {
       const t = this._floor().texts.find((x) => x.id === sel.id);
       if (!t) return html`${nothing}`;
       return html`
-        ${this._renderForm(textForm(t), (patch, live) =>
+        ${this._renderForm(textForm(t, this._areaEntitiesAt(t.x, t.y)), (patch, live) =>
           this._applyElementPatch("text", t.id, patch, live)
         )}
         ${this._renderColorRow({

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -80,6 +80,7 @@ import {
   trackerSensorReading,
   entityIsActive,
   itemBadgeLabel,
+  textLabel,
   resolveStateColor,
   itemRawValue,
   badgeContentOf,
@@ -735,7 +736,7 @@ export class FloorplanCard extends LitElement {
                color:${cssColorOr(t.color, SKIN_TEXT)};
                transform:translate(-50%,-50%) scale(var(--fp-inv-zoom,1)) rotate(${cssNumber(t.angle, 0)}deg);"
       >
-        ${t.text}
+        ${textLabel(this.hass, t)}
       </div>
     `;
   }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { html, nothing } from "lit";
-import type { Area, Furniture, FurnitureType, ItemKind, ItemReading } from "./types";
+import type { Area, FloorText, Furniture, FurnitureType, ItemKind, ItemReading } from "./types";
 import { SKIN_ACCENT, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
 import {
   DEFAULT_GLOW_RADIUS,
@@ -86,6 +86,7 @@ import {
   entityStateText,
   itemStateText,
   itemBadgeLabel,
+  textLabel,
   itemReadingText,
   itemReadings,
   badgeEntityIndex,
@@ -5387,5 +5388,57 @@ describe("stairs that change floor (issue #121)", () => {
     expect(furnitureFloorTarget(stairs("up"), two, "g")).toBe("up");
     expect(furnitureFloorTarget(stairs("down"), two, "up")).toBe("g");
     expect(furnitureFloorTarget(stairs("down"), two, "g")).toBeUndefined();
+  });
+});
+
+describe("a text label can show an entity's value (issue #225)", () => {
+  const label = (t: Partial<FloorText>) =>
+    textLabel(livingArea(), { text: "", ...t } as FloorText);
+
+  it("draws the words as typed when nothing is bound", () => {
+    expect(label({ text: "Kitchen" })).toBe("Kitchen");
+    // Every text drawn before this existed keeps working, empty included.
+    expect(label({ text: "" })).toBe("");
+  });
+
+  it("draws the reading when an entity is bound and there are no words", () => {
+    // HA's own formatter, so units and display precision come for free —
+    // which is what the reporter's `| round(1)` template was reaching for.
+    expect(label({ entity: TEMP })).toBe("17.9 °C");
+  });
+
+  it("uses the words as a prefix when both are given", () => {
+    expect(label({ text: "Outside", entity: TEMP })).toBe("Outside 17.9 °C");
+    // A space, not the " · " a device puts between its own readings: this is
+    // one reading with a name, not a list.
+    expect(label({ text: "Outside", entity: TEMP })).not.toContain("·");
+  });
+
+  it("reads an attribute instead of the state when asked", () => {
+    const h = livingArea();
+    (h.states[TEMP]!.attributes as Record<string, unknown>).battery = 84;
+    expect(textLabel(h, { text: "", entity: TEMP, attribute: "battery" } as FloorText)).toBe("84");
+    expect(textLabel(h, { text: "Batt", entity: TEMP, attribute: "battery" } as FloorText)).toBe(
+      "Batt 84"
+    );
+  });
+
+  it("says so when the entity is missing, rather than going blank", () => {
+    expect(label({ entity: "sensor.gone" })).toBe("—");
+    expect(label({ text: "PV", entity: "sensor.gone" })).toBe("PV —");
+  });
+
+  it("ignores an attribute with no entity to read it from", () => {
+    expect(label({ text: "Hall", attribute: "battery" })).toBe("Hall");
+  });
+
+  it("is watched, or the number would freeze on the plan", () => {
+    const got = collectWatchedEntities({
+      texts: [
+        { id: "t1", x: 0, y: 0, text: "PV", entity: TEMP },
+        { id: "t2", x: 0, y: 0, text: "just words" },
+      ],
+    } as unknown as FloorplanCardConfig);
+    expect([...got]).toEqual([TEMP]);
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -29,6 +29,7 @@ import type {
   RenderHass,
   HassEntity,
   FloorItem,
+  FloorText,
   OverlayScale,
   ActionConfig,
 } from "./types";
@@ -142,6 +143,12 @@ export function collectWatchedEntities(c: FloorplanCardConfig): Set<string> {
       // not frozen but *intermittent*, catching up only when some other
       // watched entity happens to move.
       for (const r of itemReadings(it)) if (r.entity) ids.add(r.entity);
+    }
+    // Entity-bound text (issue #225). Same trap as the furniture below and the
+    // areas after it: miss this and the number is painted once and then frozen,
+    // catching up only when some *other* watched entity happens to move.
+    for (const t of f.texts) {
+      if (t.entity) ids.add(t.entity);
     }
     // Entity-bound furniture (issue #82) — without this the card never
     // re-renders when the soil sensor moves, and the plant stays its
@@ -257,6 +264,34 @@ export function itemStateText(
   return item.attribute
     ? entityAttributeText(hass, item.entity, item.attribute)
     : entityStateText(hass, item.entity);
+}
+
+/**
+ * What a free text label actually draws (issue #225).
+ *
+ * Unbound it is the words as typed, which is every text on every plan drawn
+ * before this existed. Bound to an entity it is that entity's reading —
+ * formatted the way Home Assistant formats it anywhere else, so a power sensor
+ * reads `1.2 kW` and its display precision is the entity's own setting rather
+ * than something to configure again here.
+ *
+ * With **both**, the words are a prefix: `PV` and a reading of `1.2 kW` draw
+ * `PV 1.2 kW`. One rule rather than a placeholder syntax to learn, and it
+ * covers the two things people write — a bare number, or a number with a word
+ * in front of it saying which number it is.
+ *
+ * A joining space, not the ` · ` a device's label uses between its own
+ * readings: this is one reading with a name, not a list.
+ */
+export function textLabel(
+  hass: RenderHass | undefined,
+  t: Pick<FloorText, "text" | "entity" | "attribute">,
+): string {
+  if (!t.entity) return t.text;
+  const value = t.attribute
+    ? entityAttributeText(hass, t.entity, t.attribute)
+    : entityStateText(hass, t.entity);
+  return t.text ? `${t.text} ${value}` : value;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -657,7 +657,31 @@ export interface FloorText {
   id: string;
   x: number;
   y: number;
+  /**
+   * The words on the plan.
+   *
+   * With {@link entity} bound this becomes a **prefix** rather than the whole
+   * label: `PV` plus a reading of `1.2 kW` draws `PV 1.2 kW`. Left empty, the
+   * reading stands alone, which is the case issue #225 opened for — a number
+   * in the corner of the plan with nothing else to say about it.
+   */
   text: string;
+  /**
+   * An entity whose reading this label shows (issue #225).
+   *
+   * Formatted the way Home Assistant would format it anywhere else, units and
+   * display precision included — so a power sensor reads `1.2 kW` here for the
+   * same reason it does in a Tile card, and rounding it is a matter of that
+   * entity's own display-precision setting rather than anything to configure
+   * twice.
+   */
+  entity?: string;
+  /**
+   * Show this attribute of {@link entity} instead of its state — a climate's
+   * `current_temperature` rather than `heat`. Same field, and the same
+   * formatter, as a device's `attribute` (issue #70).
+   */
+  attribute?: string;
   /** Font size in pixels. Default 16. */
   size?: number;
   /** Text color (CSS color / hex). Falls back to the theme text color. */


### PR DESCRIPTION
A free text on the plan takes an `entity` and draws its reading — a power figure in the corner, a temperature over a room. Devices could already do this in their label; texts could not, so the only way to get a bare number onto a plan was to type it and let it go stale.

```yaml
texts:
  # The reading on its own.
  - { id: pv,   x: 300, y: 80,  text: "",    entity: sensor.pv_output, size: 28 }
  # Words in front of it: "Grid 0.4 kW".
  - { id: grid, x: 300, y: 130, text: Grid,  entity: sensor.grid_power }
  # An attribute rather than the state: "Hall 21.5".
  - { id: hall, x: 300, y: 180, text: Hall,  entity: climate.hall, attribute: current_temperature }
```

`text` becomes a **prefix** when an entity is bound, and an empty `text` leaves the value on its own. One rule rather than a placeholder syntax to learn, and it covers both things people write — a bare number, or a number with a word saying which number it is.

## On the template half of the request

The issue asks for either an entity id **or** a template like `{{ states('sensor.x') | round(1) }}`. This does the first and deliberately not the second, because that example is asking for **rounding** — and values here go through Home Assistant's own formatter, so precision is the entity's display-precision setting and the units come along with it. `1.234` renders as `1.2 kW` with nothing to configure.

Real template support would mean subscribing to `render_template` over the websocket, with a subscription per label to set up, tear down and re-establish on reconnect. That's a separate feature worth doing on its own if someone needs *conditions* rather than formatting — happy to open an issue for it if you'd like.

## Two things that would have failed quietly

- **`collectWatchedEntities` now reads texts.** Miss it and the number is painted once and then frozen, catching up only when some other watched entity happens to move — the trap furniture (#82) and areas (#6) each fell into. Covered by a test, and checked live in a browser.
- **The editor canvas draws the live value too**, so binding an entity is visible without leaving the editor.

## One existing behaviour changed

"Text" was unconditionally `required`. That guarded against an invisible element, which is still right with nothing bound — but a label that is only ever a number shouldn't have to carry a placeholder. It's required only while there is no entity, and the test that pinned the old rule now pins both halves.

## Verification

`npm test` (1204, 8 new), `npm run typecheck`, `npm run build` clean.

Checked in a browser against the built bundle: plain text unchanged, a bare entity reading `1.234 kW`, a prefixed one `Grid 0.42 kW`, an attribute one `Hall 21.5`, and a missing entity reading `Missing —`. Pushing a new `hass` with a changed value updates the bound label and leaves the others alone.