### PR TITLE
Named colors: name a color once, and point every field at the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ screen size.
 
 - 🏢 **Multiple floors** — per-floor elements with a switcher in both the editor and the card. Give a staircase `goToFloor: up` and clicking it takes you there.
 - 🖼️ **Background image** — trace over a floor-plan scan, per floor, with adjustable opacity.
+- 🏷️ **Named colors** 🆕 — name a colour once under Project and point any colour field at it from a dropdown, instead of copying the same hex into every sensor that uses it. Recolour the name and everything using it follows; rename or delete it and nothing breaks. See [Named colors](https://github.com/nicosandller/easy-floorplan/blob/main/docs/appearance.md#named-colors).
 - 🎨 **Skins** — restyle the whole plan from one line of config: `default` follows your Home Assistant theme, `odnetnin` is chunky charcoal on cream, `pastel` is soft and low-contrast, `tron` is neon on near-black. Colors you set on an element yourself always win.
   
 <img width="300" height="300" alt="default" src="https://github.com/user-attachments/assets/ce2d6545-10f4-4aa2-bbd7-0dcae08c27f5" />

--- a/docker/config/floorplan-demo.yaml
+++ b/docker/config/floorplan-demo.yaml
@@ -53,6 +53,22 @@ views:
             grid: 20
             snap: 0
             showDeadSpaces: true
+            # Named colours (issue #265). "Living" was the same #26c6da typed
+            # into the tracker and into the room it moves around in, which is
+            # the exact complaint the feature answers -- recolour the name here
+            # and both follow. Good/Warning/Bad are the plant's thresholds,
+            # named so the next sensor can reuse them instead of copying hexes.
+            palette:
+              - name: Living
+                color: "#26c6da"
+              - name: Kitchen
+                color: "#ffa726"
+              - name: Good
+                color: "#2e7d32"
+              - name: Warning
+                color: "#f9a825"
+              - name: Bad
+                color: "#c62828"
             historyReplay:
               enabled: true
               lookbackSeconds: 7200
@@ -320,9 +336,9 @@ views:
                     h: 60
                     entity: sensor.ficus_soil_moisture
                     stateColor:
-                      - { above: 80, color: "#2e7d32" }
-                      - { above: 65, color: "#f9a825" }
-                      - { color: "#c62828" }
+                      - { above: 80, color: var(--fp-color-good) }
+                      - { above: 65, color: var(--fp-color-warning) }
+                      - { color: var(--fp-color-bad) }
 
                 trackers:
                   # A tracker is a rectangle plus two distance sensors that map onto
@@ -335,7 +351,7 @@ views:
                     y: 120
                     w: 360
                     h: 360
-                    color: "#26c6da"
+                    color: var(--fp-color-living)
                     dotSize: 16
                     xSensor:
                       entity: sensor.tracker_distance_x
@@ -354,7 +370,7 @@ views:
                   - id: a1
                     name: Living Room
                     showName: true
-                    color: "#26c6da"
+                    color: var(--fp-color-living)
                     opacity: 0.15
                     points:
                       - { x: 100, y: 100 }
@@ -364,7 +380,7 @@ views:
                   - id: a2
                     name: Kitchen
                     showName: true
-                    color: "#ffa726"
+                    color: var(--fp-color-kitchen)
                     opacity: 0.15
                     points:
                       - { x: 500, y: 100 }

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -1,6 +1,6 @@
 # Appearance
 
-How the plan presents itself: its palette, the size of what it draws, and the hooks to restyle it.
+How the plan presents itself: its colours, the size of what it draws, and the hooks to restyle it.
 
 Back to the [README](../README.md).
 
@@ -87,6 +87,65 @@ card_mod:
     ha-card {
       --fp-skin-accent: #f2aa4c !important;
     }
+```
+
+## Named colors
+
+If every temperature sensor on a plan turns red above 25°, that hex code is written into
+every one of them — and changing your mind means finding them all again. Name the colour
+once instead, and point the fields at the name.
+
+Add names under **Project → Named colors**. Every colour field on the plan then grows a
+dropdown listing them; pick one and the field follows that name from then on. The dropdown
+only appears once a plan has a palette, so a plan that never names a colour sees the
+editor it always did.
+
+```yaml
+type: custom:easy-floorplan-card
+palette:
+  - name: Warm
+    color: "#ff8800"
+  - name: Alert
+    color: "#e53935"
+floors:
+  - id: ground
+    areas:
+      - id: living
+        color: var(--fp-color-warm)
+    items:
+      - id: thermostat
+        entity: sensor.living_temperature
+        stateColor:
+          - above: 25
+            color: var(--fp-color-alert)
+          - above: 0
+            color: var(--fp-color-warm)
+```
+
+A reference is an ordinary CSS custom property, which is what makes it work everywhere a
+colour does — room fills, badges, state rules, text, furniture, trackers, the floor
+buttons — with no separate syntax to learn. The name becomes the property by lowercasing
+it and turning anything that is not a letter or digit into a `-`, so `Warm white` is
+`var(--fp-color-warm-white)`.
+
+Two consequences worth knowing:
+
+- **Recolouring a name moves everything using it**, live. That is the point.
+- **Renaming or deleting one leaves nothing dangling.** A rename rewrites every reference
+  to the new name. A delete rewrites them to the colour the name held, so the plan looks
+  exactly as it did and has simply lost the link — a reference to a colour that no longer
+  exists is not a colour at all, and would paint black.
+
+The editor refuses a rename that would collide with another entry, since two names
+reducing to the same reference means one of them silently stops resolving.
+
+Because a reference is just CSS, you can also point one at a Home Assistant theme
+variable and let the palette follow your theme:
+
+```yaml
+palette:
+  - name: Accent
+    color: var(--primary-color)
 ```
 
 ## Overlay scale

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ Back to the [README](../README.md).
 | `overlayScale`| string  | `fixed`; `plan` in new plans | How badges, labels, room names and text are sized: `plan` = canvas units so they scale with the drawing, `fixed` = screen pixels. A card added from the picker is created with `plan`; a config that doesn't say renders `fixed`, which is what every plan drawn before the option existed was laid out in. See [Overlay scale](appearance.md#overlay-scale). |
 | `zoomedOverlayScale` | number | `1` | Overlay size while zoomed in to a room, as a multiple of its size at full plan. `1` — the default — holds badges, labels and text at the size they have unzoomed, which is what zooming has always done. Raise it for a wall tablet read at arm's length, lower it to get a dense room's badges out of the way. Applies to the whole overlay so a badge and its label scale as one thing, and does nothing at full plan. |
 | `background` | string   | skin / card bg     | Canvas background color (CSS / hex). Overrides the skin's paper. |
+| `palette`    | Palette[]| —                  | Named colours for this plan, referenced from any colour field as `var(--fp-color-<name>)`. See [Named colors](appearance.md#named-colors). |
 | `floors`     | Floor[]  | —                  | Per-floor element groups (see [Floor](#floor)).   |
 | `defaultFloor`| string  | first floor        | Id of the floor shown first.                 |
 | `walls`      | Wall[]   | `[]`               | Wall segments (single-floor / floor 1).      |
@@ -51,6 +52,20 @@ Back to the [README](../README.md).
 When `floors` is present each floor carries its own `walls`, `openings`, `items`, `texts`,
 `furniture`, `trackers` and `areas`. The top-level arrays describe a single implicit floor
 and remain valid for backward compatibility.
+
+### Palette
+
+One entry per named colour. See [Named colors](appearance.md#named-colors) for how to
+point a field at one.
+
+| Option  | Type   | Default | Description                                            |
+| ------- | ------ | ------- | ------------------------------------------------------ |
+| `name`  | string | —       | Shown in the dropdown, and what the reference is built from: lowercased, with anything but letters and digits turned into `-`. `Warm white` is `var(--fp-color-warm-white)`. |
+| `color` | string | —       | Any colour the card accepts — hex, a CSS name, `rgb()`, `color-mix()`, or a theme `var()`. |
+
+An entry with no usable name, or a colour the card would refuse anywhere else, is
+dropped — the rest of the palette still works. Two names that reduce to the same
+reference are the same colour, and only the first is kept.
 
 ## History replay
 

--- a/src/card-palette.browser.test.ts
+++ b/src/card-palette.browser.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Named colours, in a real browser (issue #265).
+ *
+ * The node suite tests what `palette.ts` computes; none of it can test the
+ * thing the whole design rests on, which is that a stored
+ * `var(--fp-color-warm)` becomes an actual painted colour. That is CSS
+ * resolution, so it needs a browser and a mounted card, and it is exactly the
+ * claim that would be silently wrong if the custom properties were declared on
+ * the wrong element — with no error anywhere, just elements drawn black.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import "./floorplan-card";
+import type { FloorplanCard } from "./floorplan-card";
+import type { FloorplanCardConfig, PaletteColor } from "./types";
+
+const WARM = "rgb(255, 136, 0)";
+const COLD = "rgb(68, 136, 255)";
+
+function config(palette: PaletteColor[] | undefined): FloorplanCardConfig {
+  return {
+    type: "custom:easy-floorplan-card",
+    width: 1000,
+    height: 600,
+    palette,
+    floors: [
+      {
+        id: "f1",
+        name: "Floor 1",
+        walls: [],
+        openings: [],
+        items: [],
+        // An inline style on HTML…
+        texts: [{ id: "t1", x: 100, y: 500, text: "Label", color: "var(--fp-color-cold)" }],
+        furniture: [],
+        trackers: [],
+        // …and an SVG presentation attribute, which is the half that has no
+        // declaration to sit in and could plausibly have behaved differently.
+        areas: [
+          {
+            id: "a1",
+            name: "Living",
+            color: "var(--fp-color-warm)",
+            points: [
+              { x: 100, y: 100 },
+              { x: 500, y: 100 },
+              { x: 500, y: 400 },
+              { x: 100, y: 400 },
+            ],
+          },
+        ],
+      },
+    ],
+  } as FloorplanCardConfig;
+}
+
+const hass = {
+  states: {},
+  entities: {},
+  formatEntityState: (st: { state: string }) => st.state,
+} as unknown as FloorplanCard["hass"];
+
+async function mount(palette: PaletteColor[] | undefined) {
+  const host = document.createElement("div");
+  host.style.width = "900px";
+  host.style.height = "540px";
+  document.body.appendChild(host);
+
+  const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+  card.setConfig(config(palette));
+  card.hass = hass;
+  host.appendChild(card);
+  await card.updateComplete;
+
+  const root = card.shadowRoot!;
+  const area = () => root.querySelector("svg polygon")!;
+  const text = () => [...root.querySelectorAll(".fp-text")].pop() as HTMLElement;
+  return {
+    card,
+    styleAttr: () => root.querySelector("ha-card")!.getAttribute("style"),
+    areaFillAttr: () => area().getAttribute("fill"),
+    areaFill: () => getComputedStyle(area()).fill,
+    textColor: () => getComputedStyle(text()).color,
+    async recolor(next: PaletteColor[] | undefined) {
+      card.setConfig(config(next));
+      card.hass = { ...hass } as FloorplanCard["hass"];
+      await card.updateComplete;
+    },
+  };
+}
+
+describe("a named color reaches the paint", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("resolves in an SVG presentation attribute and in an inline style", async () => {
+    const t = await mount([
+      { name: "Warm", color: "#ff8800" },
+      { name: "Cold", color: "#4488ff" },
+    ]);
+    expect(t.areaFill()).toBe(WARM);
+    expect(t.textColor()).toBe(COLD);
+  });
+
+  it("leaves the reference in the markup, which is what keeps it live", async () => {
+    // If this ever became a literal, recolouring the palette would stop
+    // propagating and the test below would be the only thing to notice.
+    const t = await mount([{ name: "Warm", color: "#ff8800" }]);
+    expect(t.areaFillAttr()).toBe("var(--fp-color-warm)");
+  });
+
+  it("declares the palette on the card, and nothing at all without one", async () => {
+    const t = await mount([{ name: "Warm", color: "#ff8800" }]);
+    expect(t.styleAttr()).toBe("--fp-color-warm:#ff8800;");
+
+    // An unpalettised plan must not gain a style attribute it never had.
+    const plain = await mount(undefined);
+    expect(plain.styleAttr()).toBeNull();
+  });
+
+  it("repaints when a name is given a new color", async () => {
+    // The reason both canvases key their SVG on the palette: Chromium does not
+    // repaint an element whose colour comes from a var() in a presentation
+    // attribute when the property moves under it (the trap skins hit in #122).
+    const t = await mount([
+      { name: "Warm", color: "#ff8800" },
+      { name: "Cold", color: "#4488ff" },
+    ]);
+    expect(t.areaFill()).toBe(WARM);
+
+    await t.recolor([
+      { name: "Warm", color: "#00cc44" },
+      { name: "Cold", color: "#4488ff" },
+    ]);
+    expect(t.areaFill()).toBe("rgb(0, 204, 68)");
+    // The colour that did not change did not move.
+    expect(t.textColor()).toBe(COLD);
+  });
+
+  it("paints black when a reference dangles, which is why deleting rewrites", async () => {
+    // Not a wish, a fact about CSS: an undefined custom property makes the
+    // declaration invalid, the element falls back to inherit, and an SVG fill
+    // inherits black. Pinned here because the editor's delete behaviour — and
+    // the doc comment explaining it — is built entirely on this being true.
+    const t = await mount([]);
+    expect(t.areaFill()).toBe("rgb(0, 0, 0)");
+    expect(t.textColor()).toBe("rgb(0, 0, 0)");
+  });
+});

--- a/src/editor-palette.browser.test.ts
+++ b/src/editor-palette.browser.test.ts
@@ -202,3 +202,85 @@ describe("the palette picker on a colour field", () => {
     expect(t.emitted.length).toBe(before);
   });
 });
+
+describe("the invariant that nothing dangles", () => {
+  async function withPalette(palette: unknown[], background = "var(--fp-color-warm)") {
+    const t = await mountEditor();
+    t.ed.setConfig({ ...config(), palette, background } as unknown as FloorplanCardConfig);
+    await t.ed.updateComplete;
+    await openNamedColors(t.ed);
+    return t;
+  }
+  const rows = (ed: FloorplanCardEditor) => [
+    ...(ed.shadowRoot?.querySelectorAll<HTMLInputElement>("input.palette-color") ?? []),
+  ];
+  const removeButtons = (ed: FloorplanCardEditor) => [
+    ...(ed.shadowRoot?.querySelectorAll<HTMLButtonElement>(".palette-row button") ?? []),
+  ];
+
+  it("refuses a colour the card cannot use, instead of quietly unpublishing the name", async () => {
+    // Clearing this field drops the entry from paletteEntries, so the property
+    // stops being declared and every reference to it goes black — the same
+    // damage a delete does, but with no rewrite, no error, and the row still
+    // sitting there looking live.
+    const t = await withPalette([{ name: "Warm", color: "#ff8800" }]);
+    const before = t.emitted.length;
+    const field = rows(t.ed)[0];
+
+    field.value = "";
+    field.dispatchEvent(new Event("change", { bubbles: true }));
+    await t.ed.updateComplete;
+
+    expect(t.emitted.length).toBe(before);
+    expect(field.value).toBe("#ff8800");
+    expect(t.ed.shadowRoot?.textContent).toContain("needs a color");
+  });
+
+  it("refuses whitespace as readily as an empty field", async () => {
+    // `cssColor` is a safety filter rather than a validity check — it lets any
+    // bare identifier through on purpose, since the card cannot know every
+    // colour keyword a theme or a future CSS level might use. So the set it
+    // rejects, and the set that would silently unpublish a name, is the blank
+    // one.
+    const t = await withPalette([{ name: "Warm", color: "#ff8800" }]);
+    const before = t.emitted.length;
+    const field = rows(t.ed)[0];
+
+    field.value = "   ";
+    field.dispatchEvent(new Event("change", { bubbles: true }));
+    await t.ed.updateComplete;
+
+    expect(t.emitted.length).toBe(before);
+    expect(field.value).toBe("#ff8800");
+  });
+
+  it("leaves references alone when a twin still declares the same name", async () => {
+    // paletteEntries keeps the first of two entries sharing a slug. Deleting the
+    // shadowed second one used to rewrite every reference to that slug —
+    // references belonging to the survivor — freezing them at the deleted
+    // entry's colour. The plan repaints wrong and a live link is severed.
+    const t = await withPalette([
+      { name: "Warm", color: "#ff8800" },
+      { name: "warm", color: "#000000" },
+    ]);
+    const buttons = removeButtons(t.ed);
+    expect(buttons.length).toBe(2);
+
+    buttons[1].click();
+    await t.ed.updateComplete;
+
+    const last = t.emitted[t.emitted.length - 1];
+    expect(last.palette).toHaveLength(1);
+    // Still pointing at the surviving entry, not frozen at #000000.
+    expect(last.background).toBe("var(--fp-color-warm)");
+  });
+
+  it("still freezes references when the name is genuinely gone", async () => {
+    const t = await withPalette([{ name: "Warm", color: "#ff8800" }]);
+    removeButtons(t.ed)[0].click();
+    await t.ed.updateComplete;
+
+    const last = t.emitted[t.emitted.length - 1];
+    expect(last.background).toBe("#ff8800");
+  });
+});

--- a/src/editor-palette.browser.test.ts
+++ b/src/editor-palette.browser.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Renaming a named colour, in a real browser.
+ *
+ * The rename handler is DOM-shaped — it reads an `<input>` and, when it decides
+ * not to change the config, has to put that input back itself, because Lit will
+ * not re-render a field whose bound value did not change. That last part is
+ * only observable with a real element, so it lives here rather than in the node
+ * suite (issue #265).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import "./editor";
+import type { FloorplanCardEditor } from "./editor";
+import type { FloorplanCardConfig } from "./types";
+
+function config(): FloorplanCardConfig {
+  return {
+    type: "custom:easy-floorplan-card",
+    width: 1000,
+    height: 600,
+    palette: [{ name: "Warm", color: "#ff8800" }],
+    floors: [
+      {
+        id: "f1",
+        name: "Floor 1",
+        walls: [],
+        openings: [],
+        items: [],
+        texts: [],
+        furniture: [],
+        trackers: [],
+        areas: [{ id: "living", name: "Living", points: [], color: "var(--fp-color-warm)" }],
+      },
+    ],
+  } as unknown as FloorplanCardConfig;
+}
+
+async function mountEditor() {
+  const host = document.createElement("div");
+  host.style.width = "900px";
+  document.body.appendChild(host);
+  const ed = document.createElement("easy-floorplan-card-editor") as FloorplanCardEditor;
+  ed.hass = { states: {}, entities: {} } as unknown as FloorplanCardEditor["hass"];
+  ed.setConfig(config());
+  host.appendChild(ed);
+  await ed.updateComplete;
+
+  const emitted: FloorplanCardConfig[] = [];
+  ed.addEventListener("config-changed", (ev) => {
+    emitted.push((ev as CustomEvent<{ config: FloorplanCardConfig }>).detail.config);
+  });
+  return { ed, host, emitted };
+}
+
+/**
+ * The palette fields sit behind two collapses — the Project section, then the
+ * "Named colors" group inside it — and neither is open on mount.
+ */
+async function openNamedColors(ed: FloorplanCardEditor): Promise<void> {
+  const root = () => ed.shadowRoot!;
+  if (root().querySelector("input.palette-name")) return;
+
+  const project = root().querySelector<HTMLButtonElement>("button.section-toggle");
+  if (!project) throw new Error("Project section toggle not found — did the panel change?");
+  if (project.getAttribute("aria-expanded") !== "true") {
+    project.click();
+    await ed.updateComplete;
+  }
+
+  const group = [...root().querySelectorAll<HTMLButtonElement>("button.cfg-group-title")]
+    .find((b) => b.textContent?.trim().startsWith("Named colors"));
+  if (!group) throw new Error("'Named colors' group not found — did the Project panel change?");
+  group.click();
+  await ed.updateComplete;
+}
+
+function nameInput(ed: FloorplanCardEditor): HTMLInputElement {
+  const found = ed.shadowRoot?.querySelector<HTMLInputElement>("input.palette-name");
+  if (!found) throw new Error("palette name input not found — did the Project panel change?");
+  return found;
+}
+
+async function rename(ed: FloorplanCardEditor, to: string) {
+  await openNamedColors(ed);
+  const input = nameInput(ed);
+  input.value = to;
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  await ed.updateComplete;
+  return input;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("renaming a named colour", () => {
+  it("stores the name trimmed, so the panel and the dropdowns agree", async () => {
+    const t = await mountEditor();
+    await rename(t.ed, "  Warm white  ");
+
+    const last = t.emitted[t.emitted.length - 1];
+    expect(last.palette?.[0].name).toBe("Warm white");
+    // And the reference moved with it rather than being left behind.
+    expect(last.floors?.[0].areas?.[0].color).toBe("var(--fp-color-warm-white)");
+  });
+
+  it("puts the field back when only whitespace changed", async () => {
+    // `paletteSlug` trims, so this is the same colour and the config does not
+    // change — which means Lit has no reason to re-render the input. Left
+    // alone it would keep showing the spaces while the config holds none.
+    const t = await mountEditor();
+    const before = t.emitted.length;
+    const input = await rename(t.ed, "   Warm   ");
+
+    expect(input.value).toBe("Warm");
+    expect(t.emitted.length).toBe(before);
+  });
+
+  it("still refuses a rename that would collide, whitespace or not", async () => {
+    const t = await mountEditor();
+    t.ed.setConfig({
+      ...config(),
+      palette: [
+        { name: "Warm", color: "#ff8800" },
+        { name: "Alert", color: "#e53935" },
+      ],
+    } as unknown as FloorplanCardConfig);
+    await t.ed.updateComplete;
+    await openNamedColors(t.ed);
+
+    const input = nameInput(t.ed);
+    input.value = "  Alert  ";
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    await t.ed.updateComplete;
+
+    // Refused and put back, rather than two names reducing to one property.
+    expect(input.value).toBe("Warm");
+  });
+});

--- a/src/editor-palette.browser.test.ts
+++ b/src/editor-palette.browser.test.ts
@@ -55,6 +55,23 @@ async function mountEditor() {
  * The palette fields sit behind two collapses — the Project section, then the
  * "Named colors" group inside it — and neither is open on mount.
  */
+async function openGroup(ed: FloorplanCardEditor, title: string): Promise<void> {
+  const root = () => ed.shadowRoot!;
+  const project = root().querySelector<HTMLButtonElement>("button.section-toggle");
+  if (!project) throw new Error("Project section toggle not found — did the panel change?");
+  if (project.getAttribute("aria-expanded") !== "true") {
+    project.click();
+    await ed.updateComplete;
+  }
+  const group = [...root().querySelectorAll<HTMLButtonElement>("button.cfg-group-title")]
+    .find((b) => b.textContent?.trim().startsWith(title));
+  if (!group) throw new Error(`'${title}' group not found — did the Project panel change?`);
+  if (group.getAttribute("aria-expanded") !== "true") {
+    group.click();
+    await ed.updateComplete;
+  }
+}
+
 async function openNamedColors(ed: FloorplanCardEditor): Promise<void> {
   const root = () => ed.shadowRoot!;
   if (root().querySelector("input.palette-name")) return;
@@ -134,5 +151,54 @@ describe("renaming a named colour", () => {
 
     // Refused and put back, rather than two names reducing to one property.
     expect(input.value).toBe("Warm");
+  });
+});
+
+describe("the palette picker on a colour field", () => {
+  /** Background, in Project → Look, carries a picker like every colour field. */
+  async function picker(ed: FloorplanCardEditor): Promise<HTMLSelectElement> {
+    await openGroup(ed, "Look");
+    const found = ed.shadowRoot?.querySelector<HTMLSelectElement>("select.palette-pick");
+    if (!found) throw new Error("palette picker not found — did the Look group change?");
+    return found;
+  }
+
+  async function withBackground(color: string) {
+    const t = await mountEditor();
+    t.ed.setConfig({ ...config(), background: color } as unknown as FloorplanCardConfig);
+    await t.ed.updateComplete;
+    return t;
+  }
+
+  it("sits on the name a field references", async () => {
+    const t = await withBackground("var(--fp-color-warm)");
+    expect((await picker(t.ed)).value).toBe("warm");
+  });
+
+  it("reads as Custom when the name it references is gone", async () => {
+    // A reference to a name the palette no longer has matches no <option>.
+    // Treated as "on a name", the control disagrees with what it displays — and
+    // with the plan, where a dangling reference is not a colour at all.
+    const t = await withBackground("var(--fp-color-deleted)");
+    const sel = await picker(t.ed);
+    expect(sel.value).toBe("");
+    // `value` alone would pass either way — with nothing marked selected the
+    // browser falls back to the first option, which is Custom. What separates
+    // "chose Custom" from "matched no option" is whether the markup says so.
+    const custom = sel.querySelector<HTMLOptionElement>('option[value=""]')!;
+    expect(custom.defaultSelected).toBe(true);
+  });
+
+  it("does not spend an undo step choosing Custom on a dangling reference", async () => {
+    const t = await withBackground("var(--fp-color-deleted)");
+    const sel = await picker(t.ed);
+    const before = t.emitted.length;
+
+    sel.value = "";
+    sel.dispatchEvent(new Event("change", { bubbles: true }));
+    await t.ed.updateComplete;
+
+    // There is nothing to resolve it to, so committing writes the same value.
+    expect(t.emitted.length).toBe(before);
   });
 });

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -21,6 +21,7 @@ import type {
   HaAreaInfo,
   StateColorRule,
   OverlayScale,
+  PaletteColor,
 } from "./types";
 import {
   normalizeSymbol,
@@ -128,6 +129,17 @@ import {
 import { deadSpacesCached } from "./dead-space";
 import { cssColor, cssColorOr, cssNumber, contrastText } from "./css-safe";
 import { skinStyle, skinTokens, SKIN_ACCENT, SKIN_PAPER, SKIN_TEXT, SKIN_WALL } from "./skins";
+import {
+  paletteStyle,
+  paletteKey,
+  paletteEntries,
+  paletteRef,
+  paletteRefSlug,
+  paletteSlug,
+  resolvePaletteColor,
+  rewritePaletteRefs,
+  MAX_PALETTE,
+} from "./palette";
 import {
   ENDPOINT_SNAP,
   applyDelta,
@@ -361,6 +373,7 @@ export class FloorplanCardEditor extends LitElement {
   /** Paste-a-symbol box in the Project panel, and its last validation error. */
   @state() private _symbolDraft = "";
   @state() private _symbolError = "";
+  @state() private _paletteError = "";
   /** Project section expanded? Collapsed by default — page settings are touched rarely. */
   @state() private _projectOpen = false;
   /**
@@ -2096,6 +2109,74 @@ export class FloorplanCardEditor extends LitElement {
    * Every colour in this editor is one of these. It lived as eight copies of
    * the same markup before the colour rules below needed a ninth.
    */
+  /**
+   * The plan's named colours (issue #265), usable and deduped.
+   */
+  private _palette(): PaletteColor[] {
+    return paletteEntries(this._config?.palette);
+  }
+
+  /**
+   * The dropdown that puts a named colour into a colour field, or `nothing`
+   * when the plan has no palette.
+   *
+   * Rendering nothing is the point of the empty case: a plan that never names a
+   * colour should see the editor it saw before this feature existed, not a
+   * dropdown with one greyed-out entry in it. The control appears the moment
+   * the first name is added under Project and disappears with the last.
+   *
+   * Choosing a name stores a `var()` reference rather than the colour itself,
+   * which is what makes the link live — see `src/palette.ts`. Choosing "Custom"
+   * writes back the colour the name currently resolves to, so leaving the
+   * palette breaks the link without changing what is on screen.
+   */
+  private _renderPalettePicker(
+    value: string | undefined,
+    onCommit: (color: string | undefined) => void
+  ): TemplateResult | typeof nothing {
+    const palette = this._palette();
+    if (!palette.length) return nothing;
+    const current = paletteRefSlug(value);
+    return html`
+      <select
+        class="palette-pick"
+        title="Use one of the plan's named colours"
+        @change=${(e: Event) => {
+          const slug = (e.target as HTMLSelectElement).value;
+          if (!slug) {
+            // Back to a literal: keep what is drawn, drop the link. Nothing to
+            // do if the field was never on a name — committing the value it
+            // already has would spend an undo step on no change.
+            if (current) onCommit(resolvePaletteColor(value, palette) as string);
+            return;
+          }
+          const hit = palette.find((p) => paletteSlug(p.name) === slug);
+          if (hit) onCommit(paletteRef(hit.name));
+        }}
+      >
+        <option value="" ?selected=${!current}>Custom…</option>
+        ${palette.map(
+          (p) => html`<option
+            value=${paletteSlug(p.name)}
+            ?selected=${paletteSlug(p.name) === current}
+          >
+            ${p.name}
+          </option>`
+        )}
+      </select>
+    `;
+  }
+
+  /**
+   * What an `<input type="color">` should show for a stored value: the literal
+   * colour a palette reference names, since the swatch cannot resolve a var()
+   * and would sit on black instead.
+   */
+  private _swatchValue(value: string | undefined, fallback: string): string {
+    const resolved = resolvePaletteColor(value, this._config?.palette);
+    return typeof resolved === "string" && resolved ? resolved : fallback;
+  }
+
   private _renderColorRow(opts: {
     label: string;
     value: string | undefined;
@@ -2113,7 +2194,7 @@ export class FloorplanCardEditor extends LitElement {
         <input
           type="color"
           title=${opts.title ?? nothing}
-          .value=${opts.value ?? opts.swatch}
+          .value=${this._swatchValue(opts.value, opts.swatch)}
           @input=${(e: Event) => opts.onLive((e.target as HTMLInputElement).value)}
         />
         <input
@@ -2122,6 +2203,7 @@ export class FloorplanCardEditor extends LitElement {
           .value=${opts.value ?? ""}
           @change=${(e: Event) => opts.onCommit((e.target as HTMLInputElement).value || undefined)}
         />
+        ${this._renderPalettePicker(opts.value, opts.onCommit)}
       </div>
     `;
   }
