### PR TITLE
Badges: give the plain badge the state the ripple one already had

### DIFF
--- a/src/card-badge.browser.test.ts
+++ b/src/card-badge.browser.test.ts
@@ -1,0 +1,113 @@
+/**
+ * What the card actually renders into a badge, in a real browser.
+ *
+ * This exists because of the bug it is named for: a device set to show its
+ * reading rendered the reading in the editor and the icon on the card. The
+ * card's own render path was never covered — the node suite cannot import
+ * `floorplan-card.ts` at all, since defining a custom element needs a DOM —
+ * so every test of "value or icon" was a test of the pure helper that decides
+ * the text, and the helper was right the whole time. What was wrong was the
+ * wiring around it, which only a mounted card can see (issue #254).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import "./floorplan-card";
+import type { FloorplanCard } from "./floorplan-card";
+import { badgeValue } from "./render";
+import type { FloorItem, FloorplanCardConfig } from "./types";
+
+function config(item: Partial<FloorItem>): FloorplanCardConfig {
+  return {
+    type: "custom:easy-floorplan-card",
+    width: 1000,
+    height: 600,
+    floors: [
+      {
+        id: "f1",
+        name: "Floor 1",
+        walls: [],
+        openings: [],
+        items: [
+          { id: "s1", kind: "sensor", entity: "sensor.temp", x: 500, y: 300, ...item } as FloorItem,
+        ],
+        texts: [],
+        furniture: [],
+        trackers: [],
+        areas: [],
+      },
+    ],
+  };
+}
+
+const hass = {
+  states: {
+    "sensor.temp": {
+      entity_id: "sensor.temp",
+      state: "21.5",
+      attributes: { unit_of_measurement: "°C" },
+    },
+  },
+  entities: {},
+  formatEntityState: (st: { state: string }) => st.state,
+} as unknown as FloorplanCard["hass"];
+
+async function mountCard(item: Partial<FloorItem>) {
+  const host = document.createElement("div");
+  host.style.width = "900px";
+  host.style.height = "540px";
+  document.body.appendChild(host);
+
+  const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+  card.setConfig(config(item));
+  card.hass = hass;
+  host.appendChild(card);
+  await card.updateComplete;
+
+  const root = card.shadowRoot!;
+  return {
+    card,
+    badgeValue: () => root.querySelector(".badge .badge-value")?.textContent?.trim(),
+    badgeIcon: () => root.querySelector(".badge ha-icon")?.getAttribute("icon") ?? undefined,
+  };
+}
+
+describe("badge contents on the rendered card", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // What the helper says this device's badge should read. Asserting against
+  // it rather than a literal keeps these about the *wiring* — whether the card
+  // renders the answer at all — which is what broke. How a reading is worded
+  // is `badgeValue`'s own business and has its own tests.
+  const expected = badgeValue(hass as never, {
+    entity: "sensor.temp",
+  } as never);
+
+  it("shows the reading when the badge is set to Value (issue #254)", async () => {
+    const t = await mountCard({ badgeContent: "value" });
+    expect(expected).toBeTruthy(); // the fixture has something to show
+    expect(t.badgeValue()).toBe(expected);
+    // …and the glyph it replaces is not also drawn.
+    expect(t.badgeIcon()).toBeUndefined();
+  });
+
+  it("still shows the icon when the badge is set to Icon", async () => {
+    const t = await mountCard({ badgeContent: "icon" });
+    expect(t.badgeValue()).toBeUndefined();
+    expect(t.badgeIcon()).toBeTruthy();
+  });
+
+  it("shows the reading through a ripple too, which is the path that kept working", async () => {
+    // Both branches of the same `if` call the badge renderer, and the merge
+    // that broke this one left the other correct — so a test of either alone
+    // would have missed it.
+    const t = await mountCard({ badgeContent: "value", display: "iconRipple" });
+    expect(t.badgeValue()).toBe(expected);
+  });
+
+  it("falls back to the icon when the entity has nothing numeric to show", async () => {
+    const t = await mountCard({ badgeContent: "value", entity: "sensor.missing" });
+    expect(t.badgeValue()).toBeUndefined();
+    expect(t.badgeIcon()).toBeTruthy();
+  });
+});

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -752,7 +752,7 @@ export class FloorplanCard extends LitElement {
       </div>`;
     } else if (showIcon) {
       visual = html`<span style="${hiddenStyle}">
-        ${this._renderBadge(item, scale)}
+        ${this._renderBadge(item, scale, renderHass)}
       </span>`;
     }
 


### PR DESCRIPTION
Fixes the regression in v1.7.0: a device with **Badge shows: Value** draws the reading in the editor and the **icon** on the card.

## What broke

`_renderBadge` reads state from the `renderHass` it is handed. It has two call sites, and only one of them hands it over:

```
751:  ${showIcon ? html`<div class="stack-icon">${this._renderBadge(item, scale, renderHass)}</div>` : nothing}
755:  ${this._renderBadge(item, scale)}          ← the plain badge, the common case
```

Without it, `badgeValue` is asked for a reading with no states to read (`if (!hass || !item.entity) return undefined`), answers `undefined`, and the badge falls back to its glyph. The editor has its own render path reading `this.hass` directly, which is why it kept showing the value — exactly as reported.

## Where it came from

A merge, which is why the diff that caused it looks unrelated. In `0eafc20` (`Merge remote-tracking branch 'origin/main' into feat/replay-history`) the `hiddenStyle` wrapper from `main` and the `renderHass` argument from the replay branch landed on the same line. The wrapper won and the argument went with the conflict:

```
- visual = this._renderBadge(item, scale, renderHass);
+   ${this._renderBadge(item, scale)}
```

The `iconRipple` branch of the same `if` kept its argument and kept working.

I audited every other `renderHass`-aware call site in the card — openings, shutters, icons, labels, `_isOn` — and line 755 was the only one missing it. `_renderAreaLabel` and `_renderText` don't take one and don't read state.

## Why no test caught it

Nothing could. The node suite cannot import `floorplan-card.ts` — defining a custom element needs a DOM — so every existing test of "value or icon" tested `badgeValue`, the helper that decides the *text*. The helper was right the whole time. What was wrong was the wiring around it.

So this adds the card's first browser test (`src/card-badge.browser.test.ts`, alongside the existing editor-drag one): mount the real card, set a device to Value, read what is actually in the badge. It asserts against `badgeValue`'s own answer rather than a literal string, so it stays a test of the wiring rather than of how a reading is worded.

Confirmed it catches the bug — with the fix reverted:

```
× shows the reading when the badge is set to Value (issue #254)
  → expected undefined to be '22°'
```

…and the ripple case passes without the fix, which is the whole reason this slipped through.

## Verification

- `tsc --noEmit` clean. Node suite: 8669 pass. Browser suite: 7 pass (`npm run test:browser`).
- Four new cases: Value shows the reading and no glyph, Icon still shows the glyph, Value through `iconRipple`, and a fallback to the icon when the entity has nothing numeric.

Unrelated, but you'll see it: `npm test` also reports 3 failures from `.claude/worktrees/pr-reviewer-guidelines-3775ad/src/editor-drag.browser.test.ts` — a browser test being scraped out of a stale worktree nested in the repo, because the node config's `src/**/*.browser.test.ts` exclude doesn't match a nested path. It fails the same way on a clean checkout of `main`; worth either removing that worktree or widening the exclude to `**/*.browser.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)