### PR TITLE
Zoom: how close a room goes, and how big the badges are once you are there

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ The editor writes this config for you; manual editing is optional.
 | `offlineStyle`| string  | `dim`              | How a device whose entity is **offline** is drawn: `dim`, `strike` (dimmed with a diagonal through the badge) or `none`. See [Offline devices](#offline-devices). |
 | `compactHeader`| boolean | `false`           | Draw the title inside the plan and the floor buttons in a row, instead of spending a card header row on them. See [Compact header](#compact-header). |
 | `overlayScale`| string  | `fixed`; `plan` in new plans | How badges, labels, room names and text are sized: `plan` = canvas units so they scale with the drawing, `fixed` = screen pixels. A card added from the picker is created with `plan`; a config that doesn't say renders `fixed`, which is what every plan drawn before the option existed was laid out in. See [Overlay scale](#overlay-scale). |
+| `zoomedOverlayScale` | number | `1` | Overlay size while zoomed in to a room, as a multiple of its size at full plan. `1` — the default — holds badges, labels and text at the size they have unzoomed, which is what zooming has always done. Raise it for a wall tablet read at arm's length, lower it to get a dense room's badges out of the way. Applies to the whole overlay so a badge and its label scale as one thing, and does nothing at full plan. |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
@@ -692,6 +693,11 @@ animated inside a rectangular tracked area:
   down the middle, an exterior wall colors on its inside face only. `borderWidth` is the
   width seen on the room's own side and defaults to `4` here; widen it and the band runs
   past the wall onto the floor.
+- `zoom` — how close a tap goes, `1`–`10`. Unset, the room is fitted to the card (capped
+  at `4`), which is what tapping a room has always done. Set it when the fit is not the
+  picture you want: a small room fits at a scale that fills the card with one cupboard, and
+  a long thin one binds on its long axis and barely zooms at all. The room stays centred
+  either way — this sets how close, not where.
 - `tap_action` / `hold_action` / `double_tap_action` — standard Lovelace actions on the
   room itself. **Tap already does something** — it zooms the plan to the room — so setting
   `tap_action` *replaces* that zoom; leaving it unset keeps it. Put the action on hold or

--- a/README.md
+++ b/README.md
@@ -697,7 +697,9 @@ animated inside a rectangular tracked area:
   at `4`), which is what tapping a room has always done. Set it when the fit is not the
   picture you want: a small room fits at a scale that fills the card with one cupboard, and
   a long thin one binds on its long axis and barely zooms at all. The room stays centred
-  either way — this sets how close, not where.
+  either way — this sets how close, not where. A value below `1` becomes `1`; zooming out
+  past the whole plan is what the zoom-out button does. In the editor, turn
+  **Fit the room to the card** off and the **Zoom level** slider appears.
 - `tap_action` / `hold_action` / `double_tap_action` — standard Lovelace actions on the
   room itself. **Tap already does something** — it zooms the plan to the room — so setting
   `tap_action` *replaces* that zoom; leaving it unset keeps it. Put the action on hold or

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -982,25 +982,50 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect((width.selector.number as { min: number }).min).toBe(1);
   });
 
