### PR TITLE
Drag: the host renders once per gesture, not once per pointermove

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -231,6 +231,29 @@ interface Drag {
   snapshot?: FloorplanCardConfig;
   /** The redo stack as it stood before the drag's history push cleared it. */
   priorFuture?: FloorplanCardConfig[];
+  /**
+   * Set if anything emitted while this drag was live. A drag normally emits
+   * nothing until it is released, which is what lets cancel restore the
+   * pre-drag config locally; if something did emit, the host has moved on and
+   * has to be told to go back.
+   */
+  emitted?: boolean;
+}
+
+/**
+ * One drag move, already resolved to canvas coordinates.
+ *
+ * Resolved where the event arrives rather than where it is applied: a pointer
+ * event carries screen coordinates, and turning those into canvas coordinates
+ * needs the SVG's CTM, which is live — scrolling the canvas (a plain wheel
+ * does exactly that) or zooming changes it. Transforming a frame later would
+ * read the *new* CTM against the *old* pointer position and place the element
+ * off by the scroll delta.
+ */
+interface DragMove {
+  x: number;
+  y: number;
+  altKey: boolean;
 }
 
 type Marquee = Rect;
@@ -379,8 +402,8 @@ export class FloorplanCardEditor extends LitElement {
    * frame cannot finish, so the element falls further behind the longer the
    * drag lasts.
    */
-  private _dragMoves = new FrameCoalescer<PointerEvent>(rafScheduler, (ev) => {
-    if (this._drag) this._applyDrag(ev);
+  private _dragMoves = new FrameCoalescer<DragMove>(rafScheduler, (move) => {
+    if (this._drag) this._applyDrag(move);
   });
   /** A drag changed the config and the host has not been told yet. */
   private _dragDirty = false;
@@ -443,6 +466,20 @@ export class FloorplanCardEditor extends LitElement {
     this.removeEventListener("keydown", this._onHostKeyDown);
     window.removeEventListener("focusin", this._onFocusIn);
     if (this._applyResetTimer !== null) clearTimeout(this._applyResetTimer);
+    // HA's dialog reparents the editor, so this can land mid-drag. Removal
+    // takes the pointer capture with it, so the gesture is over either way:
+    // hand the host what the drag accumulated (_config is otherwise its only
+    // copy of the edit, and a save sees only what config-changed delivered),
+    // then end the gesture. Dropping the queued move rather than settling it
+    // commits the position the canvas last actually drew — settling would be
+    // safe too, now that a queued move carries no DOM dependency, but it would
+    // commit a position that was never rendered. Clearing _gesturePointer is
+    // not optional: it gates every new gesture, and the pointer it belongs to
+    // can no longer report.
+    this._dragMoves.cancel();
+    this._flushDrag();
+    this._drag = null;
+    this._gesturePointer = null;
     this._resetPinch();
     super.disconnectedCallback();
   }
@@ -836,6 +873,7 @@ export class FloorplanCardEditor extends LitElement {
   private _lastEmitted?: FloorplanCardConfig;
 
   private _emit(config: FloorplanCardConfig): void {
+    if (this._drag) this._drag.emitted = true;
     this._config = config;
     // Recompute here, not just in setConfig: real HA deep-equal-skips the
     // setConfig echo of our own emission, so entities bound during the
@@ -1212,7 +1250,16 @@ export class FloorplanCardEditor extends LitElement {
     this._drag = null;
     if (drag?.moved && drag.snapshot) {
       this._history = this._history.filter((c) => c !== drag.snapshot);
-      this._emit(drag.snapshot);
+      if (drag.emitted) {
+        this._emit(drag.snapshot);
+      } else {
+        // Nothing emitted while the drag was live, so the host still holds
+        // exactly this config: restore locally and spare it a full re-render.
+        // _lastEmitted stays as it is — it still describes the last thing
+        // actually emitted.
+        this._config = drag.snapshot;
+        this._watchedEntities = collectWatchedEntities(drag.snapshot);
+      }
       // The push at first movement cleared the redo stack; a canceled drag
       // must be a complete no-op, so put it back.
       this._future = drag.priorFuture ?? [];
@@ -1263,7 +1310,7 @@ export class FloorplanCardEditor extends LitElement {
       this._marquee = { ...this._marquee, x1: raw.x, y1: raw.y };
       return;
     }
-    if (this._drag) this._dragMoves.push(ev);
+    if (this._drag) this._dragMoves.push({ ...this._toVirtual(ev, false), altKey: ev.altKey });
   }
 
   private _onCanvasUp(ev: PointerEvent): void {
@@ -1413,9 +1460,8 @@ export class FloorplanCardEditor extends LitElement {
     return m;
   }
 
-  private _applyDrag(ev: PointerEvent): void {
+  private _applyDrag(p: DragMove): void {
     const drag = this._drag!;
-    const p = this._toVirtual(ev, false);
     // First *effective* movement: snapshot for undo now, not at pointerdown,
     // so a plain selection click — including the ~1px jitter real clicks and
     // taps produce — doesn't spam history or wipe the redo stack. Threshold
@@ -1433,7 +1479,7 @@ export class FloorplanCardEditor extends LitElement {
     // corners of other walls travel along (Alt detaches), so dragging a room
     // corner stretches the room (issue #30).
     if (drag.endpoint) {
-      const attach = ev.altKey ? [] : (drag.attached ?? []);
+      const attach = p.altKey ? [] : (drag.attached ?? []);
       // The moving cluster must not be a snap candidate for itself — the
       // dragged corner would stick to its own last emitted position.
       const moving = new Set<string>([
@@ -1509,7 +1555,7 @@ export class FloorplanCardEditor extends LitElement {
     // Whole-wall drag: shared corners of neighboring walls follow (issue #30),
     // unless Alt detaches or the neighbor is itself part of the selection
     // (then it already translated with the group).
-    if (drag.attached?.length && !ev.altKey) {
+    if (drag.attached?.length && !p.altKey) {
       const walls = (patch.walls ?? f.walls).map((w) => {
         let out = w;
         for (const a of drag.attached!) {
@@ -1557,7 +1603,7 @@ export class FloorplanCardEditor extends LitElement {
       this._cancelGesture();
       return;
     }
-    if (this._drag) this._dragMoves.push(ev);
+    if (this._drag) this._dragMoves.push({ ...this._toVirtual(ev, false), altKey: ev.altKey });
   }
 
   private _onOverlayUp(ev: PointerEvent): void {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -143,6 +143,7 @@ import {
   type Sel,
   type SelKind,
 } from "./editor-geometry";
+import { FrameCoalescer, rafScheduler } from "./frame-coalescer";
 import { applyCardConfig } from "./editor-save";
 import type { AreaEntityScope } from "./editor-forms";
 import {
@@ -373,6 +374,17 @@ export class FloorplanCardEditor extends LitElement {
 
   private _drag: Drag | null = null;
   /**
+   * Drag moves are applied once per animation frame. A pointer reports faster
+   * than the browser renders, and applying every raw move only queues work the
+   * frame cannot finish, so the element falls further behind the longer the
+   * drag lasts.
+   */
+  private _dragMoves = new FrameCoalescer<PointerEvent>(rafScheduler, (ev) => {
+    if (this._drag) this._applyDrag(ev);
+  });
+  /** A drag changed the config and the host has not been told yet. */
+  private _dragDirty = false;
+  /**
    * Where the last plain selection click landed, for click-cycling through
    * overlapping elements (issue #52). Cleared whenever the pointer lands
    * somewhere else, so cycling only happens on repeat clicks in one spot.
@@ -506,7 +518,26 @@ export class FloorplanCardEditor extends LitElement {
 
   /** Live change to the active floor's elements (no history snapshot — for dragging). */
   private _emitFloor(partial: Partial<Floor>): void {
-    this._emit({ ...this._config, floors: this._patchFloors(partial) });
+    const config = { ...this._config, floors: this._patchFloors(partial) };
+    // A drag owns the config until pointerup. Emitting per move asks HA to
+    // re-render whatever card is being edited — for a stack, every child of it
+    // — and to echo the config back through setConfig, which stalls the gesture
+    // far longer than a frame. The canvas still follows the pointer: _config is
+    // @state, so assigning it repaints the editor without involving the host.
+    if (this._drag) {
+      this._config = config;
+      this._watchedEntities = collectWatchedEntities(config);
+      this._dragDirty = true;
+      return;
+    }
+    this._emit(config);
+  }
+
+  /** Hand the host what a drag accumulated — once, on release. */
+  private _flushDrag(): void {
+    if (!this._dragDirty) return;
+    this._dragDirty = false;
+    this._emit(this._config);
   }
 
   private _patchFloors(partial: Partial<Floor>): Floor[] {
@@ -1168,6 +1199,9 @@ export class FloorplanCardEditor extends LitElement {
    * between — is dropped, so a canceled drag leaves no trace in undo.
    */
   private _cancelGesture(): void {
+    // Whatever the drag accumulated is about to be replaced by its snapshot.
+    this._dragMoves.cancel();
+    this._dragDirty = false;
     this._gesturePointer = null;
     this._draft = null;
     this._draftTracker = null;
@@ -1229,11 +1263,14 @@ export class FloorplanCardEditor extends LitElement {
       this._marquee = { ...this._marquee, x1: raw.x, y1: raw.y };
       return;
     }
-    if (this._drag) this._applyDrag(ev);
+    if (this._drag) this._dragMoves.push(ev);
   }
 
   private _onCanvasUp(ev: PointerEvent): void {
     if (this._foreignPointer(ev)) return;
+    // Land on the last position the pointer reported, not on whatever the
+    // previous frame caught — settle while _drag is still set.
+    this._dragMoves.settle();
     this._gesturePointer = null;
     if (this._tool === "wall" && this._draft) {
       const d = this._draft;
@@ -1278,6 +1315,7 @@ export class FloorplanCardEditor extends LitElement {
     if (this._drag) {
       this._drag = null;
       this._releasePointer(ev);
+      this._flushDrag();
     }
   }
 
@@ -1519,15 +1557,17 @@ export class FloorplanCardEditor extends LitElement {
       this._cancelGesture();
       return;
     }
-    if (this._drag) this._applyDrag(ev);
+    if (this._drag) this._dragMoves.push(ev);
   }
 
   private _onOverlayUp(ev: PointerEvent): void {
     if (this._foreignPointer(ev)) return;
+    this._dragMoves.settle();
     this._gesturePointer = null;
     if (this._drag) {
       this._drag = null;
       this._releasePointer(ev, ev.currentTarget as Element);
+      this._flushDrag();
     }
   }
 

--- a/src/frame-coalescer.test.ts
+++ b/src/frame-coalescer.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { FrameCoalescer, type FrameScheduler } from "./frame-coalescer";
+
+/** A scheduler whose frames only run when the test says so. */
+function manualFrames() {
+  const queue = new Map<number, () => void>();
+  let next = 1;
+  const scheduler: FrameScheduler = {
+    request(cb) {
+      const handle = next++;
+      queue.set(handle, cb);
+      return handle;
+    },
+    cancel(handle) {
+      queue.delete(handle);
+    },
+  };
+  return {
+    scheduler,
+    get depth() {
+      return queue.size;
+    },
+    /** Run every callback currently queued. */
+    tick() {
+      const due = [...queue.entries()];
+      queue.clear();
+      for (const [, cb] of due) cb();
+    },
+  };
+}
+
+describe("FrameCoalescer", () => {
+  it("delivers only the newest value of a burst", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.push(1);
+    c.push(2);
+    c.push(3);
+    expect(deliver).not.toHaveBeenCalled();
+
+    frames.tick();
+    expect(deliver.mock.calls).toEqual([[3]]);
+  });
+
+  it("schedules one frame per burst, not one per value", () => {
+    const frames = manualFrames();
+    const c = new FrameCoalescer<number>(frames.scheduler, vi.fn());
+
+    c.push(1);
+    c.push(2);
+    expect(frames.depth).toBe(1);
+  });
+
+  it("queues again after a frame has run", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.push(1);
+    frames.tick();
+    c.push(2);
+    frames.tick();
+    expect(deliver.mock.calls).toEqual([[1], [2]]);
+  });
+
+  it("settle delivers the newest value without waiting for the frame", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.push(1);
+    c.push(2);
+    c.settle();
+    expect(deliver.mock.calls).toEqual([[2]]);
+  });
+
+  it("settle consumes the pending value, so its frame is a no-op", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.push(1);
+    c.settle();
+    frames.tick();
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("settle with nothing queued delivers nothing", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.settle();
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("cancel drops the queued value and its frame", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number>(frames.scheduler, deliver);
+
+    c.push(1);
+    c.cancel();
+    frames.tick();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(frames.depth).toBe(0);
+  });
+
+  it("reports whether a value is waiting", () => {
+    const frames = manualFrames();
+    const c = new FrameCoalescer<number>(frames.scheduler, vi.fn());
+
+    expect(c.pending).toBe(false);
+    c.push(1);
+    expect(c.pending).toBe(true);
+    frames.tick();
+    expect(c.pending).toBe(false);
+  });
+});

--- a/src/frame-coalescer.test.ts
+++ b/src/frame-coalescer.test.ts
@@ -108,6 +108,28 @@ describe("FrameCoalescer", () => {
     expect(frames.depth).toBe(0);
   });
 
+  it("delivers a queued null like any other value", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number | null>(frames.scheduler, deliver);
+
+    c.push(null);
+    expect(c.pending).toBe(true);
+    frames.tick();
+    expect(deliver).toHaveBeenCalledWith(null);
+  });
+
+  it("settles a queued null rather than treating it as nothing queued", () => {
+    const frames = manualFrames();
+    const deliver = vi.fn();
+    const c = new FrameCoalescer<number | null>(frames.scheduler, deliver);
+
+    c.push(null);
+    c.settle();
+    expect(deliver).toHaveBeenCalledWith(null);
+    expect(frames.depth).toBe(0);
+  });
+
   it("reports whether a value is waiting", () => {
     const frames = manualFrames();
     const c = new FrameCoalescer<number>(frames.scheduler, vi.fn());

--- a/src/frame-coalescer.ts
+++ b/src/frame-coalescer.ts
@@ -23,6 +23,12 @@ export const rafScheduler: FrameScheduler = {
 
 export class FrameCoalescer<T> {
   private _pending: T | null = null;
+  /**
+   * Whether `_pending` holds a value. A separate flag rather than a `null`
+   * check: `T` may itself include `null`, and a queued `null` has to be
+   * delivered like any other value instead of being read as "nothing queued".
+   */
+  private _hasPending = false;
   private _handle: number | null = null;
 
   constructor(
@@ -30,20 +36,19 @@ export class FrameCoalescer<T> {
     private readonly deliver: (value: T) => void,
   ) {}
 
-  /** True while a value is waiting for its frame. */
+  /** True while a value is queued for delivery. */
   get pending(): boolean {
-    return this._handle !== null;
+    return this._hasPending;
   }
 
   /** Queue a value, replacing any still waiting for this frame. */
   push(value: T): void {
     this._pending = value;
+    this._hasPending = true;
     if (this._handle !== null) return;
     this._handle = this.frames.request(() => {
       this._handle = null;
-      const value = this._pending;
-      this._pending = null;
-      if (value !== null) this.deliver(value);
+      this._deliverPending();
     });
   }
 
@@ -53,21 +58,28 @@ export class FrameCoalescer<T> {
    * whatever the previous frame happened to catch.
    */
   settle(): void {
-    if (this._handle !== null) {
-      this.frames.cancel(this._handle);
-      this._handle = null;
-    }
-    const value = this._pending;
-    this._pending = null;
-    if (value !== null) this.deliver(value);
+    this._cancelFrame();
+    this._deliverPending();
   }
 
   /** Drop anything queued without delivering it (the gesture was canceled). */
   cancel(): void {
-    if (this._handle !== null) {
-      this.frames.cancel(this._handle);
-      this._handle = null;
-    }
+    this._cancelFrame();
     this._pending = null;
+    this._hasPending = false;
+  }
+
+  private _cancelFrame(): void {
+    if (this._handle === null) return;
+    this.frames.cancel(this._handle);
+    this._handle = null;
+  }
+
+  private _deliverPending(): void {
+    if (!this._hasPending) return;
+    const value = this._pending as T;
+    this._pending = null;
+    this._hasPending = false;
+    this.deliver(value);
   }
 }

--- a/src/frame-coalescer.ts
+++ b/src/frame-coalescer.ts
@@ -1,0 +1,73 @@
+/**
+ * Collapses a burst of values into one delivery per animation frame.
+ *
+ * Pointer events arrive faster than a browser can render — a 1000Hz mouse
+ * against a 60Hz display is 16 events per frame. Handling every one of them
+ * does not make the drag smoother, it makes it *later*: the work queues up and
+ * the gap between the cursor and what it is dragging grows for as long as the
+ * gesture lasts. Delivering only the newest value each frame bounds that queue
+ * at one event, so the drag can fall at most one frame behind however fast the
+ * pointer moves.
+ *
+ * The scheduler is injected so tests can drive frames by hand.
+ */
+export interface FrameScheduler {
+  request(cb: () => void): number;
+  cancel(handle: number): void;
+}
+
+export const rafScheduler: FrameScheduler = {
+  request: (cb) => requestAnimationFrame(cb),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+export class FrameCoalescer<T> {
+  private _pending: T | null = null;
+  private _handle: number | null = null;
+
+  constructor(
+    private readonly frames: FrameScheduler,
+    private readonly deliver: (value: T) => void,
+  ) {}
+
+  /** True while a value is waiting for its frame. */
+  get pending(): boolean {
+    return this._handle !== null;
+  }
+
+  /** Queue a value, replacing any still waiting for this frame. */
+  push(value: T): void {
+    this._pending = value;
+    if (this._handle !== null) return;
+    this._handle = this.frames.request(() => {
+      this._handle = null;
+      const value = this._pending;
+      this._pending = null;
+      if (value !== null) this.deliver(value);
+    });
+  }
+
+  /**
+   * Deliver the newest queued value now. For the end of a gesture: pointerup
+   * must land on the last position the pointer actually reported, not on
+   * whatever the previous frame happened to catch.
+   */
+  settle(): void {
+    if (this._handle !== null) {
+      this.frames.cancel(this._handle);
+      this._handle = null;
+    }
+    const value = this._pending;
+    this._pending = null;
+    if (value !== null) this.deliver(value);
+  }
+
+  /** Drop anything queued without delivering it (the gesture was canceled). */
+  cancel(): void {
+    if (this._handle !== null) {
+      this.frames.cancel(this._handle);
+      this._handle = null;
+    }
+    this._pending = null;
+  }
+}


### PR DESCRIPTION
Fixes #230.

Dragging an element emits `config-changed` on every `pointermove`. The host answers each one by re-rendering the card being edited and echoing the config back through `setConfig`, which deep-clones every floor. Where that render is cheap the cost hides. Where it isn't — my card is one child of a `vertical-stack`, so a single emit re-renders all 19 of its siblings — each emit stalls the main thread for ~80–100ms, and the drag freezes and jumps rather than following the pointer.

Two changes, one per layer.

**`FrameCoalescer` (new, `src/frame-coalescer.ts`)** applies at most one drag move per animation frame. A pointer reports faster than a browser renders — a 1000Hz mouse against a 60Hz display is 16 events per frame — so handling every raw event doesn't make the drag smoother, it makes it *later*: the queue grows for as long as the gesture lasts. Coalescing bounds it at one event, so the drag can fall at most one frame behind however fast the pointer moves. The scheduler is injected so it can be tested without a DOM.

What it carries is the move already resolved to canvas coordinates (`DragMove {x, y, altKey}`), not the `PointerEvent`. Resolving needs `getScreenCTM()`, which is live — scrolling the canvas (a plain wheel does exactly that) or zooming changes it — so transforming a frame later would read the *new* matrix against the *old* pointer position and place the element off by the scroll delta.

Both pointerup paths call `settle()` **while `_drag` is still set**, so the element lands on the last position the pointer actually reported rather than on whatever the previous frame caught. `_cancelGesture` drops the queued frame — a canceled drag stays a no-op — and `disconnectedCallback` drops it, flushes, and ends the gesture, since HA's dialog reparents the editor and that can land mid-drag.

**`_emitFloor`** keeps the config local during a drag and emits once on release (`_flushDrag`). The canvas still follows the pointer every frame: `_config` is `@state`, so assigning it repaints the editor without involving the host at all.

### Measurements

A harness mounts the editor next to a preview card and wires them the way HA's edit dialog does (config echo, preview re-set on every `config-changed`), with an 80ms `setConfig` standing in for a heavy host. 3s drag, ~200Hz input, retina 1930×1152, a 72-item floor:

| | host re-renders during the drag | p95 frame | median frame | frames over 33ms |
| --- | --- | --- | --- | --- |
| before | 36 | 85.3ms | 83.5ms | 35 / 48 |
| after | 1 | 25.8ms | 22.4ms | 6 / 130 |

Medians of three runs per build.

Release is unchanged: one emit, and the element lands where the pointer left it (0px error, no snap-back when the host echo arrives).

Simulating the host is the part that matters. The editor's own update costs ~0.4ms at that resolution — it was never the bottleneck, and a harness whose preview is a single cheap card shows almost no difference between these two builds.

### Trade-off, deliberate

A preview outside the editor no longer updates mid-drag; it catches up on release. The editor canvas is authoritative during the gesture, so nothing is lost where the user is looking.

### Notes

- The coalescer carries a resolved point rather than the `PointerEvent`, so nothing it holds depends on state that can change before delivery. An earlier revision of this PR held the event and got this wrong; see the review thread for the measured failure.
- `setConfig`'s existing echo-detection needs no change. It's the emit that stops during a drag, so there is no echo to guard against.
- 10 unit tests for `FrameCoalescer` (manual scheduler: newest-of-burst, one frame per burst, re-queue, settle-without-waiting, settle consumes the pending frame, cancel, and a queued `null` delivered rather than read as "nothing queued"). The editor wiring itself isn't covered — the suite has no DOM environment — so it was verified in the harness above and by running the built bundle on a live HA install.
- `npm run typecheck` clean, `npm test` 1231 passed.

Independent of #231; either can go first.

