### PR TITLE
Replay: open means replay, closed means live

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,11 +58,22 @@ and remain valid for backward compatibility.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `enabled` | boolean | `false` | Shows replay controls and enables loading history for mapped entities. |
+| `enabled` | boolean | `false` | Offers the **Replay** button on the card. Replay itself stays off until you press it. |
 | `lookbackSeconds` | number | `3600` | Initial replay window length in seconds. Must be positive. |
 | `defaultSpeed` | number | auto | Playback speed in simulated seconds per real second. `1` means real-time. |
 | `debug` | boolean | `false` | Log replay lifecycle (load, seek, play, pause) to the browser console. Off by default — seeking logs once per frame. |
 | `numericSteps` | number | unset | Thin numeric sensor drift to this many levels of each sensor's observed range, to cut the time a freshly loaded window takes to draw. Discrete states — lights, doors, covers — are never thinned. Unset keeps every point. |
+
+`enabled: true` puts a **Replay** button on the card and nothing else. The plan keeps
+showing live state until you press it; opening the panel loads the chosen window and
+puts the plan at the *start* of it, and the **live** button in the panel's corner
+closes replay and hands the plan back to Home Assistant. There is no separate on/off
+setting and no mode to be stuck in: open means replay, closed means live. The panel's
+clock — the highlighted timestamp in its header, and the one riding the timeline
+playhead — is where in time the plan is being drawn from.
+
+Closing keeps the window loaded, so reopening on the same range does not fetch it
+again.
 
 A busy plan can load thousands of points a numeric sensor never meaningfully moved
 through, and each one becomes a marker on the timeline. `numericSteps: 25` keeps the