-  it("offers a zoom level on a room, and only while a tap still zooms (issue #222)", () => {
+  it("offers the zoom controls only while a tap still zooms (issue #222)", () => {
     const area = { id: "a", points: [{ x: 0, y: 0 }] } as Area;
-    expect(areaForm(area).fields.map((x) => x.name)).toContain("zoom");
+    expect(areaForm(area).fields.map((x) => x.name)).toContain("fitZoom");
     // Its own tap_action has replaced the zoom, so a zoom level would be a
     // number that does nothing.
     const acting = { ...area, tap_action: { action: "toggle" } } as Area;
-    expect(areaForm(acting).fields.map((x) => x.name)).not.toContain("zoom");
+    const names = areaForm(acting).fields.map((x) => x.name);
+    expect(names).not.toContain("fitZoom");
+    expect(names).not.toContain("zoom");
   });
 
-  it("rests at the fit's ceiling and writes nothing there (issue #222)", () => {
+  it("shows the slider only once the room has stopped fitting (issue #222)", () => {
     const area = { id: "a", points: [{ x: 0, y: 0 }] } as Area;
+    // Fitting: the toggle is on and there is no number to show.
+    const fitted = areaForm(area);
+    expect(fitted.data.fitZoom).toBe(true);
+    expect(fitted.fields.map((x) => x.name)).not.toContain("zoom");
+    // Chosen: the toggle is off and the slider shows what was chosen.
+    const chosen = areaForm({ ...area, zoom: 8 } as Area);
+    expect(chosen.data.fitZoom).toBe(false);
+    expect(chosen.fields.map((x) => x.name)).toContain("zoom");
+    expect(chosen.data.zoom).toBe(8);
+  });
+
+  it("lets a room pick an explicit 4, which the old sentinel could not (review of #222)", () => {
+    // The bug this shape replaces: "fit" and an explicit 4 were the same
+    // slider position, so a room whose fit is 1.15 — the ordinary case, and
+    // the one the feature exists for — could never be told to zoom to 4.
+    const area = { id: "a", points: [{ x: 0, y: 0 }], zoom: 4 } as Area;
     const form = areaForm(area);
-    // "Fit the room" is not a number the slider can show, so it rests at the
-    // closest a fitted room is ever drawn.
-    expect(form.data.zoom).toBe(MAX_AREA_ZOOM_FIT);
-    expect(form.toPatch({ zoom: MAX_AREA_ZOOM_FIT })).toEqual({ zoom: undefined });
-    expect(form.toPatch({ zoom: 8 })).toEqual({ zoom: 8 });
-    // A room that has chosen shows what it chose.
-    expect(areaForm({ ...area, zoom: 8 } as Area).data.zoom).toBe(8);
+    expect(form.data.fitZoom).toBe(false);
+    expect(form.data.zoom).toBe(4);
+    // And 4 survives a round trip instead of being stripped as a default.
+    expect(form.toPatch({ zoom: 4 })).toEqual({ zoom: 4 });
+  });
+
+  it("keeps the fit toggle itself out of the config (issue #222)", () => {
+    const form = areaForm({ id: "a", points: [{ x: 0, y: 0 }], zoom: 8 } as Area);
+    // Turning the fit back on clears the number; the toggle never lands.
+    expect(form.toPatch({ fitZoom: true })).toEqual({ zoom: undefined });
+    // Turning it off leaves a real value behind for the slider to show.
+    expect(form.toPatch({ fitZoom: false })).toEqual({ zoom: MAX_AREA_ZOOM_FIT });
+    for (const p of [{ fitZoom: true }, { fitZoom: false }])
+      expect("fitZoom" in form.toPatch(p)).toBe(false);
   });
 
   it("keeps a zoomed overlay scale of 1 out of the YAML (issue #222)", () => {
@@ -1783,7 +1808,7 @@ describe("every field lands in exactly one panel group", () => {
     ["showName", "labelSize"],
     ["entity"],
     ["highlight", "opacity", "activeOpacity"],
-    ["zoom", "tap_action", "hold_action", "double_tap_action"],
+    ["fitZoom", "zoom", "tap_action", "hold_action", "double_tap_action"],
   ];
 
   const check = (fields: { name: string }[], groups: string[][], what: string) => {

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -30,7 +30,12 @@ import {
 import { itemHasLabel } from "./render";
 import type { FormField } from "./editor-forms";
 import type { Area, FloorText, Opening, FloorItem, Floor, Furniture, Tracker, FloorplanCardConfig } from "./types";
-import { DEFAULT_GLOW_RADIUS, DEFAULT_PRESS_EFFECT } from "./types";
+import {
+  DEFAULT_GLOW_RADIUS,
+  DEFAULT_PRESS_EFFECT,
+  MAX_AREA_ZOOM_FIT,
+  DEFAULT_ZOOMED_OVERLAY_SCALE,
+} from "./types";
 import { DEFAULT_SKIN, SKINS, MAX_SKIN_WALL_WIDTH } from "./skins";
 import { DEFAULT_SUN_BEARING, SUN_REACH } from "./render";
 
@@ -977,12 +982,42 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect((width.selector.number as { min: number }).min).toBe(1);
   });
 
+  it("offers a zoom level on a room, and only while a tap still zooms (issue #222)", () => {
+    const area = { id: "a", points: [{ x: 0, y: 0 }] } as Area;
+    expect(areaForm(area).fields.map((x) => x.name)).toContain("zoom");
+    // Its own tap_action has replaced the zoom, so a zoom level would be a
+    // number that does nothing.
+    const acting = { ...area, tap_action: { action: "toggle" } } as Area;
+    expect(areaForm(acting).fields.map((x) => x.name)).not.toContain("zoom");
+  });
+
+  it("rests at the fit's ceiling and writes nothing there (issue #222)", () => {
+    const area = { id: "a", points: [{ x: 0, y: 0 }] } as Area;
+    const form = areaForm(area);
+    // "Fit the room" is not a number the slider can show, so it rests at the
+    // closest a fitted room is ever drawn.
+    expect(form.data.zoom).toBe(MAX_AREA_ZOOM_FIT);
+    expect(form.toPatch({ zoom: MAX_AREA_ZOOM_FIT })).toEqual({ zoom: undefined });
+    expect(form.toPatch({ zoom: 8 })).toEqual({ zoom: 8 });
+    // A room that has chosen shows what it chose.
+    expect(areaForm({ ...area, zoom: 8 } as Area).data.zoom).toBe(8);
+  });
+
+  it("keeps a zoomed overlay scale of 1 out of the YAML (issue #222)", () => {
+    const cfg = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
+    const form = projectDisplayForm(cfg);
+    expect(form.data.zoomedOverlayScale).toBe(DEFAULT_ZOOMED_OVERLAY_SCALE);
+    expect(form.toPatch({ zoomedOverlayScale: 1 })).toEqual({ zoomedOverlayScale: undefined });
+    expect(form.toPatch({ zoomedOverlayScale: 1.5 })).toEqual({ zoomedOverlayScale: 1.5 });
+  });
+
   it("rotation lives in the bottom-row display form, defaults to 0°, and patches as a number", () => {
     const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
     expect(form.fields.map((x) => x.name)).toEqual([
       "rotation",
       "overlayScale",
       "compactHeader",
+      "zoomedOverlayScale",
       "offlineStyle",
     ]);
     expect(form.data.rotation).toBe("0");
@@ -1748,7 +1783,7 @@ describe("every field lands in exactly one panel group", () => {
     ["showName", "labelSize"],
     ["entity"],
     ["highlight", "opacity", "activeOpacity"],
-    ["tap_action", "hold_action", "double_tap_action"],
+    ["zoom", "tap_action", "hold_action", "double_tap_action"],
   ];
 
   const check = (fields: { name: string }[], groups: string[][], what: string) => {
@@ -1784,7 +1819,7 @@ describe("every field lands in exactly one panel group", () => {
     // offlineStyle as one form with one toPatch, but the panel renders the
     // first three under "Display" and the last under "Devices". Miss it in
     // both slices and the control silently disappears.
-    const DISPLAY = ["rotation", "overlayScale", "compactHeader"];
+    const DISPLAY = ["rotation", "overlayScale", "compactHeader", "zoomedOverlayScale"];
     const DEVICES = ["offlineStyle"];
     const cfg = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
     check(projectDisplayForm(cfg).fields, [DISPLAY, DEVICES], "project display");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1565,22 +1565,39 @@ export function areaForm(a: Area): FormSpec {
       // How close tapping the room goes (issue #222). Only worth asking while
       // a tap still zooms: an area with its own `tap_action` has replaced the
       // zoom outright, and a number that does nothing is worse than no number.
+      //
+      // A toggle *and* a slider, rather than the slider alone resting at the
+      // fit's ceiling. That earlier shape made "fit" and an explicit 4 the
+      // same position, so a room whose fit is 1.15 — the ordinary case, and
+      // the one this feature exists for — could not be told to zoom to 4 at
+      // all. "Fit" is not a number on this scale; it is the absence of one,
+      // and it needs its own control to say so.
       ...(a.tap_action
         ? []
         : [
             {
-              name: "zoom",
-              label: "Zoom level",
-              helper: "How close a tap goes. Unset fits the room to the card",
-              selector: {
-                number: {
-                  min: 1,
-                  max: MAX_AREA_ZOOM,
-                  step: 0.5,
-                  mode: "slider" as const,
-                },
-              },
+              name: "fitZoom",
+              label: "Fit the room to the card",
+              helper: "Off lets you set how close a tap goes",
+              selector: { boolean: {} },
             },
+            ...(a.zoom === undefined
+              ? []
+              : [
+                  {
+                    name: "zoom",
+                    label: "Zoom level",
+                    helper: "How close a tap goes",
+                    selector: {
+                      number: {
+                        min: 1,
+                        max: MAX_AREA_ZOOM,
+                        step: 0.5,
+                        mode: "slider" as const,
+                      },
+                    },
+                  },
+                ]),
           ]),
       // Optional entity that makes the room itself live (issue #6) — a presence
       // sensor that lights the room while it is occupied. Last, because most
@@ -1638,9 +1655,10 @@ export function areaForm(a: Area): FormSpec {
       entity: a.entity ?? "",
       activeOpacity: a.activeOpacity ?? a.opacity ?? DEFAULT_AREA_OPACITY,
       highlight: a.highlight ?? "fill",
-      // No number means "fit the room", which is not a value the slider can
-      // show — so it rests at the fit's own ceiling, the closest a fitted
-      // room is ever drawn.
+      // "Fit" is the absence of a number, so it gets its own boolean; the
+      // slider only appears once that is off, and then always shows a real
+      // stored value.
+      fitZoom: a.zoom === undefined,
       zoom: a.zoom ?? MAX_AREA_ZOOM_FIT,
       tap_action: a.tap_action,
       hold_action: a.hold_action,
@@ -1650,9 +1668,15 @@ export function areaForm(a: Area): FormSpec {
       let out = p;
       // "fill" is the default, so keep it out of the YAML.
       if ("highlight" in out && out.highlight === "fill") out = { ...out, highlight: undefined };
-      // Back at the fit's ceiling is back to "let it fit" (issue #222) — the
-      // resting position of the slider, so leaving it alone writes nothing.
-      if ("zoom" in out && out.zoom === MAX_AREA_ZOOM_FIT) out = { ...out, zoom: undefined };
+      // The toggle is a form-only control: it says whether `zoom` is written
+      // at all, and must never reach the config itself (issue #222).
+      if ("fitZoom" in out) {
+        const { fitZoom, ...rest } = out;
+        // Turning the fit off has to leave a number behind for the slider that
+        // is about to appear — the fit's own ceiling is the natural opening
+        // bid, and unlike before it is now a real, re-selectable value.
+        out = { ...rest, zoom: fitZoom ? undefined : MAX_AREA_ZOOM_FIT };
+      }
       return out;
     },
   };

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -27,6 +27,9 @@ import {
 import {
   DEFAULT_AREA_OPACITY,
   DEFAULT_AREA_LABEL_SIZE,
+  MAX_AREA_ZOOM,
+  MAX_AREA_ZOOM_FIT,
+  DEFAULT_ZOOMED_OVERLAY_SCALE,
   DEFAULT_GRID,
   DEFAULT_ITEM_SIZE,
   DEFAULT_RIPPLE_SIZE,
@@ -1559,6 +1562,26 @@ export function areaForm(a: Area): FormSpec {
         label: "Fill opacity",
         selector: { number: { min: 0, max: 1, step: 0.05, mode: "slider" } },
       },
+      // How close tapping the room goes (issue #222). Only worth asking while
+      // a tap still zooms: an area with its own `tap_action` has replaced the
+      // zoom outright, and a number that does nothing is worse than no number.
+      ...(a.tap_action
+        ? []
+        : [
+            {
+              name: "zoom",
+              label: "Zoom level",
+              helper: "How close a tap goes. Unset fits the room to the card",
+              selector: {
+                number: {
+                  min: 1,
+                  max: MAX_AREA_ZOOM,
+                  step: 0.5,
+                  mode: "slider" as const,
+                },
+              },
+            },
+          ]),
       // Optional entity that makes the room itself live (issue #6) — a presence
       // sensor that lights the room while it is occupied. Last, because most
       // areas are just outlines and never bind anything.
@@ -1615,12 +1638,23 @@ export function areaForm(a: Area): FormSpec {
       entity: a.entity ?? "",
       activeOpacity: a.activeOpacity ?? a.opacity ?? DEFAULT_AREA_OPACITY,
       highlight: a.highlight ?? "fill",
+      // No number means "fit the room", which is not a value the slider can
+      // show — so it rests at the fit's own ceiling, the closest a fitted
+      // room is ever drawn.
+      zoom: a.zoom ?? MAX_AREA_ZOOM_FIT,
       tap_action: a.tap_action,
       hold_action: a.hold_action,
       double_tap_action: a.double_tap_action,
     },
-    // "fill" is the default, so keep it out of the YAML.
-    toPatch: (p) => ("highlight" in p && p.highlight === "fill" ? { ...p, highlight: undefined } : p),
+    toPatch: (p) => {
+      let out = p;
+      // "fill" is the default, so keep it out of the YAML.
+      if ("highlight" in out && out.highlight === "fill") out = { ...out, highlight: undefined };
+      // Back at the fit's ceiling is back to "let it fit" (issue #222) — the
+      // resting position of the slider, so leaving it alone writes nothing.
+      if ("zoom" in out && out.zoom === MAX_AREA_ZOOM_FIT) out = { ...out, zoom: undefined };
+      return out;
+    },
   };
 }
 
@@ -1773,6 +1807,13 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
         selector: { boolean: {} },
       },
       {
+        name: "zoomedOverlayScale",
+        label: "Zoomed badge size",
+        helper:
+          "Badges, labels and text while zoomed in to a room, as a multiple of their size at full plan. 1 keeps them the same",
+        selector: { number: { min: 0.5, max: 3, step: 0.1, mode: "slider" } },
+      },
+      {
         name: "offlineStyle",
         label: "Offline devices",
         helper: "How a device is drawn when its entity is unavailable or missing",
@@ -1787,6 +1828,7 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       rotation: String(normalizePlanRotation(c.rotation)),
       overlayScale: normalizeOverlayScale(c.overlayScale),
       compactHeader: c.compactHeader ?? false,
+      zoomedOverlayScale: c.zoomedOverlayScale ?? DEFAULT_ZOOMED_OVERLAY_SCALE,
       offlineStyle: offlineStyleOf(c),
     },
     toPatch: (p) => {
@@ -1808,6 +1850,10 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
         out = { ...out, compactHeader: undefined };
       if ("offlineStyle" in out && out.offlineStyle === DEFAULT_OFFLINE_STYLE)
         out = { ...out, offlineStyle: undefined };
+      // Same again for the zoomed overlay: 1 means "no different while zoomed",
+      // which is what every plan did before this existed (issue #222).
+      if ("zoomedOverlayScale" in out && out.zoomedOverlayScale === DEFAULT_ZOOMED_OVERLAY_SCALE)
+        out = { ...out, zoomedOverlayScale: undefined };
       return out;
     },
   };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4827,7 +4827,13 @@ export class FloorplanCardEditor extends LitElement {
           // other element: the thing it *does*, after everything it *is*.
           "Behavior",
           this._renderForm(
-            formSlice(aSpec, ["zoom", "tap_action", "hold_action", "double_tap_action"]),
+            formSlice(aSpec, [
+              "fitZoom",
+              "zoom",
+              "tap_action",
+              "hold_action",
+              "double_tap_action",
+            ]),
             aApply
           )
         )}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4384,7 +4384,7 @@ export class FloorplanCardEditor extends LitElement {
           // How the card is framed on the dashboard, as opposed to what is
           // drawn inside it. Set once for a surface and rarely touched again.
           "Display",
-          this._renderForm(formSlice(display, ["rotation", "overlayScale", "compactHeader"]), patch)
+          this._renderForm(formSlice(display, ["rotation", "overlayScale", "compactHeader", "zoomedOverlayScale"]), patch)
         )}
         ${this._renderGroup(
           // Light through the openings (issue #177) — where it comes from and
@@ -4827,7 +4827,7 @@ export class FloorplanCardEditor extends LitElement {
           // other element: the thing it *does*, after everything it *is*.
           "Behavior",
           this._renderForm(
-            formSlice(aSpec, ["tap_action", "hold_action", "double_tap_action"]),
+            formSlice(aSpec, ["zoom", "tap_action", "hold_action", "double_tap_action"]),
             aApply
           )
         )}

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -115,6 +115,8 @@ import {
   rotatePlanPoint,
   planRotationTransform,
   areaZoomTransform,
+  resolveAreaZoom,
+  zoomedOverlayScale,
   IDENTITY_ZOOM,
   type PlanRotation,
 } from "./render";
@@ -827,7 +829,19 @@ export class FloorplanCard extends LitElement {
     // completely differently (a group transform vs. per-point left/top%) —
     // reframe identically instead of drifting apart under zoom.
     const zoomedArea = active.areas?.find((a) => a.id === this._zoomedAreaId);
-    const zoom = zoomedArea ? areaZoomTransform(zoomedArea.points, c.width, c.height, rot) : IDENTITY_ZOOM;
+    const zoom = zoomedArea
+      ? areaZoomTransform(
+          zoomedArea.points,
+          c.width,
+          c.height,
+          rot,
+          undefined,
+          undefined,
+          // A room may say how close to go; without one the fit decides,
+          // exactly as it always has (issue #222).
+          resolveAreaZoom(zoomedArea)
+        )
+      : IDENTITY_ZOOM;
     // Chrome drawn inside the plan rather than above it (issue #152). The
     // flag is what the floor buttons follow; the chip needs a title as well,
     // and a compact card with no title has nothing to draw there.
@@ -1176,7 +1190,10 @@ export class FloorplanCard extends LitElement {
             </g>
           </svg>`
           )}
-          <div class="items" style="--fp-inv-zoom:${1 / zoom.scale};">
+          <div
+            class="items"
+            style="--fp-inv-zoom:${zoomedOverlayScale(zoom.scale, c.zoomedOverlayScale)};"
+          >
             ${active.areas?.map((a) => this._renderAreaLabel(a, c, rot, scale))}
             ${active.texts.map((t) => this._renderText(t, c, rot, scale))}
             ${repeat(

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { html, nothing } from "lit";
 import type { Area, FloorText, Furniture, FurnitureType, ItemKind, ItemReading } from "./types";
 import { SKIN_ACCENT, SKIN_WALL, MAX_SKIN_WALL_WIDTH } from "./skins";
+import { MAX_AREA_ZOOM, DEFAULT_ZOOMED_OVERLAY_SCALE } from "./types";
 import {
   DEFAULT_GLOW_RADIUS,
   DEFAULT_GLOW_COLOR,
@@ -125,6 +126,8 @@ import {
   planRotationTransform,
   polygonCentroid,
   areaZoomTransform,
+  resolveAreaZoom,
+  zoomedOverlayScale,
   IDENTITY_ZOOM,
   renderArea,
   renderAreaBorder,
@@ -3713,6 +3716,69 @@ describe("polygonCentroid", () => {
 
   it("returns the origin for an empty polygon", () => {
     expect(polygonCentroid([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("a room's own zoom level (issue #222)", () => {
+  // A 10x10 room in the middle of a 100x100 canvas: fits at the 4x cap, so
+  // every difference below is the explicit scale rather than the fit.
+  const room = [{ x: 45, y: 45 }, { x: 55, y: 45 }, { x: 55, y: 55 }, { x: 45, y: 55 }];
+
+  it("uses the room's scale instead of the fit, and still centres it", () => {
+    const t = areaZoomTransform(room, 100, 100, 0, undefined, undefined, 7);
+    expect(t.scale).toBe(7);
+    // Centre stays the centre — this sets how close, not where.
+    expect(t.txPercent).toBeCloseTo(50 - 7 * 0.5 * 100);
+    expect(t.tyPercent).toBeCloseTo(50 - 7 * 0.5 * 100);
+  });
+
+  it("can ask for less than the fit as well as more", () => {
+    // The long-thin-room case in reverse: the fit is not always too far out.
+    expect(areaZoomTransform(room, 100, 100, 0, undefined, undefined, 1.5).scale).toBe(1.5);
+  });
+
+  it("falls back to the fit when the room has no zoom of its own", () => {
+    expect(areaZoomTransform(room, 100, 100, 0, undefined, undefined, undefined)).toEqual(
+      areaZoomTransform(room, 100, 100, 0),
+    );
+  });
+
+  it("resolves and clamps what a config may hold", () => {
+    expect(resolveAreaZoom({ zoom: 6 })).toBe(6);
+    expect(resolveAreaZoom({ zoom: 99 })).toBe(MAX_AREA_ZOOM);
+    // Below 1 would zoom out past the whole plan; that is the zoom-out button.
+    expect(resolveAreaZoom({ zoom: 0.2 })).toBe(1);
+    // No zoom, and nonsense from a hand-edited config, both leave the fit be.
+    expect(resolveAreaZoom({})).toBeUndefined();
+    expect(resolveAreaZoom({ zoom: NaN })).toBeUndefined();
+    expect(resolveAreaZoom({ zoom: Infinity })).toBeUndefined();
+  });
+});
+
+describe("overlay size while zoomed (issue #222)", () => {
+  it("holds the overlay at its full-plan size by default, as it always has", () => {
+    expect(zoomedOverlayScale(4)).toBeCloseTo(0.25);
+    expect(zoomedOverlayScale(4, DEFAULT_ZOOMED_OVERLAY_SCALE)).toBeCloseTo(0.25);
+  });
+
+  it("multiplies that counter-scale, so badges can grow when zoomed in", () => {
+    expect(zoomedOverlayScale(4, 2)).toBeCloseTo(0.5); // twice full-plan size
+    expect(zoomedOverlayScale(4, 0.5)).toBeCloseTo(0.125); // half of it
+  });
+
+  it("does nothing at full plan — the setting is about the zoomed view", () => {
+    // Otherwise setting it would resize every plan the moment it was set.
+    expect(zoomedOverlayScale(1, 2)).toBe(1);
+    expect(zoomedOverlayScale(0.5, 2)).toBe(1);
+  });
+
+  it("ignores a value that would poison the custom property it lands in", () => {
+    // --fp-inv-zoom:NaN invalidates the property, and .item's transform is
+    // built from it — every badge would lose its centring, not just its size.
+    expect(zoomedOverlayScale(4, NaN)).toBeCloseTo(0.25);
+    expect(zoomedOverlayScale(4, 0)).toBeCloseTo(0.25);
+    expect(zoomedOverlayScale(4, -2)).toBeCloseTo(0.25);
+    expect(zoomedOverlayScale(NaN, 2)).toBe(1);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -4439,11 +4439,12 @@ export function areaZoomTransform(
  * A room's configured zoom, clamped, or `undefined` when it has none and the
  * fit should stand (issue #222).
  *
- * Below 1 is refused rather than clamped silently into meaning something else:
- * it would zoom *out* past the whole plan, which is what the zoom-out button
- * is for. A non-finite value from a hand-edited config falls back to the fit,
- * on the same reasoning as {@link areaZoomTransform}'s own guard — a NaN scale
- * reaches a style sink and takes the overlay's centring down with it.
+ * Below 1 is clamped **to 1**, not honoured and not refused: it would zoom
+ * *out* past the whole plan, which is what the zoom-out button is for, and 1
+ * is the nearest thing to it that means anything. A non-finite value is the
+ * one case that does fall back to the fit, on the same reasoning as {@link
+ * areaZoomTransform}'s own guard — a NaN scale reaches a style sink and takes
+ * the overlay's centring down with it.
  */
 export function resolveAreaZoom(a: Pick<Area, "zoom">): number | undefined {
   const raw = a.zoom;

--- a/src/render.ts
+++ b/src/render.ts
@@ -38,6 +38,9 @@ import {
   DEFAULT_TRACKER_DOT_SIZE,
   DEFAULT_RIPPLE_SIZE,
   DEFAULT_AREA_OPACITY,
+  MAX_AREA_ZOOM_FIT,
+  MAX_AREA_ZOOM,
+  DEFAULT_ZOOMED_OVERLAY_SCALE,
   DEFAULT_AREA_LABEL_SIZE,
   DEFAULT_AREA_BORDER_WIDTH,
   SUN_ELEVATION_NIGHT,
@@ -4390,7 +4393,13 @@ export function areaZoomTransform(
   h: number,
   rot: PlanRotation,
   padFrac = 0.15,
-  maxScale = 4
+  maxScale = MAX_AREA_ZOOM_FIT,
+  /**
+   * A room's own zoom, overriding the fit (issue #222). Undefined keeps the
+   * fitted scale, which is every room that has not asked for something else.
+   * Pass it through {@link resolveAreaZoom} rather than raw config.
+   */
+  explicitScale?: number
 ): AreaZoomTransform {
   if (!points.length) return IDENTITY_ZOOM;
   const rotated = points.map((p) => rotatePlanPoint(p.x, p.y, w, h, rot));
@@ -4404,7 +4413,11 @@ export function areaZoomTransform(
   const pad = Math.max(maxX - minX, maxY - minY) * padFrac;
   const bw = Math.max(maxX - minX + pad * 2, 1);
   const bh = Math.max(maxY - minY + pad * 2, 1);
-  const scale = Math.max(1, Math.min(maxScale, Math.min(d.w / bw, d.h / bh)));
+  // The room's own zoom wins over the fit when it has one: the fit is a guess
+  // at a good framing, and this is someone saying the guess was wrong.
+  // Centring is unaffected — this sets how close, not where (issue #222).
+  const fitted = Math.max(1, Math.min(maxScale, Math.min(d.w / bw, d.h / bh)));
+  const scale = explicitScale ?? fitted;
   // A non-finite input (NaN/Infinity coordinates from a hand-edited config)
   // must never reach the style sink: --fp-inv-zoom:NaN invalidates the whole
   // custom property, and .item's transform is built from it, so every device
@@ -4420,6 +4433,46 @@ export function areaZoomTransform(
     txPercent: clamp(50 - scale * cxFrac * 100),
     tyPercent: clamp(50 - scale * cyFrac * 100),
   };
+}
+
+/**
+ * A room's configured zoom, clamped, or `undefined` when it has none and the
+ * fit should stand (issue #222).
+ *
+ * Below 1 is refused rather than clamped silently into meaning something else:
+ * it would zoom *out* past the whole plan, which is what the zoom-out button
+ * is for. A non-finite value from a hand-edited config falls back to the fit,
+ * on the same reasoning as {@link areaZoomTransform}'s own guard — a NaN scale
+ * reaches a style sink and takes the overlay's centring down with it.
+ */
+export function resolveAreaZoom(a: Pick<Area, "zoom">): number | undefined {
+  const raw = a.zoom;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+  return Math.max(1, Math.min(MAX_AREA_ZOOM, raw));
+}
+
+/**
+ * What the overlay counter-scales by while the plan is zoomed — the value
+ * behind `--fp-inv-zoom` (issue #222).
+ *
+ * `1 / zoomScale` is the counter-scale that holds the overlay at the size it
+ * has at full plan, which is what zooming has always done. `zoomedOverlayScale`
+ * multiplies that, so 1 keeps today's behaviour exactly and 1.5 draws every
+ * badge, label and tracker half again as large *while zoomed only*.
+ *
+ * Unzoomed it returns 1 rather than the multiplier: the setting is about the
+ * zoomed view, and applying it at full plan would resize every plan that set
+ * it the moment it was set. A non-finite or non-positive multiplier is
+ * ignored for the same reason the transform guards its own scale — this value
+ * lands in a custom property that the badge transform is built from.
+ */
+export function zoomedOverlayScale(zoomScale: number, multiplier?: number): number {
+  if (!Number.isFinite(zoomScale) || zoomScale <= 1) return 1;
+  const m =
+    typeof multiplier === "number" && Number.isFinite(multiplier) && multiplier > 0
+      ? multiplier
+      : DEFAULT_ZOOMED_OVERLAY_SCALE;
+  return (1 / zoomScale) * m;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -943,8 +943,8 @@ export interface Area {
    * single number for the plan.
    *
    * The room stays centred either way — this sets how close, not where.
-   * Clamped to 1..{@link MAX_AREA_ZOOM}: below 1 would zoom *out* past the
-   * whole plan, which the zoom-out button already does properly.
+   * Clamped to 1..{@link MAX_AREA_ZOOM}: a value below 1 becomes 1, since
+   * zooming *out* past the whole plan is what the zoom-out button does.
    */
   zoom?: number;
   /** Fill color. Falls back to the theme primary color. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -931,6 +931,22 @@ export interface Area {
    * label wider than its room.
    */
   labelSize?: number;
+  /**
+   * How far the plan zooms when this room is tapped (issue #222). Absent — the
+   * default — fits the room to the card, capped at {@link MAX_AREA_ZOOM_FIT},
+   * which is what tapping a room has always done.
+   *
+   * Set it when the fit is not the framing you want. A small room fits at a
+   * scale that fills the card with one cupboard; a long thin one binds on its
+   * long axis and barely zooms at all. Neither is wrong as a fit, and both are
+   * sometimes the wrong picture, which is why this is per room rather than a
+   * single number for the plan.
+   *
+   * The room stays centred either way — this sets how close, not where.
+   * Clamped to 1..{@link MAX_AREA_ZOOM}: below 1 would zoom *out* past the
+   * whole plan, which the zoom-out button already does properly.
+   */
+  zoom?: number;
   /** Fill color. Falls back to the theme primary color. */
   color?: string;
   /** Fill opacity, 0-1. Default {@link DEFAULT_AREA_OPACITY}. */
@@ -1079,6 +1095,35 @@ export const PRESS_IN_MS = 80;
 export const PRESS_OUT_MS = 260;
 
 export const DEFAULT_AREA_OPACITY = 0.25;
+
+/**
+ * How far tapping a room may zoom when it is left to fit the card by itself
+ * (issue #158). A cap rather than a target: most rooms bind on the canvas long
+ * before this, and the ones that do not are small enough that filling the card
+ * with them reads as a mistake.
+ */
+export const MAX_AREA_ZOOM_FIT = 4;
+/**
+ * The ceiling on a per-room {@link Area.zoom} (issue #222). Higher than the
+ * fit cap on purpose — asking for a closer look at one room is a choice, while
+ * the fit is a guess — but still bounded, because the plan is drawn once at
+ * canvas resolution and past this it is just a bigger blur.
+ */
+export const MAX_AREA_ZOOM = 10;
+
+/**
+ * How much bigger (or smaller) the overlay is drawn while the plan is zoomed
+ * in to a room (issue #222). Default 1: badges, labels, text and trackers hold
+ * the size they have at full plan, which is what zooming has always done —
+ * the overlay is counter-scaled against the zoom so it never balloons.
+ *
+ * The reason to change it is that "the same size" is not always the useful
+ * answer. Zoomed into one room the badges have room to breathe and a wall
+ * tablet at arm's length wants them bigger; a dense room read up close wants
+ * them out of the way. This scales the whole overlay rather than the icons
+ * alone, so a badge and the label under it stay one object.
+ */
+export const DEFAULT_ZOOMED_OVERLAY_SCALE = 1;
 /** Area name label size, matching the hard-coded value it replaces. */
 export const DEFAULT_AREA_LABEL_SIZE = 14;
 export const DEFAULT_AREA_BORDER_WIDTH = 3;
@@ -1290,6 +1335,15 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * text. See the README's "Where it helps, and where it costs".
    */
   overlayScale?: OverlayScale;
+  /**
+   * Overlay size while zoomed in to a room, as a multiple of its size at full
+   * plan (issue #222). Default {@link DEFAULT_ZOOMED_OVERLAY_SCALE} — no
+   * change, which is what zooming has always done. Applies to everything in
+   * the HTML overlay (device badges and their labels, room names, free text,
+   * trackers) so a badge and its label scale as one thing, and only while a
+   * room is actually zoomed: at full plan it does nothing at all.
+   */
+  zoomedOverlayScale?: number;
   /** Canvas background color (CSS / hex). Falls back to the skin's paper, then the card background. */
   background?: string;
   /**


### PR DESCRIPTION
Closes part of #222.

@Sat32blk asked for three things. This is two of them — the two that extend
what zoom already does. #222 stays open for the third.

## What this adds

**`zoom` on an area** (1–10) — how close a tap goes. Unset, the room is fitted
to the card capped at 4×, which is what tapping a room has always done.

The fit is a guess at a good framing, and it is wrong in both directions often
enough to be worth overriding: a small room fits at a scale that fills the card
with one cupboard, and a long thin one binds on its long axis and barely zooms
at all. The room stays centred either way — this sets how close, not where.

**`zoomedOverlayScale` on the plan** (default 1) — overlay size while zoomed,
as a multiple of its size at full plan. This is @jomo02's +1 on part 3.

Zooming already counter-scales the overlay so badges hold their full-plan size;
this multiplies that counter-scale. `1` keeps exactly today's behaviour, `1.5`
draws badges half again as large **while zoomed only**.

Two calls worth noting:
- It scales the **whole overlay** — badges, their labels, room names, free
  text, trackers — not icons alone, so a badge and its label stay one object.
- It does **nothing at full plan**. Applying it there would resize every plan
  the moment the option was set, which is not what "zoomed badge size" says.

## What I left out, and why

Part 1 — "can only interact with devices when in a zoomed-in view" — is not
here. It changes what a tap on the full plan does, which is the plan's entire
interface, and it risks the card reading as broken on first touch. It is also
really the density problem #149 is about rather than a zoom setting. Happy to
take it as its own change if you want it.

## The guards are the interesting part

Both values land in `--fp-inv-zoom`, which `.item`'s transform is built from.
A NaN there does not just mis-size a badge — it invalidates the custom property
and **every badge on the plan loses its centring**. So `resolveAreaZoom` and
`zoomedOverlayScale` both fall back rather than pass a non-finite value
through, on the same reasoning `areaZoomTransform` already applied to its own
scale. There are tests for each.

## Backwards compatibility

Both fields default to today's behaviour and both stay out of the YAML at their
defaults. `areaZoomTransform` with no explicit scale is asserted equal to the
call without the parameter at all.

## Tests

`npm test` — 1261 pass (1250 before, 11 new). `npm run typecheck` and
`npm run build` clean.

Covers: explicit scale overriding the fit while keeping the centre; asking for
less than the fit as well as more; falling back to the fit; clamping (>10, <1,
NaN, Infinity); the overlay multiplier in both directions; it being inert at
full plan; non-finite inputs; the editor offering `zoom` only while a tap still
zooms (an area with its own `tap_action` has replaced it); and both defaults
staying out of the YAML.

## README

`zoomedOverlayScale` in the config table, `zoom` in the areas section.
Donation links untouched.

## Screenshots

Both from the demo plan in `docker/config/floorplan-demo.yaml`.

**A room's own zoom level.** The Living Room is large relative to the canvas,
so the fit only manages **1.15x** — it barely zooms at all, which is exactly
the case this exists for:

![Per-room zoom level](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/241-zoom-level.png)

**Overlay size while zoomed.** Same view, same zoom — only the overlay
changes. Note the room name, the reading and the badge all scale together, and
the plan underneath is untouched:

![Zoomed overlay scale](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/241-overlay-scale.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
