### PR TITLE
Drag: focus the canvas without scrolling it out from under the pointer

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -407,7 +407,7 @@ export class FloorplanCardEditor extends LitElement {
     if (!isTypingPath(ev.composedPath())) return;
     ev.preventDefault();
     ev.stopPropagation();
-    this._canvasWrap?.focus();
+    this._canvasWrap?.focus({ preventScroll: true });
   };
   private _onFocusIn = (ev: FocusEvent) => {
     // While the fullscreen popover is up, anything that pulls focus outside the
@@ -1109,7 +1109,7 @@ export class FloorplanCardEditor extends LitElement {
     if (ev.button !== 0) return;
     // One gesture at a time: a second touch must not hijack the state machine.
     if (this._gesturePointer !== null) return;
-    this._canvasWrap?.focus();
+    this._canvasWrap?.focus({ preventScroll: true });
     const raw = this._toVirtual(ev, false);
 
     if (this._tool === "wall") {
@@ -1319,7 +1319,7 @@ export class FloorplanCardEditor extends LitElement {
     if (this._tool !== "select") return;
     ev.stopPropagation();
     if (this._gesturePointer !== null) return;
-    this._canvasWrap?.focus();
+    this._canvasWrap?.focus({ preventScroll: true });
     // Endpoint/vertex handles always operate on that single element; every
     // other click goes through the overlap-aware picker (issue #52).
     const explicitHandle = endpoint != null || areaVertex != null;
@@ -1500,7 +1500,7 @@ export class FloorplanCardEditor extends LitElement {
     // preventDefault suppresses native mousedown focusing, so focus explicitly.
     ev.preventDefault();
     if (this._gesturePointer !== null) return;
-    this._canvasWrap?.focus();
+    this._canvasWrap?.focus({ preventScroll: true });
     const pick = this._resolvePick(ev, sel);
     this._selectForPointer(ev, pick);
     this._drag = {
@@ -2995,7 +2995,7 @@ export class FloorplanCardEditor extends LitElement {
                 // Hand focus back to the canvas: while the <select> keeps it,
                 // isTypingPath swallows every shortcut — most visibly Ctrl+V
                 // after a cross-floor copy (issue #37).
-                this._canvasWrap?.focus();
+                this._canvasWrap?.focus({ preventScroll: true });
               }}
             >
               ${floors.map(


### PR DESCRIPTION
Fixes #229.

`focus()` scrolls its element into view. Every pointerdown path calls it before
resolving the pointer, and `_toVirtual` maps `clientX/Y` through the SVG's live
`getScreenCTM()` — so when the canvas is scrolled inside its container, layout
shifts between the event being dispatched and the CTM being read, and the
resolved point is off by the scroll delta.

Measured on a tall floor in a short window: 91px of scroll became a 100.8-unit
error. That is enough to miss the dragged item's hit box and land in the Area
polygon beneath it, which is why the room drags instead of the device, and why
the gesture then appears to "barely move" — the deltas are computed from the
wrong origin.

`{ preventScroll: true }` keeps the focus behaviour and drops the scroll. Five
call sites, all of which want focus but not a scroll: the three pointerdown
paths, the Escape handler that parks focus back on the canvas, and the floor
`<select>` that hands focus back after switching.

## Testing

`npm run typecheck` and `npm test` (1221 tests) pass. Verified by A/B on a real
install: with the canvas scrolled, stock picks the Area under the item and the
patched build picks the item.

I did not add an automated test — the repo's suite is pure-unit with no DOM
environment, and this behaviour needs a scrolled layout plus a live
`getScreenCTM()`. Happy to add one if you'd like the DOM harness introduced.
