### PR TITLE
Label colour: tidy the four items left over from #264

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ screen size.
   - **Presence ripples** — presence and vibration sensors drawn as animated rings instead of a static icon.
   - **Cast light** — a light pools its own color and brightness onto the plan; overlapping pools mix, so a warm lamp and a cool one blend between them.
   - **Conditional text / icon / coloring** — threshold and state rules restyle an element from what its entity reads: the badge color, the label, and the glyph itself, so blinds swap between open and closed icons and a thermostat reddens as it heats. The same rules drive furniture and rooms.
- 
+
 <img width="195" height="278" alt="light blend" src="https://github.com/user-attachments/assets/23104587-687b-4c9a-83e8-e83c3d5eb6eb" />
 <img width="240" height="358" alt="conditionals" src="https://github.com/user-attachments/assets/11d359b6-de8c-483c-8763-105ddf7d915b" />
 
@@ -42,7 +42,7 @@ screen size.
 - 📍 **Live position trackers** — map one or two distance sensors (mmWave / radar) onto a marker that moves across the plan in real time.
 - 🧱 **Dead spaces** — hatch the spaces your walls seal off that no door or window reaches: a service shaft, the void behind a boxed-in stairwell. Nothing to draw — the regions come from the walls and openings themselves, so cutting a doorway into one stops it being dead the moment you place the door.
 - 🌗 **Follow the sun** — dim the plan through dusk and brighten it through dawn, from your HA instance's sun elevation. Any light casting light holds the dark back around itself, out to its radius, so a night plan reads as a dark house with lit rooms glowing.
- 
+
 <img width="441" height="301" alt="day" src="https://github.com/user-attachments/assets/f3dbfc88-9d06-4f44-81dc-bf499cbd9bd3" />
 <img width="444" height="313" alt="night" src="https://github.com/user-attachments/assets/1590b710-d88f-4a34-986b-b08640a45f4c" />
 
@@ -50,7 +50,7 @@ screen size.
 - 🏢 **Multiple floors** — per-floor elements with a switcher in both the editor and the card. Give a staircase `goToFloor: up` and clicking it takes you there.
 - 🖼️ **Background image** — trace over a floor-plan scan, per floor, with adjustable opacity.
 - 🎨 **Skins** — restyle the whole plan from one line of config: `default` follows your Home Assistant theme, `odnetnin` is chunky charcoal on cream, `pastel` is soft and low-contrast, `tron` is neon on near-black. Colors you set on an element yourself always win.
-  
+
 <img width="300" height="300" alt="default" src="https://github.com/user-attachments/assets/ce2d6545-10f4-4aa2-bbd7-0dcae08c27f5" />
 <img width="300" height="300" alt="odnetnin" src="https://github.com/user-attachments/assets/1d46f7a3-b894-4fcb-bdb9-a55270b8e4e4" />
 <img width="300" height="300" alt="tron" src="https://github.com/user-attachments/assets/de5b0825-3bff-4817-8a26-8f887bab8c48" />
@@ -127,37 +127,25 @@ then pick the entity in the **Element** section below the canvas.
 - **Label position** — **Below** the badge (the default), or hung off its **left** or
   **right**. A reading under a badge grows in both directions and meets whatever sits
   beside it; hung off one side it grows one way only.
-- **Disable Label Color** (disableLabelColor)
-  With the new disableLabelColor boolean toggle (available in Group 3 of the item editor), you can
-  override this behavior per item. When set to true, the label text will stay locked to its default
-  theme color, while the icon and badge continue to reflect the dynamic state colors.
-  **Label Color Customization**
+- **Disable label color** — an item's label normally follows the same state and active
+  color rules its badge does. That is useful as a status cue and awkward when it hurts
+  readability or fights a deliberately plain dashboard, so this pins the text to the
+  theme's default instead. The icon and badge keep their dynamic colors; only the text
+  stops. With **Own color** — the toggle that appears underneath once this is on — you can
+  pin it to a fixed color rather than the theme default, and the color picker follows.
 
