### PR TITLE
Replay: enabled offers the control, it does not take the plan

### DIFF
--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -269,11 +269,15 @@ export class FloorplanCard extends LitElement {
       this._lastReplayCacheKey = replayKey;
       this._replayController.historyService().clearCache();
     }
+    // A plan that has switched replay off entirely stops any playback still
+    // running. A plan that *offers* replay does not start it: `enabled` means
+    // the control is there, not that the card hands the plan over to it. It
+    // used to start on load, which quietly turned a live plan into a snapshot
+    // of the moment it loaded — a light toggled from the plan really switched
+    // while its badge and cast pool stayed put (issue #256).
     if (!this._replayController.state.configured) {
       this._replayController.pausePlayback();
       this._replayController.stopReplayLoop();
-    } else if (this.hass) {
-      this._replayController.ensureStarted();
     }
     // Restore the floor this plan was last viewed on (issue #81). Only when
     // this instance has no floor of its own yet — a live floor switch always
@@ -317,12 +321,6 @@ export class FloorplanCard extends LitElement {
     super.updated(changed);
     if (changed.has("hass") || changed.has("_activeFloorId")) {
       this._syncHistoryServiceContext();
-    }
-    if (
-      (changed.has("hass") || changed.has("_activeFloorId"))
-      && this._replayController.shouldAutoStart()
-    ) {
-      this._replayController.ensureStarted();
     }
   }
 

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -704,6 +704,61 @@ describe("FloorplanCard replay", () => {
     expect(replaySpeed).toBe(1);
   });
 
