### PR TITLE
Windows: one that does not open, and one whose sash is not the whole window

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,14 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   for one sash. The swing arc draws on as the leaf travels.
 - **Partial** — a `cover` reporting `current_position` (0–100) is drawn partly open and
   tracks the position live. Everything else uses the on/off behavior above.
-- **Motion** — **swing** (default), **slide**, or **roll** (a slatted curtain that thins
-  onto its track). Sliding openings take a **Style**, and which one you want comes down to
-  where the panels go and what is left clear:
+- **Motion** — **swing** (default), **slide**, **roll** (a slatted curtain that thins onto
+  its track), or **fixed** — a window that does not open at all: a bay window, a picture
+  window, a sealed pane. A fixed window is drawn as jambs and glass with no leaf and no
+  arc, ignores a bound sensor for its drawing (bind one anyway if you want the tap target
+  or the badge), and is never a gap — though it still lets the daylight straight through,
+  because it is still glass. Offered on windows; a door that cannot open is a wall.
+  Sliding openings take a **Style**, and which one you want comes down to where the panels
+  go and what is left clear:
 
   | Style | Panels | Where they go | What clears |
   | --- | --- | --- | --- |
@@ -222,6 +227,12 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   switch covers both, and a tap still acts on the first. A lamp's pool follows the leaves
   too: with one open, the light comes through *that* leaf's half of the doorway rather
   than the middle.
+- **Sash width** — when only part of a window opens and the rest is fixed glass, set
+  **Sash width** to the share of the frame the sash actually covers. The sash is drawn at
+  that width, hinged at its own jamb, sweeping an arc to match, and the remainder is drawn
+  as a fixed pane — so a narrow casement in a wide frame stops swinging the whole width of
+  the glass. Single-sash swing openings only: a double already splits the frame between
+  its two leaves. **Hinge** moves the sash and its pane together.
 - **Orientation** — **Hinge** (left / right) and **Opens** (this side / other side) face a
   swing door any of four ways; they're pure mirrors (`flipH` / `flipV`), so the animation
   follows.
@@ -433,9 +444,10 @@ distorted anyway.
 | ------------- | --------------------------- | ------------------------------------------------------ |
 | `id`          | string                      | Unique id.                                             |
 | `type`        | `door` \| `window`          | The kind of opening.                                   |
