### PR TITLE
Add disableLabelColor option for item labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ then pick the entity in the **Element** section below the canvas.
   With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can 
   override this behavior per item. When set to true, the label text will stay locked to its default 
   theme color, while the icon and badge continue to reflect the dynamic state colors.
-  ### Label Color Customization
+  **Label Color Customization**
 
   By default, an item's label text automatically adapts its color based on the state or active color rules.
   For some items, this can impact readability or clash with the desired design. 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ then pick the entity in the **Element** section below the canvas.
   **right**. A reading under a badge grows in both directions and meets whatever sits
   beside it; hung off one side it grows one way only.
 - **Disable Label Color** (disableLabelColor)
-  By default, an item's label text automatically adapts its color based on the state or
-  active color rules. For some items, this can impact readability or clash with the desired design.
   With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can 
   override this behavior per item. When set to true, the label text will stay locked to its default 
   theme color, while the icon and badge continue to reflect the dynamic state colors.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ then pick the entity in the **Element** section below the canvas.
 - **Label position** — **Below** the badge (the default), or hung off its **left** or
   **right**. A reading under a badge grows in both directions and meets whatever sits
   beside it; hung off one side it grows one way only.
+- **Disable Label Color** (disableLabelColor)
+  By default, an item's label text automatically adapts its color based on the state or
+  active color rules. For some items, this can impact readability or clash with the desired design.
+  With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can 
+  override this behavior per item. When set to true, the label text will stay locked to its default 
+  theme color, while the icon and badge continue to reflect the dynamic state colors.
 - **Badge shows** — one dropdown for what the device draws: *Icon* — **still**,
   **spinning** or **pulsing** — its *Value*, or *Nothing* (label only). **Value** draws
   the reading inside the badge — a thermostat reads `21°` in the circle your state rules

--- a/README.md
+++ b/README.md
@@ -115,17 +115,17 @@ then pick the entity in the **Element** section below the canvas.
   **right**. A reading under a badge grows in both directions and meets whatever sits
   beside it; hung off one side it grows one way only.
 - **Disable Label Color** (disableLabelColor)
-  With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can 
-  override this behavior per item. When set to true, the label text will stay locked to its default 
+  With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can
+  override this behavior per item. When set to true, the label text will stay locked to its default
   theme color, while the icon and badge continue to reflect the dynamic state colors.
   **Label Color Customization**
 
   By default, an item's label text automatically adapts its color based on the state or active color rules.
-  For some items, this can impact readability or clash with the desired design. 
+  For some items, this can impact readability or clash with the desired design.
   
   With the `disableLabelColor` boolean toggle (available in Group 3 of the item editor), you can override this
   behavior per item. When set to `true`, the label text will stay locked to its default theme color,
-  while the icon and badge continue to reflect the dynamic state colors. 
+  while the icon and badge continue to reflect the dynamic state colors.
   
   You can also optionally assign a fixed custom color using `useCustomLabelColor` and `labelCustomColor`.
   

--- a/README.md
+++ b/README.md
@@ -119,6 +119,33 @@ then pick the entity in the **Element** section below the canvas.
   With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can 
   override this behavior per item. When set to true, the label text will stay locked to its default 
   theme color, while the icon and badge continue to reflect the dynamic state colors.
+  ### Label Color Customization
+
+  By default, an item's label text automatically adapts its color based on the state or active color rules.
+  For some items, this can impact readability or clash with the desired design. 
+  
+  With the `disableLabelColor` boolean toggle (available in Group 3 of the item editor), you can override this
+  behavior per item. When set to `true`, the label text will stay locked to its default theme color,
+  while the icon and badge continue to reflect the dynamic state colors. 
+  
+  You can also optionally assign a fixed custom color using `useCustomLabelColor` and `labelCustomColor`.
+  
+  | YAML Key | Type | Description |
+  | :--- | :--- | :--- |
+  | `disableLabelColor` | boolean | Keeps the text in its default theme color, preventing it from inheriting active or state colors. |
+  | `useCustomLabelColor` | boolean | Activates a custom color option when `disableLabelColor` is enabled ("Own color" toggle in the editor),
+  allowing you to override the theme default. |
+  | `labelCustomColor` | string | The fixed custom color (e.g., `#ff0000` or `red`) applied to the label text. |
+  
+  The `useCustomLabelColor` toggle appears in the visual editor as "Own color" only once `disableLabelColor` is activated,
+  and toggling it reveals the color picker for precise tuning.
+  
+  *Example: Disable automatic state coloring and apply a fixed custom color to a label:*
+  ```yaml
+    disableLabelColor: true
+    useCustomLabelColor: true
+    labelCustomColor: "#00ff00"
+  ```
 - **Badge shows** — one dropdown for what the device draws: *Icon* — **still**,
   **spinning** or **pulsing** — its *Value*, or *Nothing* (label only). **Value** draws
   the reading inside the badge — a thermostat reads `21°` in the circle your state rules

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1956,3 +1956,61 @@ describe("formSlice", () => {
     expect(formSlice(spec, []).fields).toEqual([]);
   });
 });
