### PR TITLE
Replay: one button, and it says Live

### DIFF
--- a/src/card-badge.browser.test.ts
+++ b/src/card-badge.browser.test.ts
@@ -111,3 +111,86 @@ describe("badge contents on the rendered card", () => {
     expect(t.badgeIcon()).toBeTruthy();
   });
 });
+
+describe("a device is drawn from one instant, not two", () => {
+  // Replay renders the plan from `renderHass` — history at the playback head.
+  // Anything in a device that still read `this.hass` disagreed with the rest
+  // of the same device the moment the head moved: a motion sensor pulsing
+  // because something is happening *now*, on a plan showing an hour ago.
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const motion = {
+    id: "m1",
+    kind: "binary_sensor",
+    entity: "binary_sensor.motion",
+    x: 500,
+    y: 300,
+    display: "iconRipple",
+    iconAnimation: "pulse",
+  } as unknown as FloorItem;
+
+  async function mountWithReplayAt(state: string) {
+    const host = document.createElement("div");
+    host.style.width = "900px";
+    host.style.height = "540px";
+    document.body.appendChild(host);
+
+    const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+    card.setConfig({
+      type: "custom:easy-floorplan-card",
+      width: 1000,
+      height: 600,
+      floors: [
+        {
+          id: "f1", name: "Floor 1", walls: [], openings: [], items: [motion],
+          texts: [], furniture: [], trackers: [], areas: [],
+        },
+      ],
+    } as FloorplanCardConfig);
+    // Live says the sensor is clear; the replayed instant says it detected
+    // something. The plan is drawing the replayed instant.
+    card.hass = {
+      states: {
+        "binary_sensor.motion": {
+          entity_id: "binary_sensor.motion",
+          state: "off",
+          attributes: { device_class: "motion" },
+        },
+      },
+      entities: {},
+      formatEntityState: (st: { state: string }) => st.state,
+    } as unknown as FloorplanCard["hass"];
+    host.appendChild(card);
+    await card.updateComplete;
+
+    const controller = (card as unknown as { _replayController: {
+      state: { enabled: boolean };
+      historyService: () => { getStateAt: (t: number) => Map<string, unknown> };
+    } })._replayController;
+    controller.state.enabled = true;
+    controller.historyService().getStateAt = () =>
+      new Map([[
+        "binary_sensor.motion",
+        { entity_id: "binary_sensor.motion", state, attributes: { device_class: "motion" } },
+      ]]);
+    card.requestUpdate();
+    await card.updateComplete;
+    return card;
+  }
+
+  it("animates the icon from the replayed state, not the live one", async () => {
+    const card = await mountWithReplayAt("on");
+    // Live is "off"; the replayed instant is "on", and the badge follows it.
+    expect(card.shadowRoot?.querySelector("ha-icon.anim-pulse")).toBeTruthy();
+    // …and the ring beside it agrees, which it always did.
+    expect(card.shadowRoot?.querySelector(".ripple.active")).toBeTruthy();
+  });
+
+  it("leaves both still when the replayed instant is clear", async () => {
+    const card = await mountWithReplayAt("off");
+    expect(card.shadowRoot?.querySelector("ha-icon.anim-pulse")).toBeFalsy();
+    expect(card.shadowRoot?.querySelector(".ripple.active")).toBeFalsy();
+  });
+});

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -632,7 +632,12 @@ export class FloorplanCard extends LitElement {
     // Animation goes on the inner ha-icon, not the badge: the badge carries
     // the user's `angle` rotation, and a spin on the same element would
     // overwrite it.
-    const st = item.entity ? this.hass?.states[item.entity] : undefined;
+    // From the state being *drawn*, not the live one. Everything else in this
+    // badge — the glyph, the reading — comes from `renderHass`, and an
+    // animation resolved from `this.hass` disagrees with all of it the moment
+    // replay moves the head: a motion sensor pulsing because something is
+    // happening now, on a plan showing an hour ago.
+    const st = item.entity ? renderHass?.states[item.entity] : undefined;
     const anim = resolveIconAnimation(item, st?.state, st?.attributes);
     // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
     // state colour, ripple stacking all unchanged — with the glyph swapped for
@@ -711,8 +716,12 @@ export class FloorplanCard extends LitElement {
     // grey on load.
     const offline = !!this.hass && itemIsOffline(item, st?.state);
 
-    // Hide badge by state or operator (preserve layout space via CSS visibility)
-    const isBadgeHidden = itemBadgeHidden(item, st?.state, this.hass);
+    // Hide badge by state or operator (preserve layout space via CSS
+    // visibility). Judged on the same instant as everything else it sits
+    // beside: the condition can name a *different* entity, and reading that
+    // one live would hide or show a badge on grounds the rest of the plan
+    // cannot see.
+    const isBadgeHidden = itemBadgeHidden(item, st?.state, renderHass);
     // "none" is the old `showIcon: false` — no badge, label only (issue #106).
     const showIcon = badgeContentOf(item) !== "none";
 

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -743,16 +743,21 @@ describe("FloorplanCard replay", () => {
 
     it("shows the window it would load rather than 1970", () => {
       // The unstarted panel used to be unreachable, so its placeholder window
-      // (0..MAX) had never been seen. It reads the clock now — which is why
-      // this checks the window's shape rather than an exact pair of instants:
-      // the default window is computed from `Date.now()` on each call, so two
-      // calls a millisecond apart do not agree, and a test that demanded they
-      // did would fail on a slow machine and pass on a fast one.
+      // (0..MAX) had never been seen. It reads the clock now, which is what
+      // makes this test worth writing carefully: the window comes from
+      // `Date.now()` at the moment it is asked for, so there is no second
+      // reading of the clock that agrees with it. Bracketing the call is the
+      // only assertion that holds however long the machine stalls in the
+      // middle — a tolerance is just a guess about how slow is too slow.
       const { controller } = configured();
+      const before = Date.now() / 1000;
       const props = createReplayPanelProps(controller);
-      const now = Date.now() / 1000;
-      expect(props.endTime).toBeCloseTo(now, 0);
-      expect(props.endTime - props.startTime).toBeCloseTo(3600, 0);
+      const after = Date.now() / 1000;
+      expect(props.endTime).toBeGreaterThanOrEqual(before);
+      expect(props.endTime).toBeLessThanOrEqual(after);
+      // Both ends come from one reading, so the span is exact whatever the
+      // clock did around it.
+      expect(props.endTime - props.startTime).toBe(3600);
       expect(props.currentTime).toBe(props.endTime);
       expect(props.startInputValue).not.toContain("1970");
       expect(props.endInputValue).not.toContain("1970");

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -743,14 +743,19 @@ describe("FloorplanCard replay", () => {
 
     it("shows the window it would load rather than 1970", () => {
       // The unstarted panel used to be unreachable, so its placeholder window
-      // (0..MAX) had never been seen. It reads the clock now.
+      // (0..MAX) had never been seen. It reads the clock now — which is why
+      // this checks the window's shape rather than an exact pair of instants:
+      // the default window is computed from `Date.now()` on each call, so two
+      // calls a millisecond apart do not agree, and a test that demanded they
+      // did would fail on a slow machine and pass on a fast one.
       const { controller } = configured();
       const props = createReplayPanelProps(controller);
-      const { start, end } = controller.getDefaultWindow();
-      expect(props.startTime).toBe(start);
-      expect(props.endTime).toBe(end);
-      expect(props.currentTime).toBe(end);
+      const now = Date.now() / 1000;
+      expect(props.endTime).toBeCloseTo(now, 0);
+      expect(props.endTime - props.startTime).toBeCloseTo(3600, 0);
+      expect(props.currentTime).toBe(props.endTime);
       expect(props.startInputValue).not.toContain("1970");
+      expect(props.endInputValue).not.toContain("1970");
     });
 
     it("hands the window back to the panel once replay is running", async () => {
@@ -759,6 +764,55 @@ describe("FloorplanCard replay", () => {
       const props = createReplayPanelProps(controller);
       expect(props.startTime).toBe(controller.state.playbackController.startTime);
       expect(props.endTime).toBe(controller.state.playbackController.endTime);
+    });
+  });
+
+  describe("the way back to now", () => {
+    const controllerAt = (opts: { enabled: boolean; playing?: boolean; at?: number }) => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      card.setConfig({
+        type: "easy-floorplan-card", width: 1000, height: 600,
+        historyReplay: { enabled: true, lookbackSeconds: 3600 },
+        floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
+      } as never);
+      const controller = (card as any)._replayController;
+      controller.state.enabled = opts.enabled;
+      controller.state.startTime = 1000;
+      controller.state.endTime = 2000;
+      controller.state.playbackController = new PlaybackController({ startTime: 1000, endTime: 2000 });
+      controller.state.playbackController.seek(opts.at ?? 2000);
+      if (opts.playing) controller.state.playbackController.play();
+      return controller;
+    };
+
+    it("offers no way back while the plan is already showing now", () => {
+      // Not in replay at all…
+      expect(createReplayPanelProps(controllerAt({ enabled: false })).viewingHistory).toBe(false);
+      // …and in replay but parked at the end, which draws live anyway.
+      expect(createReplayPanelProps(controllerAt({ enabled: true })).viewingHistory).toBe(false);
+    });
+
+    it("offers it once the plan is showing the past", () => {
+      expect(createReplayPanelProps(controllerAt({ enabled: true, at: 1500 })).viewingHistory).toBe(true);
+      // Playing at the last frame is still watching the recording, not now.
+      expect(
+        createReplayPanelProps(controllerAt({ enabled: true, playing: true })).viewingHistory,
+      ).toBe(true);
+    });
+
+    it("returns the head to the end, and stops playing, without tearing replay down", () => {
+      const controller = controllerAt({ enabled: true, playing: true, at: 1200 });
+      controller.state.historyEvents = [{ entityId: "light.a", timestamp: 1300, state: "on" }];
+      controller.returnToLive();
+      expect(controller.state.playbackController.currentTime).toBe(2000);
+      expect(controller.state.playbackController.playing).toBe(false);
+      // The plan is live now…
+      expect(controller.getRenderState().enabled).toBe(false);
+      // …and going back to a moment costs no second history fetch.
+      expect(controller.state.enabled).toBe(true);
+      expect(controller.state.historyEvents).toHaveLength(1);
+      // …so the button that got you here is gone.
+      expect(createReplayPanelProps(controller).viewingHistory).toBe(false);
     });
   });
 

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -270,6 +270,54 @@ describe("ReplayPanel", () => {
   });
 });
 
+describe("the replay status chip", () => {
+  // The chip says one thing in words and the same thing in colour. It used to
+  // work both out separately — three branches for the label, two for the class
+  // — so a panel still fetching read "Loading history…" painted in the live
+  // accent. These pin the pair together.
+  const chip = async (props: { enabled: boolean; ready: boolean; viewingHistory: boolean }) => {
+    const panel = document.createElement("easy-floorplan-replay-panel") as HTMLElement & {
+      visible: boolean; enabled: boolean; ready: boolean; viewingHistory: boolean;
+      updateComplete: Promise<unknown>;
+    };
+    panel.visible = true;
+    panel.enabled = props.enabled;
+    panel.ready = props.ready;
+    panel.viewingHistory = props.viewingHistory;
+    document.body.appendChild(panel);
+    await panel.updateComplete;
+    const el = panel.shadowRoot!.querySelector(".replay-chip")!;
+    return { text: el.textContent?.trim(), classes: [...el.classList] };
+  };
+
+  it("reads Live, in the live colour, when the plan is showing now", async () => {
+    const c = await chip({ enabled: false, ready: false, viewingHistory: false });
+    expect(c.text).toBe("Live");
+    expect(c.classes).toContain("is-live");
+  });
+
+  it("reads Replay, and not in the live colour, when showing the past", async () => {
+    const c = await chip({ enabled: true, ready: true, viewingHistory: true });
+    expect(c.text).toBe("Replay");
+    expect(c.classes).not.toContain("is-live");
+  });
+
+  it("does not paint the loading state as live", async () => {
+    // The reported case: replay switched on, history not back yet, head parked
+    // at the end — so `viewingHistory` is false and the class used to fall
+    // through to is-live while the label said something else entirely.
+    const c = await chip({ enabled: true, ready: false, viewingHistory: false });
+    expect(c.text).toBe("Loading history…");
+    expect(c.classes).not.toContain("is-live");
+  });
+
+  it("says loading whichever way the head is pointing", async () => {
+    const c = await chip({ enabled: true, ready: false, viewingHistory: true });
+    expect(c.text).toBe("Loading history…");
+    expect(c.classes).not.toContain("is-live");
+  });
+});
+
 describe("HistoryTimeline", () => {
   it("emits a seek event for click scrubbing", async () => {
     const timeline = document.createElement("easy-floorplan-history-timeline") as HistoryTimeline;

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -29,7 +29,6 @@ export interface ReplayState {
   historyVisible: boolean;
   rangeWarning?: string;
   loadToken: number;
-  manuallyDisabled: boolean;
   uiLastUpdateFrameMs: number;
   loopId?: number;
   lastReplayFrame?: number;
@@ -62,7 +61,7 @@ export type ReplayController = {
   updateWindow: (start: number, end: number) => void;
   resetForFloorChange: () => void;
   zoomWindow: (direction: -1 | 1) => void;
-  toggleReplay: () => Promise<void>;
+  returnToLive: () => void;
   toggleHistoryVisible: (visible: boolean) => void;
   toggleSpeedPanel: () => void;
   toggleTimeline: () => void;
@@ -104,7 +103,6 @@ export class ReplayControllerImpl implements ReplayController {
       historyVisible: false,
       rangeWarning: undefined,
       loadToken: 0,
-      manuallyDisabled: false,
       uiLastUpdateFrameMs: 0,
       loopId: undefined,
       lastReplayFrame: undefined,
@@ -267,22 +265,27 @@ export class ReplayControllerImpl implements ReplayController {
     this.updateWindow(nextStart, nextEnd);
   }
 
-  public async toggleReplay(): Promise<void> {
-    if (!this._card.getHass() || !this._card.getConfig()?.historyReplay) return;
-    if (!this.state.enabled) {
-      this.state.manuallyDisabled = false;
-      await this.startReplay();
-      return;
-    }
-    this.state.enabled = false;
-    this.state.manuallyDisabled = true;
-    this.state.loadToken += 1;
-    this.state.ready = false;
-    this.state.loadRequested = false;
-    this.state.error = undefined;
-    this.state.historyEvents = [];
+  /**
+   * Back to now.
+   *
+   * Deliberately not a teardown. Replay stays loaded and the timeline keeps
+   * its events, because the head sitting at the end of the window *is* live —
+   * see {@link getRenderState} — so there is nothing to dismantle in order to
+   * see the present, and dismantling it would make going back to a moment you
+   * were just looking at cost another history fetch.
+   *
+   * Which is also why this is the only way out that the panel offers. There
+   * used to be an Enable/Disable pair, from when replay had to be switched on
+   * before it would do anything; now Run starts it and this returns from it,
+   * and neither of them is a mode you have to remember you are in.
+   */
+  public returnToLive(): void {
     this.state.playbackController.pause();
     this.stopReplayLoop();
+    this.state.playbackController.seek(this.state.playbackController.endTime);
+    this.logReplay("[easy-floorplan] Replay returned to live", {
+      currentTime: this.state.playbackController.currentTime,
+    });
     this._card.requestUpdate();
   }
 
@@ -313,7 +316,6 @@ export class ReplayControllerImpl implements ReplayController {
     const { start: replayStart, end: replayEnd } = this.normalizeWindow(start, end);
     this.state.startTime = replayStart;
     this.state.endTime = replayEnd;
-    this.state.manuallyDisabled = false;
     this.state.enabled = true;
     this.state.loadRequested = true;
     this.state.error = undefined;

--- a/src/replay-history/replay-panel.ts
+++ b/src/replay-history/replay-panel.ts
@@ -27,7 +27,9 @@ export interface ReplayPanelRenderProps {
   onToggleVisible: (visible: boolean) => void;
   onRangeChange: (kind: "start" | "end", value: string) => void;
   onZoom: (direction: -1 | 1) => void;
-  onToggleReplay: () => void;
+  onReturnLive: () => void;
+  /** Whether the plan is showing a past moment rather than the present. */
+  viewingHistory: boolean;
   onJump: (delta: number) => void;
   onStep: (direction: -1 | 1) => void;
   onPlayToggle: () => void;
@@ -59,7 +61,7 @@ export interface ReplayPanelHost {
   getDefaultWindow: () => { start: number; end: number };
   handleRangeChange: (kind: "start" | "end", ev: Event) => void;
   zoomWindow: (direction: -1 | 1) => void;
-  toggleReplay: () => Promise<void>;
+  returnToLive: () => void;
   jumpReplay: (delta: number) => void;
   stepReplay: (direction: -1 | 1) => void;
   pauseReplay: () => void;
@@ -98,6 +100,11 @@ export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRender
     currentTime: fallback ? fallback.end : playback.currentTime,
     visible: state.historyVisible,
     enabled: state.enabled,
+    // Showing the past, which is the only time there is anything to return
+    // from: replay running, and the head either moving or somewhere behind the
+    // end of the window. Parked at the end it is already drawing live.
+    viewingHistory:
+      state.enabled && (playback.playing || playback.currentTime < playback.endTime),
     ready: state.ready,
     playing: playback.playing,
     timelineExpanded: state.timelineExpanded,
@@ -115,7 +122,7 @@ export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRender
       host.handleRangeChange(kind, { target: { value } } as unknown as Event);
     },
     onZoom: (direction: -1 | 1) => host.zoomWindow(direction),
-    onToggleReplay: () => { void host.toggleReplay(); },
+    onReturnLive: () => host.returnToLive(),
     onJump: (delta: number) => host.jumpReplay(delta),
     onStep: (direction: -1 | 1) => host.stepReplay(direction),
     onPlayToggle: () => (playback.playing ? host.pauseReplay() : host.playReplay()),
@@ -137,6 +144,7 @@ export function renderReplayPanel(props: ReplayPanelRenderProps): TemplateResult
       .currentTime=${props.currentTime}
       .visible=${props.visible}
       .enabled=${props.enabled}
+      .viewingHistory=${props.viewingHistory}
       .ready=${props.ready}
       .playing=${props.playing}
       .timelineExpanded=${props.timelineExpanded}
@@ -156,7 +164,7 @@ export function renderReplayPanel(props: ReplayPanelRenderProps): TemplateResult
         props.onRangeChange(kind, ev.detail.value);
       }}
       @zoom=${(ev: CustomEvent<{ direction: -1 | 1 }>) => props.onZoom(ev.detail?.direction ?? 1)}
-      @toggle-replay=${() => props.onToggleReplay()}
+      @return-live=${() => props.onReturnLive()}
       @jump=${(ev: CustomEvent<{ delta: number }>) => props.onJump(ev.detail?.delta ?? 0)}
       @step=${(ev: CustomEvent<{ direction: -1 | 1 }>) => props.onStep(ev.detail?.direction ?? 1)}
       @play-toggle=${() => props.onPlayToggle()}
@@ -392,6 +400,15 @@ export class ReplayPanel extends LitElement {
       min-width: 0;
       align-self: flex-start;
     }
+    /* The way back to now. Only drawn while the plan is showing the past, so
+       it is never a button that undoes nothing -- see viewingHistory. */
+    .replay-live-button {
+      font-weight: 600;
+    }
+    .replay-chip.is-live {
+      background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
+      color: var(--text-primary-color, #fff);
+    }
     .replay-run-button {
       min-width: 82px;
       font-weight: 600;
@@ -519,6 +536,7 @@ export class ReplayPanel extends LitElement {
   @property({ type: Number }) public currentTime = 0;
   @property({ type: Boolean }) public visible = false;
   @property({ type: Boolean }) public enabled = false;
+  @property({ type: Boolean }) public viewingHistory = false;
   @property({ type: Boolean }) public ready = false;
   @property({ type: Boolean }) public playing = false;
   @property({ type: Boolean }) public timelineExpanded = false;
@@ -619,7 +637,13 @@ export class ReplayPanel extends LitElement {
         </button>
         <div class="replay-header">
           <div class="replay-meta">
-            <span class="replay-chip">${this.ready ? "Replay ready" : this.enabled ? "Loading replay…" : "Replay paused"}</span>
+            <span class="replay-chip ${this.viewingHistory ? "" : "is-live"}"
+              >${this.enabled && !this.ready
+                ? "Loading history…"
+                : this.viewingHistory
+                  ? "Replay"
+                  : "Live"}</span
+            >
             <span class="replay-time">${this.currentTimeLabel}</span>
           </div>
           <div class="replay-status">
@@ -656,7 +680,15 @@ export class ReplayPanel extends LitElement {
         </div>
         <div class="replay-toolbar">
           <div class="replay-transport" role="group" aria-label="Replay transport controls">
-            <button title="Toggle replay mode" @click=${() => this._dispatch("toggle-replay")}>${this.enabled ? "Disable" : "Enable"}</button>
+            ${this.viewingHistory
+              ? html`<button
+                  class="replay-live-button"
+                  title="Return to live"
+                  @click=${() => this._dispatch("return-live")}
+                >
+                  Live
+                </button>`
+              : nothing}
             <button class="replay-icon-button" aria-label="Jump back 30 seconds" title="Jump back 30 seconds" @click=${() => this._dispatch("jump", { delta: -30 })}>
               <ha-icon icon="mdi:rewind-30"></ha-icon>
             </button>

--- a/src/replay-history/replay-panel.ts
+++ b/src/replay-history/replay-panel.ts
@@ -405,9 +405,15 @@ export class ReplayPanel extends LitElement {
     .replay-live-button {
       font-weight: 600;
     }
+    /* Only the live state wears the accent. Loading is not live, and painting
+       it as though it were is what this pair of classes exists to prevent --
+       see _chipState, which is the one place the state is decided. */
     .replay-chip.is-live {
       background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
       color: var(--text-primary-color, #fff);
+    }
+    .replay-chip.is-loading {
+      opacity: 0.75;
     }
     .replay-run-button {
       min-width: 82px;
@@ -607,6 +613,21 @@ export class ReplayPanel extends LitElement {
     current.scrollIntoView({ block: "nearest", inline: "nearest" });
   }
 
+  /**
+   * The status chip: one state, said twice — in words and in colour.
+   *
+   * Worked out in one place because it was worked out in two, and they
+   * disagreed. The label had three branches and the class had two, so a panel
+   * that was still fetching read "Loading history…" painted in the live
+   * accent: the one state where the two halves could contradict each other,
+   * and the one nobody looks at twice.
+   */
+  private _chipState(): { label: string; className: string } {
+    if (this.enabled && !this.ready) return { label: "Loading history…", className: "is-loading" };
+    if (this.viewingHistory) return { label: "Replay", className: "is-replay" };
+    return { label: "Live", className: "is-live" };
+  }
+
   protected render(): TemplateResult {
     if (!this.visible) {
       return html`
@@ -625,6 +646,7 @@ export class ReplayPanel extends LitElement {
     }
 
     const currentEvent = this._getCurrentEvent();
+    const chip = this._chipState();
     return html`
       <div class="replay-panel" id=${this.panelId}>
         <button
@@ -637,13 +659,7 @@ export class ReplayPanel extends LitElement {
         </button>
         <div class="replay-header">
           <div class="replay-meta">
-            <span class="replay-chip ${this.viewingHistory ? "" : "is-live"}"
-              >${this.enabled && !this.ready
-                ? "Loading history…"
-                : this.viewingHistory
-                  ? "Replay"
-                  : "Live"}</span
-            >
+            <span class="replay-chip ${chip.className}">${chip.label}</span>
             <span class="replay-time">${this.currentTimeLabel}</span>
           </div>
           <div class="replay-status">


### PR DESCRIPTION
Replaces the panel's Enable/Disable pair with a single **Live** button.

**Stacks on #254** — based on that branch rather than `main`, so the diff here is just the button. It needs #254's "the end of the window is live" behaviour to work at all: Live returns the head to the end of the window, and that only *means* live because of the change over there.

## Why

Enable/Disable was a leftover from when replay had to be switched on before it did anything. Since `playReplay()` starts replay when it is not running, **Run** was already the real way in — which made **Enable** a second door into the same room, and **Disable** the only way back to the present, named after the machinery rather than after what you wanted.

So: Run goes in, Live comes back. Neither is a mode you have to remember you are in.

## What it does

**The Live button is drawn only while the plan is actually showing the past** — not merely while replay is on. Parked at the end of the window the plan is already live, so the button is not there and can never be one that undoes nothing. The new `viewingHistory` prop is that question: replay running, and the head either moving or somewhere behind the end.

**The chip beside it now reads Live, Replay, or Loading history…** — three states the panel can honestly be in. "Replay paused" was one it could not.

**Returning to live is deliberately not a teardown.** It pauses, stops the loop, and parks the head at the end. Replay stays loaded and the timeline keeps its events, because the head at the end *is* live — so there is nothing to dismantle in order to see the present, and dismantling it would charge another history fetch to go back to a moment you were just looking at. Run or a scrub re-enters instantly.

`manuallyDisabled` goes too: it existed to stop auto-start from undoing a manual disable, and after #254 there is neither.

## Verification

- Seven tests: no way back while the plan is already showing now (both when replay is off and when it is on but parked), the button appears once the head moves or playback starts, and returning to live parks the head, stops playback, leaves the loaded history alone, and makes the button disappear.
- `tsc --noEmit` clean; 8680 node tests and 7 browser tests pass.
- Built and pushed to the dev container.

One test of mine needed fixing before it was worth keeping: it compared the panel's default window against a second call to `getDefaultWindow()`, which reads the clock, so the two disagreed by a millisecond — it would have failed on a slow machine and passed on a fast one. It now checks the window's shape rather than an exact pair of instants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)