### PR TITLE
Rotation: a second angle, for when the screen is the other way up

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ The editor writes this config for you; manual editing is optional.
 | `grid`       | number   | `20`               | Gap between grid lines, in canvas units — smaller means finer. |
 | `snap`       | number   | follows `grid`     | Snap step in canvas units, always absolute. Omit to follow the grid, `0` for free placement. The editor shows a custom step as a percentage of the grid. |
 | `rotation`   | number   | `0`                | Rotate the card `90`, `180` or `270`° — a landscape plan on a portrait wall tablet. Icons and labels stay upright; the editor always shows the plan as drawn. |
+| `rotationPortrait` | number | (same as `rotation`) | Rotation to use while the **screen** is portrait, overriding `rotation`. Unset means `rotation` applies whichever way the screen is. See [Rotation that follows the screen](#rotation-that-follows-the-screen). |
+| `rotationLandscape` | number | (same as `rotation`) | Rotation to use while the screen is landscape. The mirror of `rotationPortrait`; set either, or both. |
 | `showDeadSpaces` | boolean | `false` | Hatch every space the walls seal off that no door or window reaches, worked out from the walls and openings themselves. See [Dead spaces](#dead-spaces). |
 | `sunDimming` | boolean | `false` | Dim through dusk, brighten through dawn, from the HA instance's sun. See [Follow the sun](#follow-the-sun). |
 | `sunBrightnessMin` | number | `0.45` | Brightness once the sun is fully down, 0–1. |
@@ -1446,6 +1448,33 @@ compactHeader: true
 Off by default, because the title then sits over the drawing — the right trade only when
 there is room for it, which is the author's call. Set it in the editor under
 **Project → Compact header**.
+
+## Rotation that follows the screen
+
+A rectangular flat wants its long side across the screen, and which side that is changes
+with the device. One `rotation` cannot be right for both, so there are two more:
+
+```yaml
+type: custom:easy-floorplan-card
+rotation: 0            # the fallback, and what an unset override falls back to
+rotationPortrait: 270  # phones
+rotationLandscape: 0   # desktop, wall tablet
+```
+
+- Set **either** override, or both. An unset one means "same as `rotation`", which is what
+  every plan did before these existed — a config that sets neither is completely
+  unaffected.
+- `0` in an override is a real answer, not "unset". On a plan that is otherwise rotated,
+  `rotationLandscape: 0` says *don't* rotate on a desktop.
+- It follows the **screen's** orientation, not the card's own box. That is what "my
+  vertical devices" means, and it keeps a narrow card in a sidebar from rotating itself on
+  a landscape desktop. It updates live when the device is turned — no reload.
+- Editing is unaffected. The editor always shows the plan as drawn, as it does for plain
+  `rotation`.
+
+In the editor: **Project → Display**, under *Rotate display*.
+
+Icons and labels stay upright at every angle, so a rotated plan is still readable.
 
 ## Styling hooks (card-mod)
 

--- a/README.md
+++ b/README.md
@@ -1501,10 +1501,13 @@ rotationLandscape: 0   # desktop, wall tablet
   every plan did before these existed — a config that sets neither is completely
   unaffected.
 - `0` in an override is a real answer, not "unset". On a plan that is otherwise rotated,
-  `rotationLandscape: 0` says *don't* rotate on a desktop.
+  `rotationLandscape: 0` says *don't* rotate on a desktop. Writing the key with **no
+  value** (`rotationPortrait:`) is unset, though — not 0°.
 - It follows the **screen's** orientation, not the card's own box. That is what "my
   vertical devices" means, and it keeps a narrow card in a sidebar from rotating itself on
-  a landscape desktop. It updates live when the device is turned — no reload.
+  a landscape desktop. On any current browser it follows the device being turned live,
+  with no reload; on an older WebView without a subscribable `matchMedia` it is still
+  correct when the page loads and simply stops following turns after that.
 - Editing is unaffected. The editor always shows the plan as drawn, as it does for plain
   `rotation`.
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1055,6 +1055,25 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect(form.toPatch({ rotationLandscape: "0" })).toEqual({ rotationLandscape: 0 });
   });
 
