### PR TITLE
Trackers: initials can ride the dot, so people stay tellable apart (rebased #164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,11 @@ rings; readings outside `[min, max]` clamp to the rectangle's edge. With one, a 
 pulsating line spans the unknown axis — honest about knowing only one coordinate. With
 neither reporting, nothing renders.
 
-The rectangle itself is editor-only; the card shows just the marker. **Color** and **dot
-size** are per tracker.
+The rectangle itself is editor-only; the card shows just the marker. **Color**, **dot
+size** and **label** are per tracker — a label (initials like `FR`, up to three
+characters) rides in the triangle's place with the same pulse and glide, so several
+people on one floor stay tellable apart when color alone isn't enough. It stays upright
+under the plan's `rotation`, like every other text on the card.
 
 #### Presence ripples
 

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -1910,7 +1910,7 @@ describe("every field lands in exactly one panel group", () => {
     ["tapTarget", "tap_action", "hold_action", "double_tap_action"],
   ];
   const FURNITURE_GROUPS = [["type", "hand", "w", "h", "angle"], ["entity"], ["goToFloor"]];
-  const TRACKER_GROUPS = [["w", "h", "x", "y", "angle"], ["dotSize"]];
+  const TRACKER_GROUPS = [["w", "h", "x", "y", "angle"], ["dotSize", "label"]];
   const AREA_GROUPS = [
     ["showName", "labelSize"],
     ["entity"],

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -1533,6 +1533,8 @@ export function trackerForm(tr: Tracker): FormSpec {
         label: "Dot size",
         selector: { number: { min: 6, max: 80, mode: "slider", unit_of_measurement: "px" } },
       },
+      // Initials in place of the triangle — see Tracker.label.
+      { name: "label", label: "Label", selector: { text: {} } },
     ],
     data: {
       w: tr.w,
@@ -1541,6 +1543,7 @@ export function trackerForm(tr: Tracker): FormSpec {
       y: Math.round(tr.y),
       angle: tr.angle ?? 0,
       dotSize: tr.dotSize ?? DEFAULT_TRACKER_DOT_SIZE,
+      label: tr.label ?? "",
     },
     toPatch: identity,
   };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2228,7 +2228,7 @@ export class FloorplanCardEditor extends LitElement {
 
   private static readonly TRACKER_GROUPS = [
     ["Zone", ["w", "h", "x", "y", "angle"]],
-    ["Marker", ["dotSize"]],
+    ["Marker", ["dotSize", "label"]],
   ] as const;
 
   /**

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -1279,6 +1279,7 @@ export class FloorplanCard extends LitElement {
                 yReading: trackerSensorReading(renderHass?.states, tr.ySensor?.entity),
                 xPresent: trackerPresenceDetected(renderHass?.states, tr.xSensor?.presence),
                 yPresent: trackerPresenceDetected(renderHass?.states, tr.ySensor?.presence),
+                planRotation: rot,
               })
             )}
             <!-- Sun dimming (issue #113). Last inside the rotated group, so it

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -80,6 +80,7 @@ import {
   furnitureFloorTarget,
   entityDefaultIcon,
   trackerSensorReading,
+  renderTracker,
   openingInMotion,
   openingIsActive,
   areaActionForGesture,
@@ -153,7 +154,7 @@ import {
   checkHideCondition,
   itemBadgeHidden,
 } from "./render";
-import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
+import type { FloorplanCardConfig, Opening, RenderHass, Tracker } from "./types";
 import { symbolCatalog, symbolSize } from "./symbols";
 
 /**
@@ -672,6 +673,65 @@ describe("trackerSensorReading", () => {
     expect(trackerSensorReading(states, "sensor.missing")).toBeNull();
     expect(trackerSensorReading(states, "sensor.bad")).toBeNull();
     expect(trackerSensorReading(states, "sensor.text")).toBeNull();
+  });
+});
+
+describe("renderTracker label", () => {
+  const base: Tracker = {
+    id: "t1",
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 100,
+    xSensor: { entity: "sensor.x", min: 0, max: 100 },
+    ySensor: { entity: "sensor.y", min: 0, max: 100 },
+  };
+  const opts = { editing: false, xReading: 50, yReading: 50 };
+
+  it("renders the classic triangle without a label", () => {
+    const out = flattenMarkup(renderTracker(base, opts));
+    expect(out).toContain('<polygon class="tracker-dot"');
+    expect(out).not.toContain("<text");
+  });
+
+  it("renders initials in the triangle's place when a label is set", () => {
+    const out = flattenMarkup(renderTracker({ ...base, label: "FR" }, opts));
+    expect(out).toContain('<text class="tracker-dot"');
+    expect(out).toContain(">FR</text>");
+    expect(out).not.toContain("<polygon");
+    // Still a marker in the same group, so pulse / glide CSS keeps applying.
+    expect(out).toContain('class="tracker-marker"');
+  });
+
+  it("treats a whitespace-only label as unset", () => {
+    const out = flattenMarkup(renderTracker({ ...base, label: "  " }, opts));
+    expect(out).toContain('<polygon class="tracker-dot"');
+    expect(out).not.toContain("<text");
+  });
+
+  it("clamps a long label to three characters", () => {
+    const out = flattenMarkup(renderTracker({ ...base, label: "Fridolin" }, opts));
+    expect(out).toContain(">Fri</text>");
+  });
+
+  it("sizes the halo with the dot, so it neither thins out nor swallows the letters", () => {
+    const small = flattenMarkup(renderTracker({ ...base, label: "FR", dotSize: 8 }, opts));
+    const big = flattenMarkup(renderTracker({ ...base, label: "FR", dotSize: 40 }, opts));
+    expect(small).toContain("stroke-width=1");
+    expect(big).toContain("stroke-width=5");
+  });
+
+  it("counter-rotates the initials so they read level under plan and tracker rotation", () => {
+    const flat = flattenMarkup(renderTracker({ ...base, label: "FR" }, opts));
+    expect(flat).toContain('transform="rotate(0)"');
+    const plan = flattenMarkup(renderTracker({ ...base, label: "FR" }, { ...opts, planRotation: 90 }));
+    expect(plan).toContain('transform="rotate(-90)"');
+    const both = flattenMarkup(
+      renderTracker({ ...base, label: "FR", angle: 30 }, { ...opts, planRotation: 180 })
+    );
+    expect(both).toContain('transform="rotate(-210)"');
+    // The triangle never needed this — it has no reading direction.
+    expect(flattenMarkup(renderTracker(base, { ...opts, planRotation: 90 }))).not.toContain("rotate(-90)");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -4896,7 +4896,22 @@ export interface TrackerRenderOptions {
    */
   xPresent?: boolean | null;
   yPresent?: boolean | null;
+  /**
+   * Whole-plan display rotation the tracker is drawn under (issue #33). The
+   * marker lives inside the rotated SVG group, so a text label would turn
+   * with the plan while every other piece of text stays upright; the label
+   * counter-rotates by this (and the tracker's own `angle`) to read level.
+   * Default 0 — the editor always shows the plan as drawn.
+   */
+  planRotation?: PlanRotation;
 }
+
+/**
+ * Longest label a tracker draws. Initials are two or three letters; anything
+ * longer would spread past the dot, and every other user-supplied value here
+ * is clamped too.
+ */
+export const TRACKER_LABEL_MAX = 3;
 
 /**
  * Render a Tracker as an SVG group: an optional editor-only zone outline plus a
@@ -4950,6 +4965,22 @@ export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTempla
     // Equilateral-ish triangle pointing up, sized in user units (≈ dotR scale).
     const tri = `0,${-dotR} ${dotR * 0.9},${dotR * 0.7} ${-dotR * 0.9},${dotR * 0.7}`;
     const ringMax = Math.max(dotR * 3.5, Math.min(t.w, t.h) * 0.45);
+    // A label rides in the triangle's place: same class, so it pulses and
+    // glides like the dot it replaces. The paint-order stroke is a halo in
+    // the card's own background color, keeping initials readable over busy
+    // plans without a box around them; its width follows dotR so it neither
+    // thins out on big dots nor swallows the letters on small ones. The text
+    // counter-rotates the tracker's own angle and the plan rotation, so the
+    // initials read level like every other text on the card.
+    const label = t.label?.trim().slice(0, TRACKER_LABEL_MAX);
+    const upright = -(angle + (opts.planRotation ?? 0));
+    const dot = label
+      ? svg`<text class="tracker-dot" text-anchor="middle" dominant-baseline="central"
+              font-size=${dotR * 1.6} font-weight="700" fill=${color}
+              stroke="var(--fp-skin-card-bg, #fff)" stroke-width=${dotR * 0.25}
+              paint-order="stroke" pointer-events="none"
+              transform="rotate(${upright})">${label}</text>`
+      : svg`<polygon class="tracker-dot" points=${tri} fill=${color} />`;
     marker = svg`
       <g class="tracker-marker" style="transform:translate(${mx}px, ${my}px);">
         <circle class="tracker-ring" cx="0" cy="0" r="0"
@@ -4958,7 +4989,7 @@ export function renderTracker(t: Tracker, opts: TrackerRenderOptions): SVGTempla
         <circle class="tracker-ring" cx="0" cy="0" r="0"
                 fill="none" stroke=${color} stroke-width="1.5"
                 style="--fp-tracker-ring-max:${ringMax}px; animation-delay:0.7s;" />
-        <polygon class="tracker-dot" points=${tri} fill=${color} />
+        ${dot}
       </g>`;
   } else if (hasX || hasY) {
     // 1-sensor: faint pulsating line + ripple bands along the unknown axis.

--- a/src/types.ts
+++ b/src/types.ts
@@ -944,6 +944,14 @@ export interface Tracker {
   color?: string;
   /** Marker diameter in pixels. Default 14. */
   dotSize?: number;
+  /**
+   * Short text drawn in place of the triangle marker — initials like "FR",
+   * so several trackers on one floor stay tellable apart when color alone
+   * isn't enough. The label keeps the triangle's pulse, ripples and glide;
+   * only the shape changes. Clamped to three characters
+   * so it never spreads past the dot. Empty / unset keeps the classic triangle.
+   */
+  label?: string;
   /** Distance sensor mapped to the X axis (rectangle's horizontal span). */
   xSensor?: TrackerSensor;
   /** Distance sensor mapped to the Y axis (rectangle's vertical span). */


### PR DESCRIPTION
Reopening #164, rebased onto v1.7.2 with every point from the review folded in — sorry for going quiet on the first one.

## What it does
An optional per-tracker `label` (initials like `FR`) rides in the triangle's place, keeping pulse, ripples and glide. Empty / unset keeps the classic triangle, so existing configs render unchanged.

## Review points from #164
- **Editor group** — `label` sits in the `Marker` panel group (and in the test's copy of the group lists), so the control renders; the "every field lands in exactly one panel group" test passes.
- **Halo width** — `stroke-width = dotR * 0.25` instead of a fixed `3`, so it stays proportional from `dotSize: 8` to `40`.
- **Rotated plans** (Codex / @amadeobriones) — the `<text>` counter-rotates by `-(angle + planRotation)`; `renderTracker` gets a new optional `planRotation` and the card passes `rot`. The editor shows the plan as drawn and passes nothing. Triangles are untouched.
- **Length cap** — labels clamp to three characters (`TRACKER_LABEL_MAX`), like the other user-supplied values.

Tests: 6 new in `render.test.ts` (triangle fallback, label, whitespace, clamp, halo scaling, counter-rotation). `npm run typecheck` clean, `vitest run` 1390/1390.

## How the trackers are used here (your questions from Aug 19)
Family house, three floors, four people. Positions do not come from distance sensors but from room-level BLE (Bermuda): a template sensor maps each person's current room to its centre as 0–100 % of the plan and feeds `xSensor`/`ySensor` with `min: 0 / max: 100`. Each person has one tracker per floor, gated with `presence` on a "person is on this floor" binary sensor — so every floor view shows only the people actually on it. That is why several trackers regularly sit on the *same* floor: on a family evening three people share the ground floor, and three coloured triangles stop telling you who is who once you look away from the legend. Initials do.