@@ -2465,7 +2547,7 @@ export class FloorplanCardEditor extends LitElement {
                 : html`<span class="cond hint">any other value</span>`}
             <input
               type="color"
-              .value=${rule.color || "#ff0000"}
+              .value=${this._swatchValue(rule.color, "#ff0000")}
               @input=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
             />
             <input
@@ -2475,6 +2557,7 @@ export class FloorplanCardEditor extends LitElement {
               .value=${rule.color ?? ""}
               @change=${(e: Event) => patch(i, { color: (e.target as HTMLInputElement).value })}
             />
+            ${this._renderPalettePicker(rule.color, (color) => patch(i, { color: color ?? "" }))}
             ${opts?.icons
               ? // Empty means "keep the device's icon", so the device's icon is
                 // the placeholder — the rule shows what leaving it blank gives
@@ -3314,14 +3397,17 @@ export class FloorplanCardEditor extends LitElement {
           <div class="stage ${overlay === "plan" ? "scale-plan" : ""}"
                style="aspect-ratio: ${cssNumber(c.width, DEFAULT_WIDTH)} / ${cssNumber(
             c.height, DEFAULT_HEIGHT)}; width:${this._zoom * 100}%;
-                   --fp-plan-w: ${cssNumber(c.width, DEFAULT_WIDTH)};${skinStyle(c.skin)}">
-            <!-- Keyed on the skin, for the repaint reason documented on the
-                 card's SVG (issue #122): a var() inside a presentation
-                 attribute does not repaint when the custom property changes,
-                 so without this the canvas kept the previous skin's doors and
-                 room fills. -->
+                   --fp-plan-w: ${cssNumber(c.width, DEFAULT_WIDTH)};${skinStyle(
+            c.skin
+          )}${paletteStyle(c.palette)}">
+            <!-- Keyed on the skin and the palette, for the repaint reason
+                 documented on the card's SVG (issue #122): a var() inside a
+                 presentation attribute does not repaint when the custom
+                 property changes, so without this the canvas kept the previous
+                 skin's doors and room fills — and, since issue #265, would show
+                 a palette colour's old value while you were editing it. -->
             ${keyed(
-              c.skin ?? "",
+              `${c.skin ?? ""}|${paletteKey(c.palette)}`,
               svg`<svg
               viewBox="0 0 ${c.width} ${c.height}"
               preserveAspectRatio="none"
@@ -4299,7 +4385,10 @@ export class FloorplanCardEditor extends LitElement {
     const active = entityIsActive(it.entity, st?.state);
     const activeColor = active ? (cssColor(it.activeColor) ?? lightBadgePaint(st)) : undefined;
     // Ink that reads on whatever the badge ends up painted, same rule as the card.
-    const badgeInk = contrastText(stateColor ?? activeColor);
+    // Palette references resolved first, for the reason the card documents.
+    const badgeInk = contrastText(
+      resolvePaletteColor(stateColor ?? activeColor, this._config?.palette)
+    );
     const rippleColor =
       it.rippleColor ?? stateColor ?? activeColor ?? SKIN_ACCENT;
     const rippleSize = it.rippleSize ?? DEFAULT_RIPPLE_SIZE;
@@ -4483,6 +4572,13 @@ export class FloorplanCardEditor extends LitElement {
           this._renderForm(projectDeadSpaceForm(c), patch)
         )}
         ${this._renderGroup(
+          // Named colours (issue #265). Its own group rather than a row inside
+          // Look: it is a list that grows, and it is the one thing here that
+          // other panels reach back into.
+          "Named colors",
+          this._renderPalettePanel()
+        )}
+        ${this._renderGroup(
           // Per floor, not per project — but it is the floor's paper, so it
           // belongs beside the plan's own.
           "Floor image",
@@ -4569,6 +4665,154 @@ export class FloorplanCardEditor extends LitElement {
    * becoming a broken glyph on the plan. Nothing pasted is ever parsed as
    * markup; see `symbols.ts`.
    */
+  /**
+   * The plan's named colours (issue #265): *"I hate copying color hex codes
+   * across so many entities."*
+   *
+   * Names are stored, but what elements store is a `var()` built from the name
+   * (see `src/palette.ts`), so the two edits that could strand a reference are
+   * the ones this panel has to be careful about — and both are handled by
+   * rewriting the plan rather than by warning about it:
+   *
+   * - **Rename** rewrites every reference to the new name, so the link
+   *   survives. Blocked when the new name would collide with another entry,
+   *   since two entries sharing a slug means one of them silently stops
+   *   resolving.
+   * - **Delete** rewrites every reference to the literal colour the entry held.
+   *   A dangling `var()` is not a colour at all, so the alternative is elements
+   *   turning black the moment a name is removed. This way the plan looks
+   *   exactly the same afterwards and has simply lost the link.
+   */
+  private _renderPalettePanel(): TemplateResult {
+    const list = this._config.palette ?? [];
+    const commit = (next: PaletteColor[]) =>
+      this._patchConfig({ palette: next.length ? next : undefined });
+    const at = (i: number, part: Partial<PaletteColor>, live = false) => {
+      const next = list.map((p, j) => (j === i ? { ...p, ...part } : p));
+      if (live) this._patchConfigLive({ palette: next });
+      else this._patchConfig({ palette: next });
+    };
+
+    return html`
+      <div class="row col palette-panel">
+        <label>Named colors</label>
+        ${list.length
+          ? nothing
+          : html`<span class="hint"
+              >Name a color here and every color field on the plan can point at it.</span
+            >`}
+        ${list.map(
+          (p, i) => html`
+            <div class="row wide palette-row">
+              <input
+                type="text"
+                class="palette-name"
+                placeholder="Warm"
+                .value=${p.name ?? ""}
+                @change=${(e: Event) =>
+                  this._renamePaletteColor(i, e.target as HTMLInputElement)}
+              />
+              <input
+                type="color"
+                .value=${this._swatchValue(p.color, "#ff8800")}
+                @input=${(e: Event) => at(i, { color: (e.target as HTMLInputElement).value }, true)}
+              />
+              <input
+                type="text"
+                class="palette-color"
+                placeholder="#ff8800"
+                .value=${p.color ?? ""}
+                @change=${(e: Event) => at(i, { color: (e.target as HTMLInputElement).value })}
+              />
+              <button
+                class="rule-remove"
+                aria-label="Remove color"
+                title="Remove this color; anything using it keeps the color it has now"
+                @click=${() => this._removePaletteColor(i)}
+              >
+                <ha-icon icon="mdi:close"></ha-icon>
+              </button>
+            </div>
+          `
+        )}
+        ${this._paletteError ? html`<div class="symbol-error">${this._paletteError}</div>` : nothing}
+        ${list.length >= MAX_PALETTE
+          ? nothing
+          : html`<div class="row wide state-color-add">
+              <button
+                @click=${() => {
+                  this._paletteError = "";
+                  commit([...list, { name: this._nextPaletteName(list), color: "#ff8800" }]);
+                }}
+              >
+                <ha-icon icon="mdi:plus"></ha-icon>Add color
+              </button>
+            </div>`}
+      </div>
+    `;
+  }
+
+  /** "Color 1", "Color 2", … — the first number no entry is already using. */
+  private _nextPaletteName(list: readonly PaletteColor[]): string {
+    const taken = new Set(list.map((p) => paletteSlug(p.name)));
+    for (let n = 1; ; n++) {
+      const name = `Color ${n}`;
+      if (!taken.has(paletteSlug(name))) return name;
+    }
+  }
+
+  /**
+   * Takes the input rather than its value so a refused rename can put the old
+   * name back. Lit will not do it: the config is unchanged, so the binding sees
+   * the same value it last wrote and skips the DOM, leaving the box showing a
+   * name the plan does not have.
+   */
+  private _renamePaletteColor(i: number, input: HTMLInputElement): void {
+    const list = this._config.palette ?? [];
+    const entry = list[i];
+    if (!entry) return;
+    const name = input.value;
+    const from = paletteSlug(entry.name);
+    const to = paletteSlug(name);
+    if (from === to) {
+      // Same colour, different spelling ("Warm" → "warm"). Nothing to rewrite.
+      this._paletteError = "";
+      this._patchConfig({ palette: list.map((p, j) => (j === i ? { ...p, name } : p)) });
+      return;
+    }
+    if (to && list.some((p, j) => j !== i && paletteSlug(p.name) === to)) {
+      // Two entries with one slug means one of them stops resolving, and which
+      // one is an accident of ordering. Refuse rather than silently pick.
+      this._paletteError = `Another color is already called “${name}”.`;
+      input.value = entry.name ?? "";
+      return;
+    }
+    this._paletteError = "";
+    const renamed = list.map((p, j) => (j === i ? { ...p, name } : p));
+    this._patchConfig(
+      // An empty new name leaves the entry unusable, so its references have
+      // nothing to point at — freeze them at the colour, as a delete does.
+      to
+        ? rewritePaletteRefs({ ...this._config, palette: renamed }, from, paletteRef(name))
+        : rewritePaletteRefs({ ...this._config, palette: renamed }, from, entry.color)
+    );
+  }
+
+  private _removePaletteColor(i: number): void {
+    const list = this._config.palette ?? [];
+    const entry = list[i];
+    if (!entry) return;
+    this._paletteError = "";
+    const next = list.filter((_, j) => j !== i);
+    this._patchConfig(
+      rewritePaletteRefs(
+        { ...this._config, palette: next.length ? next : undefined },
+        paletteSlug(entry.name),
+        entry.color
+      )
+    );
+  }
+
   private _renderSymbolsPanel(): TemplateResult {
     const own = Object.keys(this._config.symbols ?? {});
     return html`
@@ -6739,6 +6983,29 @@ export class FloorplanCardEditor extends LitElement {
       flex: 1 1 100%;
       min-width: 0;
     }
+    /* Named colours (issue #265). The dropdown is the narrowest control in
+       the row and never grows: it holds short names, and the swatch beside it
+       is what you actually read the colour off. It is absent entirely on a
+       plan with no palette, so these rules cost an unpalettised editor
+       nothing. */
+    .row select.palette-pick {
+      flex: 0 1 96px;
+      min-width: 0;
+    }
+    .palette-panel {
+      gap: 6px;
+    }
+    /* The name leads — it is what the dropdowns elsewhere will show — and the
+       colour text box gives up width first, exactly as a state rule's does. */
+    .row.palette-row input.palette-name {
+      flex: 1 1 90px;
+      min-width: 60px;
+    }
+    .row.palette-row input.palette-color {
+      flex: 1 1 60px;
+      min-width: 60px;
+    }
+    .palette-row .rule-remove,
     .state-color-rule .rule-remove,
     .state-color-add button {
       display: inline-flex;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4772,12 +4772,23 @@ export class FloorplanCardEditor extends LitElement {
     const list = this._config.palette ?? [];
     const entry = list[i];
     if (!entry) return;
-    const name = input.value;
+    // Trimmed before anything else reads it. `paletteSlug` trims, so " Warm "
+    // and "Warm" are the same colour and nothing would be rewritten — but the
+    // untrimmed spelling would still be stored, and `paletteEntries` trims for
+    // display, so the palette panel would show a label none of the dropdowns do.
+    const name = input.value.trim();
     const from = paletteSlug(entry.name);
     const to = paletteSlug(name);
     if (from === to) {
       // Same colour, different spelling ("Warm" → "warm"). Nothing to rewrite.
       this._paletteError = "";
+      if (name === (entry.name ?? "")) {
+        // Only surrounding whitespace changed, so the config will not, and Lit
+        // has no reason to re-render the field just typed into. Put it back, the
+        // same way a refused rename does.
+        input.value = name;
+        return;
+      }
       this._patchConfig({ palette: list.map((p, j) => (j === i ? { ...p, name } : p)) });
       return;
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2137,7 +2137,14 @@ export class FloorplanCardEditor extends LitElement {
   ): TemplateResult | typeof nothing {
     const palette = this._palette();
     if (!palette.length) return nothing;
-    const current = paletteRefSlug(value);
+    // Only a slug the palette actually has counts as "on a name". A reference
+    // to a name that is gone matches no <option>, so the browser falls back to
+    // showing "Custom…" while this thought otherwise — and picking "Custom…"
+    // would then commit the dangling value back unchanged, spending an undo
+    // step on nothing. Reading it as custom is also what the plan shows, since
+    // a dangling reference is not a colour.
+    const slug = paletteRefSlug(value);
+    const current = slug && palette.some((p) => paletteSlug(p.name) === slug) ? slug : undefined;
     return html`
       <select
         class="palette-pick"

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2145,10 +2145,17 @@ export class FloorplanCardEditor extends LitElement {
     // a dangling reference is not a colour.
     const slug = paletteRefSlug(value);
     const current = slug && palette.some((p) => paletteSlug(p.name) === slug) ? slug : undefined;
+    // `.value` as well as `?selected`: the attribute only sets what the option
+    // defaults to, and once the user has picked from this dropdown the option is
+    // dirty and stops following it. Selecting another element, or undoing, would
+    // otherwise leave the control showing a name the field is not on — and
+    // picking "Custom…" from that stale state does nothing, because the field
+    // was never on a name to leave.
     return html`
       <select
         class="palette-pick"
         title="Use one of the plan's named colours"
+        .value=${current ?? ""}
         @change=${(e: Event) => {
           const slug = (e.target as HTMLSelectElement).value;
           if (!slug) {
@@ -4730,7 +4737,8 @@ export class FloorplanCardEditor extends LitElement {
                 class="palette-color"
                 placeholder="#ff8800"
                 .value=${p.color ?? ""}
-                @change=${(e: Event) => at(i, { color: (e.target as HTMLInputElement).value })}
+                @change=${(e: Event) =>
+                  this._recolorPaletteColor(i, e.target as HTMLInputElement)}
               />
               <button
                 class="rule-remove"
@@ -4808,13 +4816,43 @@ export class FloorplanCardEditor extends LitElement {
     }
     this._paletteError = "";
     const renamed = list.map((p, j) => (j === i ? { ...p, name } : p));
+    const config = { ...this._config, palette: renamed };
     this._patchConfig(
-      // An empty new name leaves the entry unusable, so its references have
-      // nothing to point at — freeze them at the colour, as a delete does.
-      to
-        ? rewritePaletteRefs({ ...this._config, palette: renamed }, from, paletteRef(name))
-        : rewritePaletteRefs({ ...this._config, palette: renamed }, from, entry.color)
+      // Same shadowing caveat as delete: if another entry still declares the old
+      // slug, its references are none of this rename's business.
+      this._slugStillResolves(from, config)
+        ? config
+        : // An empty new name leaves the entry unusable, so its references have
+          // nothing to point at — freeze them at the colour, as a delete does.
+          rewritePaletteRefs(config, from, to ? paletteRef(name) : entry.color)
     );
+  }
+
+  /**
+   * The colour half of a palette row.
+   *
+   * Guarded like the name half, and for the same reason. An empty or invalid
+   * colour drops the entry from `paletteEntries`, so `paletteStyle` stops
+   * declaring its property and every reference to it dangles — which is not a
+   * fallback, it is black. That is the same damage deleting the entry does, but
+   * reached without a rewrite, without an error, and with the row still sitting
+   * there looking live. Refuse it and put the field back instead; the way out
+   * is the remove button, which freezes the references properly.
+   */
+  private _recolorPaletteColor(i: number, input: HTMLInputElement): void {
+    const list = this._config.palette ?? [];
+    const entry = list[i];
+    if (!entry) return;
+    const color = input.value.trim();
+    if (!cssColor(color)) {
+      this._paletteError = color
+        ? `“${color}” is not a color the card can use.`
+        : "A named color needs a color. Use the remove button to take the name away.";
+      input.value = entry.color ?? "";
+      return;
+    }
+    this._paletteError = "";
+    this._patchConfig({ palette: list.map((p, j) => (j === i ? { ...p, color } : p)) });
   }
 
   private _removePaletteColor(i: number): void {
@@ -4823,13 +4861,24 @@ export class FloorplanCardEditor extends LitElement {
     if (!entry) return;
     this._paletteError = "";
     const next = list.filter((_, j) => j !== i);
+    const config = { ...this._config, palette: next.length ? next : undefined };
+    // Only freeze the references if the name they point at is actually gone.
+    // Two entries may share a slug — `paletteEntries` keeps the first and
+    // shadows the rest — so deleting the shadowed one leaves the property still
+    // declared by its twin. Rewriting then, references that belong to the
+    // survivor would be frozen at the *deleted* entry's colour: the plan
+    // repaints wrong and a live link is cut, with nothing said about it.
     this._patchConfig(
-      rewritePaletteRefs(
-        { ...this._config, palette: next.length ? next : undefined },
-        paletteSlug(entry.name),
-        entry.color
-      )
+      this._slugStillResolves(paletteSlug(entry.name), config)
+        ? config
+        : rewritePaletteRefs(config, paletteSlug(entry.name), entry.color)
     );
+  }
+
+  /** Whether a slug is still declared by the palette in `config`. */
+  private _slugStillResolves(slug: string, config: FloorplanCardConfig): boolean {
+    if (!slug) return false;
+    return paletteEntries(config.palette).some((p) => paletteSlug(p.name) === slug);
   }
 
   private _renderSymbolsPanel(): TemplateResult {

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -16,6 +16,7 @@ import { buildRenderHass } from "./replay-history/render-state-service";
 import "./replay-history/history-timeline";
 import "./replay-history/replay-panel";
 import { cssColor, cssColorOr, cssNumber, cssIdent, cssEntityId, contrastText } from "./css-safe";
+import { paletteStyle, paletteKey, resolvePaletteColor } from "./palette";
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -740,7 +741,13 @@ export class FloorplanCard extends LitElement {
     // (issue #106, @MrMcFlyy): a white state colour used to take the theme's
     // white icon with it. undefined for a colour we cannot resolve — a
     // var()/color-mix()/gradient keeps the theme ink, exactly as before.
-    const badgeInk = contrastText(stateColor ?? activeColor);
+    // resolvePaletteColor first: a badge painted from the palette (issue #265)
+    // stores a var(), which contrastText cannot read and would answer
+    // undefined for — so moving a badge onto a named colour would quietly cost
+    // it the ink it had as a literal hex.
+    const badgeInk = contrastText(
+      resolvePaletteColor(stateColor ?? activeColor, this._config?.palette)
+    );
     const rippleSize = item.rippleSize ?? DEFAULT_RIPPLE_SIZE;
     const rippleDirection = item.rippleDirection ?? DEFAULT_RIPPLE_DIRECTION;
     const rippleWidth = item.rippleWidth ?? DEFAULT_RIPPLE_WIDTH;
@@ -978,7 +985,17 @@ export class FloorplanCard extends LitElement {
            where no rule of ours reaches. compactHeader therefore does not
            shrink it — it declines it, and draws the title inside the stage
            instead, where it costs no layout height at all (issue #152). -->
-      <ha-card .header=${compact ? nothing : (c.title ?? nothing)}>
+      <!-- The palette (issue #265) rides here, above everything that could
+           name one of its colours — the floor switcher and the card background
+           as well as the plan. Inline rather than on :host like the skin
+           tokens, because unlike a skin it is per-config data and there is no
+           fixed set of rules to write ahead of time. It declares only
+           --fp-color-* names, so a card-mod rule on this element still owns
+           every --fp-skin-* token exactly as issue #155 left it. -->
+      <ha-card
+        .header=${compact ? nothing : (c.title ?? nothing)}
+        style=${paletteStyle(c.palette) || nothing}
+      >
         <div class="card-shell ${this._replayController.isHistoryVisible() ? "replay-visible" : ""}">
           ${this._config.historyReplay?.enabled ? this._renderReplayPanel() : nothing}
           <div
@@ -1034,9 +1051,13 @@ export class FloorplanCard extends LitElement {
                every door, window and room fill painted in the previous skin's
                colours while the computed values were already correct. Keying
                rebuilds the subtree instead, which repaints by construction.
-               Only on a skin change; ordinary state updates are untouched. -->
+               Only on a skin change; ordinary state updates are untouched.
+
+               Recolouring a palette entry (issue #265) is the same change seen
+               from the other end — a custom property moving under a var() in a
+               presentation attribute — so it is in this key too. -->
           ${keyed(
-            c.skin ?? "",
+            `${c.skin ?? ""}|${paletteKey(c.palette)}`,
             svg`<svg viewBox="0 0 ${dims.w} ${dims.h}" preserveAspectRatio="none">
             <g transform=${rotTransform || nothing}>
             ${active.image

--- a/src/palette.test.ts
+++ b/src/palette.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_PALETTE,
+  paletteEntries,
+  paletteKey,
+  paletteRef,
+  paletteRefSlug,
+  paletteSlug,
+  paletteStyle,
+  paletteVar,
+  resolvePaletteColor,
+  rewritePaletteRefs,
+} from "./palette";
+import { cssColor } from "./css-safe";
+import type { PaletteColor } from "./types";
+
+const PALETTE: PaletteColor[] = [
+  { name: "Warm", color: "#ff8800" },
+  { name: "Cold", color: "#4488ff" },
+];
+
+describe("paletteSlug — a display name becomes a custom property", () => {
+  it("lowercases and hyphenates", () => {
+    expect(paletteSlug("Warm")).toBe("warm");
+    expect(paletteSlug("Warm White")).toBe("warm-white");
+    expect(paletteSlug("Too  Hot!!")).toBe("too-hot");
+  });
+
+  it("trims the hyphens a leading or trailing symbol would leave", () => {
+    // "--fp-color--hot-" is a legal property name but an ugly one, and it makes
+    // two names that read the same produce different properties.
+    expect(paletteSlug("  Hot  ")).toBe("hot");
+    expect(paletteSlug("!Hot!")).toBe("hot");
+    expect(paletteSlug("-hot-")).toBe("hot");
+  });
+
+  it("treats names that differ only in punctuation as the same colour", () => {
+    expect(paletteSlug("Warm white")).toBe(paletteSlug("warm-white"));
+    expect(paletteSlug("Warm_white")).toBe(paletteSlug("Warm White"));
+  });
+
+  it("returns empty for a name with nothing usable in it", () => {
+    expect(paletteSlug("")).toBe("");
+    expect(paletteSlug("   ")).toBe("");
+    expect(paletteSlug("!!!")).toBe("");
+    expect(paletteSlug(undefined)).toBe("");
+    expect(paletteSlug(42)).toBe("");
+  });
+
+  it("keeps digits, since 'Color 2' is what the editor names a new entry", () => {
+    expect(paletteSlug("Color 2")).toBe("color-2");
+  });
+});
+
+describe("paletteVar / paletteRef — what a field stores", () => {
+  it("builds the property and the reference from the name", () => {
+    expect(paletteVar("Warm White")).toBe("--fp-color-warm-white");
+    expect(paletteRef("Warm White")).toBe("var(--fp-color-warm-white)");
+  });
+
+  it("produces a reference cssColor accepts, or the plan would not paint", () => {
+    // The whole design rests on this: a reference is an ordinary CSS value that
+    // every existing sink already lets through.
+    expect(cssColor(paletteRef("Warm"))).toBe("var(--fp-color-warm)");
+  });
+});
+
+describe("paletteEntries — what the rest of the card is allowed to see", () => {
+  it("passes a good palette through", () => {
+    expect(paletteEntries(PALETTE)).toEqual(PALETTE);
+  });
+
+  it("is empty for anything that is not a list", () => {
+    expect(paletteEntries(undefined)).toEqual([]);
+    expect(paletteEntries(null)).toEqual([]);
+    expect(paletteEntries("warm")).toEqual([]);
+    expect(paletteEntries({ warm: "#f80" })).toEqual([]);
+  });
+
+  it("drops the bad entry rather than the palette", () => {
+    // A hand-written config with one typo in it should lose that colour only.
+    const entries = paletteEntries([
+      { name: "Warm", color: "#ff8800" },
+      { name: "", color: "#000000" },
+      { name: "Broken", color: "red;position:fixed;inset:0" },
+      { name: "Cold", color: "#4488ff" },
+    ]);
+    expect(entries.map((p) => p.name)).toEqual(["Warm", "Cold"]);
+  });
+
+  it("keeps the first of two names that mean the same property", () => {
+    // Two entries on one slug means one of them silently never resolves; which
+    // one is an accident of ordering, so the rule is written down and tested.
+    const entries = paletteEntries([
+      { name: "Warm white", color: "#ff8800" },
+      { name: "warm-white", color: "#000000" },
+    ]);
+    expect(entries).toEqual([{ name: "Warm white", color: "#ff8800" }]);
+  });
+
+  it("accepts every colour the card accepts, not just hex", () => {
+    const entries = paletteEntries([
+      { name: "Theme", color: "var(--primary-color)" },
+      { name: "Named", color: "rebeccapurple" },
+      { name: "Mixed", color: "color-mix(in srgb, red 50%, blue)" },
+    ]);
+    expect(entries).toHaveLength(3);
+  });
+
+  it("trims the stored name so a stray space is not part of the label", () => {
+    expect(paletteEntries([{ name: "  Warm  ", color: "#f80" }])[0].name).toBe("Warm");
+  });
+
+  it("caps the list", () => {
+    const many = Array.from({ length: MAX_PALETTE + 5 }, (_, i) => ({
+      name: `C${i}`,
+      color: "#ff8800",
+    }));
+    expect(paletteEntries(many)).toHaveLength(MAX_PALETTE);
+  });
+
+  it("survives junk in the list", () => {
+    expect(paletteEntries([null, undefined, 7, "x", { name: "Warm", color: "#f80" }])).toEqual([
+      { name: "Warm", color: "#f80" },
+    ]);
+  });
+});
+
+describe("paletteStyle — the declarations the card emits", () => {
+  it("writes one declaration per colour", () => {
+    expect(paletteStyle(PALETTE)).toBe("--fp-color-warm:#ff8800;--fp-color-cold:#4488ff;");
+  });
+
+  it("emits nothing for an empty or absent palette", () => {
+    // An unpalettised plan must not gain a style attribute it never had.
+    expect(paletteStyle(undefined)).toBe("");
+    expect(paletteStyle([])).toBe("");
+  });
+
+  it("cannot break out of the style attribute", () => {
+    // Both halves reach CSS sanitised: the name only as slug output, the colour
+    // only as cssColor output. Neither can end the declaration or start a rule.
+    const style = paletteStyle([
+      { name: "a;color:red;--x", color: "#ff0000" },
+      { name: "Evil", color: "red;position:fixed;inset:0;z-index:99999" },
+      { name: "Fetch", color: "url(https://evil/x)" },
+    ]);
+    expect(style).toBe("--fp-color-a-color-red-x:#ff0000;");
+    expect(style).not.toContain("position");
+    expect(style).not.toContain("url(");
+    // One declaration means one colon and one semicolon.
+    expect(style.match(/;/g)).toHaveLength(1);
+  });
+});
+
+describe("paletteKey — the repaint key", () => {
+  it("changes when a colour changes", () => {
+    const before = paletteKey(PALETTE);
+    const after = paletteKey([{ name: "Warm", color: "#00ff00" }, PALETTE[1]]);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when an entry is added, removed or renamed", () => {
+    const base = paletteKey(PALETTE);
+    expect(paletteKey([...PALETTE, { name: "New", color: "#111111" }])).not.toBe(base);
+    expect(paletteKey([PALETTE[0]])).not.toBe(base);
+    expect(paletteKey([{ name: "Toasty", color: "#ff8800" }, PALETTE[1]])).not.toBe(base);
+  });
+
+  it("is stable when nothing that reaches CSS changed", () => {
+    // Re-keying rebuilds the SVG subtree, so it must not happen on every render.
+    expect(paletteKey(PALETTE)).toBe(paletteKey([...PALETTE]));
+    expect(paletteKey(undefined)).toBe(paletteKey([]));
+  });
+});
+
+describe("paletteRefSlug — recognising a reference", () => {
+  it("reads the slug out of a reference", () => {
+    expect(paletteRefSlug("var(--fp-color-warm)")).toBe("warm");
+    expect(paletteRefSlug("  var( --fp-color-warm-white )  ")).toBe("warm-white");
+    expect(paletteRefSlug("var(--fp-color-warm, #ff8800)")).toBe("warm");
+  });
+
+  it("says nothing for an ordinary colour", () => {
+    expect(paletteRefSlug("#ff8800")).toBeUndefined();
+    expect(paletteRefSlug("red")).toBeUndefined();
+    expect(paletteRefSlug(undefined)).toBeUndefined();
+  });
+
+  it("does not mistake a theme variable for a palette colour", () => {
+    // --fp-color-* is ours; --primary-color and the skin tokens are not.
+    expect(paletteRefSlug("var(--primary-color)")).toBeUndefined();
+    expect(paletteRefSlug("var(--fp-skin-accent)")).toBeUndefined();
+  });
+
+  it("does not match a reference buried in a larger value", () => {
+    // color-mix(… var(--fp-color-warm) …) is a real colour, not a reference to
+    // one: resolving it to the palette entry would throw the mix away.
+    expect(paletteRefSlug("color-mix(in srgb, var(--fp-color-warm), blue)")).toBeUndefined();
+  });
+});
+
+describe("resolvePaletteColor — only for JavaScript that has to read a colour", () => {
+  it("resolves a reference to the literal it names", () => {
+    expect(resolvePaletteColor("var(--fp-color-warm)", PALETTE)).toBe("#ff8800");
+  });
+
+  it("leaves an ordinary colour exactly as it was", () => {
+    expect(resolvePaletteColor("#123456", PALETTE)).toBe("#123456");
+    expect(resolvePaletteColor("var(--primary-color)", PALETTE)).toBe("var(--primary-color)");
+    expect(resolvePaletteColor(undefined, PALETTE)).toBeUndefined();
+  });
+
+  it("leaves a dangling reference alone rather than inventing a colour", () => {
+    // The caller (contrastText, the editor swatch) has its own fallback for a
+    // colour it cannot read; guessing one here would be worse than not trying.
+    expect(resolvePaletteColor("var(--fp-color-gone)", PALETTE)).toBe("var(--fp-color-gone)");
+    expect(resolvePaletteColor("var(--fp-color-warm)", [])).toBe("var(--fp-color-warm)");
+  });
+
+  it("matches the name however it was spelled", () => {
+    expect(resolvePaletteColor("var(--fp-color-warm-white)", [
+      { name: "Warm White", color: "#ff8800" },
+    ])).toBe("#ff8800");
+  });
+
+  it("ignores an entry the palette itself would reject", () => {
+    expect(resolvePaletteColor("var(--fp-color-bad)", [{ name: "Bad", color: "url(x)" }])).toBe(
+      "var(--fp-color-bad)"
+    );
+  });
+});
+
+describe("round trip — a name picked in the editor reaches CSS", () => {
+  it("stores a reference the style it emits actually declares", () => {
+    // The one invariant that makes the feature work: whatever paletteRef writes
+    // into a config field, paletteStyle must declare a property of that name.
+    for (const name of ["Warm", "Warm White", "Color 2", "  Spaced  ", "Ünïcode 3"]) {
+      const palette = [{ name, color: "#ff8800" }];
+      const slug = paletteRefSlug(paletteRef(name));
+      expect(slug).toBeTruthy();
+      expect(paletteStyle(palette)).toContain(`--fp-color-${slug}:`);
+      expect(resolvePaletteColor(paletteRef(name), palette)).toBe("#ff8800");
+    }
+  });
+});
+
+describe("rewritePaletteRefs — renaming and deleting keep the plan honest", () => {
+  // Shaped like a real config: colours live at every depth, inside arrays,
+  // inside per-floor arrays, and inside the state-rule arrays within those.
+  const config = () => ({
+    type: "custom:easy-floorplan-card",
+    palette: [{ name: "Warm", color: "#ff8800" }],
+    background: "var(--fp-color-warm)",
+    floors: [
+      {
+        id: "ground",
+        color: "var(--fp-color-warm)",
+        texts: [{ id: "t1", text: "Hi", color: "var(--fp-color-warm)" }],
+        items: [
+          {
+            id: "i1",
+            activeColor: "var(--fp-color-cold)",
+            stateColor: [
+              { above: 20, color: "var(--fp-color-warm)" },
+              { above: 0, color: "#00ff00" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  it("finds every reference, however deeply it is buried", () => {
+    const next = rewritePaletteRefs(config(), "warm", "var(--fp-color-toasty)");
+    expect(next.background).toBe("var(--fp-color-toasty)");
+    expect(next.floors[0].color).toBe("var(--fp-color-toasty)");
+    expect(next.floors[0].texts[0].color).toBe("var(--fp-color-toasty)");
+    expect(next.floors[0].items[0].stateColor[0].color).toBe("var(--fp-color-toasty)");
+  });
+
+  it("leaves every other colour exactly as it was", () => {
+    const next = rewritePaletteRefs(config(), "warm", "#ff8800");
+    expect(next.floors[0].items[0].activeColor).toBe("var(--fp-color-cold)");
+    expect(next.floors[0].items[0].stateColor[1].color).toBe("#00ff00");
+    expect(next.floors[0].texts[0].text).toBe("Hi");
+    expect(next.type).toBe("custom:easy-floorplan-card");
+  });
+
+  it("freezes references at a literal, which is what deleting an entry does", () => {
+    // A dangling var() is not a colour: the declaration is dropped and an SVG
+    // fill inherits, which is black. Deleting a name must not repaint the plan.
+    const next = rewritePaletteRefs(config(), "warm", "#ff8800");
+    expect(next.background).toBe("#ff8800");
+    expect(next.floors[0].texts[0].color).toBe("#ff8800");
+  });
+
+  it("does not mutate the config it was given", () => {
+    const before = config();
+    rewritePaletteRefs(before, "warm", "#000000");
+    expect(before.background).toBe("var(--fp-color-warm)");
+  });
+
+  it("does nothing without a slug to look for", () => {
+    const before = config();
+    expect(rewritePaletteRefs(before, "", "#000000")).toBe(before);
+  });
+
+  it("matches a reference whatever whitespace surrounds it", () => {
+    expect(rewritePaletteRefs({ c: "  var(--fp-color-warm)  " }, "warm", "red").c).toBe("red");
+  });
+
+  it("does not touch a value that merely contains the reference", () => {
+    // A mix built on a palette colour is its own colour, and rewriting it to a
+    // flat literal would throw the mix away.
+    const mixed = { c: "color-mix(in srgb, var(--fp-color-warm), blue)" };
+    expect(rewritePaletteRefs(mixed, "warm", "red").c).toBe(mixed.c);
+  });
+
+  it("survives nulls and non-objects in the tree", () => {
+    const tree = { a: null, b: undefined, c: 3, d: true, e: ["var(--fp-color-warm)", null] };
+    expect(rewritePaletteRefs(tree, "warm", "red")).toEqual({
+      a: null,
+      b: undefined,
+      c: 3,
+      d: true,
+      e: ["red", null],
+    });
+  });
+});

--- a/src/palette.test.ts
+++ b/src/palette.test.ts
@@ -338,7 +338,7 @@ describe("rewritePaletteRefs — every spelling the card recognises", () => {
     ["canonical", "var(--fp-color-warm)"],
     ["inner whitespace", "var( --fp-color-warm )"],
     ["surrounding whitespace", "  var(--fp-color-warm)  "],
-    ["uppercase", "VAR(--FP-COLOR-WARM)"],
+    ["with the function name in caps", "VAR(--fp-color-warm)"],
     ["with a fallback", "var(--fp-color-warm, red)"],
   ];
 
@@ -400,13 +400,28 @@ describe("a reference whose fallback has parentheses of its own", () => {
     expect(paletteRefSlug("var(--fp-color-warm, var(--other))")).toBe("warm");
   });
 
-  it("rewrites one, so the link survives a rename", () => {
+  it("rewrites one, keeping the fallback the config was written with", () => {
+    // An earlier version of this test asserted the fallback was dropped. It is
+    // the one thing a hand-written reference says about what to do when the
+    // name is not there, and a rename is no reason to throw it away.
     const out = rewritePaletteRefs(
       { areas: [{ color: "var(--fp-color-warm, rgb(255,136,0))" }] },
       "warm",
       "var(--fp-color-warm-white)"
     );
-    expect(out.areas[0].color).toBe("var(--fp-color-warm-white)");
+    expect(out.areas[0].color).toBe("var(--fp-color-warm-white, rgb(255,136,0))");
+  });
+
+  it("drops the fallback when the rewrite lands on a literal", () => {
+    // Deleting freezes at the colour the element was already showing, and a
+    // literal has nowhere to carry a fallback — nor any need to, since the case
+    // it described cannot arise once nothing references the name.
+    const out = rewritePaletteRefs(
+      { areas: [{ color: "var(--fp-color-warm, #333333)" }] },
+      "warm",
+      "#ff8800"
+    );
+    expect(out.areas[0].color).toBe("#ff8800");
   });
 
   it("does not swallow a compound value that merely ends in a paren", () => {
@@ -414,5 +429,26 @@ describe("a reference whose fallback has parentheses of its own", () => {
     // rewriting it would replace the whole declaration.
     expect(paletteRefSlug("var(--fp-color-a, b) var(--c)")).toBeUndefined();
     expect(paletteRefSlug("var(--other)")).toBeUndefined();
+  });
+});
+
+describe("the case rules CSS actually applies", () => {
+  // Checked in a browser, both halves: `VAR(--fp-color-warm)` paints orange,
+  // `var(--FP-COLOR-WARM)` paints as though nothing were declared. Function
+  // names are case-insensitive in CSS; custom property names are not.
+  it("accepts the function name in any case", () => {
+    expect(paletteRefSlug("VAR(--fp-color-warm)")).toBe("warm");
+    expect(paletteRefSlug("Var(--fp-color-warm)")).toBe("warm");
+  });
+
+  it("does not claim a differently-cased property is the same colour", () => {
+    // Matching this case-insensitively made the editor report the field as on a
+    // name while the plan drew it black.
+    expect(paletteRefSlug("var(--FP-COLOR-WARM)")).toBeUndefined();
+  });
+
+  it("leaves a differently-cased reference alone on rename", () => {
+    const out = rewritePaletteRefs({ areas: [{ color: "var(--FP-COLOR-WARM)" }] }, "warm", "#ff8800");
+    expect(out.areas[0].color).toBe("var(--FP-COLOR-WARM)");
   });
 });

--- a/src/palette.test.ts
+++ b/src/palette.test.ts
@@ -360,3 +360,59 @@ describe("rewritePaletteRefs — every spelling the card recognises", () => {
     expect(out.areas[0].color).toBe("#123456");
   });
 });
+
+describe("names and references that are not ASCII", () => {
+  // CSS custom properties take non-ASCII identifiers, and restricting the slug
+  // to a-z did not merely mangle these names — a name written entirely in a
+  // non-Latin script slugged to "", so paletteEntries dropped the entry and the
+  // colour never appeared, with nothing on screen saying why.
+  it("slugs a name in any script", () => {
+    expect(paletteSlug("温かい")).toBe("温かい");
+    expect(paletteSlug("Тёплый")).toBe("тёплый");
+    expect(paletteSlug("Café")).toBe("café");
+    expect(paletteSlug("Ünter Blau")).toBe("ünter-blau");
+  });
+
+  it("keeps an entry whose name is not Latin", () => {
+    const kept = paletteEntries([
+      { name: "温かい", color: "#ff8800" },
+      { name: "Café", color: "#00ff00" },
+    ]);
+    expect(kept.map((p) => p.name)).toEqual(["温かい", "Café"]);
+  });
+
+  it("still refuses a name with no letter or digit in it at all", () => {
+    expect(paletteSlug("!!!")).toBe("");
+    expect(paletteSlug("   ")).toBe("");
+  });
+
+  it("resolves a reference built from such a name", () => {
+    expect(paletteRefSlug("var(--fp-color-温かい)")).toBe("温かい");
+  });
+});
+
+describe("a reference whose fallback has parentheses of its own", () => {
+  // `rgb(...)` and `var(...)` are ordinary things to write as a fallback.
+  // Stopping at the first `)` read them as not-a-reference, so the editor showed
+  // the field as custom and a rename quietly stopped following it.
+  it("resolves through a function-valued fallback", () => {
+    expect(paletteRefSlug("var(--fp-color-warm, rgb(255,136,0))")).toBe("warm");
+    expect(paletteRefSlug("var(--fp-color-warm, var(--other))")).toBe("warm");
+  });
+
+  it("rewrites one, so the link survives a rename", () => {
+    const out = rewritePaletteRefs(
+      { areas: [{ color: "var(--fp-color-warm, rgb(255,136,0))" }] },
+      "warm",
+      "var(--fp-color-warm-white)"
+    );
+    expect(out.areas[0].color).toBe("var(--fp-color-warm-white)");
+  });
+
+  it("does not swallow a compound value that merely ends in a paren", () => {
+    // Matching up to the *last* `)` would call this a reference to `a`, and
+    // rewriting it would replace the whole declaration.
+    expect(paletteRefSlug("var(--fp-color-a, b) var(--c)")).toBeUndefined();
+    expect(paletteRefSlug("var(--other)")).toBeUndefined();
+  });
+});

--- a/src/palette.test.ts
+++ b/src/palette.test.ts
@@ -328,3 +328,35 @@ describe("rewritePaletteRefs — renaming and deleting keep the plan honest", ()
     });
   });
 });
+
+describe("rewritePaletteRefs — every spelling the card recognises", () => {
+  // paletteRefSlug is what the rest of the card reads a reference with, and it
+  // accepts more than the canonical spelling the editor writes. Anything it
+  // resolves must be rewritable, or a rename leaves a reference pointing at a
+  // property nothing declares — and that paints black rather than falling back.
+  const cases: [string, string][] = [
+    ["canonical", "var(--fp-color-warm)"],
+    ["inner whitespace", "var( --fp-color-warm )"],
+    ["surrounding whitespace", "  var(--fp-color-warm)  "],
+    ["uppercase", "VAR(--FP-COLOR-WARM)"],
+    ["with a fallback", "var(--fp-color-warm, red)"],
+  ];
+
+  for (const [name, ref] of cases) {
+    it(`rewrites a reference written ${name}`, () => {
+      expect(paletteRefSlug(ref)).toBe("warm");
+      const out = rewritePaletteRefs({ areas: [{ color: ref }] }, "warm", "#ff8800");
+      expect(out.areas[0].color).toBe("#ff8800");
+    });
+  }
+
+  it("leaves a reference to a different name alone", () => {
+    const out = rewritePaletteRefs({ areas: [{ color: "var(--fp-color-alert)" }] }, "warm", "#ff8800");
+    expect(out.areas[0].color).toBe("var(--fp-color-alert)");
+  });
+
+  it("leaves an ordinary colour alone", () => {
+    const out = rewritePaletteRefs({ areas: [{ color: "#123456" }] }, "warm", "#ff8800");
+    expect(out.areas[0].color).toBe("#123456");
+  });
+});

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -1,0 +1,199 @@
+/**
+ * Named colours for a plan (issue #265).
+ *
+ * *"I want all my temperature sensors to use the same conditional colours but I
+ * hate copying colour hex codes across so many entities."* A plan can name a
+ * handful of colours once, under Project, and every colour field then offers
+ * them in a dropdown. Change the name's colour and every element using it
+ * follows.
+ *
+ * ## A reference is a `var()`, and that is the whole design
+ *
+ * Picking "Warm" from a dropdown stores the literal string
+ * `var(--fp-color-warm)` in the colour field. The palette is emitted as those
+ * custom properties on the card, and CSS resolves the reference at every sink
+ * by itself.
+ *
+ * The alternative — a sentinel like `palette:warm` resolved in TypeScript —
+ * would have to be understood at *every* place a config colour is read, and
+ * there are around twenty of them across `render.ts`, the card and the editor,
+ * in inline styles and in SVG presentation attributes alike. Each one is a
+ * place the resolution could be forgotten, and forgetting it paints the literal
+ * word `palette:warm`, which is not a colour, so the element would silently
+ * draw as nothing.
+ *
+ * Going through `var()` instead means:
+ *
+ * - **no sink changes at all.** `var()` is already on {@link cssColor}'s
+ *   allowlist (Home Assistant's own themes are built on it), and it is equally
+ *   valid in an inline style and in a `fill=` attribute.
+ * - **hand-written configs get the feature too**, without learning a syntax
+ *   this card invented — `color: var(--fp-color-warm)` is just CSS.
+ * - **live updates are free.** Recolouring a palette entry changes one custom
+ *   property and the whole plan follows, with no re-resolution anywhere.
+ *
+ * It costs two things, and both are handled rather than accepted:
+ *
+ * - JavaScript that needs to *read* the colour cannot resolve a `var()`. That
+ *   is `contrastText` (which picks a badge's ink) and the editor's `<input
+ *   type="color">` swatch. Both go through {@link resolvePaletteColor} first.
+ * - Chromium does not repaint an SVG element whose colour comes from a `var()`
+ *   in a presentation attribute when the custom property changes — the same
+ *   trap skins hit in issue #122. Both canvases key their SVG subtree on
+ *   {@link paletteKey} for exactly that reason.
+ */
+
+import { cssColor } from "./css-safe";
+import type { PaletteColor } from "./types";
+
+/**
+ * Prefix for the custom property a palette entry becomes. Namespaced like
+ * `--fp-skin-*` so it cannot collide with a Home Assistant theme variable, and
+ * short enough to type by hand in YAML.
+ *
+ * Changing this breaks every saved plan that references a palette colour, since
+ * the reference is stored as the full `var(--fp-color-…)` string.
+ */
+export const PALETTE_VAR_PREFIX = "--fp-color-";
+
+/** How many colours a palette may hold. */
+export const MAX_PALETTE = 24;
+
+/**
+ * The custom-property suffix a display name maps to: lowercased, with every run
+ * of anything that is not a letter or digit collapsed to a single `-`.
+ *
+ * "Warm white" and "warm-white" therefore mean the same colour, which is the
+ * behaviour you want when someone renames an entry casually — but it also means
+ * two entries can collide, so {@link paletteEntries} drops the later of any two
+ * that produce the same slug. Returns `""` for a name with nothing usable in
+ * it, which that same function treats as unusable.
+ */
+export function paletteSlug(name: unknown): string {
+  if (typeof name !== "string") return "";
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** The custom property a name declares, e.g. `--fp-color-warm`. */
+export function paletteVar(name: unknown): string {
+  return PALETTE_VAR_PREFIX + paletteSlug(name);
+}
+
+/** What a colour field stores to reference a name, e.g. `var(--fp-color-warm)`. */
+export function paletteRef(name: unknown): string {
+  return `var(${paletteVar(name)})`;
+}
+
+/**
+ * The palette as the rest of the card should see it: entries with a usable name
+ * *and* a colour that passes {@link cssColor}, deduped by slug (first wins), and
+ * capped at {@link MAX_PALETTE}.
+ *
+ * Fails entry-by-entry rather than all-or-nothing. A hand-written config with
+ * one bad colour in it should lose that colour, not its palette.
+ */
+export function paletteEntries(palette: unknown): PaletteColor[] {
+  if (!Array.isArray(palette)) return [];
+  const seen = new Set<string>();
+  const out: PaletteColor[] = [];
+  for (const entry of palette) {
+    if (!entry || typeof entry !== "object") continue;
+    const { name, color } = entry as PaletteColor;
+    const slug = paletteSlug(name);
+    const safe = cssColor(color);
+    if (!slug || !safe || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push({ name: (name as string).trim(), color: safe });
+    if (out.length >= MAX_PALETTE) break;
+  }
+  return out;
+}
+
+/**
+ * The palette as declarations for a `style` attribute, e.g.
+ * `--fp-color-warm:#ff8800;`. Empty string for an empty palette, so an
+ * unpalettised plan emits no attribute at all.
+ *
+ * Safe to interpolate: names reach CSS only as {@link paletteSlug} output
+ * (letters, digits and `-`), and colours only as {@link cssColor} output, so
+ * neither half can close the declaration or open a new one.
+ */
+export function paletteStyle(palette: unknown): string {
+  return paletteEntries(palette)
+    .map((p) => `${paletteVar(p.name)}:${p.color};`)
+    .join("");
+}
+
+/**
+ * A string that changes whenever the palette does — the key both canvases hand
+ * `keyed()` so their SVG repaints when a colour is edited. Combined with the
+ * skin, which needs keying for the identical reason (issue #122), so the two
+ * share one key rather than nesting two.
+ */
+export function paletteKey(palette: unknown): string {
+  return paletteEntries(palette)
+    .map((p) => `${paletteSlug(p.name)}=${p.color}`)
+    .join(",");
+}
+
+/** `var(--fp-color-slug)` or `var(--fp-color-slug, …)`, captured to the slug. */
+const PALETTE_REF = /^var\(\s*--fp-color-([a-z0-9-]+)\s*(?:,[^)]*)?\)$/i;
+
+/**
+ * The slug a value references, or `undefined` if it is an ordinary colour.
+ * Used by the editor to show which palette entry a field is on.
+ */
+export function paletteRefSlug(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return PALETTE_REF.exec(value.trim())?.[1].toLowerCase();
+}
+
+/**
+ * A palette reference resolved to the literal colour it names, or the value
+ * unchanged when it is not a reference (or names an entry that is gone).
+ *
+ * Only for JavaScript that has to *read* a colour — `contrastText` choosing a
+ * badge's ink, the editor's colour swatch. Never use it to paint: rendering
+ * must keep the `var()` so a palette edit still propagates through CSS.
+ */
+export function resolvePaletteColor(value: unknown, palette: unknown): unknown {
+  const slug = paletteRefSlug(value);
+  if (!slug) return value;
+  const hit = paletteEntries(palette).find((p) => paletteSlug(p.name) === slug);
+  return hit ? hit.color : value;
+}
+
+/**
+ * A deep copy of `value` with every reference to one palette slug replaced.
+ *
+ * The editor's answer to the two edits that could strand a reference: renaming
+ * an entry rewrites them to the new name, and deleting one rewrites them to the
+ * colour it held. A dangling `var()` is not a colour at all — the declaration is
+ * dropped and the element falls back to `inherit`, which for an SVG `fill` is
+ * black — so removing a name would otherwise repaint half a plan.
+ *
+ * Deliberately a blind walk rather than a list of the fields that hold a
+ * colour. There are around twenty of those spread across floors, walls,
+ * openings, devices, texts, furniture, areas, trackers and the state-rule
+ * arrays inside several of them, and a list would be one more place to forget
+ * the field the next feature adds — leaving exactly the dangling reference this
+ * exists to prevent. It matches whole strings only, against a value nothing but
+ * this feature writes, so there is nothing else in a config it can hit.
+ */
+export function rewritePaletteRefs<T>(value: T, fromSlug: string, to: string): T {
+  if (!fromSlug) return value;
+  const ref = `var(${PALETTE_VAR_PREFIX}${fromSlug})`;
+  const walk = (node: unknown): unknown => {
+    if (typeof node === "string") return node.trim() === ref ? to : node;
+    if (Array.isArray(node)) return node.map(walk);
+    if (node && typeof node === "object") {
+      return Object.fromEntries(Object.entries(node).map(([k, v]) => [k, walk(v)]));
+    }
+    return node;
+  };
+  return walk(value) as T;
+}

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -186,9 +186,15 @@ export function resolvePaletteColor(value: unknown, palette: unknown): unknown {
  */
 export function rewritePaletteRefs<T>(value: T, fromSlug: string, to: string): T {
   if (!fromSlug) return value;
-  const ref = `var(${PALETTE_VAR_PREFIX}${fromSlug})`;
   const walk = (node: unknown): unknown => {
-    if (typeof node === "string") return node.trim() === ref ? to : node;
+    // Matched with the same parser the rest of the card reads references with,
+    // not by string equality against the canonical spelling. The editor only
+    // ever writes `var(--fp-color-slug)`, but a hand-written plan is a
+    // supported way in — and `var( --fp-color-warm )`, a `, fallback`, or a
+    // different case all resolve as this reference everywhere else. Missing
+    // them here would leave exactly the dangling reference this function
+    // exists to prevent, and a dangling reference paints black.
+    if (typeof node === "string") return paletteRefSlug(node) === fromSlug ? to : node;
     if (Array.isArray(node)) return node.map(walk);
     if (node && typeof node === "object") {
       return Object.fromEntries(Object.entries(node).map(([k, v]) => [k, walk(v)]));

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -155,18 +155,43 @@ export function paletteKey(palette: unknown): string {
  * as custom and a rename quietly stopped following it. Deliberately only one
  * level: a pattern that swallowed anything up to the last `)` would also match a
  * compound value like `var(--fp-color-a, b) var(--c)`, and rewriting that would
- * replace the whole thing.
+ * replace the whole thing. The fallback text is captured too, so a rewrite can
+ * put it back.
+ *
+ * Case-sensitivity is split, because CSS splits it. Function names are
+ * case-insensitive, so `VAR(--fp-color-warm)` resolves and has to match here.
+ * Custom property *names* are not, so `var(--FP-COLOR-WARM)` does **not**
+ * resolve — it renders as if nothing were declared. Verified in a browser, both
+ * halves. A blanket `/i` made this parser claim the second one was a live
+ * reference while the plan drew it black; dropping `/i` altogether would have
+ * stopped recognising the first, which is a real reference someone may have
+ * written. Hence the spelled-out `[Vv][Aa][Rr]` and an otherwise exact match.
  */
 const PALETTE_REF =
-  /^var\(\s*--fp-color-([\p{L}\p{N}-]+)\s*(?:,(?:[^()]|\([^()]*\))*)?\)$/iu;
+  /^[Vv][Aa][Rr]\(\s*--fp-color-([\p{L}\p{N}-]+)\s*(?:,((?:[^()]|\([^()]*\))*))?\)$/u;
 
 /**
  * The slug a value references, or `undefined` if it is an ordinary colour.
  * Used by the editor to show which palette entry a field is on.
  */
 export function paletteRefSlug(value: unknown): string | undefined {
+  return paletteRefParts(value)?.slug;
+}
+
+/**
+ * A reference broken into the name it points at and the fallback it carries, or
+ * `undefined` for an ordinary colour. The fallback is what a rewrite has to put
+ * back — dropping it would rewrite a hand-written `var(--fp-color-warm, #333)`
+ * into something that no longer says what to do when the name is not there.
+ */
+export function paletteRefParts(
+  value: unknown
+): { slug: string; fallback?: string } | undefined {
   if (typeof value !== "string") return undefined;
-  return PALETTE_REF.exec(value.trim())?.[1].toLowerCase();
+  const m = PALETTE_REF.exec(value.trim());
+  if (!m) return undefined;
+  const fallback = m[2]?.trim();
+  return { slug: m[1], fallback: fallback ? fallback : undefined };
 }
 
 /**
@@ -211,7 +236,21 @@ export function rewritePaletteRefs<T>(value: T, fromSlug: string, to: string): T
     // different case all resolve as this reference everywhere else. Missing
     // them here would leave exactly the dangling reference this function
     // exists to prevent, and a dangling reference paints black.
-    if (typeof node === "string") return paletteRefSlug(node) === fromSlug ? to : node;
+    if (typeof node === "string") {
+      const parts = paletteRefParts(node);
+      if (parts?.slug !== fromSlug) return node;
+      // A rename lands on another reference, which can still carry the fallback
+      // the config was written with. A delete lands on a literal colour, where
+      // there is nowhere to put one — and none is needed: the literal is what
+      // the element was already showing while the name existed, and the
+      // fallback described the case that is now impossible.
+      const target = paletteRefParts(to);
+      // Only splice into a target that is a reference and does not already
+      // carry a fallback of its own — otherwise `to` is already complete.
+      return parts.fallback && target && !target.fallback
+        ? `var(${PALETTE_VAR_PREFIX}${target.slug}, ${parts.fallback})`
+        : to;
+    }
     if (Array.isArray(node)) return node.map(walk);
     if (node && typeof node === "object") {
       return Object.fromEntries(Object.entries(node).map(([k, v]) => [k, walk(v)]));

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -68,13 +68,19 @@ export const MAX_PALETTE = 24;
  * two entries can collide, so {@link paletteEntries} drops the later of any two
  * that produce the same slug. Returns `""` for a name with nothing usable in
  * it, which that same function treats as unusable.
+ *
+ * "Letter" means any letter, not an ASCII one. Restricted to `a-z`, a name in
+ * Japanese, Cyrillic, Greek or Arabic slugs to `""` — so the entry is dropped as
+ * unusable and the colour silently never appears, with nothing on screen saying
+ * why. "Café" fared no better, quietly becoming `caf`. CSS custom properties
+ * take non-ASCII identifiers, so there is nothing to gain by narrowing here.
  */
 export function paletteSlug(name: unknown): string {
   if (typeof name !== "string") return "";
   return name
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
     .replace(/^-+|-+$/g, "");
 }
 
@@ -140,8 +146,19 @@ export function paletteKey(palette: unknown): string {
     .join(",");
 }
 
-/** `var(--fp-color-slug)` or `var(--fp-color-slug, …)`, captured to the slug. */
-const PALETTE_REF = /^var\(\s*--fp-color-([a-z0-9-]+)\s*(?:,[^)]*)?\)$/i;
+/**
+ * `var(--fp-color-slug)` or `var(--fp-color-slug, …)`, captured to the slug.
+ *
+ * The fallback may itself contain one level of parentheses — `rgb(255,136,0)`
+ * and `var(--other)` are both ordinary things to write there. Stopping at the
+ * first `)` read those as not-a-reference at all, so the editor showed the field
+ * as custom and a rename quietly stopped following it. Deliberately only one
+ * level: a pattern that swallowed anything up to the last `)` would also match a
+ * compound value like `var(--fp-color-a, b) var(--c)`, and rewriting that would
+ * replace the whole thing.
+ */
+const PALETTE_REF =
+  /^var\(\s*--fp-color-([\p{L}\p{N}-]+)\s*(?:,(?:[^()]|\([^()]*\))*)?\)$/iu;
 
 /**
  * The slug a value references, or `undefined` if it is an ordinary colour.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1399,6 +1399,22 @@ export interface HistoryReplayConfig {
   numericSteps?: number;
 }
 
+/**
+ * One named colour in a plan's palette (issue #265).
+ *
+ * The `name` is both the label in the dropdown and the identity of the colour:
+ * the custom property it declares is derived from it, so renaming an entry does
+ * **not** move the elements already pointing at the old name — they keep
+ * referencing a property nothing declares any more and fall back to whatever
+ * that field's default is. The editor warns before letting that happen.
+ */
+export interface PaletteColor {
+  /** Shown in the dropdown, e.g. `Warm white`. */
+  name: string;
+  /** Any colour the card accepts — hex, a CSS name, `rgb()`, even a theme `var()`. */
+  color: string;
+}
+
 export interface FloorplanCardConfig extends LovelaceCardConfig {
   type: string;
   title?: string;
@@ -1461,6 +1477,19 @@ export interface FloorplanCardConfig extends LovelaceCardConfig {
    * `src/skins.ts`.
    */
   skin?: string;
+  /**
+   * Named colours for this plan (issue #265), offered in a dropdown beside
+   * every colour field: *"I want all my temperature sensors to use the same
+   * conditional colours but I hate copying colour hex codes across so many
+   * entities."*
+   *
+   * A field references an entry by storing `var(--fp-color-<name>)` — the name
+   * lowercased with anything but letters and digits turned into `-`. That is a
+   * plain CSS custom property, declared on the card from this list, so a
+   * hand-written config can use the feature without the editor and recolouring
+   * an entry moves every element that names it. See `src/palette.ts`.
+   */
+  palette?: PaletteColor[];
   /**
    * How the HTML overlay (badges, labels, room names, text) is sized.
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -1410,10 +1410,15 @@ export interface HistoryReplayConfig {
  * One named colour in a plan's palette (issue #265).
  *
  * The `name` is both the label in the dropdown and the identity of the colour:
- * the custom property it declares is derived from it, so renaming an entry does
- * **not** move the elements already pointing at the old name — they keep
- * referencing a property nothing declares any more and fall back to whatever
- * that field's default is. The editor warns before letting that happen.
+ * the custom property every reference points at is derived from it. So the
+ * editor rewrites the references rather than leaving them behind — a rename
+ * moves them to the new name, and a delete freezes them at the colour the name
+ * was holding.
+ *
+ * That rewriting is not politeness. A reference to a property nothing declares
+ * is not a colour to fall back from: the declaration is dropped, the element
+ * inherits, and an SVG `fill` inherits **black**. A dangling reference would
+ * repaint half a plan.
  */
 export interface PaletteColor {
   /** Shown in the dropdown, e.g. `Warm white`. */


### PR DESCRIPTION
Closes #265.

> I want all my temperature sensors to use the same conditional colors but I hate copying color hex codes across so many entities.

Name colors once under **Project → Named colors**. Every color field on the plan then grows a dropdown listing them — device badges, state rules, room fills, text, furniture, trackers, the floor buttons. Recolor a name and everything using it follows.

```yaml
palette:
  - name: Warm
    color: "#ff8800"
  - name: Alert
    color: "#e53935"
areas:
  - id: living
    color: var(--fp-color-warm)
items:
  - entity: sensor.living_temperature
    stateColor:
      - above: 25
        color: var(--fp-color-alert)
```

## A reference is a `var()`, and that is the whole design

Picking "Warm" stores `var(--fp-color-warm)`. The palette is emitted as those custom properties on the card, and CSS resolves it at every sink.

The alternative — a `palette:warm` sentinel resolved in TypeScript — would have to be understood at *each* of the ~20 places a config color is read, spread across `render.ts`, the card and the editor, in inline styles and SVG presentation attributes alike. Any one left out paints the literal string `palette:warm`, which is not a color, so the element draws as nothing. Going through `var()` instead means:

- **no sink changes at all** — `var()` is already on `cssColor`'s allowlist, since HA themes are built on it;
- **hand-written configs get it too**, with no syntax this card invented;
- **live recoloring is free** — one property moves and the plan follows.

It costs two things, both handled rather than accepted:

- JavaScript that has to *read* a color can't resolve a `var()`. That's `contrastText` (which picks a badge's ink) and the editor's `<input type="color">` swatch — both resolve references first, so moving a badge onto a named color doesn't quietly cost it the ink it had as a literal hex.
- Chromium won't repaint an SVG element whose color comes from a `var()` in a presentation attribute when the property moves under it — the trap skins hit in #122. Both canvases now key their SVG on the palette as well as the skin.

## Renaming and deleting rewrite the plan instead of warning about it

- **Rename** rewrites every reference to the new name, so the link survives.
- **Delete** rewrites them to the color the name held.

That second one isn't politeness. A dangling reference is not a color: the declaration is dropped, the element inherits, and an SVG `fill` inherits **black**. Verified in a browser, and pinned by a test — deleting a name would otherwise repaint half a plan.

The rewrite is a blind deep walk rather than a list of the fields that hold a color, so the field the next feature adds can't be the one that gets forgotten.

A rename that would collide with another entry is refused (two names reducing to one property means one silently stops resolving), and the input is put back — Lit won't do it, since the config didn't change.

## Not there when you don't use it

The dropdown renders only when a plan has a palette, and an empty palette emits no `style` attribute at all. An editor that never names a color is exactly the editor it was.

## Tests

- **39** in the node suite for `palette.ts` — slugs, dedupe, the fail-closed entry filter, style-attribute breakout, the repaint key, and the rewrite walk.
- **5** in the browser suite for the part only a real browser can check: that a reference reaches the paint through an SVG attribute *and* an inline style, that the reference survives in the markup (which is what keeps it live), that recoloring repaints, and that a dangling reference goes black.

`1439` node + `14` browser passing, typecheck and build clean.

## Demo plan

`#26c6da` was typed into both the tracker and the room it moves around in — the complaint in miniature. It's one name now, along with the plant's three thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