+  describe("what the plan draws from while replay is on (issue #256)", () => {
+    // Replay being switched on means the timeline exists and the head can be
+    // moved. It does not mean the plan stops tracking reality: parked at the
+    // end of the window, the head points at the newest thing replay knows, and
+    // live state is newer still.
+    //
+    // Left rendering from history there, turning replay on quietly froze the
+    // plan at the instant it loaded — a light toggled from the plan really
+    // switched, while its badge and cast pool never moved.
+    const replayCard = () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      card.setConfig({
+        type: "easy-floorplan-card",
+        width: 1000,
+        height: 600,
+        historyReplay: { enabled: true, lookbackSeconds: 3600 },
+        floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
+      } as never);
+      const controller = (card as any)._replayController;
+      controller.state.enabled = true;
+      controller.state.playbackController = new PlaybackController({ startTime: 1000, endTime: 2000 });
+      return { card, controller };
+    };
+
+    it("draws live state when the head is parked at the end of the window", () => {
+      const { controller } = replayCard();
+      controller.state.playbackController.seek(2000);
+      expect(controller.getRenderState().enabled).toBe(false);
+    });
+
+    it("draws history as soon as the head moves back", () => {
+      const { controller } = replayCard();
+      controller.state.playbackController.seek(1500);
+      const render = controller.getRenderState();
+      expect(render.enabled).toBe(true);
+      // …and still reports where the head is, so the plan draws that moment.
+      expect(render.currentTime).toBe(1500);
+    });
+
+    it("draws history while playing, even on the last frame", () => {
+      // Playing *to* the end is watching history arrive, not returning to now.
+      const { controller } = replayCard();
+      controller.state.playbackController.seek(2000);
+      controller.state.playbackController.play();
+      expect(controller.getRenderState().enabled).toBe(true);
+    });
+
+    it("stays live when replay is off, whatever the head says", () => {
+      const { controller } = replayCard();
+      controller.state.enabled = false;
+      controller.state.playbackController.seek(1500);
+      expect(controller.getRenderState().enabled).toBe(false);
+    });
+  });
+
   describe("the history cache survives an unrelated setConfig", () => {
     // HA calls setConfig on every keystroke in the config box. Clearing the
     // cache there meant one history query per character typed.

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -4,6 +4,7 @@ import { PlaybackController } from "./playback-controller";
 import { HistoryService, type HistoryEventInput } from "./history-service";
 import { HistoryStateProvider, LiveStateProvider } from "./state-provider";
 import { HistoryTimeline } from "./history-timeline";
+import { createReplayPanelProps } from "./replay-panel";
 import { FloorplanCard } from "../floorplan-card";
 import type { HomeAssistant, HassEntity } from "../types";
 import {
@@ -704,6 +705,63 @@ describe("FloorplanCard replay", () => {
     expect(replaySpeed).toBe(1);
   });
 
+  describe("enabled means the control is offered, not taken (issue #256)", () => {
+    const replayConfig = {
+      type: "easy-floorplan-card",
+      width: 1000,
+      height: 600,
+      historyReplay: { enabled: true, lookbackSeconds: 3600 },
+      floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], texts: [], furniture: [], trackers: [], areas: [],
+        items: [{ id: "a", entity: "light.kitchen", x: 10, y: 10, kind: "light" }] }],
+    };
+    const hass = {
+      states: { "light.kitchen": { entity_id: "light.kitchen", state: "on", attributes: {} } },
+      entities: {}, callApi: vi.fn(async () => []), callService: vi.fn(),
+      formatEntityState: (st: HassEntity) => st.state,
+    } as unknown as HomeAssistant;
+
+    const configured = () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      document.body.appendChild(card);
+      card.hass = hass;
+      card.setConfig(replayConfig as never);
+      return { card, controller: (card as any)._replayController };
+    };
+
+    it("does not switch replay on by itself", () => {
+      const { controller } = configured();
+      expect(controller.state.enabled).toBe(false);
+      // …so the plan is drawing live state, which is the whole point.
+      expect(controller.getRenderState().enabled).toBe(false);
+    });
+
+    it("still offers the panel, so there is something to switch on with", async () => {
+      const { card } = configured();
+      await card.updateComplete;
+      expect(card.shadowRoot?.querySelector("easy-floorplan-replay-panel")).toBeTruthy();
+    });
+
+    it("shows the window it would load rather than 1970", () => {
+      // The unstarted panel used to be unreachable, so its placeholder window
+      // (0..MAX) had never been seen. It reads the clock now.
+      const { controller } = configured();
+      const props = createReplayPanelProps(controller);
+      const { start, end } = controller.getDefaultWindow();
+      expect(props.startTime).toBe(start);
+      expect(props.endTime).toBe(end);
+      expect(props.currentTime).toBe(end);
+      expect(props.startInputValue).not.toContain("1970");
+    });
+
+    it("hands the window back to the panel once replay is running", async () => {
+      const { controller } = configured();
+      await controller.startReplay();
+      const props = createReplayPanelProps(controller);
+      expect(props.startTime).toBe(controller.state.playbackController.startTime);
+      expect(props.endTime).toBe(controller.state.playbackController.endTime);
+    });
+  });
+
   describe("what the plan draws from while replay is on (issue #256)", () => {
     // Replay being switched on means the timeline exists and the head can be
     // moved. It does not mean the plan stops tracking reality: parked at the
@@ -1092,7 +1150,7 @@ describe("FloorplanCard replay", () => {
     expect(events.some((event: { entityId: string; oldState: string; newState: string }) => event.entityId === "binary_sensor.front_door" && event.oldState === "off" && event.newState === "on")).toBe(true);
   });
 
-  it("starts loading history automatically when replay is enabled", async () => {
+  it("loads history when replay is switched on, not merely offered (issue #256)", async () => {
     const card = document.createElement("easy-floorplan-card") as FloorplanCard;
     const now = new Date();
     const recent = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
@@ -1150,8 +1208,16 @@ describe("FloorplanCard replay", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    // Configuring replay offers the control; it does not take the plan over,
+    // so nothing has been fetched yet and the plan is still drawing live.
+    expect(callApi).not.toHaveBeenCalled();
+
     const showButton = getReplayPanelShadowRoot(card)?.querySelector(".replay-show-toggle") as HTMLButtonElement | null;
     showButton?.click();
+    await card.updateComplete;
+
+    // Switching it on is what loads the history behind the timeline.
+    await (card as any)._replayController.startReplay();
     await card.updateComplete;
 
     expect(callApi).toHaveBeenCalled();
@@ -1485,6 +1551,10 @@ describe("FloorplanCard replay", () => {
         ],
       }],
     });
+
+    // Replay is offered, not started (issue #256), so ask for it — the point
+    // of this test is *which* entities the request covers, not when it fires.
+    await (card as any)._replayController.startReplay();
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -54,7 +54,6 @@ export type ReplayController = {
   isHistoryVisible: () => boolean;
   isReplayReady: () => boolean;
   isReplayEnabled: () => boolean;
-  shouldAutoStart: () => boolean;
   getRenderState: () => { enabled: boolean; currentTime: number; historyVisible: boolean };
   clearConfigColorCache: () => void;
   pausePlayback: () => void;
@@ -63,7 +62,6 @@ export type ReplayController = {
   updateWindow: (start: number, end: number) => void;
   resetForFloorChange: () => void;
   zoomWindow: (direction: -1 | 1) => void;
-  ensureStarted: () => void;
   toggleReplay: () => Promise<void>;
   toggleHistoryVisible: (visible: boolean) => void;
   toggleSpeedPanel: () => void;
@@ -173,14 +171,6 @@ export class ReplayControllerImpl implements ReplayController {
     return this.state.enabled;
   }
 
-  public shouldAutoStart(): boolean {
-    return !!this._card.getHass()
-      && !!this._card.getConfig()?.historyReplay?.enabled
-      && !this.state.loadRequested
-      && !this.state.enabled
-      && !this.state.manuallyDisabled;
-  }
-
   /**
    * What the plan should draw from: history at `currentTime`, or the live
    * states Home Assistant is pushing.
@@ -275,13 +265,6 @@ export class ReplayControllerImpl implements ReplayController {
     const nextStart = Math.max(0, anchor - halfSpan);
     const nextEnd = nextStart + nextSpan;
     this.updateWindow(nextStart, nextEnd);
-  }
-
-  public ensureStarted(): void {
-    if (!this._card.getHass() || !this._card.getConfig()?.historyReplay?.enabled || this.state.loadRequested || this.state.enabled || this.state.manuallyDisabled) {
-      return;
-    }
-    void this.startReplay();
   }
 
   public async toggleReplay(): Promise<void> {

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -181,10 +181,32 @@ export class ReplayControllerImpl implements ReplayController {
       && !this.state.manuallyDisabled;
   }
 
+  /**
+   * What the plan should draw from: history at `currentTime`, or the live
+   * states Home Assistant is pushing.
+   *
+   * `enabled` here is not the same question as "is replay switched on". Replay
+   * being on means the timeline exists and the head can be moved; it does not
+   * mean the plan must stop tracking reality. Parked at the end of the window
+   * and not playing, the head is pointing at the newest thing replay knows —
+   * and the newest thing *anything* knows is the live state, so that is what
+   * to draw.
+   *
+   * Without this, turning replay on quietly froze the plan at the instant it
+   * loaded. Every watched entity with a recorded state rendered from that
+   * moment forever, so a light toggled from the plan really did switch — the
+   * service call is live either way — while its badge and its cast pool stayed
+   * exactly as they had been, and lights that happened to be on at that instant
+   * stayed lit and casting no matter what you did to them. Entities with no
+   * history at that point fell through to live state, which is why only *some*
+   * of the plan looked stuck (issue #256).
+   */
   public getRenderState(): { enabled: boolean; currentTime: number; historyVisible: boolean } {
+    const playback = this.state.playbackController;
+    const atLiveEnd = !playback.playing && playback.currentTime >= playback.endTime;
     return {
-      enabled: this.state.enabled,
-      currentTime: this.state.playbackController.currentTime,
+      enabled: this.state.enabled && !atLiveEnd,
+      currentTime: playback.currentTime,
       historyVisible: this.state.historyVisible,
     };
   }

--- a/src/replay-history/replay-panel.ts
+++ b/src/replay-history/replay-panel.ts
@@ -56,6 +56,7 @@ export interface ReplayPanelHost {
     playbackController: { startTime: number; endTime: number; currentTime: number; speed: number; playing: boolean };
   };
   formatReplayTime: (timestamp: number) => string;
+  getDefaultWindow: () => { start: number; end: number };
   handleRangeChange: (kind: "start" | "end", ev: Event) => void;
   zoomWindow: (direction: -1 | 1) => void;
   toggleReplay: () => Promise<void>;
@@ -75,13 +76,26 @@ export interface ReplayPanelHost {
 export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRenderProps {
   const playback = host.state.playbackController;
   const state = host.state;
-  const currentTimeLabel = host.formatReplayTime(playback.currentTime);
+  // Before replay has ever been started there is no window and no head: the
+  // controller holds a placeholder spanning 0..MAX, whose timestamps format as
+  // 1970. That state used to be unreachable, because enabling the feature
+  // started replay outright; now that it means *offering* the control, it is
+  // the first thing anyone sees. So the panel presents the window it would
+  // load — the same default `startReplay` falls back to — and reads the clock
+  // for the head, since not having started is another way of saying "now".
+  const started = state.enabled || state.startTime > 0;
+  const fallback = started ? undefined : host.getDefaultWindow();
+  const windowStart = fallback ? fallback.start : state.startTime;
+  const windowEnd = fallback ? fallback.end : state.endTime;
+  const currentTimeLabel = host.formatReplayTime(
+    fallback ? fallback.end : playback.currentTime,
+  );
 
   return {
     events: state.historyEvents,
-    startTime: playback.startTime,
-    endTime: playback.endTime,
-    currentTime: playback.currentTime,
+    startTime: fallback ? fallback.start : playback.startTime,
+    endTime: fallback ? fallback.end : playback.endTime,
+    currentTime: fallback ? fallback.end : playback.currentTime,
     visible: state.historyVisible,
     enabled: state.enabled,
     ready: state.ready,
@@ -94,8 +108,8 @@ export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRender
     panelId: state.panelId,
     replaySpeed: playback.speed,
     currentTimeLabel,
-    startInputValue: formatReplayInputValue(state.startTime),
-    endInputValue: formatReplayInputValue(state.endTime),
+    startInputValue: formatReplayInputValue(windowStart),
+    endInputValue: formatReplayInputValue(windowEnd),
     onToggleVisible: (visible: boolean) => host.toggleHistoryVisible(visible),
     onRangeChange: (kind: "start" | "end", value: string) => {
       host.handleRangeChange(kind, { target: { value } } as unknown as Event);


### PR DESCRIPTION
Fixes the "clicking a light turns it on but the badge doesn't activate and the light isn't cast" report.

## What was happening

`historyReplay.enabled: true` auto-started replay and parked the playback head at the end of the window — a timestamp that stops being "now" the moment it is set. Every render then asked history what the world looked like *then*, so the plan was frozen at the instant the card loaded. A light toggled from the plan really did switch (the service call is live either way) while its badge and cast pool never moved.

Only *part* of the plan looked stuck, which is what made it confusing: `HistoryStateProvider` falls back to live state for entities with no recorded state at that timestamp, so anything without history behaved normally.

## The end of the window is now, and now is live

`getRenderState` was answering one question where there are two. Replay being switched on means the timeline exists and the head can be moved; it does not mean the plan stops tracking reality. Parked at the end of the window and not playing, the head points at the newest thing replay knows — and live state is newer still, so that is what to draw. Move the head back, or press play, and it draws history again.

Playing *to* the end stays history on purpose: that is watching the recording arrive, not returning to the present.

## `enabled` offers the control

Configuring replay puts the panel there. It does not hand the plan over. The plan stays live until someone asks for the past — `playReplay()` already starts replay when it is not running, so Run was always the real way in.

The panel was already gated on config rather than on replay running, so the offered-but-not-started state existed — it was just unreachable, because the card started replay before anyone could see it. Which is why it had a bug sitting in it: with no window loaded the controller holds a placeholder spanning `0..MAX_SAFE_INTEGER`, and the panel rendered its timestamps as **1970**. It now presents the window it *would* load, and reads the clock for the head.

`shouldAutoStart` and `ensureStarted` go with it — nothing calls them, and a method named for a behaviour the card no longer has is worse than no method.

## Verification

- Ten tests: replay does not switch itself on, the panel is still offered, the unstarted panel shows a real window rather than 1970, the window is handed back once replay runs, live at the head's end, history once it moves back, history while playing on the last frame, live when replay is off.
- Two existing tests asserted auto-start and now assert the opposite. The history-loading one is sharper for it: it checks nothing is fetched until replay is switched on, which is the promise this makes.
- `tsc --noEmit` clean; node and browser suites pass.
- Built and pushed to the dev container, where this was found.

The panel's Enable/Disable button becomes a **Live** button in #256, which stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)