### PR TITLE
Sunlight: a beam carries on through a clear opening

### DIFF
--- a/src/render.opening.test.ts
+++ b/src/render.opening.test.ts
@@ -284,6 +284,33 @@ describe("renderSunlight — the markup, not just the geometry", () => {
     expect(spans.some((xs) => xs[0]! <= 190 && xs[1]! >= 210)).toBe(false);
   });
 
+  it("a beam carries on through a shut glazed door (#262)", () => {
+    // The patio door the reporter had between a balcony and the room behind
+    // it. Glass, so the wall's shade already has its gap cut and nothing
+    // stands in the light — but the beam's own length was measured against
+    // the *uncut* wall, so it faded to nothing at the door and the room
+    // beyond stayed as dark as if the door were brick. The gap the shade
+    // leaves is only worth having if there is still light arriving at it.
+    const mid = { id: "m", x1: 0, y1: 180, x2: 400, y2: 180 };
+    const far = { id: "f", x1: 0, y1: 220, x2: 400, y2: 220 };
+    const patio = { ...win, id: "d", type: "door", glazed: true, y: 180, length: 200 } as Opening;
+    const s = serialize(
+      renderSunlight([wall, mid, far], [win, patio], 400, 400, "sun", {
+        dir: sun,
+        // Shut, which is the whole point: glass admits its gap whatever the
+        // sash is doing, and the door in the report was a shut one.
+        openAmount: () => 0,
+        shutterOpen: () => undefined,
+      })
+    );
+    // Still one source — the glazed door is not a second sun (#177 / #178).
+    expect(s.match(/class="fp-sunbeam"/g)?.length).toBe(1);
+    // The falloff is scaled by how far the light travels, and that is now the
+    // wall past the door, 120 away, rather than the door's own wall at 80.
+    expect(s).toContain("scale(120 ");
+    expect(s).not.toContain("scale(80 ");
+  });
+
   it("an opening switched out of the sunlight is wall to it (#177)", () => {
     // The solid front door the plan draws open because nothing is bound to it.
     const shut = { ...win, type: "door", sunlight: false } as Opening;

--- a/src/render.ts
+++ b/src/render.ts
@@ -4319,7 +4319,7 @@ export function renderSunlight(
     // How far the light gets before a wall stops it. The falloff is measured
     // against this, so a patch is faint by the time it ends however deep or
     // shallow the room is.
-    const along = sunTravelDistance(o, dir, walls, reach);
+    const along = sunTravelDistance(o, dir, blockers, reach);
     // …and how wide it is, measured across the light rather than along the
     // wall: a gap seen obliquely admits a narrower beam than its own length.
     const [ga, gb] = openingEnds(o);


### PR DESCRIPTION
Fixes #262.

## The problem

A shut patio door let no sunlight into the room behind it. The door is `glazed`, so the
plan draws no shade at it — but no light arrives either. The room stays as dark as if the
door were brick.

## The cause

`renderSunlight` asks "where does the light stop?" twice, against two different sets of
walls.

- The **shade** uses `wallsLightPassesThrough(walls, openings, clear)`. This cuts the
  glazed door out of the wall. That part was already right.
- The **beam** used `sunTravelDistance(o, dir, walls, reach)`, with the **uncut** walls.
  `rayWallHit` is a plain segment test and knows nothing about openings.

So the beam's falloff reached zero exactly at the wall line, even where that wall is fully
open. The gap in the shade was there, but no light was left to pass through it.

This is not the documented behaviour. `docs/lighting.md` says: "Light still travels
*through* an interior doorway — the beam from the window upstream carries on, because that
wall's shade has the same gap cut in it."

## The fix

One line. The beam now measures its travel against the same cut walls the shadows use:

```diff
-    const along = sunTravelDistance(o, dir, walls, reach);
+    const along = sunTravelDistance(o, dir, blockers, reach);
```

The beam now stops at the next **solid** wall, not at the first wall line it crosses. An
opening with `sunlight: false`, or a shut opaque door, still stops it: those keep their
wall uncut, so the ray hits them as before. `sunReachesOpening` keeps the uncut walls on
purpose, so an interior door is still not a second sun (#177 / #178).

## Why the tests did not catch it

The #178 case only checked that no shadow polygon covered the beam. That was true all
along. It never checked that the beam is long enough to arrive. The new case in
`src/render.opening.test.ts` puts a shut glazed door 80 units downstream of a window and a
solid wall 40 units past it. It asserts the falloff scales to 120, not 80. It fails on
`main` and passes here.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 1400 tests pass in 17 files.
- Built and loaded in a real Home Assistant.

Before — the light stops at the balcony's glazed door:

![before](https://github.com/user-attachments/assets/2c609c8c-6377-4174-b6f1-2930af24eb18)

After — the same plan, same sun, light carries into the Living room:

![Sunlight carries through the shut glazed balcony door into the Living room](https://github.com/user-attachments/assets/5cbf71a5-be90-4830-8433-1cc4046d7fdb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