+
+describe("itemLabelForm — disableLabelColor and custom color state machine", () => {
+  const item = { id: "i", entity: "light.a", kind: "light", x: 0, y: 0, showName: true } as FloorItem;
+
+  it("offers disableLabelColor field when labelled", () => {
+    const fields = itemLabelForm(item)?.fields.map((f) => f.name) ?? [];
+    expect(fields).toContain("disableLabelColor");
+  });
+
+  it("clears custom color fields when disableLabelColor is toggled off", () => {
+    const form = itemLabelForm({
+      ...item,
+      disableLabelColor: true,
+      useCustomLabelColor: true,
+      labelCustomColor: "#ff0000",
+    } as FloorItem);
+
+    // Toggling disableLabelColor OFF must clear both useCustomLabelColor and labelCustomColor
+    const patch = form!.toPatch({ disableLabelColor: false });
+    expect(patch).toEqual({
+      disableLabelColor: undefined,
+      useCustomLabelColor: undefined,
+      labelCustomColor: undefined,
+    });
+  });
+
+  it("clears only labelCustomColor when useCustomLabelColor is toggled off", () => {
+    const form = itemLabelForm({
+      ...item,
+      disableLabelColor: true,
+      useCustomLabelColor: true,
+      labelCustomColor: "#ff0000",
+    } as FloorItem);
+
+    // Toggling useCustomLabelColor OFF must clear only labelCustomColor, keeping disableLabelColor
+    const patch = form!.toPatch({ useCustomLabelColor: false });
+    expect(patch).toEqual({
+      useCustomLabelColor: undefined,
+      labelCustomColor: undefined,
+    });
+  });
+
+  it("round-trips custom color when both toggles are enabled", () => {
+    const form = itemLabelForm(item);
+    
+    expect(
+      form!.toPatch({
+        disableLabelColor: true,
+        useCustomLabelColor: true,
+        labelCustomColor: "#00ff00",
+      })
+    ).toEqual({
+      disableLabelColor: true,
+      useCustomLabelColor: true,
+      labelCustomColor: "#00ff00",
+    });
+  });
+});

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -494,7 +494,7 @@ describe("itemForm", () => {
       ["name", "showName"], // 1. Identity — what it is
       ["entity", "attribute"], // 2. What it reads…
       ["showState"], //         …including whether its own state shows
-      ["labelPosition", "labelSize"], // 3. Label
+      ["labelPosition", "labelSize", "disableLabelColor"], // 3. Label
       ["badgeMode", "size", "angle"], // 4. Badge
       // 5. Colour and the readings list are hand-rolled rows, not ha-form
       //    fields, so they do not appear here — the editor slots them into

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -923,17 +923,27 @@ export function itemLabelForm(it: FloorItem): FormSpec {
         label: "Label size",
         selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
       },
+      {
+        name: "disableLabelColor",
+        label: "Disable label color",
+        helper: "Keeps the text in its default color even if the icon changes color",
+        selector: { boolean: {} },
+      },
     ],
     data: {
       labelPosition: labelPositionOf(it),
       labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
+      disableLabelColor: it.disableLabelColor ?? false,
     },
-    // Below is the default, so it stays out of the YAML.
-    toPatch: (p) =>
-      "labelPosition" in p && p.labelPosition === "below" ? { ...p, labelPosition: undefined } : p,
+    // Defaults stay out of the YAML to keep the configuration clean
+    toPatch: (p) => {
+      const out = { ...p };
+      if (out.labelPosition === "below") out.labelPosition = undefined;
+      if (out.disableLabelColor === false) out.disableLabelColor = undefined;
+      return out;
+    },
   };
 }
