### PR TITLE
Lock in place: it can still be selected and edited, just not moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ screen size.
 
 ## Features
 - **Visual editor** — draw walls, drop doors and windows that snap onto them, drag, nudge with arrow keys, multi-select, copy/paste, undo/redo, zoom.
+  - (${\color{red}NEW!}$) **Lock in place** — pin anything you have finished positioning. A locked element still selects and edits but never moves, and it yields the click to whatever is unlocked on top of it, so reaching for a window stops grabbing the wall behind it. See [Locking elements in place](#locking-elements-in-place).
   - (${\color{red}NEW!}$) **Apply** — save the plan to the dashboard *without* closing the editor, so you can judge a change on the real card (in a second tab, or by collapsing the editor) instead of in the small preview beside it, then carry straight on. Needs Home Assistant 2025.3 or newer; on anything older the button says so and Save still works.
 - **Devices** — bind any entity to an icon: tap to toggle or open more-info, live state or attribute label, custom icon, size, rotation.
   - **Presence ripples** — presence and vibration sensors drawn as animated rings instead of a static icon.
@@ -1446,6 +1447,36 @@ compactHeader: true
 Off by default, because the title then sits over the drawing — the right trade only when
 there is room for it, which is the author's call. Set it in the editor under
 **Project → Compact header**.
+
+## Locking elements in place
+
+Select anything and press the padlock in the **Element** header. It applies to every kind
+of element — walls, doors and windows, devices, text, furniture, trackers and rooms — and
+to a whole multi-selection at once.
+
+A locked element:
+
+- **still selects, still edits, still deletes.** Everything works except *moving* it.
+- **never moves.** Not by dragging, not by its endpoint or vertex handles (which stop
+  being drawn, so nothing on it pretends to be draggable), and not by arrow keys — alone
+  or as part of a group. Drag a group by an unlocked member and the locked ones stay put
+  while the rest travel.
+- **yields the click.** Anything unlocked under the pointer is picked first, whatever kind
+  it is. Lock the wall and a window drawn on it selects on the first click instead of
+  after cycling past the wall.
+
+Both halves are the point. Yielding alone would still let a stray drag move the wall;
+pinning alone would still cost a click to get past it. Together they answer the thing
+that prompted this: *"every time I want to move a window, I end up moving a wall
+instead"*.
+
+Locked elements stay selectable on purpose — a design tool hides them behind a layers
+panel to unlock from, and this editor has none, so an element you could not click would
+be one you could never unlock. Pasted copies are never locked: a duplicate lands offset
+and the first thing you do is position it.
+
+Nothing about the rendered card reads this — it is an editing aid, and `locked: true` in
+the YAML changes nothing a viewer sees.
 
 ## Styling hooks (card-mod)
 

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -541,6 +541,35 @@ describe("a nudge with nothing movable does nothing at all (review of #191)", ()
     ).toEqual([{ kind: "item", id: "loose" }]);
   });
 