-| `motion`      | `swing` \| `slide` \| `roll` | How it moves: hinged (default), sliding panels, or a roll-up curtain (garage / roller shutter). |
+| `motion`      | `swing` \| `slide` \| `roll` \| `fixed` | How it moves: hinged (default), sliding panels, a roll-up curtain (garage / roller shutter), or `fixed` — a window that does not open (bay, picture, sealed pane). A fixed opening draws no leaf and no arc, ignores `entity` for its drawing, and never counts as a gap; glazing still applies, so it passes daylight like the glass it is. |
 | `sunlight`    | boolean                     | `false` takes this opening out of [Sunlight](#sunlight) entirely — it admits no light and blocks it like wall, however open it is drawn. Editor: **Lets sunlight in**. For the solid door with no sensor, which the plan draws open. |
 | `glazed`      | boolean                     | Lets sunlight through even when shut. Defaults per type — a window is glass, a door is not. Set `true` on a **patio or French door**, which is drawn as a door because that is how it swings but is a wall of glass; set `false` on an opaque window like a glass-brick panel or a hatch, which then admits light only as far as it is open. Only [Sunlight](#sunlight) reads it. |
+| `sashSpan`    | number (0–1)                | Share of the opening the operable sash covers; the rest is drawn as a fixed pane. Default 1 (the sash fills the frame). Single-sash swing openings only — a double already splits the frame between its leaves. The sash hangs at the hinge jamb, so `flipH` moves it and its pane together, and a half-width sash swung wide open clears half the opening rather than all of it. |
 | `sash`        | `single` \| `double`        | Swing openings only: how many hinged leaves. The default differs by type, because the ordinary cases do — a window opens with `double` (two casement sashes), a door with `single` (one leaf across the opening). Set it to draw a single-sash window or a **double door**; both leaves then hinge at their own jamb and trace their own arc. Ignored by sliding and rolling openings. |
 | `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |

--- a/README.md
+++ b/README.md
@@ -227,12 +227,14 @@ window, a `blind` → a slider, a `garage` or `shutter` → a roll-up); adjust a
   switch covers both, and a tap still acts on the first. A lamp's pool follows the leaves
   too: with one open, the light comes through *that* leaf's half of the doorway rather
   than the middle.
-- **Sash width** — when only part of a window opens and the rest is fixed glass, set
-  **Sash width** to the share of the frame the sash actually covers. The sash is drawn at
-  that width, hinged at its own jamb, sweeping an arc to match, and the remainder is drawn
-  as a fixed pane — so a narrow casement in a wide frame stops swinging the whole width of
-  the glass. Single-sash swing openings only: a double already splits the frame between
-  its two leaves. **Hinge** moves the sash and its pane together.
+- **Sash width** (**Leaf width** on a door) — when only part of the opening actually
+  moves and the rest is fixed, set this to the share of the frame the operable leaf
+  covers, `0.05`–`1`. The leaf is drawn at that width, hinged at its own jamb, sweeping an
+  arc to match, and the remainder is drawn as a fixed pane — so a narrow casement in a
+  wide frame stops swinging the whole width of the glass, and a sidelight door stops
+  swinging its fixed panel. The pane follows the type: thin glass on a window, solid on a
+  door. Single-leaf swing openings only — a double already splits the frame between its
+  two leaves. **Hinge** moves the leaf and its pane together.
 - **Orientation** — **Hinge** (left / right) and **Opens** (this side / other side) face a
   swing door any of four ways; they're pure mirrors (`flipH` / `flipV`), so the animation
   follows.
@@ -447,7 +449,7 @@ distorted anyway.
 | `motion`      | `swing` \| `slide` \| `roll` \| `fixed` | How it moves: hinged (default), sliding panels, a roll-up curtain (garage / roller shutter), or `fixed` — a window that does not open (bay, picture, sealed pane). A fixed opening draws no leaf and no arc, ignores `entity` for its drawing, and never counts as a gap; glazing still applies, so it passes daylight like the glass it is. |
 | `sunlight`    | boolean                     | `false` takes this opening out of [Sunlight](#sunlight) entirely — it admits no light and blocks it like wall, however open it is drawn. Editor: **Lets sunlight in**. For the solid door with no sensor, which the plan draws open. |
 | `glazed`      | boolean                     | Lets sunlight through even when shut. Defaults per type — a window is glass, a door is not. Set `true` on a **patio or French door**, which is drawn as a door because that is how it swings but is a wall of glass; set `false` on an opaque window like a glass-brick panel or a hatch, which then admits light only as far as it is open. Only [Sunlight](#sunlight) reads it. |
-| `sashSpan`    | number (0–1)                | Share of the opening the operable sash covers; the rest is drawn as a fixed pane. Default 1 (the sash fills the frame). Single-sash swing openings only — a double already splits the frame between its leaves. The sash hangs at the hinge jamb, so `flipH` moves it and its pane together, and a half-width sash swung wide open clears half the opening rather than all of it. |
+| `sashSpan`    | number (0.05–1)             | Share of the opening the operable leaf covers; the rest is drawn as a fixed pane — thin glass on a window, a solid panel on a door. Default 1 (the leaf fills the frame). Single-**leaf** swing openings, doors included — a double already splits the frame between its leaves. The leaf hangs at the hinge jamb, so `flipH` moves it and its pane together, and a half-width leaf swung wide open clears half the opening rather than all of it. Values below `0.05` are clamped to it: a leaf of no width is a fixed pane, which `motion: fixed` says properly. |
 | `sash`        | `single` \| `double`        | Swing openings only: how many hinged leaves. The default differs by type, because the ordinary cases do — a window opens with `double` (two casement sashes), a door with `single` (one leaf across the opening). Set it to draw a single-sash window or a **double door**; both leaves then hinge at their own jamb and trace their own arc. Ignored by sliding and rolling openings. |
 | `shutterEntity` | string                     | An external shutter over the same gap (`cover` or contact), with its own open/closed state. With `entity` bound too, the card draws the shutter's own icon beside the opening — open/closed in both glyph and colour — and tapping that icon opens the shutter. |
 | `shutterStyle` | `swing` \| `roll`           | Louvered panels or a roll-up curtain. Defaults from the entity (contact → `swing`, `cover` → `roll`). |

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -122,6 +122,54 @@ describe("openingForm", () => {
     expect(names).not.toContain("slide");
   });
 
+  it("offers Fixed on a window and not on a door (issue #218)", () => {
+    // A door that cannot open is a wall; offering it would only invite one.
+    const optsOf = (o: Opening) => {
+      const f = openingForm(o).fields.find((x) => x.name === "motion")!;
+      return (f.selector as { select: { options: { value: string }[] } }).select.options.map(
+        (x) => x.value,
+      );
+    };
+    expect(optsOf({ ...door, type: "window" } as Opening)).toContain("fixed");
+    expect(optsOf(door)).not.toContain("fixed");
+  });
+
+  it("asks for the sash's share only where there is a leftover pane (issue #218)", () => {
+    const win = { ...door, type: "window" } as Opening;
+    const names = (o: Opening) => openingForm(o).fields.map((x) => x.name);
+    expect(names({ ...win, sash: "single" } as Opening)).toContain("sashSpan");
+    // A double already splits the frame between its two leaves.
+    expect(names({ ...win, sash: "double" } as Opening)).not.toContain("sashSpan");
+    // Sliders, roll-ups and a fixed pane have nothing that swings.
+    expect(names({ ...win, motion: "slide" } as Opening)).not.toContain("sashSpan");
+    expect(names({ ...win, motion: "fixed" } as Opening)).not.toContain("sashSpan");
+  });
+
+  it("keeps a full-width sash and a swing motion out of the YAML (issue #218)", () => {
+    const form = openingForm({ ...door, type: "window", sash: "single" } as Opening);
+    expect(form.toPatch({ sashSpan: 1 })).toEqual({ sashSpan: undefined });
+    expect(form.toPatch({ sashSpan: 0.4 })).toEqual({ sashSpan: 0.4 });
+  });
+
+  it("drops the sash's share when the opening stops swinging (issue #218)", () => {
+    const win = { ...door, type: "window", sash: "single", sashSpan: 0.4 } as Opening;
+    const form = openingForm(win);
+    expect(form.toPatch({ motion: "fixed" })).toMatchObject({
+      motion: "fixed",
+      sashSpan: undefined,
+    });
+    expect(form.toPatch({ motion: "slide" })).toMatchObject({ sashSpan: undefined });
+    // A patch says only what changes, so "cleared" is the key present and
+    // undefined — while *absent* means the sash keeps the width it had. Still
+    // swinging is the second of those, and asserting it loosely would not
+    // tell the two apart.
+    expect("sashSpan" in form.toPatch({ motion: "swing" })).toBe(false);
+    // And a second sash leaves no remainder to describe.
+    const twoSash = form.toPatch({ sash: "double" });
+    expect("sashSpan" in twoSash).toBe(true);
+    expect(twoSash.sashSpan).toBeUndefined();
+  });
+
   it("sliding opening shows slide + style, hides hinge; biparting hides slide", () => {
     const slide = openingForm({ ...door, motion: "slide" } as Opening).fields.map((x) => x.name);
     expect(slide).toContain("slide");
@@ -1727,7 +1775,7 @@ describe("areaForm — actions on rooms (issue #181)", () => {
 // each form can produce appears in exactly one of them.
 describe("every field lands in exactly one panel group", () => {
   const OPENING_GROUPS = [
-    ["type", "motion", "length", "sash", "hinge", "opens", "slide", "style", "angle"],
+    ["type", "motion", "length", "sash", "sashSpan", "hinge", "opens", "slide", "style", "angle"],
     ["entity", "secondaryEntity", "invert"],
     ["glazed", "sunlight"],
     [
@@ -1770,6 +1818,8 @@ describe("every field lands in exactly one panel group", () => {
       { type: "window", sash: "single", entity: "binary_sensor.a" },
       { motion: "slide", sliderStyle: "biparting", entity: "binary_sensor.a" },
       { motion: "roll", entity: "cover.g" },
+      { type: "window", motion: "fixed" },
+      { type: "window", sash: "single", sashSpan: 0.4 },
       { shutterEntity: "binary_sensor.s", shutterStyle: "swing" },
       { shutterEntity: "cover.s", shutterStyle: "roll", entity: "binary_sensor.a" },
       { entity: "binary_sensor.a", showIcon: true },

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -145,6 +145,20 @@ describe("openingForm", () => {
     expect(names({ ...win, motion: "fixed" } as Opening)).not.toContain("sashSpan");
   });
 
+  it("names the field for the opening it is on (review of #218)", () => {
+    // Offered on doors as well — a sidelight door is ordinary — but a door's
+    // remainder is a panel, not glass, so the wording has to follow the type.
+    const win = openingForm({ ...door, type: "window", sash: "single" } as Opening);
+    const dr = openingForm({ ...door, sash: "single" } as Opening);
+    const f = (spec: ReturnType<typeof openingForm>) =>
+      spec.fields.find((x) => x.name === "sashSpan")!;
+    expect(f(win).label).toBe("Sash width");
+    expect(f(win).helper).toContain("glass");
+    expect(f(dr).label).toBe("Leaf width");
+    expect(f(dr).helper).toContain("panel");
+    expect(f(dr).helper).not.toContain("glass");
+  });
+
   it("keeps a full-width sash and a swing motion out of the YAML (issue #218)", () => {
     const form = openingForm({ ...door, type: "window", sash: "single" } as Opening);
     expect(form.toPatch({ sashSpan: 1 })).toEqual({ sashSpan: undefined });

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -48,6 +48,7 @@ import {
   normalizePlanRotation,
   openingActionForGesture,
   openingMotion,
+  MIN_SASH_SPAN,
   openingHasTwoLeaves,
   sliderStyleHasTwoLeaves,
   pressEffectOf,
@@ -239,7 +240,13 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         // Not "garage / shutter": an external shutter is the Shutter field
         // below, a layer over any opening, and naming it here read as the
         // place to set one up.
-        opt("roll", "Roll up (garage)")
+        opt("roll", "Roll up (garage)"),
+        // Windows only (issue #218). A bay or picture window is an ordinary
+        // thing to draw; a door that cannot open is a wall, and offering it
+        // here would only invite drawing one. A hand-written config may still
+        // set it on a door, and the card draws that honestly as a sealed
+        // panel — this is about what the editor suggests, not what it allows.
+        ...(o.type === "window" ? [opt("fixed", "Fixed (does not open)")] : [])
       ),
     },
     { name: "length", label: "Length", required: true, selector: { number: { min: 1, mode: "box" } } },
@@ -258,6 +265,18 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
       selector: door
         ? dropdown(opt("single", "Single (one leaf)"), opt("double", "Double (two leaves)"))
         : dropdown(opt("double", "Double (two leaves)"), opt("single", "Single sash")),
+    });
+  }
+  // How much of the frame actually opens (issue #218). Only a single sash has
+  // a remainder to be fixed: a double already splits the opening between its
+  // two leaves. Left at 1 it writes nothing, so this appears in no YAML that
+  // has not asked for it.
+  if (motion === "swing" && openingSash(o) === "single") {
+    fields.push({
+      name: "sashSpan",
+      label: "Sash width",
+      helper: "Share of the opening that actually opens — the rest is fixed glass",
+      selector: { number: { min: MIN_SASH_SPAN, max: 1, step: 0.05, mode: "slider" } },
     });
   }
   // Glass, for a door. A window never needs asking, and the only thing that
@@ -586,11 +605,17 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
           if (!v) out.icon = undefined;
         }
         else if (k === "motion") {
-          const motion = v === "slide" || v === "roll" ? (v as "slide" | "roll") : undefined;
+          const motion =
+            v === "slide" || v === "roll" || v === "fixed"
+              ? (v as "slide" | "roll" | "fixed")
+              : undefined;
           out.motion = motion;
           // sliderStyle only applies while sliding — drop it when switching
           // away (issue #145).
           if (v !== "slide") out.sliderStyle = undefined;
+          // Nothing swings any more, so the sash's share of the frame has
+          // nothing left to describe (issue #218).
+          if (v !== "swing") out.sashSpan = undefined;
           // The second leaf's sensor goes only if the opening this *becomes*
           // has no second leaf. Asked of the result rather than of the motion,
           // because since issue #159 a hinged double has one too: a two-sensor
@@ -601,6 +626,10 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
             sliderStyle: v === "slide" ? o.sliderStyle : undefined,
           } as Opening))
             out.secondaryEntity = undefined;
+        } else if (k === "sashSpan") {
+          // A full-width sash is what every opening drew before this field,
+          // so it is the default and stays out of the YAML (issue #218).
+          out.sashSpan = typeof v === "number" && v < 1 ? v : undefined;
         } else if (k === "sash") {
           // The two types default the other way round — a window opens with
           // two sashes, a door with one leaf — so only the value that is *not*
@@ -610,6 +639,9 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
           // drive (issue #159).
           if (!openingHasTwoLeaves({ ...o, sash: v as "single" | "double" } as Opening))
             out.secondaryEntity = undefined;
+          // Two sashes already split the opening between them, so there is no
+          // leftover pane for `sashSpan` to describe (issue #218).
+          if (v === "double") out.sashSpan = undefined;
         } else if (k === "shutterStyle") {
           out.shutterStyle = v;
           // Only a hinged pair has a second panel — a roll curtain is one

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -267,15 +267,24 @@ export function openingForm(o: Opening, featuresOf: (entityId: string) => number
         : dropdown(opt("double", "Double (two leaves)"), opt("single", "Single sash")),
     });
   }
-  // How much of the frame actually opens (issue #218). Only a single sash has
+  // How much of the frame actually opens (issue #218). Only a single leaf has
   // a remainder to be fixed: a double already splits the opening between its
-  // two leaves. Left at 1 it writes nothing, so this appears in no YAML that
-  // has not asked for it.
+  // two. Left at 1 it writes nothing, so this appears in no YAML that has not
+  // asked for it.
+  //
+  // Offered on doors as well as windows, unlike `fixed` above. A door leaf
+  // narrower than its frame is an ordinary sidelight door, not a degenerate
+  // case, and `renderOpening` already draws that remainder as a solid panel
+  // rather than glass — so the only thing that would be window-only here is
+  // the wording, which is why the wording is what varies.
   if (motion === "swing" && openingSash(o) === "single") {
     fields.push({
       name: "sashSpan",
-      label: "Sash width",
-      helper: "Share of the opening that actually opens — the rest is fixed glass",
+      label: o.type === "door" ? "Leaf width" : "Sash width",
+      helper:
+        o.type === "door"
+          ? "Share of the opening that actually swings — the rest is a fixed panel"
+          : "Share of the opening that actually opens — the rest is fixed glass",
       selector: { number: { min: MIN_SASH_SPAN, max: 1, step: 0.05, mode: "slider" } },
     });
   }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2118,7 +2118,7 @@ export class FloorplanCardEditor extends LitElement {
    */
   private static readonly OPENING_GROUPS = [
     // What it is, and how it is drawn.
-    ["Shape", ["type", "motion", "length", "sash", "hinge", "opens", "slide", "style", "angle"]],
+    ["Shape", ["type", "motion", "length", "sash", "sashSpan", "hinge", "opens", "slide", "style", "angle"]],
     // Which contacts drive it — the opening's own, before the shutter's.
     ["What it reads", ["entity", "secondaryEntity", "invert"]],
     // How it behaves toward the sun (issue #177), which is neither shape nor

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -1200,6 +1200,18 @@ describe("renderOpening — a sash narrower than its frame (issue #218)", () => 
     expect(full).not.toContain('y1="0" x2=45 y2="0"'); // no fixed pane
   });
 
+  it("a door's remainder is a solid panel, not glass (review of #218)", () => {
+    // A door leaf narrower than its frame is a sidelight door, so the field is
+    // offered on doors too — and what it draws beside the leaf has to be the
+    // door's own solid panel, not the window's thin glass line.
+    const d = svgOf({ type: "door", sash: "single", sashSpan: 0.4 }, { open: true });
+    expect(d).toContain('x1=-9 y1="0" x2=45');
+    expect(d).toContain("stroke-width=2.5"); // solid panel
+    expect(d).not.toContain("stroke-width=1.5"); // not glass
+    // And still no jambs — a door is drawn by its leaf and arc alone.
+    expect(d).not.toContain('stroke-width="2"');
+  });
+
   it("is ignored by a double sash, which has no leftover to fix", () => {
     const two = svgOf({ type: "window", sash: "double", sashSpan: 0.4 } as Partial<Opening>, {
       open: true,

--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -1142,3 +1142,69 @@ describe("renderOpening — the shutter's own accent (issue #74 follow-up)", () 
     expect(swing).toContain("fill:#00ff00");
   });
 });
+
+describe("renderOpening — a window that does not open (issue #218)", () => {
+  const fixed = { type: "window", motion: "fixed" } as Partial<Opening>;
+
+  it("draws jambs and glass, and nothing that could move", () => {
+    const s = svgOf(fixed, { open: true, amount: 1 });
+    expect(s).not.toContain("fp-door-leaf");
+    expect(s).not.toContain("fp-leaf-r");
+    expect(s).not.toContain("fp-door-arc");
+    // Jambs still say "window", and the pane still fills the gap.
+    expect(s).toContain('stroke-width="2"');
+    expect(s).toContain("stroke-width=1.5");
+  });
+
+  it("stays put when a bound sensor says open — there is nothing to open", () => {
+    // The case this exists for: people bind a contact to a fixed pane for the
+    // tap target and the badge. Shut and wide open must draw identically.
+    expect(svgOf(fixed, { open: true, amount: 1 })).toBe(svgOf(fixed, { open: false, amount: 0 }));
+  });
+
+  it("never wears the accent, because no part of it is ever the moving part", () => {
+    const s = svgOf(fixed, { open: true, amount: 1, active: true, accent: "#ff0000" });
+    expect(s).not.toContain("#ff0000");
+  });
+
+  it("a fixed door is a sealed panel: solid, and no jambs to read as glass", () => {
+    const s = svgOf({ type: "door", motion: "fixed" }, { open: true });
+    expect(s).toContain("stroke-width=2.5"); // solid, not the 1.5 of glass
+    expect(s).not.toContain('stroke-width="2"'); // no jambs
+  });
+});
+
+describe("renderOpening — a sash narrower than its frame (issue #218)", () => {
+  const partial = { type: "window", sash: "single", sashSpan: 0.4 } as Partial<Opening>;
+
+  it("draws the sash at its own width, not the frame's", () => {
+    const s = svgOf(partial, { open: true });
+    expect(s).toContain("width=36"); // 90 × 0.4
+    expect(s).not.toContain("width=90");
+  });
+
+  it("fills the rest of the frame with fixed glass", () => {
+    const s = svgOf(partial, { open: true });
+    // Pane runs from where the sash ends (-45 + 36 = -9) to the far jamb.
+    expect(s).toContain('x1=-9 y1="0" x2=45');
+  });
+
+  it("sweeps an arc the sash's own width, hinged at its own jamb", () => {
+    const s = svgOf(partial, { open: true });
+    expect(s).toContain("M -9 0 A 36 36 0 0 0 -45 -36");
+  });
+
+  it("a full-width sash is untouched — the arc it always drew", () => {
+    const full = svgOf({ type: "window", sash: "single" } as Partial<Opening>, { open: true });
+    expect(full).toContain("M 45 0 A 90 90 0 0 0 -45 -90");
+    expect(full).not.toContain('y1="0" x2=45 y2="0"'); // no fixed pane
+  });
+
+  it("is ignored by a double sash, which has no leftover to fix", () => {
+    const two = svgOf({ type: "window", sash: "double", sashSpan: 0.4 } as Partial<Opening>, {
+      open: true,
+    });
+    expect(two).toContain("fp-leaf-r");
+    expect(two).toContain("width=45"); // each leaf still half the opening
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -137,6 +137,8 @@ import {
   wallsLightPassesThrough,
   openingClearFraction,
   openingClearSpan,
+  openingSashSpan,
+  MIN_SASH_SPAN,
   glowClearSpan,
   glowClearFraction,
   renderGlowMask,
@@ -4517,6 +4519,69 @@ describe("lightBadgePaint (#106)", () => {
 // Issue #145 meets #143: a two-panel slider has two sensors and its leaves do
 // not travel the full width, so neither the amount nor the leaf count could be
 // read off `entity` alone.
+describe("a fixed opening and a partial sash, as gaps (issue #218)", () => {
+  const win = (extra: Partial<Opening>) =>
+    ({ id: "o", type: "window", x: 0, y: 0, length: 100, angle: 0, ...extra }) as Opening;
+
+  it("a fixed opening is never a gap, whatever a sensor says", () => {
+    const f = win({ motion: "fixed" });
+    expect(openingClearFraction(f, 0)).toBe(0);
+    expect(openingClearFraction(f, 1)).toBe(0);
+    expect(openingClearSpan(f, 1)).toEqual([0.5, 0.5]);
+  });
+
+  it("but it is still glass, so light goes straight through it", () => {
+    // The distinction the feature turns on: no *airflow* gap, full daylight.
+    const f = win({ motion: "fixed" });
+    expect(glowClearFraction(f, 0)).toBe(1);
+    expect(openingSunFraction(f, openingClearFraction(f, 0))).toBe(1);
+  });
+
+  it("an opaque fixed panel is neither a gap nor a window", () => {
+    const f = win({ motion: "fixed", glazed: false });
+    expect(glowClearFraction(f, 1)).toBe(0);
+    expect(openingSunFraction(f, openingClearFraction(f, 1))).toBe(0);
+  });
+
+  it("a half-width sash swung wide open clears half the opening", () => {
+    const half = win({ sash: "single", sashSpan: 0.5 });
+    expect(openingClearFraction(half, 1)).toBeCloseTo(0.5);
+    expect(openingClearFraction(half, 0.5)).toBeCloseTo(0.25);
+    expect(openingClearFraction(half, 0)).toBe(0);
+  });
+
+  it("and clears it at its own jamb, where the sash is — not in the middle", () => {
+    const half = win({ sash: "single", sashSpan: 0.5 });
+    expect(openingClearSpan(half, 1)).toEqual([0, 0.5]);
+    // flipH hangs the sash on the other jamb, so the clear half moves with it.
+    expect(openingClearSpan(win({ sash: "single", sashSpan: 0.5, flipH: true }), 1)).toEqual([
+      0.5, 1,
+    ]);
+  });
+
+  it("a full-width sash keeps the centred span every plan already lights by", () => {
+    const full = win({ sash: "single" });
+    expect(openingClearFraction(full, 1)).toBe(1);
+    expect(openingClearSpan(full, 0.5)).toEqual([0.25, 0.75]);
+  });
+
+  it("clamps a nonsense span rather than drawing a sliver or an inside-out sash", () => {
+    expect(openingSashSpan(win({ sash: "single", sashSpan: 0 }))).toBe(MIN_SASH_SPAN);
+    expect(openingSashSpan(win({ sash: "single", sashSpan: -3 }))).toBe(MIN_SASH_SPAN);
+    expect(openingSashSpan(win({ sash: "single", sashSpan: 4 }))).toBe(1);
+    expect(openingSashSpan(win({ sash: "single", sashSpan: NaN }))).toBe(1);
+  });
+
+  it("is ignored where there is no leftover pane to describe", () => {
+    // A double splits the frame between its leaves; a slider and a roll-up
+    // have panel arithmetic of their own.
+    expect(openingSashSpan(win({ sash: "double", sashSpan: 0.4 }))).toBe(1);
+    expect(openingSashSpan(win({ motion: "slide", sashSpan: 0.4 }))).toBe(1);
+    expect(openingSashSpan(win({ motion: "roll", sashSpan: 0.4 }))).toBe(1);
+    expect(openingClearFraction(win({ sash: "double", sashSpan: 0.4 }), 1, 1)).toBe(1);
+  });
+});
+
 describe("openingClearFraction (#145 / #143)", () => {
   const slider = (sliderStyle: string): Opening =>
     ({ id: "o", type: "window", motion: "slide", sliderStyle, x: 300, y: 300, length: 200, angle: 0 }) as Opening;

--- a/src/render.ts
+++ b/src/render.ts
@@ -66,6 +66,14 @@ import { OPENING_ON_WALL_EPS } from "./dead-space";
 
 export const WALL_THICKNESS = 8;
 
+/**
+ * The narrowest an operable sash may be drawn, as a fraction of its opening
+ * (issue #218). Not zero: a sash of no width is a fixed pane, which
+ * `motion: "fixed"` says outright, and one drawn at a hair's width would read
+ * as a rendering fault rather than as a choice.
+ */
+export const MIN_SASH_SPAN = 0.05;
+
 /** Shown in place of a reading when an entity is unset or absent from `hass`. */
 const NO_STATE = "—";
 
@@ -664,10 +672,18 @@ function clipWallToBox(
  * and the mean of it is itself.
  */
 export function openingClearFraction(o: Opening, amount: number, secondAmount?: number): number {
+  // Nothing moves, so nothing is ever clear — whatever a bound sensor says
+  // (issue #218). Asked before `amount` is even read, because a fixed pane
+  // with a contact on it is exactly the case that would otherwise open.
+  if (openingMotion(o) === "fixed") return 0;
   const a1 = Math.max(0, Math.min(1, amount));
   const a2 = Math.max(0, Math.min(1, secondAmount ?? amount));
+  // A sash narrower than its frame clears only its own share of the opening
+  // (issue #218): swung fully open, a half-width sash leaves half the glass
+  // still in place. `openingSashSpan` is 1 for everything else, so this is
+  // the identity for every opening that has always filled its frame.
   if (openingMotion(o) === "swing")
-    return openingSash(o) === "double" ? (a1 + a2) / 2 : a1;
+    return openingSash(o) === "double" ? (a1 + a2) / 2 : a1 * openingSashSpan(o);
   switch (sliderStyleOf(o)) {
     case "biparting":
       // Each leaf recesses into its own wall, so between them they can clear
@@ -774,6 +790,16 @@ export function openingClearSpan(
 ): [number, number] {
   const clear = openingClearFraction(o, amount, secondAmount);
   const centred: [number, number] = [(1 - clear) / 2, (1 + clear) / 2];
+  // A sash narrower than its frame is hinged at one jamb with fixed glass
+  // beside it, so what it clears is at *that* jamb — never in the middle,
+  // where the pane is (issue #218). Placed rather than centred because it can
+  // be: `sashSpan` is new config, so no existing plan can light up
+  // differently for it, which is exactly the argument that keeps the centred
+  // approximation for everything below.
+  if (openingSashSpan(o) < 1) {
+    const span: [number, number] = [0, clear];
+    return o.flipH ? [1 - span[1], 1 - span[0]] : span;
+  }
   if (openingMotion(o) !== "swing" || openingSash(o) !== "double") return centred;
   // Each leaf is hinged at its own jamb and covers its own half, so its
   // projection on the wall shrinks toward that jamb as it swings: the first
@@ -2399,11 +2425,29 @@ export function kindFromEntity(entity: string): ItemKind {
 }
 
 /**
- * How an opening moves — `swing` (hinged door / casement window) or `slide`
- * (panels travelling along the wall). Defaults to `swing`.
+ * How an opening moves — `swing` (hinged door / casement window), `slide`
+ * (panels travelling along the wall), `roll` (a curtain leaving the floor
+ * plane) or `fixed` (issue #218: it does not). Defaults to `swing`.
  */
-export function openingMotion(o: Opening): "swing" | "slide" | "roll" {
+export function openingMotion(o: Opening): "swing" | "slide" | "roll" | "fixed" {
   return o.motion ?? "swing";
+}
+
+/**
+ * How much of a single-sash opening its sash covers, 0..1 (issue #218).
+ * Clamped, and 1 for everything that has no leftover pane to speak of: a
+ * double sash splits the opening between its two leaves, and sliders and
+ * roll-ups have panel arithmetic of their own.
+ *
+ * A `sashSpan` of 0 would be a window with no opening part, which is what
+ * `motion: "fixed"` says properly — so it clamps to the smallest sash that
+ * still draws rather than silently becoming a fixed pane.
+ */
+export function openingSashSpan(o: Opening): number {
+  if (openingMotion(o) !== "swing" || openingSash(o) !== "single") return 1;
+  const raw = o.sashSpan;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return 1;
+  return Math.max(MIN_SASH_SPAN, Math.min(1, raw));
 }
 
 /**
@@ -3253,9 +3297,12 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
     // the same markup, which is how the door came to have no way of being a
     // double at all.
     const two = openingSash(o) === "double";
-    // One leaf spans the opening; two split it. The arc radius follows,
-    // because it is the path the leaf's own tip sweeps.
-    const leafW = two ? half : o.length;
+    // One leaf spans the opening; two split it. A single sash may also be
+    // narrower than its frame (issue #218), the rest of which is fixed glass.
+    // The arc radius follows, because it is the path the leaf's own tip
+    // sweeps — a half-width sash sweeps a half-width quarter-circle.
+    const span = openingSashSpan(o);
+    const leafW = two ? half : o.length * span;
     const arcLen = (Math.PI / 2) * leafW;
     // Revealed via stroke-dashoffset so each arc "draws on" as its leaf opens.
     // Each arc is drawn from its own leaf's state, so a pair of casement sashes
@@ -3284,7 +3331,19 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
                 tone2,
                 amt2
               )}`
-            : arc(`M ${half} 0 A ${o.length} ${o.length} 0 0 0 ${-half} ${-o.length}`, tone, amt)
+            : // Hinged at the −x jamb, so the tip starts `leafW` along the wall
+              // and ends `leafW` out from it. At full span that is exactly the
+              // arc this drew before `sashSpan` existed.
+              arc(`M ${-half + leafW} 0 A ${leafW} ${leafW} 0 0 0 ${-half} ${-leafW}`, tone, amt)
+        }
+        ${
+          // The pane the sash does not cover: fixed glass, drawn in the base
+          // colour because it never opens and so is never the active part.
+          // Nothing at full span, which is every opening that predates this.
+          span < 1
+            ? svg`<line x1=${-half + leafW} y1="0" x2=${half} y2="0"
+              stroke=${color} stroke-width=${o.type === "window" ? 1.5 : 2.5} />`
+            : nothing
         }
         <!-- leaf hinged at the left jamb (flipH mirrors it to the right one) -->
         <g transform="translate(${-half} 0)">
@@ -3305,6 +3364,28 @@ export function renderOpening(o: Opening, style: OpeningStyle): SVGTemplateResul
             : nothing
         }
       `;
+  } else if (openingMotion(o) === "fixed") {
+    // A window that does not open (issue #218): a bay window, a picture
+    // window, a sealed pane. Jambs and glass, no leaf, no arc, no track —
+    // there is nothing here that could move, which is the whole statement.
+    //
+    // Drawn from `color` rather than `tone` on purpose: `tone` is the accent a
+    // moving part wears while it is open, and this one is never either. A
+    // fixed pane with a contact bound to it (people do bind them, for the tap
+    // target and the badge) must not light up as though it had swung.
+    const t = o.type === "window" ? 1.5 : 2.5; // glass vs solid panel
+    body = svg`
+        ${
+          o.type === "window"
+            ? svg`
+        <line x1=${-half} y1=${-cutH / 2} x2=${-half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />
+        <line x1=${half} y1=${-cutH / 2} x2=${half} y2=${cutH / 2}
+              stroke=${color} stroke-width="2" />`
+            : nothing
+        }
+        <line x1=${-half} y1="0" x2=${half} y2="0"
+              stroke=${color} stroke-width=${t} />`;
   } else if (openingMotion(o) === "roll") {
     // Roll-up cover — garage door, roller shutter (issues #45 / #47). Unlike a
     // slider nothing travels along the wall: the curtain leaves the floor

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,8 +78,44 @@ export interface Opening {
    * wall (see {@link sliderStyle}); `roll` is a roll-up cover — garage door,
    * roller shutter — whose slatted curtain leaves the floor plane (issue #45),
    * drawn thinning toward the track line as it opens.
+   *
+   * `fixed` is the one that does not move at all (issue #218): a bay window, a
+   * picture window, a glass-brick panel — a hole in the wall filled with glass
+   * and nothing hinged about it. It is a fourth *motion* rather than a flag
+   * because that is what it is the fourth of, and because every other way of
+   * saying it lies: a swing window with no sensor draws shut but still carries
+   * a leaf and an arc, and one bound to a sensor could be told to open.
+   *
+   * A fixed opening ignores `entity` **for its drawing** — nothing to animate —
+   * but keeps everything else an opening has: it is still tappable, still
+   * badges, and still glass to the light. What it never is, is a gap: see
+   * {@link openingClearFraction}, which answers 0 for it whatever a sensor says.
    */
-  motion?: "swing" | "slide" | "roll";
+  motion?: "swing" | "slide" | "roll" | "fixed";
+  /**
+   * How much of the opening the operable sash actually covers, as a fraction
+   * of `length` (0..1]. Default 1 — the sash fills the opening, which is what
+   * every window drew before this existed.
+   *
+   * The case it exists for (issue #218): a window where only part of it opens
+   * and the rest is a fixed pane — one tall casement beside a wide fixed
+   * light, the sash hung in a frame twice its width. Drawn shut the two are
+   * indistinguishable; drawn open the difference is the whole point, because
+   * a sash that swings the full width of the frame is a lie about how much
+   * glass moves.
+   *
+   * Read by **single-sash swing openings only**. A double is two sashes that
+   * already split the opening between them, so there is no leftover to be
+   * fixed; sliders and roll-ups have their own panel arithmetic. The sash
+   * hangs at the hinge jamb and the remainder is drawn as fixed glass, so
+   * `flipH` moves both — the operable half and the pane — as one.
+   *
+   * Sunlight and lamp glow are unaffected: glass admits its whole gap however
+   * the sash sits, which is the rule {@link glowClearFraction} already
+   * applies. What it does change is {@link openingClearFraction} — a half-width
+   * sash swung fully open clears half the opening, not all of it.
+   */
+  sashSpan?: number;
   x: number;
   y: number;
   /** Length along the wall, in virtual units. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,11 +104,16 @@ export interface Opening {
    * a sash that swings the full width of the frame is a lie about how much
    * glass moves.
    *
-   * Read by **single-sash swing openings only**. A double is two sashes that
-   * already split the opening between them, so there is no leftover to be
-   * fixed; sliders and roll-ups have their own panel arithmetic. The sash
-   * hangs at the hinge jamb and the remainder is drawn as fixed glass, so
-   * `flipH` moves both — the operable half and the pane — as one.
+   * Read by **single-leaf swing openings**, doors included — a door leaf
+   * narrower than its frame is an ordinary sidelight door. The remainder
+   * follows the type the rest of the symbol does: thin for a window's glass,
+   * solid for a door's panel. A double is two leaves that already split the
+   * opening between them, so there is no leftover to be fixed; sliders and
+   * roll-ups have their own panel arithmetic. The leaf hangs at the hinge
+   * jamb and the remainder beside it, so `flipH` moves both as one.
+   *
+   * Clamped to {@link MIN_SASH_SPAN}..1: a leaf of no width is a fixed pane,
+   * which `motion: "fixed"` says properly.
    *
    * Sunlight and lamp glow are unaffected: glass admits its whole gap however
    * the sash sits, which is the rule {@link glowClearFraction} already


### PR DESCRIPTION
Closes part of #218.

@alinelena asked for three window shapes. This is two of them. The third — a
top-hung window opening from its top edge — waits on the drawing they offered
to make, and nothing here forecloses it, so #218 stays open.

## What this adds

**`motion: fixed`** — a window that does not open at all: a bay window, a
picture window, a sealed pane. Drawn as jambs and glass, with no leaf and no
arc.

A fourth *motion* rather than a flag, because that is what it is the fourth
of. It ignores `entity` for its drawing — people bind contacts to fixed panes
for the tap target and the badge, and one of those must never swing — but it
is never a gap either: `openingClearFraction` answers 0 for it whatever a
sensor says. It stays glass to the light, which is the distinction that makes
it worth having: no draught, full daylight.

Offered on windows in the editor. A door that cannot open is a wall, and
offering it there would only invite drawing one; a hand-written config may
still set it, and the card draws that honestly as a sealed panel.

**`sashSpan`** — for the window where only part of it opens and the rest is
fixed glass. The sash is drawn at its share of the frame, hinged at its own
jamb, sweeping an arc to match; the remainder is drawn as a fixed pane.
Single-sash swing openings only — a double already splits the frame between
its two leaves.

## Nothing existing moves

The single-leaf arc generalises instead of branching: hinged at the −x jamb
with radius `leafW`, which at full span is *exactly* the path it drew before.
A plan that never sets `sashSpan` renders identically, and a test pins the old
arc (`M 45 0 A 90 90 0 0 0 -45 -90`) to say so.

## Two behavioural calls worth a look

- A half-width sash swung wide open clears **half** the opening, not all of
  it — so `openingClearFraction` multiplies by the span.
- It clears at **the sash's own jamb**, not in the middle. `openingClearSpan`
  centres every gap it is unsure about, on purpose, because moving those would
  relight existing plans. `sashSpan` is new config, so nothing can regress —
  the same argument #219 used to place the double door's open leaf.

## Tests

`npm test` — 1271 pass (1250 before, 21 new). `npm run typecheck` and
`npm run build` clean.

New coverage: a fixed opening drawing identically at `amount` 0 and 1; never
wearing the accent; a fixed door as a solid panel; sash width, pane and arc
geometry; the full-span arc unchanged; `sashSpan` ignored by doubles, sliders
and roll-ups; clamping; the editor offering `fixed` on windows only and
`sashSpan` only where a leftover pane exists; and the patch writer dropping
both when the shape stops having them.

## README

New `fixed` and `sashSpan` rows in the openings table, plus prose under
Doors and windows. Donation links untouched.

## Screenshots

![Window shapes](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/240-windows.png)

Left to right: a **fixed** window with its sensor reading *open* — jambs and
glass, nothing moved; an ordinary single sash wide open, **unchanged** by this
PR; and `sashSpan: 0.4` shut and then wide open, where the sash covers 40% of
the frame and the rest is drawn as a fixed pane.

The `fixed` pane renders identically at `amount` 0 and 1 — there is a test
asserting the two are byte-identical, which is the point of the first tile.

Rendered headlessly from `renderOpening`; the arc in tile 2 is pixel-identical
to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