-
 /**
  * Group 4: the badge — what it holds, which reading, and how big it is.
  *

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -910,36 +910,66 @@ export function itemShowStateForm(it: FloorItem): FormSpec {
 
 /** Group 3: where the label sits and how big it is. */
 export function itemLabelForm(it: FloorItem): FormSpec {
+  const fields: FormField[] = [
+    {
+      name: "labelPosition",
+      label: "Label position",
+      helper: "Beside the badge instead of under it — a long reading then grows one way only",
+      selector: dropdown(opt("below", "Below"), opt("left", "Left"), opt("right", "Right")),
+    },
+    {
+      name: "labelSize",
+      label: "Label size",
+      selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
+    },
+    {
+      name: "disableLabelColor",
+      label: "Disable label color",
+      helper: "Keeps the text in its default color even if the icon changes color",
+      selector: { boolean: {} },
+    },
+  ];
+
+  if (it.disableLabelColor) {
+    fields.push({
+      name: "useCustomLabelColor",
+      label: "Own color",
+      helper: "Override the theme default with a fixed custom color",
+      selector: { boolean: {} },
+    });
+  }
+
   return {
-    fields: [
-      {
-        name: "labelPosition",
-        label: "Label position",
-        helper: "Beside the badge instead of under it — a long reading then grows one way only",
-        selector: dropdown(opt("below", "Below"), opt("left", "Left"), opt("right", "Right")),
-      },
-      {
-        name: "labelSize",
-        label: "Label size",
-        selector: { number: { min: 8, max: 40, step: 1, mode: "slider", unit_of_measurement: "px" } },
-      },
-      {
-        name: "disableLabelColor",
-        label: "Disable label color",
-        helper: "Keeps the text in its default color even if the icon changes color",
-        selector: { boolean: {} },
-      },
-    ],
+    fields,
     data: {
       labelPosition: labelPositionOf(it),
       labelSize: it.labelSize ?? DEFAULT_LABEL_SIZE,
       disableLabelColor: it.disableLabelColor ?? false,
+      useCustomLabelColor: it.useCustomLabelColor ?? false,
+      labelCustomColor: it.labelCustomColor ?? "",
     },
-    // Defaults stay out of the YAML to keep the configuration clean
     toPatch: (p) => {
       const out = { ...p };
+      
+      // WICHTIG: Wir ermitteln den echten zukünftigen Status, 
+      // indem wir den Patch (out) mit dem aktuellen Status (it) abgleichen.
+      const isDisable = out.disableLabelColor ?? it.disableLabelColor ?? false;
+      const isCustom = out.useCustomLabelColor ?? it.useCustomLabelColor ?? false;
+
       if (out.labelPosition === "below") out.labelPosition = undefined;
       if (out.disableLabelColor === false) out.disableLabelColor = undefined;
+      if (out.useCustomLabelColor === false) out.useCustomLabelColor = undefined;
+
+      // Aufräumen basierend auf dem ECHTEN Status
+      if (!isDisable) {
+        out.useCustomLabelColor = undefined;
+        out.labelCustomColor = undefined;
+      } else if (!isCustom) {
+        out.labelCustomColor = undefined;
+      }
+
+      if (out.labelCustomColor === "") out.labelCustomColor = undefined;
+      
       return out;
     },
   };

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -951,8 +951,7 @@ export function itemLabelForm(it: FloorItem): FormSpec {
     toPatch: (p) => {
       const out = { ...p };
       
-      // WICHTIG: Wir ermitteln den echten zukünftigen Status, 
-      // indem wir den Patch (out) mit dem aktuellen Status (it) abgleichen.
+      // IMPORTANT: Determine the actual future state
       const isDisable = out.disableLabelColor ?? it.disableLabelColor ?? false;
       const isCustom = out.useCustomLabelColor ?? it.useCustomLabelColor ?? false;
 
@@ -960,7 +959,7 @@ export function itemLabelForm(it: FloorItem): FormSpec {
       if (out.disableLabelColor === false) out.disableLabelColor = undefined;
       if (out.useCustomLabelColor === false) out.useCustomLabelColor = undefined;
 
-      // Aufräumen basierend auf dem ECHTEN Status
+      // Clean up based on the ACTUAL state
       if (!isDisable) {
         out.useCustomLabelColor = undefined;
         out.labelCustomColor = undefined;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4758,7 +4758,7 @@ export class FloorplanCardEditor extends LitElement {
           ? this._renderGroup(
               "Label",
               this._renderForm(itemLabelForm(it), apply),
-              it.useCustomLabelColor
+              it.disableLabelColor && it.useCustomLabelColor
                 ? this._renderColorRow({
                     label: "Custom color",
                     value: it.labelCustomColor,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -114,6 +114,7 @@ import {
   itemLabelSize,
   textLabel,
   labelPositionOf,
+  itemLabelColor,
   itemReadings,
   itemHasLabel,
   snapToWall,
@@ -4182,7 +4183,7 @@ export class FloorplanCardEditor extends LitElement {
     // will actually render (state rules first, then the active colour).
     const rawValue = itemRawValue(it, st);
     const stateColor = cssColor(resolveStateColor(it.stateColor, rawValue));
-    // …and the same badge contents, so "Badge shows: Value" previews here too.
+    const labelColor = itemLabelColor(it, stateColor);   
     const value = badgeContentOf(it) === "value" ? badgeValue(this.hass, it) : undefined;
     // The active colour — the one the user set, else the bulb's own colour
     // (issue #106). The canvas never previewed either, so setting "Active
@@ -4262,15 +4263,15 @@ export class FloorplanCardEditor extends LitElement {
              The Labels toolbar toggle hides either on dense plans (issue
              #52), and the size previews the card's labelSize (issue #59). -->
         ${this._hideLabels
-          ? nothing
-          : html`<span
-              class="ilabel ${cardLabel ? "live" : ""} ilabel-${labelPositionOf(it)}"
-              style="font-size:${overlayLength(
-                cardLabel || it.labelSize != null ? itemLabelSize(it.labelSize) : 11,
-                scale
-              )};${cardLabel && stateColor ? `color:${stateColor};` : ""}"
-              >${label}</span
-            >`}
+        ? nothing
+        : html`<span
+            class="ilabel ${cardLabel ? "live" : ""} ilabel-${labelPositionOf(it)}"
+            style="font-size:${overlayLength(
+              cardLabel || it.labelSize != null ? itemLabelSize(it.labelSize) : 11,
+              scale
+            )};${cardLabel && labelColor ? `color:${labelColor};` : ""}"
+            >${label}</span
+          >`}
       </div>
     `;
   }
@@ -4648,8 +4649,20 @@ export class FloorplanCardEditor extends LitElement {
           this._renderItemReadings(it)
         )}
         ${itemHasLabel(it)
-          ? // Nothing to place or size while the device draws no label at all.
-            this._renderGroup("Label", this._renderForm(itemLabelForm(it), apply))
+          ? this._renderGroup(
+              "Label",
+              this._renderForm(itemLabelForm(it), apply),
+              it.useCustomLabelColor
+                ? this._renderColorRow({
+                    label: "Custom color",
+                    value: it.labelCustomColor,
+                    swatch: "#ffffff",
+                    placeholder: "e.g. #ff0000 or red",
+                    onLive: (labelCustomColor) => this._updateItemLive(it.id, { labelCustomColor }),
+                    onCommit: (labelCustomColor) => this._updateItem(it.id, { labelCustomColor }),
+                  })
+                : nothing
+            )
           : nothing}
         ${this._renderGroup(
           "Badge",

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -596,16 +596,19 @@ export class FloorplanCard extends LitElement {
   private _renderBadge(item: FloorItem, scale: OverlayScale, renderHass?: RenderHass): TemplateResult {
     const size = cssNumber(item.size, DEFAULT_ITEM_SIZE);
     const box = overlayLength(size, scale);
+    
+    // Use renderHass when available to keep state context consistent, fallback to this.hass
+    const hassContext = renderHass ?? this.hass;
+
     // Animation goes on the inner ha-icon, not the badge: the badge carries
     // the user's `angle` rotation, and a spin on the same element would
     // overwrite it.
-    const st = item.entity ? this.hass?.states[item.entity] : undefined;
+    const st = item.entity ? hassContext?.states[item.entity] : undefined;
     const anim = resolveIconAnimation(item, st?.state, st?.attributes);
     // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
     // state colour, ripple stacking all unchanged — with the glyph swapped for
     // the number. A device with nothing numeric to show keeps its icon.
-    const value = badgeContentOf(item) === "value" ? badgeValue(this.hass, item) : undefined;
-    console.log("Card Badge Debug -> Content:", badgeContentOf(item), "Value:", value, "Scale:", scale);
+    const value = badgeContentOf(item) === "value" ? badgeValue(hassContext, item) : undefined;
     return html`
       <div
         class="badge"
@@ -619,7 +622,7 @@ export class FloorplanCard extends LitElement {
             >`
           : html`<ha-icon
               class=${anim ? `anim-${anim}` : ""}
-              icon=${this._itemIcon(item, renderHass)}
+              icon=${this._itemIcon(item, hassContext)}
               style="--mdc-icon-size:${overlayLength(itemIconSize(size), scale)};"
             ></ha-icon>`}
       </div>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -604,7 +604,8 @@ export class FloorplanCard extends LitElement {
     // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
     // state colour, ripple stacking all unchanged — with the glyph swapped for
     // the number. A device with nothing numeric to show keeps its icon.
-    const value = badgeContentOf(item) === "value" ? badgeValue(renderHass, item) : undefined;
+    const value = badgeContentOf(item) === "value" ? badgeValue(this.hass, item) : undefined;
+    console.log("Card Badge Debug -> Content:", badgeContentOf(item), "Value:", value, "Scale:", scale);
     return html`
       <div
         class="badge"

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -670,7 +670,7 @@ export class FloorplanCard extends LitElement {
     // active state alone left threshold colours invisible on exactly the
     // devices they were written for.
     const stateColor = cssColor(resolveStateColor(item.stateColor, rawValue));
-    const labelColor = stateColor;
+    const labelColor = item.disableLabelColor ? undefined : stateColor;
     // Offline (issue #162): the entity is unavailable, unknown, or gone from
     // Home Assistant altogether. Guarded on `hass` — before the first states
     // arrive every device would answer "offline" and the plan would flash

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -97,6 +97,7 @@ import {
   itemHiddenWhenInactive,
   itemBadgeHidden,
   itemLabelSize,
+  itemLabelColor,
   areaLabelFontSize,
   wallStrokeStyle,
   normalizeOverlayScale,
@@ -670,7 +671,7 @@ export class FloorplanCard extends LitElement {
     // active state alone left threshold colours invisible on exactly the
     // devices they were written for.
     const stateColor = cssColor(resolveStateColor(item.stateColor, rawValue));
-    const labelColor = item.disableLabelColor ? undefined : stateColor;
+    const labelColor = itemLabelColor(item, stateColor);
     // Offline (issue #162): the entity is unavailable, unknown, or gone from
     // Home Assistant altogether. Guarded on `hass` — before the first states
     // arrive every device would answer "offline" and the plan would flash

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -150,6 +150,7 @@ import {
   renderRipple,
   checkHideCondition,
   itemBadgeHidden,
+  itemLabelColor,
 } from "./render";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 import { symbolCatalog, symbolSize } from "./symbols";
@@ -5984,5 +5985,24 @@ describe("hide by condition, through the card's own entry points", () => {
       ],
     } as unknown as FloorplanCardConfig);
     for (const id of [RADIATOR, OUTSIDE, "sensor.a", "sensor.b"]) expect(ids.has(id)).toBe(true);
+  });
+});
+
+describe("item label color (itemLabelColor)", () => {
+  it("returns the state color by default when disableLabelColor is false", () => {
+    expect(itemLabelColor({ disableLabelColor: false }, "#ff0000")).toBe("#ff0000");
+  });
+
+  it("returns the state color when disableLabelColor is omitted", () => {
+    expect(itemLabelColor({}, "#ff0000")).toBe("#ff0000");
+  });
+
+  it("suppresses the state color and returns undefined when disableLabelColor is true", () => {
+    expect(itemLabelColor({ disableLabelColor: true }, "#ff0000")).toBe(undefined);
+  });
+
+  it("returns undefined when no state color is provided, regardless of the toggle", () => {
+    expect(itemLabelColor({ disableLabelColor: false }, undefined)).toBe(undefined);
+    expect(itemLabelColor({ disableLabelColor: true }, undefined)).toBe(undefined);
   });
 });

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -5989,20 +5989,17 @@ describe("hide by condition, through the card's own entry points", () => {
 });
 
 describe("item label color (itemLabelColor)", () => {
-  it("returns the state color by default when disableLabelColor is false", () => {
+  it("returns the state color by default when disableLabelColor is false or omitted", () => {
     expect(itemLabelColor({ disableLabelColor: false }, "#ff0000")).toBe("#ff0000");
-  });
-
-  it("returns the state color when disableLabelColor is omitted", () => {
     expect(itemLabelColor({}, "#ff0000")).toBe("#ff0000");
   });
 
-  it("suppresses the state color and returns undefined when disableLabelColor is true", () => {
+  it("returns undefined when disableLabelColor is true and custom color is off", () => {
+    expect(itemLabelColor({ disableLabelColor: true, useCustomLabelColor: false }, "#ff0000")).toBe(undefined);
     expect(itemLabelColor({ disableLabelColor: true }, "#ff0000")).toBe(undefined);
   });
 
-  it("returns undefined when no state color is provided, regardless of the toggle", () => {
-    expect(itemLabelColor({ disableLabelColor: false }, undefined)).toBe(undefined);
-    expect(itemLabelColor({ disableLabelColor: true }, undefined)).toBe(undefined);
+  it("returns the custom color when both toggles are true", () => {
+    expect(itemLabelColor({ disableLabelColor: true, useCustomLabelColor: true, labelCustomColor: "#00ff00" }, "#ff0000")).toBe("#00ff00");
   });
 });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1481,14 +1481,16 @@ export function itemLabelSize(v: unknown): number {
   return Math.min(40, Math.max(8, cssNumber(v, DEFAULT_LABEL_SIZE)));
 }
 /**
- * Resolves the label color for an item, respecting the `disableLabelColor` toggle.
- * When disabled, it returns undefined so the label falls back to the theme default.
+ * Resolves the label color for an item, respecting disableLabelColor,
+ * useCustomLabelColor, and any custom color set.
  */
 export function itemLabelColor(
-  item: { disableLabelColor?: boolean },
+  item: { disableLabelColor?: boolean; useCustomLabelColor?: boolean; labelCustomColor?: string },
   stateColor: string | undefined
 ): string | undefined {
-  return item.disableLabelColor ? undefined : stateColor;
+  if (!item.disableLabelColor) return stateColor;
+  if (!item.useCustomLabelColor) return undefined;
+  return cssColor(item.labelCustomColor) ?? undefined;
 }
 
 /** Clamp a config area `labelSize` to the same 8–40 range item labels use. */

--- a/src/render.ts
+++ b/src/render.ts
@@ -1480,6 +1480,16 @@ export function editorItemLabel(
 export function itemLabelSize(v: unknown): number {
   return Math.min(40, Math.max(8, cssNumber(v, DEFAULT_LABEL_SIZE)));
 }
+/**
+ * Resolves the label color for an item, respecting the `disableLabelColor` toggle.
+ * When disabled, it returns undefined so the label falls back to the theme default.
+ */
+export function itemLabelColor(
+  item: { disableLabelColor?: boolean },
+  stateColor: string | undefined
+): string | undefined {
+  return item.disableLabelColor ? undefined : stateColor;
+}
 
 /** Clamp a config area `labelSize` to the same 8–40 range item labels use. */
 export function areaLabelSize(v: unknown): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -630,6 +630,8 @@ export interface FloorItem {
   activeColor?: string;
   /** new option to prevent using the state color for the label too */
   disableLabelColor?: boolean;
+  useCustomLabelColor?: boolean;
+  labelCustomColor?: string;
   /** Ripple ring color (CSS/hex). Falls back to `activeColor`, then the primary color. */
   rippleColor?: string;
   /** Max ripple ring diameter in pixels. Default 80. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -658,8 +658,11 @@ export interface FloorItem {
    */
   activeColor?: string;
   /** new option to prevent using the state color for the label too */
+  /** Disables the state-driven color inheritance for the label, falling back to the default theme text color. */
   disableLabelColor?: boolean;
+  /** Activates a custom color override for the label. Only applies when disableLabelColor is true. */
   useCustomLabelColor?: boolean;
+  /** The specific custom color applied to the label when useCustomLabelColor is true. */
   labelCustomColor?: string;
   /** Ripple ring color (CSS/hex). Falls back to `activeColor`, then the primary color. */
   rippleColor?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -628,6 +628,8 @@ export interface FloorItem {
    * Same meaning as {@link Opening.activeColor}.
    */
   activeColor?: string;
+  /** new option to prevent using the state color for the label too */
+  disableLabelColor?: boolean;
   /** Ripple ring color (CSS/hex). Falls back to `activeColor`, then the primary color. */
   rippleColor?: string;
   /** Max ripple ring diameter in pixels. Default 80. */


### PR DESCRIPTION
### Description

This PR introduces a new configuration option, `disableLabelColor`, which allows users to disable label color customization for specific items.

By default, item label texts automatically inherit the active or state-driven color. While useful for status indication, this can sometimes impact readability or clash with a clean dashboard design. With this toggle, the label text remains locked to its default theme color, while the icon and badge continue to reflect dynamic state colors.

Additionally, this release adds support for a custom fixed label color ("Own color" via `useCustomLabelColor` and `labelCustomColor`) and ensures complete synchronization and rendering parity between the Visual Editor and the live dashboard card.

---

### Changes Made

* **Types & Editor**: Added the `disableLabelColor`, `useCustomLabelColor`, and `labelCustomColor` fields to `FloorItem` and integrated them into Group 3 (`itemLabelForm`) of the visual editor (`editor-forms.ts`).
* **Rendering Logic**: 
  * Updated `floorplan-card.ts` and `render.ts` to respect `disableLabelColor` and custom label colors.
  * Implemented a stable `hassContext` (`renderHass ?? this.hass`) and ensured `renderHass` is correctly passed in `_renderItem`, fixing regressions where badge values and certain icons failed to render on the live card.
* **Build & Code Hygiene**: Restored pristine build and configuration files (`package.json`, `package-lock.json`, `vite.config.ts`) to upstream defaults.
* **Testing & Quality**: Verified that 1,300+ unit tests pass successfully and `npm run typecheck` runs completely clean.

**Normal behavior**
<img width="550" height="392" alt="Bildschirmfoto 2026-09-01 um 19 47 55" src="https://github.com/user-attachments/assets/30271b18-5292-4668-b821-845ebeea8f57" />
<img width="156" height="477" alt="Bildschirmfoto 2026-09-01 um 19 53 06" src="https://github.com/user-attachments/assets/fc9f33e9-b3e9-442d-875f-9588c3b5c191" />


**New behavior**
<img width="550" height="392" alt="Bildschirmfoto 2026-09-01 um 19 47 47" src="https://github.com/user-attachments/assets/393922f7-1dc6-48e0-a148-012baabc0850" />

<img width="156" height="477" alt="Bildschirmfoto 2026-09-01 um 19 52 45" src="https://github.com/user-attachments/assets/200d58ac-2a38-43aa-9188-e41ab4b27914" />

**- added function to select specific own color.**

**without "own color"**
<img width="171" height="187" alt="Bildschirmfoto 2026-09-02 um 21 44 57" src="https://github.com/user-attachments/assets/f0f71c71-b3aa-402f-8fd6-7563ef569c72" />
<img width="492" height="185" alt="Bildschirmfoto 2026-09-02 um 21 44 00" src="https://github.com/user-attachments/assets/56ff212e-25c3-43d7-8ab1-fa637afa3007" />

**with "own color" active **
<img width="492" height="219" alt="Bildschirmfoto 2026-09-02 um 21 44 36" src="https://github.com/user-attachments/assets/ecfc7b47-1091-41f6-82f0-68dfedc1a88c" />
<img width="171" height="187" alt="Bildschirmfoto 2026-09-02 um 21 44 46" src="https://github.com/user-attachments/assets/1555ff13-6c79-471f-90ec-330efed2b778" />