+  it("drops a selection that outlived its element (review of #191)", () => {
+    // setConfig does not clear _selection, so a config pushed from elsewhere
+    // can leave the editor holding ids for elements that are gone. They must
+    // not count as movable, or the nudge guard passes and _commitFloor spends
+    // an undo step on a plan where nothing could move.
+    expect(movableSelection(floor, [{ kind: "wall", id: "gone" }])).toEqual([]);
+    expect(
+      movableSelection(floor, [
+        { kind: "wall", id: "gone" },
+        { kind: "wall", id: "pinned" },
+      ]),
+    ).toEqual([]);
+    // A live element alongside a stale one still moves.
+    expect(
+      movableSelection(floor, [
+        { kind: "item", id: "vanished" },
+        { kind: "item", id: "loose" },
+      ]),
+    ).toEqual([{ kind: "item", id: "loose" }]);
+  });
+
+  it("keeps stale and locked as different questions", () => {
+    // isLocked stays false for a stale id on purpose — calling it locked would
+    // make a group refuse to move because one member had been deleted. It is
+    // movableSelection that has to know the difference.
+    expect(isLocked(floor, { kind: "wall", id: "gone" })).toBe(false);
+    expect(movableSelection(floor, [{ kind: "wall", id: "gone" }])).toEqual([]);
+  });
+
   it("passes an ordinary selection through untouched", () => {
     const sel = [{ kind: "item", id: "loose" }] as const;
     expect(movableSelection(floor, sel)).toEqual([...sel]);

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -10,6 +10,7 @@ import {
   applyDelta,
   attachedCorners,
   elementsAtPoint,
+  isLocked,
   cyclePick,
 } from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
@@ -435,5 +436,103 @@ describe("applyDelta (area case)", () => {
     expect(out.areas![0]).toMatchObject({
       points: [{ x: 5, y: 5 }, { x: 15, y: 5 }, { x: 15, y: 15 }],
     });
+  });
+});
+
+describe("locked elements yield the click (issue #191)", () => {
+  const opts = { itemSize: 34, textSize: 16, wallThickness: 8 };
+  // The reporter's case: a window sitting on a wall. Both are under the
+  // pointer at (300, 200).
+  const floor = {
+    id: "f",
+    name: "F",
+    walls: [{ id: "w", x1: 0, y1: 200, x2: 400, y2: 200 }],
+    openings: [{ id: "o", type: "door", x: 300, y: 200, length: 90, angle: 0 }],
+    items: [],
+    texts: [],
+    furniture: [],
+    trackers: [],
+    areas: [],
+  } as unknown as Floor;
+
+  const kindsAt = (f: Floor) => elementsAtPoint(f, 300, 200, opts).map((s) => s.kind);
+
+  it("an unlocked pair keeps the usual most-specific-first order", () => {
+    expect(kindsAt(floor)).toEqual(["opening", "wall"]);
+  });
+
+  it("a locked element sorts behind an unlocked one whatever its kind", () => {
+    // Lock the *opening* — normally the most specific — and the wall wins.
+    const f = {
+      ...floor,
+      openings: [{ ...floor.openings[0], locked: true }],
+    } as unknown as Floor;
+    expect(kindsAt(f)).toEqual(["wall", "opening"]);
+  });
+
+  it("a locked wall stops shadowing the window drawn on it", () => {
+    const f = { ...floor, walls: [{ ...floor.walls[0], locked: true }] } as unknown as Floor;
+    expect(kindsAt(f)[0]).toEqual("opening");
+  });
+
+  it("locked elements stay in the list, so cycling can still reach them", () => {
+    // Without this there would be no way to select one and unlock it again —
+    // this editor has no layers panel to unlock from.
+    const f = {
+      ...floor,
+      walls: [{ ...floor.walls[0], locked: true }],
+      openings: [{ ...floor.openings[0], locked: true }],
+    } as unknown as Floor;
+    expect(kindsAt(f)).toEqual(["opening", "wall"]);
+    expect(elementsAtPoint(f, 300, 200, opts)).toHaveLength(2);
+  });
+
+  it("isLocked answers for every kind, and calls a stale id unlocked", () => {
+    const f = {
+      ...floor,
+      walls: [{ ...floor.walls[0], locked: true }],
+      items: [{ id: "i", entity: "light.a", x: 0, y: 0 }],
+      areas: [{ id: "a", points: [{ x: 0, y: 0 }], locked: true }],
+      trackers: [{ id: "tr", x: 0, y: 0, w: 10, h: 10 }],
+    } as unknown as Floor;
+    expect(isLocked(f, { kind: "wall", id: "w" })).toBe(true);
+    expect(isLocked(f, { kind: "area", id: "a" })).toBe(true);
+    expect(isLocked(f, { kind: "item", id: "i" })).toBe(false);
+    expect(isLocked(f, { kind: "tracker", id: "tr" })).toBe(false);
+    // A selection naming something that no longer exists is stale state, not
+    // a pinned element — calling it locked would refuse to move its group.
+    expect(isLocked(f, { kind: "wall", id: "gone" })).toBe(false);
+  });
+});
+
+describe("a pinned element sits out a group drag (issue #191)", () => {
+  // The editor pins by leaving an element out of the drag snapshot, so this
+  // is the property that mechanism rests on: applyDelta moves exactly what
+  // the map names and nothing else. Asserted here because the editor's own
+  // gesture wiring has no test environment to assert it in (issue #233).
+  const floor = {
+    id: "f",
+    name: "F",
+    walls: [{ id: "pinned", x1: 0, y1: 0, x2: 100, y2: 0, locked: true }],
+    openings: [],
+    items: [{ id: "loose", entity: "light.a", x: 50, y: 50 }],
+    texts: [],
+    furniture: [],
+    trackers: [],
+    areas: [],
+  } as unknown as Floor;
+
+  it("moves what the snapshot names and leaves out what it does not", () => {
+    // What the editor builds for a two-element selection with one locked.
+    const orig = new Map<string, OrigPos>([["item:loose", { kind: "pt", x: 50, y: 50 }]]);
+    const out = applyDelta(floor, 10, -5, orig);
+    expect(out.items![0]).toMatchObject({ id: "loose", x: 60, y: 45 });
+    // The wall is returned untouched — the same object, not a moved copy.
+    expect(out.walls![0]).toBe(floor.walls[0]);
+  });
+
+  it("keeps the pinned element still even when it is the only thing selected", () => {
+    const out = applyDelta(floor, 25, 25, new Map());
+    expect(out.walls![0]).toMatchObject({ x1: 0, y1: 0, x2: 100, y2: 0 });
   });
 });

--- a/src/editor-geometry.test.ts
+++ b/src/editor-geometry.test.ts
@@ -11,6 +11,7 @@ import {
   attachedCorners,
   elementsAtPoint,
   isLocked,
+  movableSelection,
   cyclePick,
 } from "./editor-geometry";
 import type { OrigPos } from "./editor-geometry";