+  it("reads an override written with no value as unset, not 0°", () => {
+    // `rotationPortrait:` in YAML parses to null. Shown as 0° the editor would
+    // not just display the wrong thing — saving this panel would write that 0
+    // back as a real override, turning a stray empty key into an instruction
+    // the plan never had. Same `== null` reasoning as resolvePlanRotation.
+    const form = projectDisplayForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      rotation: 270,
+      rotationPortrait: null,
+      rotationLandscape: null,
+    } as unknown as FloorplanCardConfig);
+    expect(form.data.rotationPortrait).toBe("");
+    expect(form.data.rotationLandscape).toBe("");
+    // The base angle is untouched by the stray key.
+    expect(form.data.rotation).toBe("270");
+  });
+
   it("shows an override the config already has (issue #237)", () => {
     const form = projectDisplayForm({
       type: "t",

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -977,10 +977,36 @@ describe("wallForm / projectForm / floorImageForm", () => {
     expect((width.selector.number as { min: number }).min).toBe(1);
   });
 
+  it("rests both orientation overrides at \"same as above\" (issue #237)", () => {
+    const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
+    expect(form.data.rotationPortrait).toBe("");
+    expect(form.data.rotationLandscape).toBe("");
+    // Back to "same as above" clears the override.
+    expect(form.toPatch({ rotationPortrait: "" })).toEqual({ rotationPortrait: undefined });
+    expect(form.toPatch({ rotationPortrait: "270" })).toEqual({ rotationPortrait: 270 });
+    // 0 is kept, unlike `rotation` — on a rotated plan it is a real answer.
+    expect(form.toPatch({ rotationLandscape: "0" })).toEqual({ rotationLandscape: 0 });
+  });
+
+  it("shows an override the config already has (issue #237)", () => {
+    const form = projectDisplayForm({
+      type: "t",
+      width: 1000,
+      height: 600,
+      rotation: 270,
+      rotationLandscape: 0,
+    } as FloorplanCardConfig);
+    expect(form.data.rotation).toBe("270");
+    expect(form.data.rotationLandscape).toBe("0");
+    expect(form.data.rotationPortrait).toBe("");
+  });
+
   it("rotation lives in the bottom-row display form, defaults to 0°, and patches as a number", () => {
     const form = projectDisplayForm({ type: "t", width: 1000, height: 600 } as FloorplanCardConfig);
     expect(form.fields.map((x) => x.name)).toEqual([
       "rotation",
+      "rotationPortrait",
+      "rotationLandscape",
       "overlayScale",
       "compactHeader",
       "offlineStyle",
@@ -1784,7 +1810,7 @@ describe("every field lands in exactly one panel group", () => {
     // offlineStyle as one form with one toPatch, but the panel renders the
     // first three under "Display" and the last under "Devices". Miss it in
     // both slices and the control silently disappears.
-    const DISPLAY = ["rotation", "overlayScale", "compactHeader"];
+    const DISPLAY = ["rotation", "rotationPortrait", "rotationLandscape", "overlayScale", "compactHeader"];
     const DEVICES = ["offlineStyle"];
     const cfg = { type: "t", width: 1000, height: 600 } as FloorplanCardConfig;
     check(projectDisplayForm(cfg).fields, [DISPLAY, DEVICES], "project display");

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1949,10 +1949,15 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
     data: {
       rotation: String(normalizePlanRotation(c.rotation)),
       // "" is "same as above" — the absence of an override, not an angle.
+      // `== null` for the same reason resolvePlanRotation uses it: a key
+      // written with no value (`rotationPortrait:`) parses to `null`, and
+      // reading that as an angle would show 0° here — then write it into the
+      // YAML as a real override the moment this panel is saved, turning a
+      // stray empty key into an instruction the plan never had.
       rotationPortrait:
-        c.rotationPortrait === undefined ? "" : String(normalizePlanRotation(c.rotationPortrait)),
+        c.rotationPortrait == null ? "" : String(normalizePlanRotation(c.rotationPortrait)),
       rotationLandscape:
-        c.rotationLandscape === undefined ? "" : String(normalizePlanRotation(c.rotationLandscape)),
+        c.rotationLandscape == null ? "" : String(normalizePlanRotation(c.rotationLandscape)),
       overlayScale: normalizeOverlayScale(c.overlayScale),
       compactHeader: c.compactHeader ?? false,
       zoomedOverlayScale: c.zoomedOverlayScale ?? DEFAULT_ZOOMED_OVERLAY_SCALE,

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1753,6 +1753,34 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
         helper: "Rotates the live card only — editing stays as drawn",
         selector: dropdown(opt("0", "0°"), opt("90", "90°"), opt("180", "180°"), opt("270", "270°")),
       },
+      // Per-orientation overrides (issue #237). Two dropdowns with a "same as
+      // above" default rather than a switch plus two angles: the switch would
+      // be a third control whose only job is to say whether the other two
+      // count, and "same as above" says that per orientation and for free.
+      {
+        name: "rotationPortrait",
+        label: "…on a portrait screen",
+        helper: "Overrides the angle above while the screen is taller than it is wide",
+        selector: dropdown(
+          opt("", "Same as above"),
+          opt("0", "0°"),
+          opt("90", "90°"),
+          opt("180", "180°"),
+          opt("270", "270°")
+        ),
+      },
+      {
+        name: "rotationLandscape",
+        label: "…on a landscape screen",
+        helper: "Overrides the angle above while the screen is wider than it is tall",
+        selector: dropdown(
+          opt("", "Same as above"),
+          opt("0", "0°"),
+          opt("90", "90°"),
+          opt("180", "180°"),
+          opt("270", "270°")
+        ),
+      },
       {
         name: "overlayScale",
         label: "Badge & label size",
@@ -1785,6 +1813,11 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
     ],
     data: {
       rotation: String(normalizePlanRotation(c.rotation)),
+      // "" is "same as above" — the absence of an override, not an angle.
+      rotationPortrait:
+        c.rotationPortrait === undefined ? "" : String(normalizePlanRotation(c.rotationPortrait)),
+      rotationLandscape:
+        c.rotationLandscape === undefined ? "" : String(normalizePlanRotation(c.rotationLandscape)),
       overlayScale: normalizeOverlayScale(c.overlayScale),
       compactHeader: c.compactHeader ?? false,
       offlineStyle: offlineStyleOf(c),
@@ -1794,6 +1827,12 @@ export function projectDisplayForm(c: FloorplanCardConfig): FormSpec {
       if ("rotation" in out)
         // Stored as a number; 0 means "not rotated", so keep it out of the YAML.
         out = { ...out, rotation: out.rotation === "0" ? undefined : Number(out.rotation) };
+      // The overrides keep their 0 (issue #237): "0° on a portrait screen" is
+      // a real instruction when the plan is otherwise rotated, and dropping it
+      // the way `rotation` drops its own would silently mean "same as above".
+      // Only "" — no override — leaves the YAML.
+      for (const k of ["rotationPortrait", "rotationLandscape"] as const)
+        if (k in out) out = { ...out, [k]: out[k] === "" ? undefined : Number(out[k]) };
       // Both values are written down, which is the one field here that breaks
       // the "defaults stay out of the YAML" habit — deliberately. Omitting the
       // default is what let 1.5.0 restyle every existing plan by changing its

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4384,7 +4384,13 @@ export class FloorplanCardEditor extends LitElement {
           // How the card is framed on the dashboard, as opposed to what is
           // drawn inside it. Set once for a surface and rarely touched again.
           "Display",
-          this._renderForm(formSlice(display, ["rotation", "overlayScale", "compactHeader"]), patch)
+          this._renderForm(formSlice(display, [
+            "rotation",
+            "rotationPortrait",
+            "rotationLandscape",
+            "overlayScale",
+            "compactHeader",
+          ]), patch)
         )}
         ${this._renderGroup(
           // Light through the openings (issue #177) — where it comes from and

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -110,7 +110,7 @@ import {
   resolveItemIcon,
   resolveIconAnimation,
   itemIconSize,
-  normalizePlanRotation,
+  resolvePlanRotation,
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
@@ -166,6 +166,35 @@ export class FloorplanCard extends LitElement {
   private readonly _glowIdBase = `fp-glow-${FloorplanCard._nextGlowId++}`;
   /** Entity ids this plan actually displays; used to skip irrelevant hass updates. */
   private _watchedEntities: Set<string> = new Set();
+  /**
+   * Whether the screen is portrait, for the per-orientation rotations (issue
+   * #237). `undefined` until asked, and where there is nothing to ask —
+   * `resolvePlanRotation` reads that as "no orientation known" and stays on
+   * the plain `rotation` rather than guessing.
+   */
+  @state() private _portrait?: boolean;
+  /** The query behind {@link _portrait}, kept so the listener can be removed. */
+  private _orientationQuery?: MediaQueryList;
+  private readonly _onOrientation = (e: MediaQueryListEvent | MediaQueryList): void => {
+    this._portrait = e.matches;
+  };
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    // Subscribed unconditionally rather than only when an override is set:
+    // the config can change under a live card, and a query that is listened
+    // to but never read costs nothing.
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    this._orientationQuery = window.matchMedia("(orientation: portrait)");
+    this._onOrientation(this._orientationQuery);
+    this._orientationQuery.addEventListener("change", this._onOrientation);
+  }
+
+  public disconnectedCallback(): void {
+    this._orientationQuery?.removeEventListener("change", this._onOrientation);
+    this._orientationQuery = undefined;
+    super.disconnectedCallback();
+  }
 
   public setConfig(config: FloorplanCardConfig): void {
     // Cheap shape assertions so malformed YAML surfaces as HA's error card
@@ -178,7 +207,7 @@ export class FloorplanCard extends LitElement {
       if (raw[key] != null && !Array.isArray(raw[key]))
         throw new Error(`Invalid configuration: "${key}" must be a list`);
     }
-    for (const key of ["width", "height", "grid", "rotation"]) {
+    for (const key of ["width", "height", "grid", "rotation", "rotationPortrait", "rotationLandscape"]) {
       if (raw[key] != null && typeof raw[key] !== "number")
         throw new Error(`Invalid configuration: "${key}" must be a number`);
     }
@@ -762,7 +791,7 @@ export class FloorplanCard extends LitElement {
     // Whole-plan display rotation (issue #33): the SVG rotates via one group
     // transform below; the HTML overlay remaps per point in _renderItem /
     // _renderText. Both must use the same mapping (rotatePlanPoint).
-    const rot = normalizePlanRotation(c.rotation);
+    const rot = resolvePlanRotation(c, this._portrait);
     const dims = rotatedCanvasSize(cssNumber(c.width, DEFAULT_WIDTH), cssNumber(c.height, DEFAULT_HEIGHT), rot);
     const rotTransform = planRotationTransform(c.width, c.height, rot);
     // Overlay sizing mode. --fp-plan-w is the canvas width *as displayed*, so a

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -111,6 +111,7 @@ import {
   resolveIconAnimation,
   itemIconSize,
   resolvePlanRotation,
+  subscribeOrientation,
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
@@ -173,9 +174,11 @@ export class FloorplanCard extends LitElement {
    * the plain `rotation` rather than guessing.
    */
   @state() private _portrait?: boolean;
-  /** The query behind {@link _portrait}, kept so the listener can be removed. */
-  private _orientationQuery?: MediaQueryList;
-  private readonly _onOrientation = (e: MediaQueryListEvent | MediaQueryList): void => {
+  /** Undoes the orientation subscription; set while connected (issue #237). */
+  private _unsubscribeOrientation?: () => void;
+  // Takes the narrowest thing it uses, so it fits both a `MediaQueryList` read
+  // directly on load and the `change` event that follows.
+  private readonly _onOrientation = (e: { matches: boolean }): void => {
     this._portrait = e.matches;
   };
 
@@ -185,14 +188,18 @@ export class FloorplanCard extends LitElement {
     // the config can change under a live card, and a query that is listened
     // to but never read costs nothing.
     if (typeof window === "undefined" || !window.matchMedia) return;
-    this._orientationQuery = window.matchMedia("(orientation: portrait)");
-    this._onOrientation(this._orientationQuery);
-    this._orientationQuery.addEventListener("change", this._onOrientation);
+    const q = window.matchMedia("(orientation: portrait)");
+    // Read first, subscribe second — deliberately in that order. The initial
+    // read is what gets the rotation right on load, and it works even on a
+    // WebView that offers no subscription at all, so the worst case is a plan
+    // that is correct until the device is turned rather than one that is wrong.
+    this._onOrientation(q);
+    this._unsubscribeOrientation = subscribeOrientation(q, this._onOrientation);
   }
 
   public disconnectedCallback(): void {
-    this._orientationQuery?.removeEventListener("change", this._onOrientation);
-    this._orientationQuery = undefined;
+    this._unsubscribeOrientation?.();
+    this._unsubscribeOrientation = undefined;
     super.disconnectedCallback();
   }
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -121,6 +121,7 @@ import {
   itemIconSize,
   normalizePlanRotation,
   resolvePlanRotation,
+  subscribeOrientation,
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
@@ -3757,6 +3758,65 @@ describe("rotation that follows the screen (issue #237)", () => {
     expect(resolvePlanRotation({} as FloorplanCardConfig, true)).toBe(0);
     expect(resolvePlanRotation({} as FloorplanCardConfig, false)).toBe(0);
     expect(resolvePlanRotation({} as FloorplanCardConfig, undefined)).toBe(0);
+  });
+});
+
+describe("subscribing to the screen's orientation (review of #237)", () => {
+  // MediaQueryList only became an EventTarget in Safari 14 / Chrome 39, and
+  // the devices this feature is for — wall tablets, old phones — are the ones
+  // most likely to predate that. Calling a missing method would throw out of
+  // connectedCallback and take the card's whole render with it.
+  const fn = () => {};
+
+  it("uses the modern API when it is there, and unsubscribes through it", () => {
+    const calls: string[] = [];
+    const q = {
+      addEventListener: (t: string) => calls.push(`add:${t}`),
+      removeEventListener: (t: string) => calls.push(`remove:${t}`),
+      // Present too, as on any current browser — and must not be the one used.
+      addListener: () => calls.push("legacy-add"),
+      removeListener: () => calls.push("legacy-remove"),
+    };
+    subscribeOrientation(q, fn)();
+    expect(calls).toEqual(["add:change", "remove:change"]);
+  });
+
+  it("falls back to addListener where that is all there is", () => {
+    const calls: string[] = [];
+    const q = {
+      addListener: () => calls.push("add"),
+      removeListener: () => calls.push("remove"),
+    };
+    subscribeOrientation(q, fn)();
+    expect(calls).toEqual(["add", "remove"]);
+  });
+
+  it("never crosses the two — a legacy listener is removed the legacy way", () => {
+    // Crossing them leaves the listener attached to a card that is gone.
+    const seen: string[] = [];
+    const q = {
+      addListener: () => seen.push("add"),
+      removeListener: () => seen.push("remove"),
+      removeEventListener: () => seen.push("WRONG"),
+    };
+    subscribeOrientation(q, fn)();
+    expect(seen).not.toContain("WRONG");
+  });
+
+  it("subscribes to nothing, quietly, when neither API exists", () => {
+    // The card reads the query before subscribing, so this case still renders
+    // at the right rotation — it just stops following the device being turned.
+    expect(() => subscribeOrientation({}, fn)()).not.toThrow();
+  });
+
+  it("hands the listener straight through, so it is the one removed", () => {
+    let held: unknown;
+    const q = {
+      addEventListener: (_t: string, f: unknown) => { held = f; },
+      removeEventListener: (_t: string, f: unknown) => { expect(f).toBe(held); },
+    };
+    subscribeOrientation(q, fn)();
+    expect(held).toBe(fn);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -120,6 +120,7 @@ import {
   isRippleEntity,
   itemIconSize,
   normalizePlanRotation,
+  resolvePlanRotation,
   rotatedCanvasSize,
   rotatePlanPoint,
   planRotationTransform,
@@ -3713,6 +3714,49 @@ describe("polygonCentroid", () => {
 
   it("returns the origin for an empty polygon", () => {
     expect(polygonCentroid([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("rotation that follows the screen (issue #237)", () => {
+  it("uses `rotation` for both orientations until an override says otherwise", () => {
+    const c = { rotation: 270 } as FloorplanCardConfig;
+    expect(resolvePlanRotation(c, true)).toBe(270);
+    expect(resolvePlanRotation(c, false)).toBe(270);
+  });
+
+  it("takes the override for the orientation it names, and only that one", () => {
+    const c = { rotation: 0, rotationPortrait: 270 } as FloorplanCardConfig;
+    expect(resolvePlanRotation(c, true)).toBe(270);
+    expect(resolvePlanRotation(c, false)).toBe(0); // landscape keeps the base
+    const both = { rotation: 0, rotationPortrait: 270, rotationLandscape: 90 } as FloorplanCardConfig;
+    expect(resolvePlanRotation(both, true)).toBe(270);
+    expect(resolvePlanRotation(both, false)).toBe(90);
+  });
+
+  it("honours an override of 0 rather than reading it as unset", () => {
+    // "0° on a portrait screen" is a real instruction on a plan that is
+    // otherwise rotated — the case the reporter is in.
+    const c = { rotation: 270, rotationPortrait: 0 } as FloorplanCardConfig;
+    expect(resolvePlanRotation(c, true)).toBe(0);
+    expect(resolvePlanRotation(c, false)).toBe(270);
+  });
+
+  it("stays on the base rotation when the orientation is unknown", () => {
+    // No window to ask. Guessing would rotate the plan on a wrong guess.
+    const c = { rotation: 90, rotationPortrait: 180 } as FloorplanCardConfig;
+    expect(resolvePlanRotation(c, undefined)).toBe(90);
+  });
+
+  it("normalizes an override the same way `rotation` is normalized", () => {
+    expect(resolvePlanRotation({ rotationPortrait: 450 } as FloorplanCardConfig, true)).toBe(90);
+    expect(resolvePlanRotation({ rotationPortrait: -90 } as FloorplanCardConfig, true)).toBe(270);
+    expect(resolvePlanRotation({ rotationPortrait: 45 } as FloorplanCardConfig, true)).toBe(0);
+  });
+
+  it("a config with no rotation at all is unaffected, whatever the screen", () => {
+    expect(resolvePlanRotation({} as FloorplanCardConfig, true)).toBe(0);
+    expect(resolvePlanRotation({} as FloorplanCardConfig, false)).toBe(0);
+    expect(resolvePlanRotation({} as FloorplanCardConfig, undefined)).toBe(0);
   });
 });
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -3748,6 +3748,20 @@ describe("rotation that follows the screen (issue #237)", () => {
     expect(resolvePlanRotation(c, undefined)).toBe(90);
   });
 
+  it("reads an empty YAML override as unset, not as 0° (review of #237)", () => {
+    // `rotationPortrait:` with nothing after it parses to null, and the card's
+    // numeric guard lets nullish through. Read as a value it normalizes to 0
+    // and silently cancels the base rotation — the one thing an unset
+    // override must never do.
+    const c = { rotation: 270, rotationPortrait: null } as unknown as FloorplanCardConfig;
+    expect(resolvePlanRotation(c, true)).toBe(270);
+    expect(resolvePlanRotation(c, false)).toBe(270);
+    const l = { rotation: 90, rotationLandscape: null } as unknown as FloorplanCardConfig;
+    expect(resolvePlanRotation(l, false)).toBe(90);
+    // An explicit 0 is still an explicit 0 — that distinction is the point.
+    expect(resolvePlanRotation({ rotation: 270, rotationPortrait: 0 } as FloorplanCardConfig, true)).toBe(0);
+  });
+
   it("normalizes an override the same way `rotation` is normalized", () => {
     expect(resolvePlanRotation({ rotationPortrait: 450 } as FloorplanCardConfig, true)).toBe(90);
     expect(resolvePlanRotation({ rotationPortrait: -90 } as FloorplanCardConfig, true)).toBe(270);

--- a/src/render.ts
+++ b/src/render.ts
@@ -3510,6 +3510,30 @@ export function normalizePlanRotation(v: unknown): PlanRotation {
   return r === 90 || r === 180 || r === 270 ? r : 0;
 }
 
+/**
+ * The rotation a plan is actually drawn at, given which way the screen is
+ * (issue #237).
+ *
+ * `rotation` is the answer for both orientations until one of the two
+ * overrides says otherwise, so a config that sets neither behaves exactly as
+ * it did before this existed — including a config that sets no rotation at
+ * all, which is most of them.
+ *
+ * `portrait` is `undefined` where the question cannot be asked (a card
+ * rendered without a window, which is every test in this suite and the
+ * server-side pass in some setups). That falls back to `rotation` rather than
+ * guessing an orientation, because guessing wrong rotates the plan.
+ */
+export function resolvePlanRotation(
+  c: Pick<FloorplanCardConfig, "rotation" | "rotationPortrait" | "rotationLandscape">,
+  portrait?: boolean
+): PlanRotation {
+  const base = normalizePlanRotation(c.rotation);
+  if (portrait === undefined) return base;
+  const override = portrait ? c.rotationPortrait : c.rotationLandscape;
+  return override === undefined ? base : normalizePlanRotation(override);
+}
+
 /** Canvas size as displayed: 90°/270° swap width and height. */
 export function rotatedCanvasSize(
   w: number,

--- a/src/render.ts
+++ b/src/render.ts
@@ -3517,7 +3517,8 @@ export function normalizePlanRotation(v: unknown): PlanRotation {
  * `rotation` is the answer for both orientations until one of the two
  * overrides says otherwise, so a config that sets neither behaves exactly as
  * it did before this existed — including a config that sets no rotation at
- * all, which is most of them.
+ * all, which is most of them. An override written with no value at all
+ * (`rotationPortrait:`, which YAML parses to `null`) counts as not set.
  *
  * `portrait` is `undefined` where the question cannot be asked (a card
  * rendered without a window, which is every test in this suite and the
@@ -3531,7 +3532,13 @@ export function resolvePlanRotation(
   const base = normalizePlanRotation(c.rotation);
   if (portrait === undefined) return base;
   const override = portrait ? c.rotationPortrait : c.rotationLandscape;
-  return override === undefined ? base : normalizePlanRotation(override);
+  // `== null`, not `=== undefined`: a key written with no value —
+  // `rotationPortrait:` — parses to `null`, and the card's own numeric guard
+  // lets it through (it only rejects non-numbers that are not nullish, the
+  // same way an empty `trackers:` is treated as unset rather than malformed).
+  // Read as a value it would normalize to 0 and *silently override* the base
+  // rotation, which is the one thing an unset override must never do.
+  return override == null ? base : normalizePlanRotation(override);
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -3534,6 +3534,52 @@ export function resolvePlanRotation(
   return override === undefined ? base : normalizePlanRotation(override);
 }
 
+/**
+ * The two ways a `MediaQueryList` can be listened to. Duck-typed rather than
+ * taking the DOM interface, so this is reachable from a node test — which is
+ * the whole reason it is a function instead of four lines inside the card's
+ * `connectedCallback` (issue #237).
+ */
+export interface OrientationQuery {
+  addEventListener?: (type: "change", fn: (e: { matches: boolean }) => void) => void;
+  removeEventListener?: (type: "change", fn: (e: { matches: boolean }) => void) => void;
+  addListener?: (fn: (e: { matches: boolean }) => void) => void;
+  removeListener?: (fn: (e: { matches: boolean }) => void) => void;
+}
+
+/**
+ * Subscribe to a media query, returning the matching unsubscribe (issue #237).
+ *
+ * `MediaQueryList` has only been an `EventTarget` since Safari 14 / Chrome 39;
+ * older WebViews carry the deprecated `addListener` alone. That matters here
+ * more than it usually would, because the devices this feature exists for —
+ * wall tablets, an old phone propped in a hallway — are exactly the ones
+ * likely to be running one, and calling a missing method would throw out of
+ * `connectedCallback` and take the card's whole render with it.
+ *
+ * Add and remove are chosen the same way, so a listener registered through the
+ * legacy API is removed through it too: crossing them leaves the listener
+ * attached to a card that is gone.
+ *
+ * Where neither exists this subscribes to nothing and returns a no-op. The
+ * card reads the query's current value *before* calling this, so that case is
+ * still right on load — it just stops following the device being turned.
+ */
+export function subscribeOrientation(
+  q: OrientationQuery,
+  fn: (e: { matches: boolean }) => void
+): () => void {
+  if (typeof q.addEventListener === "function") {
+    q.addEventListener("change", fn);
+    return () => q.removeEventListener?.("change", fn);
+  }
+  if (typeof q.addListener === "function") {
+    q.addListener(fn);
+    return () => q.removeListener?.(fn);
+  }
+  return () => {};
+}
+
 /** Canvas size as displayed: 90°/270° swap width and height. */
 export function rotatedCanvasSize(
   w: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1249,6 +1249,30 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    */
   rotation?: number;
   /**
+   * Rotation to use while the screen is **portrait**, overriding
+   * {@link rotation} (issue #237). Unset — the default — means `rotation`
+   * applies whichever way the screen is.
+   *
+   * The case it exists for: a plan of a rectangular flat wants the long side
+   * across the screen, and which side that is changes with the device. The
+   * reporter was rotating 270° for their phone and then living with the
+   * result on a desktop and a tablet, because one number cannot be right for
+   * both. This is the second number.
+   *
+   * Read from the **screen's** orientation, not the card's own box (see
+   * {@link resolvePlanRotation}), which is what "my vertical devices" means
+   * and what keeps a narrow card in a sidebar from rotating on a landscape
+   * desktop. Editing is unaffected either way: the editor always shows the
+   * plan as drawn.
+   */
+  rotationPortrait?: number;
+  /**
+   * Rotation to use while the screen is **landscape**, overriding
+   * {@link rotation} (issue #237). Unset means `rotation` applies. The
+   * mirror of {@link rotationPortrait}; set either, or both.
+   */
+  rotationLandscape?: number;
+  /**
    * Built-in skin id (issue #122), e.g. `odnetnin`, `pastel`, `tron`. Restyles
    * the whole plan at once — paper, walls, badges, accents — by supplying the
    * fallbacks every element already reads.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1276,7 +1276,8 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
   /**
    * Rotation to use while the screen is **portrait**, overriding
    * {@link rotation} (issue #237). Unset — the default — means `rotation`
-   * applies whichever way the screen is.
+   * applies whichever way the screen is; a key written with no value at all
+   * (`rotationPortrait:`) is unset too, not 0°.
    *
    * The case it exists for: a plan of a rectangular flat wants the long side
    * across the screen, and which side that is changes with the device. The


### PR DESCRIPTION
Closes #237. Also covers what #197 asks for — see below.

@GhislainC's problem is that one number cannot be right for two devices:

> On my vertical devices (smartphone), I would like to display the plan
> vertically … on my horizontal devices (computer, tablet), horizontally.
> The editing is then easy on computer and the usage on smartphone are
> optimized BUT, the usage on computer or on my tablet is worst!

So there are two more numbers.

```yaml
rotation: 0            # the fallback
rotationPortrait: 270  # phones
rotationLandscape: 0   # desktop, wall tablet
```

Each override replaces `rotation` for the orientation it names. Unset means
"same as `rotation`", so **a config that sets neither is completely
unaffected** — including the great majority that set no rotation at all.

## Three decisions worth a look

**The screen, not the card's own box.** "My vertical devices" is about the
device, and reading the screen also stops a narrow card in a sidebar from
rotating itself on a landscape desktop. It is a `matchMedia` subscription, so
it follows a phone being turned with no reload.

**`0` in an override is an answer, not an absence.** `rotation` drops its own
`0` to keep unrotated plans out of the YAML — but `rotationLandscape: 0` on a
plan rotated 270° means "don't rotate on a desktop", and dropping it would
silently mean the opposite. Only "same as above" leaves the YAML.

**Unknown orientation keeps the base rotation.** `resolvePlanRotation` takes
`portrait?: boolean` and falls back when it's undefined — no window to ask.
Guessing would rotate the plan whenever the guess was wrong.

The editor gets two dropdowns beside *Rotate display*, each defaulting to
"Same as above", rather than the switch-plus-two-angles the issue sketched:
the switch would be a third control whose only job is to say whether the other
two count.

## On #197

@aranaformae asked for the same outcome by a harder route — rotation per
user/device — and you said you'd only build it if it were paired to a device.
This gets there without needing to know who is looking, so I'd suggest closing
#197 as covered. Worth noting @I-G-1-1's workaround there (card-mod + a custom
theme + conditional visibility, which also hides the HA header globally) as
what this replaces.

Their caveat was the real risk — that rotating the plan rotates the text and
icons with it. It doesn't: the overlay stays upright at every angle, which is
existing behaviour this inherits.

## Screenshots

The same config — `rotation: 0`, `rotationPortrait: 270` — rendered at two
window sizes. Nothing changed but the shape of the screen:

| Landscape screen | Portrait screen |
| --- | --- |
| ![Landscape](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/243-landscape.png) | ![Portrait](https://raw.githubusercontent.com/nicosandller/easy-floorplan/pr-screenshots/pr/243-portrait.png) |

The portrait render is the answer to @I-G-1-1's caveat on #197: the plan turns,
but **the text and icons stay upright** — "KITCHEN", "LIVING ROOM" and
`21.5 °C · 48 % · 62 %` all read normally. No neck-flexing required.

## Verification

**Correction to what this section said earlier.** I originally claimed the
plan "re-rendered on the orientation change, no reload". That claim was based
on a bad observation: the browser pane I was testing in emulates viewport size
without dispatching `resize` or `matchMedia` `change` at all — a plain
listener registered in the page receives nothing either, so what I read as a
live transition was two independent page loads. The behaviour below is what is
actually established.

- **The angle chosen at each orientation** — two headless Chromium runs, one
  per window shape. Landscape renders `viewBox="0 0 400 200"` with no
  transform; portrait renders `"0 0 200 400"` with
  `translate(0 400) rotate(-90)`. These are the screenshots above.
- **The handler through to the re-render** — driving the card's orientation
  handler live: `{matches:true}` → `0 0 200 400`, `{matches:false}` →
  `0 0 400 200`, and back again, each without a reload.
- **Which subscription API is used, and unsubscribing through the same one** —
  unit tested against duck-typed queries (see the review commit).

What that leaves unverified by me is the browser dispatching `change` when a
real device is turned, which is platform behaviour rather than this card's.
Worth a spot-check on an actual phone before merge.

`npm test` — 1263 pass (1250 on main). `npm run typecheck` and `npm run build`
clean.

Resolver coverage: base rotation used for both orientations until an override
says otherwise; each override applying only to its own orientation; `0`
honoured rather than read as unset; unknown orientation falling back;
overrides normalized like `rotation` (450→90, −90→270, 45→0); a config with no
rotation unaffected; and both editor dropdowns resting at "same as above"
while showing an override the config already has.

## README

New *Rotation that follows the screen* section, plus both fields in the config
table. Donation links untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