--- a/src/card-badge.browser.test.ts
+++ b/src/card-badge.browser.test.ts
@@ -166,10 +166,13 @@ describe("a device is drawn from one instant, not two", () => {
     await card.updateComplete;
 
     const controller = (card as unknown as { _replayController: {
-      state: { enabled: boolean };
+      state: { enabled: boolean; historyVisible: boolean };
       historyService: () => { getStateAt: (t: number) => Map<string, unknown> };
     } })._replayController;
+    // Both, because both are required: replay has been started, and the panel
+    // is open. A closed panel draws live no matter what history is loaded.
     controller.state.enabled = true;
+    controller.state.historyVisible = true;
     controller.historyService().getStateAt = () =>
       new Map([[
         "binary_sensor.motion",

--- a/src/card-badge.browser.test.ts
+++ b/src/card-badge.browser.test.ts
@@ -142,6 +142,9 @@ describe("a device is drawn from one instant, not two", () => {
       type: "custom:easy-floorplan-card",
       width: 1000,
       height: 600,
+      // Replay only reaches the plan from a panel that is on screen, which
+      // takes the config as well as the open flag set below.
+      historyReplay: { enabled: true, lookbackSeconds: 3600 },
       floors: [
         {
           id: "f1", name: "Floor 1", walls: [], openings: [], items: [motion],

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -269,14 +269,13 @@ export class FloorplanCard extends LitElement {
       this._lastReplayCacheKey = replayKey;
       this._replayController.historyService().clearCache();
     }
-    // A plan whose replay panel is shut has no clock to run. `enabled` in the
-    // config means the control is offered, not that the card hands the plan
-    // over to it; opening the panel is what does that, and until then nothing
-    // should be ticking (issue #256).
-    if (!this._replayController.isHistoryVisible()) {
-      this._replayController.pausePlayback();
-      this._replayController.stopReplayLoop();
-    }
+    // A plan not showing the replay panel has no clock to run, and nothing on
+    // screen to stop one with. `enabled` in the config means the control is
+    // offered, not that the card hands the plan over to it; opening the panel
+    // is what does that. Switching the feature off with the panel open takes
+    // the control away without taking replay with it, which is the one case
+    // that leaves a plan in history with no way out (issue #256).
+    this._replayController.syncToConfig();
     // Restore the floor this plan was last viewed on (issue #81). Only when
     // this instance has no floor of its own yet — a live floor switch always
     // wins — and only if that floor still exists.

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -269,13 +269,11 @@ export class FloorplanCard extends LitElement {
       this._lastReplayCacheKey = replayKey;
       this._replayController.historyService().clearCache();
     }
-    // A plan that has switched replay off entirely stops any playback still
-    // running. A plan that *offers* replay does not start it: `enabled` means
-    // the control is there, not that the card hands the plan over to it. It
-    // used to start on load, which quietly turned a live plan into a snapshot
-    // of the moment it loaded — a light toggled from the plan really switched
-    // while its badge and cast pool stayed put (issue #256).
-    if (!this._replayController.state.configured) {
+    // A plan whose replay panel is shut has no clock to run. `enabled` in the
+    // config means the control is offered, not that the card hands the plan
+    // over to it; opening the panel is what does that, and until then nothing
+    // should be ticking (issue #256).
+    if (!this._replayController.isHistoryVisible()) {
       this._replayController.pausePlayback();
       this._replayController.stopReplayLoop();
     }

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -963,6 +963,29 @@ describe("FloorplanCard replay", () => {
       controller.toggleHistoryVisible(true);
       expect(startSpy).not.toHaveBeenCalled();
       expect(controller.getRenderState().enabled).toBe(false);
+      // And it does not record the panel as open either: the flag means "on
+      // screen", so leaving it set against a config that draws no panel would
+      // have the two halves of that disagree.
+      expect(controller.isHistoryVisible()).toBe(false);
+      expect(controller.isReplayShowing()).toBe(false);
+    });
+
+    it("does not reopen already-open when the feature comes back", () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      const config = (replay: boolean) => ({
+        type: "easy-floorplan-card", width: 1000, height: 600,
+        historyReplay: { enabled: replay, lookbackSeconds: 3600 },
+        floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
+      });
+      card.setConfig(config(false) as never);
+      const controller = (card as any)._replayController;
+
+      controller.toggleHistoryVisible(true);
+      card.setConfig(config(true) as never);
+
+      // A panel that comes back open would come back unstarted, because
+      // nothing ever ran startReplay behind it.
+      expect(controller.isHistoryVisible()).toBe(false);
     });
   });
 

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -913,6 +913,59 @@ describe("FloorplanCard replay", () => {
     });
   });
 
+  describe("switching the feature off while the panel is open", () => {
+    // The panel is only rendered while `historyReplay.enabled` is set, so
+    // turning it off takes the control off screen. Left alone, that took the
+    // way out without taking replay with it: the plan went on drawing an hour
+    // ago with nothing anywhere to stop it.
+    const openedThenDisabled = () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      const config = (replay: boolean) => ({
+        type: "easy-floorplan-card", width: 1000, height: 600,
+        historyReplay: { enabled: replay, lookbackSeconds: 3600 },
+        floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
+      });
+      card.setConfig(config(true) as never);
+      const controller = (card as any)._replayController;
+      controller.state.enabled = true;
+      controller.state.historyVisible = true;
+      controller.state.playbackController = new PlaybackController({ startTime: 1000, endTime: 2000 });
+      controller.state.playbackController.seek(1500);
+      controller.state.playbackController.play();
+      card.setConfig(config(false) as never);
+      return controller;
+    };
+
+    it("puts the plan back to live", () => {
+      expect(openedThenDisabled().getRenderState().enabled).toBe(false);
+    });
+
+    it("stops the clock and shuts the panel", () => {
+      const controller = openedThenDisabled();
+      expect(controller.state.playbackController.playing).toBe(false);
+      expect(controller.state.historyVisible).toBe(false);
+    });
+
+    it("will not open replay a config does not offer", async () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      card.setConfig({
+        type: "easy-floorplan-card", width: 1000, height: 600,
+        historyReplay: { enabled: false, lookbackSeconds: 3600 },
+        floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
+      } as never);
+      card.hass = {
+        states: {}, entities: {}, callApi: vi.fn(async () => []), callService: vi.fn(),
+        formatEntityState: (st: HassEntity) => st.state,
+      } as unknown as HomeAssistant;
+      const controller = (card as any)._replayController;
+      const startSpy = vi.spyOn(controller, "startReplay");
+
+      controller.toggleHistoryVisible(true);
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(controller.getRenderState().enabled).toBe(false);
+    });
+  });
+
   describe("a closed panel draws nothing from history (issue #256)", () => {
     // The reported symptom, on the rendered plan rather than in the controller:
     // a light that is on drew off, and a presence ripple that should have been

--- a/src/replay-history/history-replay.test.ts
+++ b/src/replay-history/history-replay.test.ts
@@ -270,51 +270,39 @@ describe("ReplayPanel", () => {
   });
 });
 
-describe("the replay status chip", () => {
-  // The chip says one thing in words and the same thing in colour. It used to
-  // work both out separately — three branches for the label, two for the class
-  // — so a panel still fetching read "Loading history…" painted in the live
-  // accent. These pin the pair together.
-  const chip = async (props: { enabled: boolean; ready: boolean; viewingHistory: boolean }) => {
+describe("the moment the panel is reporting", () => {
+  // With the panel open the plan is always showing the past, so "where in time
+  // am I" is the only question the header has left to answer. It used to be
+  // buried in a row of grey text beside a Live/Replay chip that said which mode
+  // you were in — a question that no longer exists, because the panel being
+  // open *is* the mode.
+  const header = async () => {
     const panel = document.createElement("easy-floorplan-replay-panel") as HTMLElement & {
-      visible: boolean; enabled: boolean; ready: boolean; viewingHistory: boolean;
-      updateComplete: Promise<unknown>;
+      visible: boolean; currentTimeLabel: string; updateComplete: Promise<unknown>;
     };
     panel.visible = true;
-    panel.enabled = props.enabled;
-    panel.ready = props.ready;
-    panel.viewingHistory = props.viewingHistory;
+    panel.currentTimeLabel = "3/14/25, 1:59:26 PM";
     document.body.appendChild(panel);
     await panel.updateComplete;
-    const el = panel.shadowRoot!.querySelector(".replay-chip")!;
-    return { text: el.textContent?.trim(), classes: [...el.classList] };
+    return panel.shadowRoot!;
   };
 
-  it("reads Live, in the live colour, when the plan is showing now", async () => {
-    const c = await chip({ enabled: false, ready: false, viewingHistory: false });
-    expect(c.text).toBe("Live");
-    expect(c.classes).toContain("is-live");
+  it("shows the head's timestamp", async () => {
+    const root = await header();
+    expect(root.querySelector(".replay-time")?.textContent?.trim()).toBe("3/14/25, 1:59:26 PM");
   });
 
-  it("reads Replay, and not in the live colour, when showing the past", async () => {
-    const c = await chip({ enabled: true, ready: true, viewingHistory: true });
-    expect(c.text).toBe("Replay");
-    expect(c.classes).not.toContain("is-live");
+  it("paints it rather than leaving it as running text", async () => {
+    // The user-visible ask: make where-we-are-in-time obvious at a glance.
+    const root = await header();
+    const styles = root.querySelector("style")!.textContent!;
+    const rule = styles.slice(styles.indexOf(".replay-time {"));
+    expect(rule.slice(0, rule.indexOf("}"))).toContain("background:");
   });
 
-  it("does not paint the loading state as live", async () => {
-    // The reported case: replay switched on, history not back yet, head parked
-    // at the end — so `viewingHistory` is false and the class used to fall
-    // through to is-live while the label said something else entirely.
-    const c = await chip({ enabled: true, ready: false, viewingHistory: false });
-    expect(c.text).toBe("Loading history…");
-    expect(c.classes).not.toContain("is-live");
-  });
-
-  it("says loading whichever way the head is pointing", async () => {
-    const c = await chip({ enabled: true, ready: false, viewingHistory: true });
-    expect(c.text).toBe("Loading history…");
-    expect(c.classes).not.toContain("is-live");
+  it("no longer carries a mode chip", async () => {
+    const root = await header();
+    expect(root.querySelector(".replay-chip")).toBeNull();
   });
 });
 
@@ -820,8 +808,8 @@ describe("FloorplanCard replay", () => {
     });
   });
 
-  describe("the way back to now", () => {
-    const controllerAt = (opts: { enabled: boolean; playing?: boolean; at?: number }) => {
+  describe("closing the panel is the way back to now", () => {
+    const opened = async () => {
       const card = document.createElement("easy-floorplan-card") as FloorplanCard;
       card.setConfig({
         type: "easy-floorplan-card", width: 1000, height: 600,
@@ -829,55 +817,51 @@ describe("FloorplanCard replay", () => {
         floors: [{ id: "f1", name: "Floor 1", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [], areas: [] }],
       } as never);
       const controller = (card as any)._replayController;
-      controller.state.enabled = opts.enabled;
+      controller.state.enabled = true;
+      controller.state.historyVisible = true;
       controller.state.startTime = 1000;
       controller.state.endTime = 2000;
       controller.state.playbackController = new PlaybackController({ startTime: 1000, endTime: 2000 });
-      controller.state.playbackController.seek(opts.at ?? 2000);
-      if (opts.playing) controller.state.playbackController.play();
+      controller.state.playbackController.seek(1200);
+      controller.state.playbackController.play();
+      controller.state.historyEvents = [{ entityId: "light.a", timestamp: 1300, state: "on" }];
       return controller;
     };
 
-    it("offers no way back while the plan is already showing now", () => {
-      // Not in replay at all…
-      expect(createReplayPanelProps(controllerAt({ enabled: false })).viewingHistory).toBe(false);
-      // …and in replay but parked at the end, which draws live anyway.
-      expect(createReplayPanelProps(controllerAt({ enabled: true })).viewingHistory).toBe(false);
-    });
-
-    it("offers it once the plan is showing the past", () => {
-      expect(createReplayPanelProps(controllerAt({ enabled: true, at: 1500 })).viewingHistory).toBe(true);
-      // Playing at the last frame is still watching the recording, not now.
-      expect(
-        createReplayPanelProps(controllerAt({ enabled: true, playing: true })).viewingHistory,
-      ).toBe(true);
-    });
-
-    it("returns the head to the end, and stops playing, without tearing replay down", () => {
-      const controller = controllerAt({ enabled: true, playing: true, at: 1200 });
-      controller.state.historyEvents = [{ entityId: "light.a", timestamp: 1300, state: "on" }];
-      controller.returnToLive();
-      expect(controller.state.playbackController.currentTime).toBe(2000);
+    it("stops the clock and hands the plan back to Home Assistant", async () => {
+      const controller = await opened();
+      controller.toggleHistoryVisible(false);
       expect(controller.state.playbackController.playing).toBe(false);
-      // The plan is live now…
       expect(controller.getRenderState().enabled).toBe(false);
-      // …and going back to a moment costs no second history fetch.
+    });
+
+    it("keeps what it loaded, so reopening costs no second fetch", async () => {
+      const controller = await opened();
+      controller.toggleHistoryVisible(false);
       expect(controller.state.enabled).toBe(true);
       expect(controller.state.historyEvents).toHaveLength(1);
-      // …so the button that got you here is gone.
-      expect(createReplayPanelProps(controller).viewingHistory).toBe(false);
+    });
+
+    it("offers no separate button back, because closing is the button", async () => {
+      const controller = await opened();
+      const panel = document.createElement("easy-floorplan-replay-panel") as HTMLElement & {
+        visible: boolean; updateComplete: Promise<unknown>;
+      };
+      panel.visible = true;
+      document.body.appendChild(panel);
+      await panel.updateComplete;
+      expect(panel.shadowRoot!.querySelector(".replay-live-button")).toBeNull();
+      expect("onReturnLive" in createReplayPanelProps(controller)).toBe(false);
     });
   });
 
-  describe("what the plan draws from while replay is on (issue #256)", () => {
-    // Replay being switched on means the timeline exists and the head can be
-    // moved. It does not mean the plan stops tracking reality: parked at the
-    // end of the window, the head points at the newest thing replay knows, and
-    // live state is newer still.
-    //
-    // Left rendering from history there, turning replay on quietly froze the
-    // plan at the instant it loaded — a light toggled from the plan really
-    // switched, while its badge and cast pool never moved.
+  describe("what the plan draws from (issue #256)", () => {
+    // One rule: the panel is open, or the plan is live. Replay used to be able
+    // to reach the plan through any path that started it — switching floors was
+    // enough — and the symptom was silent, because a closed panel says nothing
+    // about the head sitting an hour back. Lights that were on drew off and a
+    // tripping presence sensor drew still, while toggling that light from the
+    // plan really switched it, since the service call is live either way.
     const replayCard = () => {
       const card = document.createElement("easy-floorplan-card") as FloorplanCard;
       card.setConfig({
@@ -893,34 +877,107 @@ describe("FloorplanCard replay", () => {
       return { card, controller };
     };
 
-    it("draws live state when the head is parked at the end of the window", () => {
+    it("draws live while the panel is closed, wherever the head is", () => {
       const { controller } = replayCard();
-      controller.state.playbackController.seek(2000);
+      for (const at of [1000, 1500, 2000]) {
+        controller.state.playbackController.seek(at);
+        expect(controller.getRenderState().enabled).toBe(false);
+      }
+    });
+
+    it("draws live while the panel is closed, even mid-playback", () => {
+      // The loaded-and-running case, which is what a floor switch used to leave
+      // behind: a clock ticking against a plan nobody had asked to rewind.
+      const { controller } = replayCard();
+      controller.state.playbackController.seek(1500);
+      controller.state.playbackController.play();
       expect(controller.getRenderState().enabled).toBe(false);
     });
 
-    it("draws history as soon as the head moves back", () => {
+    it("draws history once the panel is open", () => {
       const { controller } = replayCard();
+      controller.state.historyVisible = true;
       controller.state.playbackController.seek(1500);
       const render = controller.getRenderState();
       expect(render.enabled).toBe(true);
-      // …and still reports where the head is, so the plan draws that moment.
+      // …and reports where the head is, so the plan draws that moment.
       expect(render.currentTime).toBe(1500);
     });
 
-    it("draws history while playing, even on the last frame", () => {
-      // Playing *to* the end is watching history arrive, not returning to now.
+    it("stays live when replay has never been started", () => {
       const { controller } = replayCard();
-      controller.state.playbackController.seek(2000);
-      controller.state.playbackController.play();
-      expect(controller.getRenderState().enabled).toBe(true);
-    });
-
-    it("stays live when replay is off, whatever the head says", () => {
-      const { controller } = replayCard();
+      controller.state.historyVisible = true;
       controller.state.enabled = false;
       controller.state.playbackController.seek(1500);
       expect(controller.getRenderState().enabled).toBe(false);
+    });
+  });
+
+  describe("a closed panel draws nothing from history (issue #256)", () => {
+    // The reported symptom, on the rendered plan rather than in the controller:
+    // a light that is on drew off, and a presence ripple that should have been
+    // pulsing sat still, on a plan whose replay panel was shut. Replay had been
+    // started by something that was not a person opening the panel, and there
+    // was nothing on screen to say the plan had stopped being live.
+    const rippleCard = () => {
+      const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+      document.body.appendChild(card);
+      card.setConfig({
+        type: "easy-floorplan-card",
+        width: 1000,
+        height: 600,
+        historyReplay: { enabled: true, lookbackSeconds: 3600 },
+        floors: [{
+          id: "f1", name: "Floor 1", walls: [], openings: [], texts: [], furniture: [], trackers: [], areas: [],
+          items: [{ id: "a", entity: "binary_sensor.hall", x: 500, y: 300, kind: "sensor", display: "ripple" }],
+        }],
+      } as never);
+      // On now; off an hour ago. The two disagree, so what gets drawn says
+      // which one the plan is reading.
+      card.hass = {
+        states: { "binary_sensor.hall": { entity_id: "binary_sensor.hall", state: "on", attributes: {} } },
+        entities: {}, callApi: vi.fn(async () => []), callService: vi.fn(),
+        formatEntityState: (st: HassEntity) => st.state,
+      } as unknown as HomeAssistant;
+
+      const controller = (card as any)._replayController;
+      controller.state.enabled = true;
+      controller.state.ready = true;
+      controller.state.playbackController = new PlaybackController({ startTime: 1000, endTime: 2000 });
+      controller.state.playbackController.seek(1500);
+      vi.spyOn(controller.historyService(), "getStateAt").mockReturnValue(
+        new Map([["binary_sensor.hall", { entity_id: "binary_sensor.hall", state: "off", attributes: {} }]]),
+      );
+      return { card, controller };
+    };
+
+    const rippleIsPulsing = (card: FloorplanCard) =>
+      card.shadowRoot!.querySelector(".ripple")?.classList.contains("active");
+
+    it("keeps pulsing for a sensor that is tripping now, whatever history loaded", async () => {
+      const { card } = rippleCard();
+      await card.updateComplete;
+      expect(rippleIsPulsing(card)).toBe(true);
+    });
+
+    it("shows the past only once the panel is open", async () => {
+      const { card, controller } = rippleCard();
+      await card.updateComplete;
+      controller.state.historyVisible = true;
+      card.requestUpdate();
+      await card.updateComplete;
+      expect(rippleIsPulsing(card)).toBe(false);
+    });
+
+    it("goes back to now when the panel is closed again", async () => {
+      const { card, controller } = rippleCard();
+      controller.state.historyVisible = true;
+      card.requestUpdate();
+      await card.updateComplete;
+
+      controller.toggleHistoryVisible(false);
+      await card.updateComplete;
+      expect(rippleIsPulsing(card)).toBe(true);
     });
   });
 
@@ -1027,7 +1084,7 @@ describe("FloorplanCard replay", () => {
     expect(speedToSlider(1000)).toBeCloseTo(3, 3);
   });
 
-  it("reloads replay when the visible floor changes", async () => {
+  it("reloads replay when the visible floor changes, but only while the panel is open", async () => {
     const card = document.createElement("easy-floorplan-card") as FloorplanCard;
     const floors = [
       { id: "floor-1", name: "Floor 1", walls: [], openings: [], items: [{ id: "item-1", entity: "light.kitchen", x: 0, y: 0, kind: "light" as const, icon: "mdi:lightbulb" }], texts: [], furniture: [], trackers: [], areas: [] },
@@ -1065,10 +1122,18 @@ describe("FloorplanCard replay", () => {
     } as unknown as HomeAssistant;
 
     const startSpy = vi.spyOn((card as any)._replayController, "startReplay");
-    (card as any)._goToFloor(floors, "floor-2");
 
-    expect(startSpy).toHaveBeenCalledTimes(1);
+    // Closed: a floor switch is not a request to rewind, and reloading here is
+    // how replay used to turn itself on behind a shut panel (issue #256).
+    (card as any)._goToFloor(floors, "floor-2");
+    expect(startSpy).not.toHaveBeenCalled();
     expect(getReplayWatchedEntities((card as any)._config, (card as any)._activeFloorId)).toEqual(["switch.lounge"]);
+
+    // Open: the window on screen has to follow the floor on screen.
+    (card as any)._replayController.state.historyVisible = true;
+    (card as any)._goToFloor(floors, "floor-1");
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(getReplayWatchedEntities((card as any)._config, (card as any)._activeFloorId)).toEqual(["light.kitchen"]);
   });
 
   it("keeps badge as the default item display when display is unset", async () => {
@@ -1531,7 +1596,10 @@ describe("FloorplanCard replay", () => {
 
     const hideButton = getReplayPanelShadowRoot(card)?.querySelector(".replay-hide-toggle") as HTMLButtonElement | null;
     expect(hideButton).not.toBeNull();
-    expect(hideButton?.textContent).toContain("hide");
+    // Closing is what returns the plan to now, so the button says what it does
+    // rather than what it does to the panel.
+    expect(hideButton?.textContent?.trim()).toBe("live");
+    expect(hideButton?.getAttribute("aria-label")).toBe("Close replay and return to live");
   });
 
   it("filters replay history to entities mapped on the active floor only", async () => {

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -61,7 +61,6 @@ export type ReplayController = {
   updateWindow: (start: number, end: number) => void;
   resetForFloorChange: () => void;
   zoomWindow: (direction: -1 | 1) => void;
-  returnToLive: () => void;
   toggleHistoryVisible: (visible: boolean) => void;
   toggleSpeedPanel: () => void;
   toggleTimeline: () => void;
@@ -173,28 +172,25 @@ export class ReplayControllerImpl implements ReplayController {
    * What the plan should draw from: history at `currentTime`, or the live
    * states Home Assistant is pushing.
    *
-   * `enabled` here is not the same question as "is replay switched on". Replay
-   * being on means the timeline exists and the head can be moved; it does not
-   * mean the plan must stop tracking reality. Parked at the end of the window
-   * and not playing, the head is pointing at the newest thing replay knows —
-   * and the newest thing *anything* knows is the live state, so that is what
-   * to draw.
+   * The panel being open is the whole answer. Closed, replay is not a mode the
+   * plan is quietly in -- it is off, whatever the controller has loaded and
+   * wherever the head happens to sit, so a plan nobody has asked to rewind is
+   * indistinguishable from one with the feature switched off entirely.
    *
-   * Without this, turning replay on quietly froze the plan at the instant it
-   * loaded. Every watched entity with a recorded state rendered from that
-   * moment forever, so a light toggled from the plan really did switch — the
-   * service call is live either way — while its badge and its cast pool stayed
-   * exactly as they had been, and lights that happened to be on at that instant
-   * stayed lit and casting no matter what you did to them. Entities with no
-   * history at that point fell through to live state, which is why only *some*
-   * of the plan looked stuck (issue #256).
+   * Deliberately blunt, because the subtle version kept failing. Replay leaked
+   * into a live plan through any path that started it without anyone opening
+   * the panel -- switching floors was enough, and that path parked the head at
+   * the *start* of the window rather than the end -- and the symptom was
+   * silent: every watched entity with a recorded state drew from an hour ago,
+   * so lights that were on drew off and a presence sensor that was tripping
+   * drew still, while a light toggled from the plan really did switch, because
+   * the service call is live either way. Nothing on a closed panel said why
+   * (issue #256).
    */
   public getRenderState(): { enabled: boolean; currentTime: number; historyVisible: boolean } {
-    const playback = this.state.playbackController;
-    const atLiveEnd = !playback.playing && playback.currentTime >= playback.endTime;
     return {
-      enabled: this.state.enabled && !atLiveEnd,
-      currentTime: playback.currentTime,
+      enabled: this.state.historyVisible && this.state.enabled,
+      currentTime: this.state.playbackController.currentTime,
       historyVisible: this.state.historyVisible,
     };
   }
@@ -236,7 +232,10 @@ export class ReplayControllerImpl implements ReplayController {
     this.state.playbackController.pause();
     this.stopReplayLoop();
     this._card.requestUpdate();
-    if (!this._card.getHass() || !this._card.getConfig()?.historyReplay?.enabled) return;
+    // Only while the panel is open: `historyReplay.enabled` says the control is
+    // offered, not that the plan is in replay, and reloading on a closed panel
+    // is a history query nobody asked for and nobody can see.
+    if (!this._card.getHass() || !this.state.historyVisible) return;
     void this.startReplay({ preserveCurrentTime: true, keepPlaying: wasPlaying });
   }
 
@@ -250,7 +249,10 @@ export class ReplayControllerImpl implements ReplayController {
     this.clearHistoryCache();
     this.stopReplayLoop();
     this._card.requestUpdate();
-    if (this._card.getHass() && this._card.getConfig()?.historyReplay?.enabled) {
+    // Same rule as updateWindow: a floor switch reloads replay only if replay
+    // is what you are looking at. This path is how replay used to turn itself
+    // on behind a closed panel -- see getRenderState.
+    if (this._card.getHass() && this.state.historyVisible) {
       void this.startReplay({ preserveCurrentTime: true, keepPlaying: this.state.playbackController.playing });
     }
   }
@@ -266,32 +268,31 @@ export class ReplayControllerImpl implements ReplayController {
   }
 
   /**
-   * Back to now.
+   * Opening and closing the panel is the whole of turning replay on and off.
    *
-   * Deliberately not a teardown. Replay stays loaded and the timeline keeps
-   * its events, because the head sitting at the end of the window *is* live —
-   * see {@link getRenderState} — so there is nothing to dismantle in order to
-   * see the present, and dismantling it would make going back to a moment you
-   * were just looking at cost another history fetch.
+   * There is no separate enable switch and no button back to now, because
+   * those used to be separate questions whose answers could disagree: the plan
+   * could be showing an hour ago with nothing on screen saying so. Opening
+   * loads the window and parks the head at its start, so replay begins where
+   * the calendar says it does; closing stops the clock and hands the plan back
+   * to Home Assistant.
    *
-   * Which is also why this is the only way out that the panel offers. There
-   * used to be an Enable/Disable pair, from when replay had to be switched on
-   * before it would do anything; now Run starts it and this returns from it,
-   * and neither of them is a mode you have to remember you are in.
+   * Closing is not a teardown. The window and its events stay loaded, so
+   * reopening on the same range costs no second history fetch -- it just
+   * cannot reach the plan while the panel is shut (see {@link getRenderState}).
    */
-  public returnToLive(): void {
-    this.state.playbackController.pause();
-    this.stopReplayLoop();
-    this.state.playbackController.seek(this.state.playbackController.endTime);
-    this.logReplay("[easy-floorplan] Replay returned to live", {
-      currentTime: this.state.playbackController.currentTime,
-    });
-    this._card.requestUpdate();
-  }
-
   public toggleHistoryVisible(visible: boolean): void {
     this.state.historyVisible = visible;
+    if (!visible) {
+      this.state.playbackController.pause();
+      this.stopReplayLoop();
+      this.logReplay("[easy-floorplan] Replay closed, plan is live");
+      this._card.requestUpdate();
+      return;
+    }
     this._card.requestUpdate();
+    if (!this._card.getHass()) return;
+    void this.startReplay();
   }
 
   public toggleSpeedPanel(): void {
@@ -320,9 +321,12 @@ export class ReplayControllerImpl implements ReplayController {
     this.state.loadRequested = true;
     this.state.error = undefined;
     this.state.ready = false;
+    // A fresh start begins at the top of the window the calendar shows, so
+    // opening the panel and pressing Run play the range through rather than
+    // sitting on its last instant with nowhere left to go.
     const initialTime = options.preserveCurrentTime
       ? Math.min(replayEnd, Math.max(replayStart, this.state.playbackController.currentTime))
-      : replayEnd;
+      : replayStart;
     this.state.playbackController = new PlaybackController({
       startTime: replayStart,
       endTime: replayEnd,

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -177,7 +177,12 @@ export class ReplayControllerImpl implements ReplayController {
    * clock running.
    */
   public isReplayShowing(): boolean {
-    return !!this._card.getConfig()?.historyReplay?.enabled && this.state.historyVisible;
+    return this._replayOffered() && this.state.historyVisible;
+  }
+
+  /** Whether the config puts a replay control on the card at all. */
+  private _replayOffered(): boolean {
+    return !!this._card.getConfig()?.historyReplay?.enabled;
   }
 
   /**
@@ -313,8 +318,15 @@ export class ReplayControllerImpl implements ReplayController {
    * cannot reach the plan while the panel is shut (see {@link getRenderState}).
    */
   public toggleHistoryVisible(visible: boolean): void {
-    this.state.historyVisible = visible;
-    if (!visible) {
+    // Asked to open, and there is something to open: the flag means "the panel
+    // is on screen", so a config that draws no panel cannot set it. Committing
+    // it first and bailing afterwards left it true with replay switched off --
+    // a state where isHistoryVisible and isReplayShowing disagree, and where
+    // switching the feature back on would find the panel already open with
+    // nothing ever loaded behind it.
+    const open = visible && this._replayOffered();
+    this.state.historyVisible = open;
+    if (!open) {
       this.state.playbackController.pause();
       this.stopReplayLoop();
       this.logReplay("[easy-floorplan] Replay closed, plan is live");
@@ -322,10 +334,7 @@ export class ReplayControllerImpl implements ReplayController {
       return;
     }
     this._card.requestUpdate();
-    // isReplayShowing, not just hass: a caller can set this true against a
-    // config with replay switched off, and loading history for a panel that
-    // will not be rendered is work nobody can see or stop.
-    if (!this._card.getHass() || !this.isReplayShowing()) return;
+    if (!this._card.getHass()) return;
     void this.startReplay();
   }
 

--- a/src/replay-history/replay-controller.ts
+++ b/src/replay-history/replay-controller.ts
@@ -51,6 +51,8 @@ export type ReplayController = {
   speedForRange: (start: number, end: number) => number;
   currentTime: () => number;
   isHistoryVisible: () => boolean;
+  isReplayShowing: () => boolean;
+  syncToConfig: () => void;
   isReplayReady: () => boolean;
   isReplayEnabled: () => boolean;
   getRenderState: () => { enabled: boolean; currentTime: number; historyVisible: boolean };
@@ -169,6 +171,32 @@ export class ReplayControllerImpl implements ReplayController {
   }
 
   /**
+   * Whether the replay panel is on screen: the config offers it, and it is
+   * open. Both halves, because a panel that is not rendered can neither be
+   * read nor closed -- so nothing behind it may draw on the plan or keep a
+   * clock running.
+   */
+  public isReplayShowing(): boolean {
+    return !!this._card.getConfig()?.historyReplay?.enabled && this.state.historyVisible;
+  }
+
+  /**
+   * Bring replay back in line with a config that no longer offers it.
+   *
+   * Switching `historyReplay.enabled` off takes the panel off screen but not,
+   * on its own, the state behind it: the plan went on rendering history with
+   * no control left anywhere to leave it. Called from setConfig, so it also
+   * covers the ordinary case of a shut panel, where it just makes sure no
+   * clock is ticking against a plan nobody is replaying.
+   */
+  public syncToConfig(): void {
+    if (this.isReplayShowing()) return;
+    this.state.historyVisible = false;
+    this.state.playbackController.pause();
+    this.stopReplayLoop();
+  }
+
+  /**
    * What the plan should draw from: history at `currentTime`, or the live
    * states Home Assistant is pushing.
    *
@@ -176,6 +204,9 @@ export class ReplayControllerImpl implements ReplayController {
    * plan is quietly in -- it is off, whatever the controller has loaded and
    * wherever the head happens to sit, so a plan nobody has asked to rewind is
    * indistinguishable from one with the feature switched off entirely.
+   *
+   * "Open" means on screen, which takes the config as well as the panel --
+   * see {@link isReplayShowing}.
    *
    * Deliberately blunt, because the subtle version kept failing. Replay leaked
    * into a live plan through any path that started it without anyone opening
@@ -189,7 +220,7 @@ export class ReplayControllerImpl implements ReplayController {
    */
   public getRenderState(): { enabled: boolean; currentTime: number; historyVisible: boolean } {
     return {
-      enabled: this.state.historyVisible && this.state.enabled,
+      enabled: this.isReplayShowing() && this.state.enabled,
       currentTime: this.state.playbackController.currentTime,
       historyVisible: this.state.historyVisible,
     };
@@ -291,7 +322,10 @@ export class ReplayControllerImpl implements ReplayController {
       return;
     }
     this._card.requestUpdate();
-    if (!this._card.getHass()) return;
+    // isReplayShowing, not just hass: a caller can set this true against a
+    // config with replay switched off, and loading history for a panel that
+    // will not be rendered is work nobody can see or stop.
+    if (!this._card.getHass() || !this.isReplayShowing()) return;
     void this.startReplay();
   }
 

--- a/src/replay-history/replay-panel.ts
+++ b/src/replay-history/replay-panel.ts
@@ -27,9 +27,6 @@ export interface ReplayPanelRenderProps {
   onToggleVisible: (visible: boolean) => void;
   onRangeChange: (kind: "start" | "end", value: string) => void;
   onZoom: (direction: -1 | 1) => void;
-  onReturnLive: () => void;
-  /** Whether the plan is showing a past moment rather than the present. */
-  viewingHistory: boolean;
   onJump: (delta: number) => void;
   onStep: (direction: -1 | 1) => void;
   onPlayToggle: () => void;
@@ -61,7 +58,6 @@ export interface ReplayPanelHost {
   getDefaultWindow: () => { start: number; end: number };
   handleRangeChange: (kind: "start" | "end", ev: Event) => void;
   zoomWindow: (direction: -1 | 1) => void;
-  returnToLive: () => void;
   jumpReplay: (delta: number) => void;
   stepReplay: (direction: -1 | 1) => void;
   pauseReplay: () => void;
@@ -100,11 +96,6 @@ export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRender
     currentTime: fallback ? fallback.end : playback.currentTime,
     visible: state.historyVisible,
     enabled: state.enabled,
-    // Showing the past, which is the only time there is anything to return
-    // from: replay running, and the head either moving or somewhere behind the
-    // end of the window. Parked at the end it is already drawing live.
-    viewingHistory:
-      state.enabled && (playback.playing || playback.currentTime < playback.endTime),
     ready: state.ready,
     playing: playback.playing,
     timelineExpanded: state.timelineExpanded,
@@ -122,7 +113,6 @@ export function createReplayPanelProps(host: ReplayPanelHost): ReplayPanelRender
       host.handleRangeChange(kind, { target: { value } } as unknown as Event);
     },
     onZoom: (direction: -1 | 1) => host.zoomWindow(direction),
-    onReturnLive: () => host.returnToLive(),
     onJump: (delta: number) => host.jumpReplay(delta),
     onStep: (direction: -1 | 1) => host.stepReplay(direction),
     onPlayToggle: () => (playback.playing ? host.pauseReplay() : host.playReplay()),
@@ -144,7 +134,6 @@ export function renderReplayPanel(props: ReplayPanelRenderProps): TemplateResult
       .currentTime=${props.currentTime}
       .visible=${props.visible}
       .enabled=${props.enabled}
-      .viewingHistory=${props.viewingHistory}
       .ready=${props.ready}
       .playing=${props.playing}
       .timelineExpanded=${props.timelineExpanded}
@@ -164,7 +153,6 @@ export function renderReplayPanel(props: ReplayPanelRenderProps): TemplateResult
         props.onRangeChange(kind, ev.detail.value);
       }}
       @zoom=${(ev: CustomEvent<{ direction: -1 | 1 }>) => props.onZoom(ev.detail?.direction ?? 1)}
-      @return-live=${() => props.onReturnLive()}
       @jump=${(ev: CustomEvent<{ delta: number }>) => props.onJump(ev.detail?.delta ?? 0)}
       @step=${(ev: CustomEvent<{ direction: -1 | 1 }>) => props.onStep(ev.detail?.direction ?? 1)}
       @play-toggle=${() => props.onPlayToggle()}
@@ -243,22 +231,22 @@ export class ReplayPanel extends LitElement {
       gap: 8px;
       flex-wrap: wrap;
     }
-    .replay-chip {
-      display: inline-flex;
-      align-items: center;
-      padding: 2px 8px;
-      border-radius: 999px;
-      background: var(--card-background-color, #fff);
-      color: var(--primary-text-color);
-      font-size: 11px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-    }
+    /*
+     * The moment being drawn, painted as its own thing rather than set in a
+     * line of grey text. This is the one fact the panel exists to report --
+     * with the panel open the plan is always showing the past, so "where in
+     * time am I" is the only question left -- and a plain timestamp beside a
+     * row of controls does not read as an answer to it. Matches the clock
+     * riding the timeline playhead, which wears the same accent.
+     */
     .replay-time {
       font-size: 12px;
       font-variant-numeric: tabular-nums;
-      color: var(--primary-text-color);
+      padding: 3px 9px;
+      border-radius: 999px;
+      background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
+      color: var(--fp-skin-accent-ink, var(--text-primary-color, #fff));
+      font-weight: 600;
     }
     .replay-status {
       font-size: 12px;
@@ -400,21 +388,6 @@ export class ReplayPanel extends LitElement {
       min-width: 0;
       align-self: flex-start;
     }
-    /* The way back to now. Only drawn while the plan is showing the past, so
-       it is never a button that undoes nothing -- see viewingHistory. */
-    .replay-live-button {
-      font-weight: 600;
-    }
-    /* Only the live state wears the accent. Loading is not live, and painting
-       it as though it were is what this pair of classes exists to prevent --
-       see _chipState, which is the one place the state is decided. */
-    .replay-chip.is-live {
-      background: var(--fp-skin-accent, var(--primary-color, #03a9f4));
-      color: var(--text-primary-color, #fff);
-    }
-    .replay-chip.is-loading {
-      opacity: 0.75;
-    }
     .replay-run-button {
       min-width: 82px;
       font-weight: 600;
@@ -542,7 +515,6 @@ export class ReplayPanel extends LitElement {
   @property({ type: Number }) public currentTime = 0;
   @property({ type: Boolean }) public visible = false;
   @property({ type: Boolean }) public enabled = false;
-  @property({ type: Boolean }) public viewingHistory = false;
   @property({ type: Boolean }) public ready = false;
   @property({ type: Boolean }) public playing = false;
   @property({ type: Boolean }) public timelineExpanded = false;
@@ -613,21 +585,6 @@ export class ReplayPanel extends LitElement {
     current.scrollIntoView({ block: "nearest", inline: "nearest" });
   }
 
-  /**
-   * The status chip: one state, said twice — in words and in colour.
-   *
-   * Worked out in one place because it was worked out in two, and they
-   * disagreed. The label had three branches and the class had two, so a panel
-   * that was still fetching read "Loading history…" painted in the live
-   * accent: the one state where the two halves could contradict each other,
-   * and the one nobody looks at twice.
-   */
-  private _chipState(): { label: string; className: string } {
-    if (this.enabled && !this.ready) return { label: "Loading history…", className: "is-loading" };
-    if (this.viewingHistory) return { label: "Replay", className: "is-replay" };
-    return { label: "Live", className: "is-live" };
-  }
-
   protected render(): TemplateResult {
     if (!this.visible) {
       return html`
@@ -646,20 +603,22 @@ export class ReplayPanel extends LitElement {
     }
 
     const currentEvent = this._getCurrentEvent();
-    const chip = this._chipState();
     return html`
       <div class="replay-panel" id=${this.panelId}>
+        <!-- Closing the panel is how you get back to now, so the button says
+             so. It used to say "hide", next to a separate Live button that did
+             the returning; one control does both because they were never two
+             things (see ReplayController.toggleHistoryVisible). -->
         <button
           class="replay-hide-toggle"
-          aria-label="Hide replay panel"
+          aria-label="Close replay and return to live"
           aria-controls=${this.panelId}
           @click=${() => this._dispatch("toggle-visible", { visible: false })}
         >
-          hide
+          live
         </button>
         <div class="replay-header">
           <div class="replay-meta">
-            <span class="replay-chip ${chip.className}">${chip.label}</span>
             <span class="replay-time">${this.currentTimeLabel}</span>
           </div>
           <div class="replay-status">
@@ -696,15 +655,6 @@ export class ReplayPanel extends LitElement {
         </div>
         <div class="replay-toolbar">
           <div class="replay-transport" role="group" aria-label="Replay transport controls">
-            ${this.viewingHistory
-              ? html`<button
-                  class="replay-live-button"
-                  title="Return to live"
-                  @click=${() => this._dispatch("return-live")}
-                >
-                  Live
-                </button>`
-              : nothing}
             <button class="replay-icon-button" aria-label="Jump back 30 seconds" title="Jump back 30 seconds" @click=${() => this._dispatch("jump", { delta: -30 })}>
               <ha-icon icon="mdi:rewind-30"></ha-icon>
             </button>


### PR DESCRIPTION
## The bug

With `historyReplay.enabled: true` in the config, the plan could quietly stop being live — lights that were on drew off, and presence sensors with a ripple sat still even while tripping. Toggling that light from the plan really did switch it, because the service call is live either way, which made it read as a rendering bug rather than a replay one.

Replay could reach the plan through any path that *started* it, not only through someone opening the panel. Switching floors was one such path, and it parked the head at the **start** of the window — so the whole plan rendered from an hour ago, behind a panel that was shut and said nothing about it.

The previous fix (#256) narrowed the rule to "history, unless the head is parked at the end of the window". That is true but subtle, and it still left every not-parked-at-the-end path able to take over a live plan invisibly.

## The change

The panel being open is the whole question:

- **Closed → live.** `getRenderState()` returns `enabled: false` whenever the panel is shut, whatever replay has loaded and wherever the head sits. A plan nobody asked to rewind is indistinguishable from one with the feature off.
- **Opening starts replay** and parks the head at the *start* of the chosen window, so it begins where the calendar says it does.
- **Closing returns to live** — stops the clock, keeps the loaded events, so reopening on the same range costs no second history fetch.
- A floor switch or a window change reloads replay **only while the panel is open**.

That removes the need for a separate way back, so:

- The **Live** button is gone, and the corner button says `live` instead of `hide` (aria-label: "Close replay and return to live").
- The **Live/Replay chip** is gone — with the panel open there is only one mode left to be in.
- The header's **clock takes the accent** the chip was wearing, which answers the only question the panel still has: where in time is this. It matches the clock riding the timeline playhead.

## Tests

New tests assert the symptom on the rendered plan, not just in the controller: a ripple sensor that is tripping now keeps pulsing behind a closed panel with contradicting history loaded, shows the past once the panel opens, and goes back to now when it closes. Verified they fail against the old rule.

Rewritten: the chip tests (now about the highlighted timestamp), the "way back to now" tests (now about closing), and the floor-switch test (now asserts it does *not* reload while closed).

Full node suite and browser suite pass. The 3 node failures on this repo come from a stale nested worktree under `.claude/worktrees/` and are present on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)