-  By default, an item's label text automatically adapts its color based on the state or active color rules.
-  For some items, this can impact readability or clash with the desired design.
-  
-  With the `disableLabelColor` boolean toggle (available in Group 3 of the item editor), you can override this
-  behavior per item. When set to `true`, the label text will stay locked to its default theme color,
-  while the icon and badge continue to reflect the dynamic state colors.
-  
-  You can also optionally assign a fixed custom color using `useCustomLabelColor` and `labelCustomColor`.
-  
-  | YAML Key | Type | Description |
+  | YAML key | Type | Description |
   | :--- | :--- | :--- |
-  | `disableLabelColor` | boolean | Keeps the text in its default theme color, preventing it from inheriting active or state colors. |
-  | `useCustomLabelColor` | boolean | Activates a custom color option when `disableLabelColor` is enabled ("Own color" toggle in the editor),
-  allowing you to override the theme default. |
-  | `labelCustomColor` | string | The fixed custom color (e.g., `#ff0000` or `red`) applied to the label text. |
-  
-  The `useCustomLabelColor` toggle appears in the visual editor as "Own color" only once `disableLabelColor` is activated,
-  and toggling it reveals the color picker for precise tuning.
-  
-  *Example: Disable automatic state coloring and apply a fixed custom color to a label:*
+  | `disableLabelColor` | boolean | Keeps the label text in the theme's default color instead of inheriting the active or state color. |
+  | `useCustomLabelColor` | boolean | Use a fixed color for the label instead of the theme default. Only read when `disableLabelColor` is on. |
+  | `labelCustomColor` | string | The fixed color (e.g. `#ff0000` or `red`), used when `useCustomLabelColor` is on. |
+
   ```yaml
-    disableLabelColor: true
-    useCustomLabelColor: true
-    labelCustomColor: "#00ff00"
+  disableLabelColor: true
+  useCustomLabelColor: true
+  labelCustomColor: "#00ff00"
   ```
+
 - **Badge shows** — one dropdown for what the device draws: *Icon* — **still**,
   **spinning** or **pulsing** — its *Value*, or *Nothing* (label only). **Value** draws
   the reading inside the badge — a thermostat reads `21°` in the circle your state rules

