### PR TITLE
Overlay: a unit that resolves everywhere, and the answer to a shrinking card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,13 @@ apart when the card resizes" — though the better answer is often to have no cl
 all: put the readings on **one** device with [`readings`](#more-readings-per-device) and
 there is no relative position left to preserve.)
 
+> **"It looks right on my computer and wrong on my phone."** Same plan, same config —
+> a phone just gives the card less width. Under `fixed` the badges stay 34px and the text
+> stays 12px while everything they were spaced against halves, so a badge ends up sitting
+> on the label or the free text beside it, and it reads as a label that has moved. Nothing
+> has moved: the gaps shrank and the badges did not. `overlayScale: plan` is the answer —
+> it is what a plan drawn once and shown at two sizes wants. (Issue #217.)
+
 Reach for `fixed` when the card renders **larger** than its canvas, or on a wall tablet
 where a px floor under the text is what keeps it readable from across the room.
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -5587,8 +5587,31 @@ export class FloorplanCardEditor extends LitElement {
     .stage.scale-plan {
       container-type: inline-size;
     }
+    /*
+     * The unit itself, declared twice on purpose.
+     *
+     * The fallback in var(--fp-u, 1px) is not the safety net it looks like: it
+     * fires when the property is *unset*, never when its value fails to
+     * resolve. A browser with no container queries parses the calc quite
+     * happily -- a custom property takes almost any token stream -- and then
+     * every property using it is invalid at computed-value time, so each falls
+     * back to its own initial value. Width becomes auto, and a badge collapses
+     * to its borders: about 3px, with its label landing on top of it because
+     * the item's box collapsed with it.
+     *
+     * So the plain value is declared first, and the container-query one only
+     * where it can actually be computed. One pixel per canvas unit is exactly
+     * what overlayScale fixed draws, which is the right thing to degrade to: a
+     * plan that looks like it did before canvas units existed, rather than one
+     * with 3px badges.
+     */
     .stage.scale-plan .items {
-      --fp-u: calc(100cqw / var(--fp-plan-w));
+      --fp-u: 1px;
+    }
+    @supports (container-type: inline-size) {
+      .stage.scale-plan .items {
+        --fp-u: calc(100cqw / var(--fp-plan-w));
+      }
     }
     /* Label padding and offsets go to em so they track the text with the plan,
        exactly as the card's own scale-plan rules do. Hairlines stay px on

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -5604,11 +5604,17 @@ export class FloorplanCardEditor extends LitElement {
      * what overlayScale fixed draws, which is the right thing to degrade to: a
      * plan that looks like it did before canvas units existed, rather than one
      * with 3px badges.
+     *
+     * The guard tests the unit as well as the property, because they are two
+     * features and only one of them is what the declaration is made of. A
+     * browser with container-type but no cqw would pass a check for the
+     * property and then fail on the value, which is the exact collapse this is
+     * here to stop. Test what is actually used; it costs one more clause.
      */
     .stage.scale-plan .items {
       --fp-u: 1px;
     }
-    @supports (container-type: inline-size) {
+    @supports (container-type: inline-size) and (width: 1cqw) {
       .stage.scale-plan .items {
         --fp-u: calc(100cqw / var(--fp-plan-w));
       }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1340,11 +1340,17 @@ export class FloorplanCard extends LitElement {
      * what overlayScale fixed draws, which is the right thing to degrade to: a
      * plan that looks like it did before canvas units existed, rather than one
      * with 3px badges.
+     *
+     * The guard tests the unit as well as the property, because they are two
+     * features and only one of them is what the declaration is made of. A
+     * browser with container-type but no cqw would pass a check for the
+     * property and then fail on the value, which is the exact collapse this is
+     * here to stop. Test what is actually used; it costs one more clause.
      */
     .plan.scale-plan .items {
       --fp-u: 1px;
     }
-    @supports (container-type: inline-size) {
+    @supports (container-type: inline-size) and (width: 1cqw) {
       .plan.scale-plan .items {
         --fp-u: calc(100cqw / var(--fp-plan-w));
       }

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1323,8 +1323,31 @@ export class FloorplanCard extends LitElement {
     .plan.scale-plan {
       container-type: inline-size;
     }
+    /*
+     * The unit itself, declared twice on purpose.
+     *
+     * The fallback in var(--fp-u, 1px) is not the safety net it looks like: it
+     * fires when the property is *unset*, never when its value fails to
+     * resolve. A browser with no container queries parses the calc quite
+     * happily -- a custom property takes almost any token stream -- and then
+     * every property using it is invalid at computed-value time, so each falls
+     * back to its own initial value. Width becomes auto, and a badge collapses
+     * to its borders: about 3px, with its label landing on top of it because
+     * the item's box collapsed with it.
+     *
+     * So the plain value is declared first, and the container-query one only
+     * where it can actually be computed. One pixel per canvas unit is exactly
+     * what overlayScale fixed draws, which is the right thing to degrade to: a
+     * plan that looks like it did before canvas units existed, rather than one
+     * with 3px badges.
+     */
     .plan.scale-plan .items {
-      --fp-u: calc(100cqw / var(--fp-plan-w));
+      --fp-u: 1px;
+    }
+    @supports (container-type: inline-size) {
+      .plan.scale-plan .items {
+        --fp-u: calc(100cqw / var(--fp-plan-w));
+      }
     }
     /* The measures that aren't config-driven, so they never reach an inline
        style. Label padding goes to em rather than canvas units because it


### PR DESCRIPTION
Refs #217. **Does not close it** — see the diagnosis below, which is a config answer rather than a code fix.

## What #217 turned out to be

Not a label that moved. The device labels are oriented correctly on mobile; what changes is the width the card gets.

Under `overlayScale: fixed` the badges stay 34px and the text stays 12px while everything they were spaced against halves on a phone. So a badge ends up sitting on the label or the hand-placed text beside it, and it reads as an orientation bug.

Reproduced by rendering a 1000-unit canvas at 355px with text placed beside badges, which is the shape of the reported plan:

| | result |
| --- | --- |
| `overlayScale: fixed` | badge lands mid-word — `!3.95 °C`, `06.39 hPa` |
| `overlayScale: plan`, same width | everything shrinks together, nothing collides |

So the answer for @alinelena is `overlayScale: plan`. Their plan predates that default and #193 deliberately left existing plans on `fixed`, which is exactly why they see it and a new plan would not.

I've added a README note under Overlay scale, because this will be asked again and "it looks right on my computer and wrong on my phone" is not an obvious search for `overlayScale`.

## The real bug I found on the way

`overlayLength` emits `calc(N * var(--fp-u, 1px))`, and that fallback is not the safety net it looks like. It fires when `--fp-u` is **unset**, never when its value **fails to resolve** — and those are different failures.

A browser with no container queries parses `calc(100cqw / var(--fp-plan-w))` quite happily; a custom property takes almost any token stream. The declaration only goes wrong later, when a `width` or `font-size` tries to use it: invalid at computed-value time, so each falls back to its own initial value. `width` becomes `auto` and the badge collapses to roughly its borders.

Measured, by setting `--fp-u` to a unit the browser doesn't know:

| | badge |
| --- | --- |
| resolves | 37px |
| cannot resolve | **3px** |

`--fp-u` is now declared plainly first and behind `@supports (container-type: inline-size)` second. One pixel per canvas unit is what `overlayScale: fixed` already draws, so a browser without the feature gets a plan that looks like it did before canvas units existed rather than one with 3px badges.

Verified by deleting the `@supports` rule from the live stylesheet, which is precisely what such a browser does:

| | `--fp-u` | badge | label gap |
| --- | --- | --- | --- |
| with container queries | `calc(100cqw / 1000)` | 26.8px | 4px, beside |
| without (before) | unusable | 3px | beside the wreckage |
| without (after) | `1px` | 37px | 4px, beside |

Same in the editor, which has its own copy of the rule.

## What I could not do

I could not reproduce @alinelena's screenshot exactly — I don't have their YAML or their client. The collision above matches the appearance closely, and the fix for it is a config change they can make today, but it is worth them confirming before the issue is closed. Worth asking for: the card's `overlayScale`, whether the overlapping text is a device label or a **text** element, and their HA app version.

## Verification

- 8821 tests pass, `tsc --noEmit` clean. The change is CSS cascade behaviour, so it is verified in a browser rather than by unit test — numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)