@@ -502,6 +503,48 @@ describe("locked elements yield the click (issue #191)", () => {
     // A selection naming something that no longer exists is stale state, not
     // a pinned element — calling it locked would refuse to move its group.
     expect(isLocked(f, { kind: "wall", id: "gone" })).toBe(false);
+  });
+});
+
+describe("a nudge with nothing movable does nothing at all (review of #191)", () => {
+  // _commitFloor pushes history unconditionally and .map() hands it freshly
+  // allocated arrays, so "every selected element is locked" has to be caught
+  // before the commit or an arrow key spends an undo step on nothing — and
+  // clears the redo stack while doing it.
+  const floor = {
+    id: "f",
+    name: "F",
+    walls: [{ id: "pinned", x1: 0, y1: 0, x2: 100, y2: 0, locked: true }],
+    openings: [],
+    items: [{ id: "loose", entity: "light.a", x: 50, y: 50 }],
+    texts: [],
+    furniture: [],
+    trackers: [],
+    areas: [{ id: "room", points: [{ x: 0, y: 0 }], locked: true }],
+  } as unknown as Floor;
+
+  it("reports nothing movable when every selected element is pinned", () => {
+    expect(
+      movableSelection(floor, [
+        { kind: "wall", id: "pinned" },
+        { kind: "area", id: "room" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("reports the loose ones when a selection is mixed", () => {
+    expect(
+      movableSelection(floor, [
+        { kind: "wall", id: "pinned" },
+        { kind: "item", id: "loose" },
+      ]),
+    ).toEqual([{ kind: "item", id: "loose" }]);
+  });
+
+  it("passes an ordinary selection through untouched", () => {
+    const sel = [{ kind: "item", id: "loose" }] as const;
+    expect(movableSelection(floor, sel)).toEqual([...sel]);
+    expect(movableSelection(floor, [])).toEqual([]);
   });
 });
 

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -452,6 +452,20 @@ export function isLocked(f: Floor, sel: Sel): boolean {
 }
 
 /**
+ * The selected elements that a move may actually touch — everything not pinned
+ * (issue #191).
+ *
+ * The editor asks this before spending an undo step: a nudge whose whole
+ * selection is locked must do nothing at all, rather than commit arrays that
+ * are freshly allocated but value-identical. `_commitFloor` pushes history
+ * unconditionally and clears the redo stack, so "nothing moved" and "nothing
+ * happened" have to be the same thing here.
+ */
+export function movableSelection(f: Floor, sel: readonly Sel[]): Sel[] {
+  return sel.filter((s) => !isLocked(f, s));
+}
+
+/**
  * The element a click should select, given the candidates under the cursor and
  * what is selected now (issue #52). Repeat clicks at the same spot step
  * *down* the stack and wrap; a click elsewhere restarts at the most specific

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -372,13 +372,13 @@ export function elementsAtPoint(
   y: number,
   opts: { itemSize: number; textSize: number; wallThickness: number; hass?: RenderHass }
 ): Sel[] {
-  const hits: { sel: Sel; rank: number; order: number }[] = [];
-  const push = (kind: SelKind, id: string, order: number) =>
-    hits.push({ sel: { kind, id }, rank: PICK_ORDER.indexOf(kind), order });
+  const hits: { sel: Sel; rank: number; order: number; locked: boolean }[] = [];
+  const push = (kind: SelKind, id: string, order: number, locked?: boolean) =>
+    hits.push({ sel: { kind, id }, rank: PICK_ORDER.indexOf(kind), order, locked: !!locked });
 
   f.items.forEach((it, i) => {
     const r = (it.size ?? opts.itemSize) / 2 + HIT.pad;
-    if (Math.abs(x - it.x) <= r && Math.abs(y - it.y) <= r) push("item", it.id, i);
+    if (Math.abs(x - it.x) <= r && Math.abs(y - it.y) <= r) push("item", it.id, i, it.locked);
   });
   f.texts.forEach((t, i) => {
     // Rough box: text is centered on (x, y); width scales with the string.
@@ -392,31 +392,63 @@ export function elementsAtPoint(
     const hw = (size * 0.6 * Math.max(1, textLabel(opts.hass, t).length)) / 2 + HIT.pad;
     const hh = size / 2 + HIT.pad;
     const p = toLocal(x, y, t.x, t.y, t.angle ?? 0);
-    if (Math.abs(p.x) <= hw && Math.abs(p.y) <= hh) push("text", t.id, i);
+    if (Math.abs(p.x) <= hw && Math.abs(p.y) <= hh) push("text", t.id, i, t.locked);
   });
   f.openings.forEach((o, i) => {
     const p = toLocal(x, y, o.x, o.y, o.angle ?? 0);
     if (Math.abs(p.x) <= o.length / 2 && Math.abs(p.y) <= opts.wallThickness / 2 + HIT.pad) {
-      push("opening", o.id, i);
+      push("opening", o.id, i, o.locked);
     }
   });
   f.furniture.forEach((fu, i) => {
     const p = toLocal(x, y, fu.x, fu.y, fu.angle ?? 0);
-    if (Math.abs(p.x) <= fu.w / 2 && Math.abs(p.y) <= fu.h / 2) push("furniture", fu.id, i);
+    if (Math.abs(p.x) <= fu.w / 2 && Math.abs(p.y) <= fu.h / 2) push("furniture", fu.id, i, fu.locked);
   });
   f.walls.forEach((w, i) => {
-    if (distToSegment(x, y, w) <= HIT.wall) push("wall", w.id, i);
+    if (distToSegment(x, y, w) <= HIT.wall) push("wall", w.id, i, w.locked);
   });
   (f.trackers ?? []).forEach((tr, i) => {
     const p = toLocal(x, y, tr.x + tr.w / 2, tr.y + tr.h / 2, tr.angle ?? 0);
-    if (Math.abs(p.x) <= tr.w / 2 && Math.abs(p.y) <= tr.h / 2) push("tracker", tr.id, i);
+    if (Math.abs(p.x) <= tr.w / 2 && Math.abs(p.y) <= tr.h / 2) push("tracker", tr.id, i, tr.locked);
   });
   (f.areas ?? []).forEach((a, i) => {
-    if (pointInPolygon(a.points, x, y)) push("area", a.id, i);
+    if (pointInPolygon(a.points, x, y)) push("area", a.id, i, a.locked);
   });
 
-  // Specific kinds first; within a kind, the last drawn sits on top.
-  return hits.sort((a, b) => a.rank - b.rank || b.order - a.order).map((h) => h.sel);
+  // Locked elements yield (issue #191): anything unlocked under the pointer is
+  // picked first, whatever kind it is, so an unlocked window on a locked wall
+  // selects the window. They stay in the list rather than dropping out of it —
+  // cycling must still reach a locked element, or there would be no way to
+  // select one and unlock it again.
+  //
+  // Then specific kinds first; within a kind, the last drawn sits on top.
+  return hits
+    .sort((a, b) => Number(a.locked) - Number(b.locked) || a.rank - b.rank || b.order - a.order)
+    .map((h) => h.sel);
+}
+
+/**
+ * Whether a selection names a locked element (issue #191). Unknown ids are not
+ * locked: an id that no longer resolves is stale selection state, and treating
+ * it as pinned would quietly refuse to move the rest of a group with it.
+ */
+export function isLocked(f: Floor, sel: Sel): boolean {
+  switch (sel.kind) {
+    case "wall":
+      return !!f.walls.find((x) => x.id === sel.id)?.locked;
+    case "opening":
+      return !!f.openings.find((x) => x.id === sel.id)?.locked;
+    case "item":
+      return !!f.items.find((x) => x.id === sel.id)?.locked;
+    case "text":
+      return !!f.texts.find((x) => x.id === sel.id)?.locked;
+    case "furniture":
+      return !!f.furniture.find((x) => x.id === sel.id)?.locked;
+    case "tracker":
+      return !!(f.trackers ?? []).find((x) => x.id === sel.id)?.locked;
+    case "area":
+      return !!(f.areas ?? []).find((x) => x.id === sel.id)?.locked;
+  }
 }
 
 /**

--- a/src/editor-geometry.ts
+++ b/src/editor-geometry.ts
@@ -428,27 +428,43 @@ export function elementsAtPoint(
 }
 
 /**
- * Whether a selection names a locked element (issue #191). Unknown ids are not
- * locked: an id that no longer resolves is stale selection state, and treating
- * it as pinned would quietly refuse to move the rest of a group with it.
+ * The element a selection names, or `undefined` when nothing answers to it.
+ *
+ * `undefined` is a real answer here, not a failure: a selection can outlive
+ * what it pointed at. `setConfig` does not clear `_selection`, so a config
+ * pushed from elsewhere — another tab, a YAML edit — can leave the editor
+ * holding ids for elements that no longer exist.
  */
-export function isLocked(f: Floor, sel: Sel): boolean {
+function findElement(f: Floor, sel: Sel): { id: string; locked?: boolean } | undefined {
   switch (sel.kind) {
     case "wall":
-      return !!f.walls.find((x) => x.id === sel.id)?.locked;
+      return f.walls.find((x) => x.id === sel.id);
     case "opening":
-      return !!f.openings.find((x) => x.id === sel.id)?.locked;
+      return f.openings.find((x) => x.id === sel.id);
     case "item":
-      return !!f.items.find((x) => x.id === sel.id)?.locked;
+      return f.items.find((x) => x.id === sel.id);
     case "text":
-      return !!f.texts.find((x) => x.id === sel.id)?.locked;
+      return f.texts.find((x) => x.id === sel.id);
     case "furniture":
-      return !!f.furniture.find((x) => x.id === sel.id)?.locked;
+      return f.furniture.find((x) => x.id === sel.id);
     case "tracker":
-      return !!(f.trackers ?? []).find((x) => x.id === sel.id)?.locked;
+      return (f.trackers ?? []).find((x) => x.id === sel.id);
     case "area":
-      return !!(f.areas ?? []).find((x) => x.id === sel.id)?.locked;
+      return (f.areas ?? []).find((x) => x.id === sel.id);
   }
+}
+
+/**
+ * Whether a selection names a locked element (issue #191). A stale id is not
+ * locked: treating a selection that outlived its element as pinned would
+ * quietly refuse to move the rest of a group with it.
+ *
+ * Note this is not the same question as {@link movableSelection}'s — a stale
+ * id is not locked *and* not movable, because there is nothing there to be
+ * either.
+ */
+export function isLocked(f: Floor, sel: Sel): boolean {
+  return !!findElement(f, sel)?.locked;
 }
 
 /**
@@ -462,7 +478,12 @@ export function isLocked(f: Floor, sel: Sel): boolean {
  * happened" have to be the same thing here.
  */
 export function movableSelection(f: Floor, sel: readonly Sel[]): Sel[] {
-  return sel.filter((s) => !isLocked(f, s));
+  return sel.filter((s) => {
+    const el = findElement(f, s);
+    // Pinned cannot move; missing has nothing *to* move. Both keep the editor
+    // from spending an undo step, which is the only thing this answer feeds.
+    return !!el && !el.locked;
+  });
 }
 
 /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -133,6 +133,7 @@ import {
   attachedCorners,
   elementsAtPoint,
   cyclePick,
+  isLocked,
   elementsInRect,
   layoutPointsInPolygon,
   nearestAreaSnapPoint,
@@ -1122,13 +1123,21 @@ export class FloorplanCardEditor extends LitElement {
   private _nudge(dx: number, dy: number): void {
     if (!this._selection.length) return;
     const f = this._floor();
-    const wIds = this._idsOfKind("wall");
-    const oIds = this._idsOfKind("opening");
-    const iIds = this._idsOfKind("item");
-    const tIds = this._idsOfKind("text");
-    const fIds = this._idsOfKind("furniture");
-    const trIds = this._idsOfKind("tracker");
-    const aIds = this._idsOfKind("area");
+    // Pinned elements sit out the nudge as they sit out a drag (issue #191).
+    // Filtered per kind rather than from the selection, because _idsOfKind
+    // also feeds copy and delete, which a lock deliberately does not block.
+    const movable = (kind: SelKind) => {
+      const ids = this._idsOfKind(kind);
+      for (const id of ids) if (isLocked(f, { kind, id })) ids.delete(id);
+      return ids;
+    };
+    const wIds = movable("wall");
+    const oIds = movable("opening");
+    const iIds = movable("item");
+    const tIds = movable("text");
+    const fIds = movable("furniture");
+    const trIds = movable("tracker");
+    const aIds = movable("area");
     this._commitFloor({
       walls: f.walls.map((w) =>
         wIds.has(w.id) ? { ...w, x1: w.x1 + dx, y1: w.y1 + dy, x2: w.x2 + dx, y2: w.y2 + dy } : w
@@ -1413,6 +1422,15 @@ export class FloorplanCardEditor extends LitElement {
     const pick = explicitHandle ? sel : this._resolvePick(ev, sel);
     if (explicitHandle) this._selectOne(pick);
     else this._selectForPointer(ev, pick);
+    // A locked element selects but never drags (issue #191). Refused here
+    // rather than inside _applyDrag so it covers the handle branches too —
+    // a wall endpoint and an area vertex are written straight to the floor
+    // and never consult the drag snapshot that pins everything else.
+    // The selection above stands; nothing else happens. No `_drag`, no
+    // captured pointer and no `_gesturePointer`, so pointermove has nothing
+    // to apply — and `ev.stopPropagation()` at the top already kept the
+    // canvas marquee out of it.
+    if (isLocked(this._floor(), pick)) return;
     this._drag = {
       primary: pick,
       start: this._toVirtual(ev, false),
@@ -1435,6 +1453,12 @@ export class FloorplanCardEditor extends LitElement {
     const f = this._floor();
     const m = new Map<string, OrigPos>();
     for (const s of this._selection) {
+      // What is not snapshotted does not move. That is the whole mechanism
+      // for a pinned member of a group drag (issue #191): the delta is still
+      // taken from the primary, and _applyDelta only writes the elements this
+      // map names — so dragging a group by an unlocked handle leaves the
+      // locked ones exactly where they were.
+      if (isLocked(f, s)) continue;
       if (s.kind === "wall") {
         const w = f.walls.find((x) => x.id === s.id);
         if (w) m.set(`wall:${w.id}`, { kind: "wall", x1: w.x1, y1: w.y1, x2: w.x2, y2: w.y2 });
@@ -1769,8 +1793,14 @@ export class FloorplanCardEditor extends LitElement {
     // Fall back to the grid when snap is explicitly off (`0`) to avoid overlap.
     const off = this._resolvedSnap || this.grid;
     const f = this._floor();
+    // A pasted copy is never pinned (issue #191). It lands offset from the
+    // original and the first thing anyone does with it is put it somewhere —
+    // inheriting the lock would hand back a copy that cannot be moved into
+    // place, which reads as the paste being broken rather than as a lock.
+    const loose = { locked: undefined };
     const newWalls: Wall[] = cb.walls.map((w) => ({
       ...w,
+      ...loose,
       id: uid("wall"),
       x1: w.x1 + off,
       y1: w.y1 + off,
@@ -1779,36 +1809,42 @@ export class FloorplanCardEditor extends LitElement {
     }));
     const newOpenings: Opening[] = cb.openings.map((o) => ({
       ...o,
+      ...loose,
       id: uid(o.type),
       x: o.x + off,
       y: o.y + off,
     }));
     const newItems: FloorItem[] = cb.items.map((it) => ({
       ...it,
+      ...loose,
       id: uid("item"),
       x: it.x + off,
       y: it.y + off,
     }));
     const newTexts: FloorText[] = cb.texts.map((t) => ({
       ...t,
+      ...loose,
       id: uid("text"),
       x: t.x + off,
       y: t.y + off,
     }));
     const newFurn: Furniture[] = cb.furniture.map((fu) => ({
       ...fu,
+      ...loose,
       id: uid("furn"),
       x: fu.x + off,
       y: fu.y + off,
     }));
     const newTrackers: Tracker[] = (cb.trackers ?? []).map((tr) => ({
       ...tr,
+      ...loose,
       id: uid("tracker"),
       x: tr.x + off,
       y: tr.y + off,
     }));
     const newAreas: Area[] = (cb.areas ?? []).map((a) => ({
       ...a,
+      ...loose,
       id: uid("area"),
       points: a.points.map((p) => ({ x: p.x + off, y: p.y + off })),
     }));
@@ -1836,6 +1872,37 @@ export class FloorplanCardEditor extends LitElement {
   private _duplicate(): void {
     this._copy();
     this._paste();
+  }
+
+  /**
+   * Pin (or release) every selected element (issue #191). One history entry
+   * for the whole selection, since it is one press.
+   *
+   * `undefined` rather than `false` when releasing: unlocked is the default,
+   * so a released element goes back to saying nothing about it rather than
+   * leaving `locked: false` behind in the YAML.
+   */
+  private _setLocked(locked: boolean): void {
+    if (!this._selection.length) return;
+    const f = this._floor();
+    // `undefined` rather than `false` when releasing: unlocked is the default,
+    // so a released element goes back to saying nothing about it rather than
+    // leaving `locked: false` behind in the YAML.
+    const flag = locked || undefined;
+    const set = <T extends { id: string; locked?: boolean }>(xs: readonly T[], kind: SelKind) => {
+      const ids = this._idsOfKind(kind);
+      return xs.map((x) => (ids.has(x.id) ? { ...x, locked: flag } : x));
+    };
+    // One _commitFloor for the whole selection — one press, one undo step.
+    this._commitFloor({
+      walls: set(f.walls, "wall"),
+      openings: set(f.openings, "opening"),
+      items: set(f.items, "item"),
+      texts: set(f.texts, "text"),
+      furniture: set(f.furniture, "furniture"),
+      trackers: set(f.trackers ?? [], "tracker"),
+      areas: set(f.areas ?? [], "area"),
+    });
   }
 
   // ---- floors -------------------------------------------------------------
@@ -3878,6 +3945,30 @@ export class FloorplanCardEditor extends LitElement {
           <ha-icon icon=${icon}></ha-icon>
           <span class="edit-title" title=${summary}>${summary}</span>
           <span class="head-spacer"></span>
+          ${(() => {
+            // Lock in place (issue #191). Beside duplicate and delete because
+            // it is the same kind of thing — an action on the selection, not a
+            // property of it — and because this header is the one place that
+            // says what a selected element can have done to it.
+            //
+            // With several selected the button reports the whole group: it
+            // reads "locked" only when every one of them is, so the first
+            // press pins whatever is still loose rather than unpinning the
+            // ones already done.
+            const f = this._floor();
+            const all = this._selection.every((x) => isLocked(f, x));
+            return html`<button
+              class=${all ? "on" : ""}
+              aria-label=${all ? "Unlock" : "Lock in place"}
+              aria-pressed=${all ? "true" : "false"}
+              title=${all
+                ? "Unlock — let it be dragged again"
+                : "Lock in place — it can still be selected and edited, just not moved"}
+              @click=${() => this._setLocked(!all)}
+            >
+              <ha-icon icon=${all ? "mdi:lock" : "mdi:lock-open-variant-outline"}></ha-icon>
+            </button>`;
+          })()}
           <button aria-label="Duplicate" title="Duplicate (Ctrl/Cmd+D)" @click=${this._duplicate}>
             <ha-icon icon="mdi:content-duplicate"></ha-icon>
           </button>
@@ -3897,6 +3988,11 @@ export class FloorplanCardEditor extends LitElement {
 
   private _renderWall(w: Wall): TemplateResult {
     const selected = this._isSel("wall", w.id);
+    // A pinned wall still *looks* selected — it is — but shows no endpoint
+    // handles (issue #191): they would be drawn as grab targets that refuse
+    // to grab, and their absence is the clearest signal on the canvas that
+    // the wall is pinned.
+    const handles = selected && !w.locked;
     return svg`
       <g>
         <line x1=${w.x1} y1=${w.y1} x2=${w.x2} y2=${w.y2}
@@ -3907,7 +4003,7 @@ export class FloorplanCardEditor extends LitElement {
               mask=${`url(#${this._wallMaskId})`}
               style=${wallStrokeStyle(w.thickness)} stroke-linecap="round" /></g>
         ${
-          selected
+          handles
             ? svg`
                 <circle cx=${w.x1} cy=${w.y1} r="9" class="handle"
                         @pointerdown=${(e: PointerEvent) =>
@@ -4038,7 +4134,10 @@ export class FloorplanCardEditor extends LitElement {
                  @pointerdown=${(e: PointerEvent) => this._startDrag(e, { kind: "area", id: a.id })} />
         ${selected ? svg`<polygon points=${pts} class="area-outline" />` : nothing}
         ${
-          selected
+          // Outline yes, vertex handles no, for a pinned room — same reasoning
+          // as the wall's endpoints (issue #191): still visibly selected, with
+          // nothing on it that pretends to be draggable.
+          selected && !a.locked
             ? a.points.map(
                 (p, i) => svg`
                   <circle cx=${p.x} cy=${p.y} r="7" class="handle"
@@ -6282,6 +6381,13 @@ export class FloorplanCardEditor extends LitElement {
     .edit-head button ha-icon {
       --mdc-icon-size: 16px;
       color: inherit;
+    }
+    /* Lock in place (issue #191). The pressed state has to read at a glance:
+       it is the only one of these buttons that describes a state rather than
+       performing an action, and "why won't this drag" is the question it
+       exists to answer. */
+    .edit-head button.on {
+      color: var(--primary-color);
     }
     /* Collapsible Project section header. */
     .section-toggle {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -134,6 +134,7 @@ import {
   elementsAtPoint,
   cyclePick,
   isLocked,
+  movableSelection,
   elementsInRect,
   layoutPointsInPolygon,
   nearestAreaSnapPoint,
@@ -1123,6 +1124,12 @@ export class FloorplanCardEditor extends LitElement {
   private _nudge(dx: number, dy: number): void {
     if (!this._selection.length) return;
     const f = this._floor();
+    // Every selected element is pinned, so there is nothing to move. Return
+    // before committing: `_commitFloor` pushes a history entry unconditionally
+    // and `.map()` below hands it freshly allocated arrays, so an arrow key on
+    // a locked selection would otherwise spend an undo step on nothing — and
+    // wipe the redo stack while doing it (issue #191).
+    if (!movableSelection(f, this._selection).length) return;
     // Pinned elements sit out the nudge as they sit out a drag (issue #191).
     // Filtered per kind rather than from the selection, because _idsOfKind
     // also feeds copy and delete, which a lock deliberately does not block.

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,29 @@ export interface Wall {
    * cleared by its own opening. Raise the ceiling only alongside that mask.
    */
   thickness?: number;
+  /**
+   * Pinned in place in the editor (issue #191).
+   *
+   * A locked element still selects, still edits, still deletes — everything but
+   * *move*. It cannot be dragged, its handles do not stretch it, and arrow keys
+   * do not nudge it, alone or as part of a group. It also yields the click:
+   * anything unlocked under the pointer is picked first, so an unlocked window
+   * on a locked wall selects the window instead of the wall behind it.
+   *
+   * Both halves matter and neither is enough alone. Yielding the click without
+   * pinning still lets a determined mis-click drag the wall; pinning without
+   * yielding still costs a second click to get past it. Together they are what
+   * the reporter asked for: "every time I want to move a window, I end up moving
+   * a wall instead".
+   *
+   * Selectable on purpose, rather than untouchable the way a design tool's
+   * locked layer is: those tools have a layers panel to unlock from and this
+   * editor does not, so an element that could not be picked could never be
+   * unlocked either.
+   *
+   * The editor writes it; nothing about the rendered card reads it.
+   */
+  locked?: boolean;
 }
 
 export type OpeningType = "door" | "window";
@@ -298,6 +321,12 @@ export interface Opening {
    * Ignored for swinging openings.
    */
   sliderStyle?: SliderStyle;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 /**
@@ -615,6 +644,12 @@ export interface FloorItem {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 export type ItemDisplay = "badge" | "ripple" | "iconRipple";
@@ -726,6 +761,12 @@ export interface FloorText {
   color?: string;
   /** Rotation in degrees. Default 0. */
   angle?: number;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 /**
@@ -825,6 +866,12 @@ export interface Furniture {
   stateColor?: StateColorRule[];
   /** Color while `entity` is active. Used when no {@link stateColor} rule matches. */
   activeColor?: string;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 /**
@@ -860,6 +907,12 @@ export interface Tracker {
   xSensor?: TrackerSensor;
   /** Distance sensor mapped to the Y axis (rectangle's vertical span). */
   ySensor?: TrackerSensor;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 /**
@@ -1005,6 +1058,12 @@ export interface Area {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  /**
+   * Pinned in place in the editor (issue #191): selects and edits normally, but
+   * never moves, and yields the click to anything unlocked under the pointer.
+   * See {@link Wall.locked} for why it stays selectable.
+   */
+  locked?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #191.

@Dragi2k's complaint is two problems wearing one coat:

> Every time I want to move a window, I end up moving a wall instead, and
> whenever I try to move a switch, I move the area.

A lock only fixes that if it answers both halves, so `locked` does two things.

## What a locked element does

- **Never moves.** Not by drag, not by its endpoint or vertex handles, not by
  arrow keys — alone or as part of a group. Drag a group by an unlocked member
  and the locked ones stay put while the rest travel.
- **Yields the click.** Anything unlocked under the pointer sorts ahead of it
  in `elementsAtPoint`, whatever kind it is. Lock the wall and a window drawn
  on it is picked first, with no cycling.
- **Still selects, still edits, still deletes.** Only moving is blocked.

Neither half is enough alone: yielding without pinning still lets a stray drag
move the wall, and pinning without yielding still costs a click to get past it.

Works on every element kind — walls, openings, devices, text, furniture,
trackers, rooms — and on a whole multi-selection at once. The button is a
padlock in the Element header, beside duplicate and delete; with several
selected it reads "locked" only when all of them are, so the first press pins
whatever is still loose.

## Note on the previous discussion

@ombre33 and you both pointed out that undo exists and that devices/windows
already outrank areas in the picker, which narrowed this a lot — this is only
the "lock in place" part you said was worth testing, not a re-do of either.

## Implementation notes

The pinning is one line rather than a check at every call site:
`_snapshotSelection` skips locked elements, and `applyDelta` only writes what
the snapshot names — so a group drag leaves them behind for free.
`_startDrag` refuses separately, because the handle branches write walls and
area vertices straight to the floor and never consult that snapshot.

Two details that would otherwise have been papercuts:

- **Handles are not drawn** on a locked element — they would be grab targets
  that refuse to grab, and their absence is the clearest cue on the canvas.
  The selection outline stays, because it *is* selected.
- **Paste never carries the lock.** A copy lands offset and the first thing
  anyone does is move it; inheriting the lock would read as a broken paste.

Releasing writes `undefined`, not `false`, so an unlocked element goes back to
saying nothing in the YAML.

## Tests — and one honest gap

`npm test` — 1257 pass (1250 before, 7 new). `npm run typecheck` and
`npm run build` clean.

Covered: the pick ordering in both directions (locked opening falls behind an
unlocked wall, locked wall stops shadowing its window), locked elements
staying reachable by cycling, `isLocked` across every kind including a stale
id, and `applyDelta` moving exactly what the snapshot names.

**The gap:** the drag and nudge paths live in `editor.ts`, which has no test
environment — which is exactly what #233 is about. I verified those by reading
and tested the pure property they rest on instead. If #233's browser project
lands, "a locked element does not move under a drag" is a good first case for
it.

## README

New *Locking elements in place* section plus a Features bullet. Donation links
untouched.

## Screenshots

**The button.** Element header, same wall, before and after one press:

| | |
| --- | --- |
| ![Unlocked](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/242-unlocked.png) | open padlock — the wall drags normally |
| ![Locked](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/242-locked.png) | closed and tinted — the wall no longer moves |

**The canvas.** The same wall selected, unlocked then locked. It stays
outlined — it *is* selected — but the round endpoint handles are gone, because
they would be grab targets that refuse to grab:

| | |
| --- | --- |
| ![Handles](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/242-handles-unlocked.png) | unlocked: two endpoint handles |
| ![No handles](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/242-handles-locked.png) | locked: still selected, no handles |

Captured from the real editor. Driving it headlessly also exercised the
behaviour end to end: selecting `w1` and pressing lock takes the handle count
from 2 to 0, writes `locked: true` on the wall, and flips the button to
"Unlock" with `aria-pressed="true"`. That is not a substitute for the drag
coverage #233 would give, but it is more than the unit tests alone reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
