### PR TITLE
An idle HVAC keeps its colour but stops spinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ distorted anyway.
 | `size`        | number                                 | `34`         | Icon badge diameter (px).                              |
 | `angle`       | number                                 | `0`          | Icon rotation (deg).                                   |
 | `display`     | `badge` \| `ripple` \| `iconRipple`    | `badge`      | How the device is drawn. The editor spells this as the **Ripple** toggle (plus **Badge shows: Nothing** for `ripple`) and offers it only on devices that detect something where they sit (see [Presence ripples](#presence-ripples)); in YAML it works on any entity. |
-| `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. The editor spells this as the icon options of **Badge shows**, showing `auto` as whatever it resolves to. |
+| `iconAnimation` | `auto` \| `none` \| `spin` \| `pulse` | `auto`       | Animate the icon while active. `auto`: fan spins; media player / vacuum pulse. A `climate` entity animates only while its `hvac_action` says it is working — an AC holding `cool` at temperature keeps its colour but stops moving. The editor spells this as the icon options of **Badge shows**, showing `auto` as whatever it resolves to. |
 | `activeColor` | string                                 | theme color  | Badge color while on. Ignored while `stateColor` rules match. |
 | `rippleColor` | string                                 | `activeColor`| Ripple ring color, falling back to `activeColor` then the primary color. |
 | `rippleSize`  | number                                 | `80`         | Max ripple diameter (px).                              |
@@ -1505,6 +1505,34 @@ npm test           # vitest (pure-logic tests; no browser)
 
 Releases are built and attached automatically by GitHub Actions when a GitHub release
 is published.
+
+### What the suite does not cover
+
+The tests run in node against the pure modules — geometry, config migration, rendering
+decisions, the frame coalescer with an injected scheduler. That covers most of the
+codebase, and it runs in about a second.
+
+It does **not** cover the editor's gesture wiring in [`src/editor.ts`](src/editor.ts):
+the pointerdown/move/up listeners, pointer capture, what gets queued for the next frame,
+and what happens to an in-flight drag on teardown. Those are verified by reading and by
+hand, so a green suite says nothing about them (issue
+[#233](https://github.com/nicosandller/easy-floorplan/issues/233)).
+
+**Changing anything on a drag path therefore needs manual verification in a real
+browser** — [`npm run ha`](#local-home-assistant) is the way — and the check has to
+include a moving viewport, because that is where these bugs live. Drag an element while
+the canvas scrolls under it: positions are mapped through the SVG's live
+`getScreenCTM()`, so anything deferred by a frame resolves against a matrix that may have
+moved since. A 150px wheel scroll mid-drag is enough to turn an 8-unit move into a
+288-unit one.
+
+A DOM shim is not a shortcut past this. Both candidates were measured against these
+exact needs: jsdom has no `getScreenCTM` at all, and happy-dom has one that always
+returns the identity matrix with a canvas that can never scroll — so a regression test
+for the bug above would run, pass, and prove nothing. Real coverage here means a real
+browser (`@vitest/browser` with the Playwright provider, as a second vitest project);
+that has been prototyped successfully but is not wired up, and the CI weight is the open
+question. Until it is, this section is the honest version.
 
 ### Local Home Assistant
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4196,7 +4196,7 @@ export class FloorplanCardEditor extends LitElement {
     // Live preview: the icon animates exactly when the card would animate it
     // (entity currently active), so the "Badge shows" dropdown shows its
     // effect without leaving the editor.
-    const anim = resolveIconAnimation(it, st?.state);
+    const anim = resolveIconAnimation(it, st?.state, st?.attributes);
     // Every measure the card expresses in canvas units, expressed the same way
     // here (issue #192) — the badge box, the value inside it, the glyph, the
     // ripple and the label below.

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -523,10 +523,8 @@ export class FloorplanCard extends LitElement {
     // Animation goes on the inner ha-icon, not the badge: the badge carries
     // the user's `angle` rotation, and a spin on the same element would
     // overwrite it.
-    const anim = resolveIconAnimation(
-      item,
-      item.entity ? this.hass?.states[item.entity]?.state : undefined,
-    );
+    const st = item.entity ? this.hass?.states[item.entity] : undefined;
+    const anim = resolveIconAnimation(item, st?.state, st?.attributes);
     // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
     // state colour, ripple stacking all unchanged — with the glyph swapped for
     // the number. A device with nothing numeric to show keeps its icon.

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1787,6 +1787,59 @@ describe("resolveIconAnimation (issue #48)", () => {
     expect(resolveIconAnimation({ entity: "climate.ac" }, "off")).toBeUndefined();
   });
 
+  it("a climate entity animates only while hvac_action says it is working (issue #235)", () => {
+    // The reported case: an AC set to "cool" that has reached its setpoint
+    // reports state "cool" with hvac_action "idle". The mode is a setting,
+    // not moving air, so a spin there is a claim the unit is not making.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "cool", {
+        hvac_action: "idle",
+      }),
+    ).toBeUndefined();
+    // Same unit a minute later, actually cooling: the spin is true again.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "cool", {
+        hvac_action: "cooling",
+      }),
+    ).toBe("spin");
+    // Every other working action counts the same way.
+    for (const action of ["heating", "drying", "fan", "preheating", "defrosting"]) {
+      expect(
+        resolveIconAnimation({ entity: "climate.ac", iconAnimation: "pulse" }, "heat", {
+          hvac_action: action,
+        }),
+      ).toBe("pulse");
+    }
+    // "off" as an action is the same story as idle: nothing is running.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "cool", {
+        hvac_action: "off",
+      }),
+    ).toBeUndefined();
+    // fan_only's own spin is gated too — a stopped fan is not spinning
+    // whatever the mode says — but still plays while the fan runs.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac" }, "fan_only", { hvac_action: "idle" }),
+    ).toBeUndefined();
+    expect(
+      resolveIconAnimation({ entity: "climate.ac" }, "fan_only", { hvac_action: "fan" }),
+    ).toBe("spin");
+    // An integration that reports no hvac_action at all keeps animating:
+    // the attribute is optional, and going quiet on those would be a second
+    // regression to fix the first.
+    expect(
+      resolveIconAnimation({ entity: "climate.ac", iconAnimation: "spin" }, "cool", {
+        current_temperature: 20,
+      }),
+    ).toBe("spin");
+    expect(resolveIconAnimation({ entity: "climate.ac" }, "fan_only", {})).toBe("spin");
+    // The gate is climate-only: a fan entity has no hvac_action to consult,
+    // and an unrelated domain that happens to carry one is not a thermostat.
+    expect(
+      resolveIconAnimation({ entity: "fan.ceiling" }, "on", { hvac_action: "idle" }),
+    ).toBe("spin");
+  });
+
   it("a forced spin plays for a climate entity running in any mode (issue #206)", () => {
     // The reported bug exactly: an AC in "cool" with iconAnimation: "spin"
     // read as off (entityIsActive didn't know "cool" from "off") and never

--- a/src/render.ts
+++ b/src/render.ts
@@ -1750,27 +1750,65 @@ export function domainIconAnimation(entity: string | undefined): "spin" | "pulse
 }
 
 /**
+ * The `hvac_action` values that mean a climate entity is switched on but not
+ * moving any air or heat right now — HA's own HVACAction enum, whose other
+ * members (heating, cooling, drying, preheating, defrosting, fan) all
+ * describe work in progress.
+ */
+const CLIMATE_IDLE_ACTIONS = new Set(["idle", "off"]);
+
+/**
+ * Whether a climate entity is doing something *right now*, as opposed to
+ * merely being set to a mode (issue #235, @GhislainC). Its state is the mode
+ * the user asked for — a thermostat sitting at temperature reads "cool" all
+ * night — while `hvac_action` is what the hardware is doing about it, so a
+ * unit that has reached its setpoint reports `cool` / `idle` together.
+ *
+ * An entity that reports no `hvac_action` at all is treated as working: the
+ * attribute is optional in HA, and the alternative is to silently stop
+ * animating every integration that omits it.
+ */
+function climateIsWorking(attributes: Record<string, unknown> | undefined): boolean {
+  const action = attributes?.["hvac_action"];
+  if (typeof action !== "string") return true;
+  return !CLIMATE_IDLE_ACTIONS.has(action);
+}
+
+/**
  * Which animation an item's icon should play right now, or undefined for
  * none. Shared by card and editor. Never animates an inactive (or
  * unavailable) entity — including when the config forces "spin"/"pulse": a
  * spinning fan icon is a claim that the fan is running, so it obeys the same
  * fail-closed rule as the active highlight ({@link entityIsActive}).
  *
+ * A climate entity extends that same claim one step further (issue #235): its
+ * mode is a *setting*, not a fact about moving air, so an idle unit holding
+ * "cool" animates nothing however `iconAnimation` is set. The badge still
+ * lights — {@link entityIsActive} is untouched, so the AC still reads as on,
+ * it just stops pretending to blow. Only the animation is gated, and only
+ * when the entity actually reports `hvac_action`.
+ *
  * A climate entity in `fan_only` spins regardless of `iconAnimation`
  * (issue #206 follow-up) — its own fan is what's actually running, the same
  * physical fact that makes a `fan` domain entity spin by default, just
  * decided from this entity's *state* rather than its domain. `none` still
  * wins over it: that is a decision to show no animation at all, not a
- * preference between spin and pulse for this one to override.
+ * preference between spin and pulse for this one to override. It is gated by
+ * `hvac_action` like every other mode: a fan that has stopped is not spinning
+ * whatever the mode says.
  */
 export function resolveIconAnimation(
   item: { entity?: string; iconAnimation?: IconAnimation },
   state: string | undefined,
+  attributes?: Record<string, unknown>,
 ): "spin" | "pulse" | undefined {
   const mode = item.iconAnimation ?? "auto";
   if (mode === "none") return undefined;
   if (!entityIsActive(item.entity, state)) return undefined;
-  if (item.entity?.split(".")[0] === "climate" && state === "fan_only") return "spin";
+  if (item.entity?.split(".")[0] === "climate") {
+    if (!climateIsWorking(attributes)) return undefined;
+    if (state === "fan_only") return "spin";
+  }
   if (mode === "spin" || mode === "pulse") return mode;
   return domainIconAnimation(item.entity);
 }


### PR DESCRIPTION
Both open `bug` issues, reviewed. One is a regression with a code fix; the other is a coverage gap whose honest answer is a doc note.

## #235 — HVAC icons spin while the unit is idle

@GhislainC upgraded and every climate badge with an animation started moving and would not stop.

The cause is the fix for #206 (9502f81). Before it, `entityIsActive` only recognised the literal `"on"`, so a climate entity — whose state *is* its HVAC mode — always read as off and never animated at all, whatever `iconAnimation` said. Adding climate's real active states corrected the colour, and in the same stroke woke up every animation those configs had been carrying silently.

The colour is right. The animation is the part that overreaches: a climate entity's state is the mode the user *asked for*, not a fact about moving air. A thermostat that has reached its setpoint sits in `cool` all night with `hvac_action: idle` — exactly the entity in the issue. Colouring that badge is true (the unit is on); spinning it claims the fan is turning when it is not.

So the animation consults `hvac_action`, and nothing else changes:

- `idle` / `off` → no animation, whatever `iconAnimation` says.
- every working action (`heating`, `cooling`, `drying`, `preheating`, `defrosting`, `fan`) → animates as before.
- `entityIsActive` is **untouched**, so an idle unit keeps its active colour exactly as it looks today — the "coloured but still" the issue asked for.
- `fan_only`'s forced spin is gated the same way: a stopped fan is not spinning whatever the mode says.
- an entity reporting **no** `hvac_action` keeps animating. The attribute is optional in HA, and going quiet on every integration that omits it would be a second regression in the shape of a fix for the first.

The gate is climate-only and lives in `resolveIconAnimation`, so card and editor preview stay in step. Both call sites now pass the entity's attributes through.

Nine assertions cover it in `render.test.ts`, including the reported entity verbatim, the no-attribute fallback, and a `fan` entity carrying a stray `hvac_action` (not a thermostat, still spins).

## #233 — editor gesture wiring is untested

No code change. @sasha-id's write-up is right about the gap and right that a DOM shim would widen it, and it offers "not worth the CI weight" as an acceptable answer with a note in CONTRIBUTING as the honest fallback. This PR takes that path: the repo has no CONTRIBUTING file, so the note goes in README's **Development** section, where the test commands already are.

It says what the node suite does not cover (the pointer listeners, capture, frame queueing and teardown in `editor.ts`), that changing a drag path needs manual verification in a real browser **with a moving viewport**, why — the live `getScreenCTM()`, with the measured 8-units-intended/288-units-moved number — and why jsdom and happy-dom do not help. The `@vitest/browser` + Playwright route is named as the real answer, prototyped but unwired, with the CI weight left as the open question, so the next person neither assumes the green suite covered them nor rediscovers the shim dead-end.

That leaves the harness PR to @sasha-id, who already has the working one.

## Verification

`npm run typecheck`, `npm test` (1241 passing), `npm run build` all clean.

Closes #235.
Addresses #233 — leaving it open for the browser-harness decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)