--- a/src/editor-forms.test.ts
+++ b/src/editor-forms.test.ts
@@ -2052,7 +2052,7 @@ describe("itemLabelForm — disableLabelColor and custom color state machine", (
 
   it("round-trips custom color when both toggles are enabled", () => {
     const form = itemLabelForm(item);
-    
+
     expect(
       form!.toPatch({
         disableLabelColor: true,

--- a/src/editor-forms.ts
+++ b/src/editor-forms.ts
@@ -952,7 +952,7 @@ export function itemLabelForm(it: FloorItem): FormSpec {
     },
     toPatch: (p) => {
       const out = { ...p };
-      
+
       // IMPORTANT: Determine the actual future state
       const isDisable = out.disableLabelColor ?? it.disableLabelColor ?? false;
       const isCustom = out.useCustomLabelColor ?? it.useCustomLabelColor ?? false;
@@ -970,7 +970,7 @@ export function itemLabelForm(it: FloorItem): FormSpec {
       }
 
       if (out.labelCustomColor === "") out.labelCustomColor = undefined;
-      
+
       return out;
     },
   };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4291,7 +4291,7 @@ export class FloorplanCardEditor extends LitElement {
     // will actually render (state rules first, then the active colour).
     const rawValue = itemRawValue(it, st);
     const stateColor = cssColor(resolveStateColor(it.stateColor, rawValue));
-    const labelColor = itemLabelColor(it, stateColor);   
+    const labelColor = itemLabelColor(it, stateColor);
     const value = badgeContentOf(it) === "value" ? badgeValue(this.hass, it) : undefined;
     // The active colour — the one the user set, else the bulb's own colour
     // (issue #106). The canvas never previewed either, so setting "Active

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -629,10 +629,6 @@ export class FloorplanCard extends LitElement {
   private _renderBadge(item: FloorItem, scale: OverlayScale, renderHass?: RenderHass): TemplateResult {
     const size = cssNumber(item.size, DEFAULT_ITEM_SIZE);
     const box = overlayLength(size, scale);
-    
-    // Use renderHass when available to keep state context consistent, fallback to this.hass
-    const hassContext = renderHass ?? this.hass;
-
     // Animation goes on the inner ha-icon, not the badge: the badge carries
     // the user's `angle` rotation, and a spin on the same element would
     // overwrite it.
@@ -646,7 +642,7 @@ export class FloorplanCard extends LitElement {
     // "Show the reading, not a picture" (issue #106). Same badge — size, angle,
     // state colour, ripple stacking all unchanged — with the glyph swapped for
     // the number. A device with nothing numeric to show keeps its icon.
-    const value = badgeContentOf(item) === "value" ? badgeValue(hassContext, item) : undefined;
+    const value = badgeContentOf(item) === "value" ? badgeValue(renderHass, item) : undefined;
     return html`
       <div
         class="badge"
@@ -660,7 +656,7 @@ export class FloorplanCard extends LitElement {
             >`
           : html`<ha-icon
               class=${anim ? `anim-${anim}` : ""}
-              icon=${this._itemIcon(item, hassContext)}
+              icon=${this._itemIcon(item, renderHass)}
               style="--mdc-icon-size:${overlayLength(itemIconSize(size), scale)};"
             ></ha-icon>`}
       </div>

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -353,19 +353,19 @@ export class FloorplanCard extends LitElement {
     return { columns: 12, rows: 8, min_columns: 6, min_rows: 4 };
   }
 
-  private _isOn(item: FloorItem, renderHass?: RenderHass): boolean {
+  private _isOn(item: FloorItem, renderHass: RenderHass | undefined): boolean {
     // Domain-aware: locks say "unlocked", vacuums "cleaning" — never "on".
     return entityIsActive(item.entity, renderHass?.states[item.entity]?.state);
   }
 
   /** How far open an opening should be drawn (0..1), from its entity (or default). */
-  private _openingAmount(o: Opening, renderHass?: RenderHass): number {
+  private _openingAmount(o: Opening, renderHass: RenderHass | undefined): number {
     const state = o.entity ? renderHass?.states[o.entity] : undefined;
     return resolveOpeningAmount(o, state);
   }
 
   /** Whether an opening wears its accent: drawn open, or a cover still in transit. */
-  private _openingActive(o: Opening, renderHass?: RenderHass): boolean {
+  private _openingActive(o: Opening, renderHass: RenderHass | undefined): boolean {
     const state = o.entity ? renderHass?.states[o.entity] : undefined;
     return openingIsActive(o, state);
   }
@@ -376,7 +376,7 @@ export class FloorplanCard extends LitElement {
    * `undefined` — no second sensor, or a shape with only one leaf — leaves both
    * on the first entity, so nothing about a single-sensor opening changes.
    */
-  private _openingSecond(o: Opening, renderHass?: RenderHass): { amount: number; active: boolean } | undefined {
+  private _openingSecond(o: Opening, renderHass: RenderHass | undefined): { amount: number; active: boolean } | undefined {
     if (!o.secondaryEntity || !openingHasTwoLeaves(o)) return undefined;
     const leaf = secondLeafOf(o);
     const state = renderHass?.states[o.secondaryEntity];
@@ -389,7 +389,7 @@ export class FloorplanCard extends LitElement {
    * is drawn from `shutterAmount` / `shutterActive`, not the sash's — and only
    * for a `swing` shutter, since a roll curtain has no second panel to drive.
    */
-  private _shutterSecond(o: Opening, renderHass?: RenderHass): { amount: number; active: boolean } | undefined {
+  private _shutterSecond(o: Opening, renderHass: RenderHass | undefined): { amount: number; active: boolean } | undefined {
     if (!o.shutterSecondaryEntity || shutterStyleOf(o) !== "swing") return undefined;
     const state = renderHass?.states[o.shutterSecondaryEntity];
     return {
@@ -398,7 +398,7 @@ export class FloorplanCard extends LitElement {
     };
   }
 
-  private _itemIcon(item: FloorItem, renderHass?: RenderHass): string {
+  private _itemIcon(item: FloorItem, renderHass: RenderHass | undefined): string {
     return resolveItemIcon(
       item,
       renderHass?.states[item.entity],
@@ -406,7 +406,7 @@ export class FloorplanCard extends LitElement {
     );
   }
 
-  private _label(item: FloorItem, renderHass?: RenderHass): string {
+  private _label(item: FloorItem, renderHass: RenderHass | undefined): string {
     return item.name ?? renderHass?.states[item.entity]?.attributes?.friendly_name ?? item.entity ?? "";
   }
 
@@ -481,7 +481,7 @@ export class FloorplanCard extends LitElement {
     c: FloorplanCardConfig,
     rot: PlanRotation,
     scale: OverlayScale,
-    renderHass?: RenderHass
+    renderHass: RenderHass | undefined
   ): TemplateResult {
     const id = o.shutterEntity!;
     const st = renderHass?.states[id];
@@ -543,7 +543,7 @@ export class FloorplanCard extends LitElement {
     c: FloorplanCardConfig,
     rot: PlanRotation,
     scale: OverlayScale,
-    renderHass?: RenderHass
+    renderHass: RenderHass | undefined
   ): TemplateResult {
     const id = o.entity!;
     const st = renderHass?.states[id];
@@ -626,7 +626,7 @@ export class FloorplanCard extends LitElement {
     executeAction(this, this.hass, { entity: press.entity }, press.config);
   }
 
-  private _renderBadge(item: FloorItem, scale: OverlayScale, renderHass?: RenderHass): TemplateResult {
+  private _renderBadge(item: FloorItem, scale: OverlayScale, renderHass: RenderHass | undefined): TemplateResult {
     const size = cssNumber(item.size, DEFAULT_ITEM_SIZE);
     const box = overlayLength(size, scale);
     // Animation goes on the inner ha-icon, not the badge: the badge carries
@@ -694,7 +694,7 @@ export class FloorplanCard extends LitElement {
     c: FloorplanCardConfig,
     rot: PlanRotation,
     scale: OverlayScale,
-    renderHass?: RenderHass
+    renderHass: RenderHass | undefined
   ): TemplateResult {
     const on = this._isOn(item, renderHass);
     // Name/state composition lives in itemBadgeLabel, including #39's

--- a/src/types.ts
+++ b/src/types.ts
@@ -657,7 +657,6 @@ export interface FloorItem {
    * Same meaning as {@link Opening.activeColor}.
    */
   activeColor?: string;
-  /** new option to prevent using the state color for the label too */
   /** Disables the state-driven color inheritance for the label, falling back to the default theme text color. */
   disableLabelColor?: boolean;
   /** Activates a custom color override for the label. Only applies when disableLabelColor is true. */


### PR DESCRIPTION
Follow-up to #264, which merged with four review items still open. No behaviour change — this is the tidy-up.

## 1. The `hassContext` fallback cannot fire

`_renderBadge` computed:

```ts
const hassContext = renderHass ?? this.hass;
```

`renderHass` is built unconditionally in `render()` (`floorplan-card.ts:882`) and both call sites pass it. `buildRenderHass` returns `undefined` only when `this.hass` is undefined — in which case the fallback is undefined too. So `hassContext` equalled `renderHass` in every reachable case.

Worth being precise, because I got this wrong once during review: while #264 was open I called it a live-vs-replay correctness bug. It was, until `main` gained the call-site fix; after that merge it stopped being one. It still comes out, for a smaller reason — left in, it would silently absorb a future call site that forgot to pass `renderHass`, rendering live data during replay instead of failing visibly. The call sites should stay the single place that decides what state a badge draws from.

## 2. A duplicate JSDoc

```ts
/** new option to prevent using the state color for the label too */   ← removed
/** Disables the state-driven color inheritance for the label, … */
disableLabelColor?: boolean;
```

## 3. The README said the same thing twice

The bullet opened on *"override this behavior"* while the sentence defining that behaviour sat six lines below, inside a second near-verbatim copy under a bold **Label Color Customization** heading nested in a bullet list.

Rewritten as one explanation in the voice of the bullets around it, saying what the option does and why you'd reach for it. The YAML table stays — it earns its place — with one row unwrapped: it spanned two lines, and GFM does not render a wrapped row as a table at all, so that part of the docs was not displaying.

## 4. Trailing whitespace

Four lines the feature introduced, in `editor-forms.ts`, `editor-forms.test.ts` and `editor.ts`.

## Verification

```
npx tsc --noEmit       clean
npm test               1407 pass (17 files)
npm run test:browser      9 pass
npm run build          clean
```

The badge paths item 1 touches are covered by `card-badge.browser.test.ts` — six tests including *"animates the icon from the replayed state, not the live one"*, which is the behaviour the fallback was nominally protecting. They pass with it removed, which is the point.

Thanks to @Pagenstecher79 for the feature — this is only the leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
