### PR TITLE
Cover position keeps its unit on the card (#260)

### DIFF
--- a/src/card-badge.browser.test.ts
+++ b/src/card-badge.browser.test.ts
@@ -112,6 +112,59 @@ describe("badge contents on the rendered card", () => {
   });
 });
 
+describe("an attribute reading is worded by HA, on the card too (issue #260)", () => {
+  // A cover's position is a bare number on the state object; the "%" comes
+  // from HA's own attribute formatter. The editor hands the real `hass` to the
+  // helper that asks for it, the card hands it a RenderHass built from that —
+  // and the build did not carry the formatter, so the same cover read "50%"
+  // while you were editing it and "50" once you saved.
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  async function mountCover() {
+    const host = document.createElement("div");
+    host.style.width = "900px";
+    host.style.height = "540px";
+    document.body.appendChild(host);
+
+    const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+    card.setConfig({
+      type: "custom:easy-floorplan-card",
+      width: 1000,
+      height: 600,
+      floors: [{
+        id: "f1", name: "Floor 1", walls: [], openings: [], texts: [], furniture: [], trackers: [], areas: [],
+        items: [{
+          id: "c1", kind: "cover", entity: "cover.blind", x: 500, y: 300,
+          name: "Blind", showName: true, showState: true, attribute: "current_position",
+        } as unknown as FloorItem],
+      }],
+    } as FloorplanCardConfig);
+    card.hass = {
+      states: {
+        "cover.blind": {
+          entity_id: "cover.blind",
+          state: "open",
+          attributes: { current_position: 50, device_class: "shutter" },
+        },
+      },
+      entities: {},
+      formatEntityState: (st: { state: string }) => st.state,
+      formatEntityAttributeValue: (_st: unknown, attribute: string) =>
+        attribute === "current_position" ? "50%" : "?",
+    } as unknown as FloorplanCard["hass"];
+    host.appendChild(card);
+    await card.updateComplete;
+    return card;
+  }
+
+  it("keeps the unit HA put on the position", async () => {
+    const card = await mountCover();
+    expect(card.shadowRoot?.querySelector(".label")?.textContent?.trim()).toContain("50%");
+  });
+});
+
 describe("a device is drawn from one instant, not two", () => {
   // Replay renders the plan from `renderHass` — history at the playback head.
   // Anything in a device that still read `this.hass` disagreed with the rest

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -154,6 +154,7 @@ import {
   itemBadgeHidden,
   itemLabelColor,
 } from "./render";
+import { buildRenderHass } from "./replay-history/render-state-service";
 import type { FloorplanCardConfig, Opening, RenderHass } from "./types";
 import { symbolCatalog, symbolSize } from "./symbols";
 
@@ -2181,6 +2182,34 @@ describe("itemStateText with attributes (issue #70)", () => {
 
   it("missing attribute renders the em dash", () => {
     expect(itemStateText(climate(), { entity: "climate.home", attribute: "nope" })).toBe("—");
+  });
+
+  it("carries that formatter through the slice the card renders from (issue #260)", () => {
+    // The editor hands the real `hass` to these helpers; the card hands them a
+    // RenderHass built from it. Anything the build drops is not missing, it is
+    // replaced by the raw attribute — which is how a cover position read "50%"
+    // in the editor and "50" on the card.
+    const h = climate() as unknown as Record<string, unknown>;
+    h.formatEntityAttributeValue = (_s: unknown, a: string) => `fmt:${a}`;
+    const rendered = buildRenderHass(
+      h as never,
+      ["climate.home"],
+      { getStateAt: () => new Map() } as never,
+      false,
+      0,
+    );
+    expect(itemStateText(rendered, { entity: "climate.home", attribute: "current_temperature" }))
+      .toBe("fmt:current_temperature");
+  });
+
+  it("re-renders when HA rebuilds the attribute formatter", () => {
+    // A plan built only out of attribute readings never calls the state
+    // formatter, so its identity is not a signal that this plan's wording
+    // changed.
+    const base = climate() as unknown as Record<string, unknown>;
+    const prev = { ...base, formatEntityAttributeValue: () => "old" } as never;
+    const next = { ...base, formatEntityAttributeValue: () => "new" } as never;
+    expect(hassRenderInputsChanged(prev, next, ["climate.home"])).toBe(true);
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -114,6 +114,9 @@ export function hassRenderInputsChanged(
   watchedEntities: Iterable<string>,
 ): boolean {
   if (prev.formatEntityState !== next.formatEntityState) return true;
+  // Both formatters, because a plan can be built entirely out of attribute
+  // readings and would otherwise be watching a function it never calls.
+  if (prev.formatEntityAttributeValue !== next.formatEntityAttributeValue) return true;
   for (const id of watchedEntities) {
     if (prev.states[id] !== next.states[id]) return true;
   }
@@ -201,8 +204,7 @@ export function entityAttributeText(
   if (!entityId || !hass) return NO_STATE;
   const stateObj = hass.states[entityId];
   if (!stateObj) return NO_STATE;
-  const fmt = (hass as { formatEntityAttributeValue?: (s: unknown, a: string) => string })
-    .formatEntityAttributeValue;
+  const fmt = hass.formatEntityAttributeValue;
   if (typeof fmt === "function") return fmt(stateObj, attribute);
   const raw = (stateObj.attributes as Record<string, unknown>)?.[attribute];
   return raw === undefined || raw === null || raw === "" ? NO_STATE : String(raw);

--- a/src/replay-history/render-state-service.ts
+++ b/src/replay-history/render-state-service.ts
@@ -32,8 +32,13 @@ export function buildRenderHass(
     states[entityId] = provider.getEntityState(entityId);
   }
 
+  // Every formatter the plan draws through, forwarded: what is not here is not
+  // missing, it is silently replaced by the raw attribute (issue #260).
   return {
     states,
     formatEntityState: (stateObj: HassEntity) => hass.formatEntityState(stateObj),
+    formatEntityAttributeValue: hass.formatEntityAttributeValue
+      ? (stateObj: HassEntity, attribute: string) => hass.formatEntityAttributeValue!(stateObj, attribute)
+      : undefined,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface HomeAssistant extends BaseHomeAssistant {
    */
   formatEntityState(stateObj: HassEntity, state?: string): string;
   /**
+   * The same, for one of an entity's attributes. Carried by HA since 2023.9
+   * and, like `formatEntityState`, the only thing that knows a cover position
+   * is a percentage or a temperature has a degree sign — the raw attribute is
+   * a bare number. Optional because a frontend older than that has none, which
+   * {@link entityAttributeText} falls back for.
+   */
+  formatEntityAttributeValue?(stateObj: HassEntity, attribute: string): string;
+  /**
    * The entity registry as the frontend exposes it. `custom-card-helpers` does
    * not declare it, though HA has handed it to cards since 2023.4. It carries
    * the user's per-entity icon override, which never appears in the state's
@@ -30,10 +38,19 @@ export interface HomeAssistant extends BaseHomeAssistant {
   entities?: Record<string, { icon?: string } | undefined>;
 }
 
-/** The slice of `hass` the card draws from. */
+/**
+ * The slice of `hass` the card draws from.
+ *
+ * Every wording HA owns has to be listed here, not just reachable off the real
+ * `hass`: this is what the card renders through, and anything missing silently
+ * degrades to whatever the raw state object says. A cover position left off
+ * this interface drew "50" on the card and "50%" in the editor, because the
+ * editor hands the real `hass` straight to the same helper (issue #260).
+ */
 export interface RenderHass {
   states: Record<string, HassEntity | undefined>;
   formatEntityState(stateObj: HassEntity): string;
+  formatEntityAttributeValue?(stateObj: HassEntity, attribute: string): string;
 }
 
 /** A straight wall segment in virtual coordinate space. */


### PR DESCRIPTION
Fixes #260.

## Cause

A cover's `current_position` is a bare number on the state object — the `%` comes from HA's own `formatEntityAttributeValue`. `entityAttributeText` asks for that formatter and falls back to `String(raw)` when it isn't there.

The editor hands those helpers the real `hass`, which has it. The card hands them a `RenderHass` built by `buildRenderHass`, which only ever forwarded `formatEntityState`. So the same cover read `50%` while you were editing it and `50` once you saved.

@thewan056's hunch was right on both counts — it is because it's an attribute, and humidity was fine because that's an entity *state*, which was already routed through `formatEntityState`.

## Fix

`RenderHass` now declares both formatters and `buildRenderHass` forwards both. The interface is what the card renders through, so anything left off it isn't missing — it's silently replaced by the raw attribute, which is what made this look like a rendering bug rather than a wiring one.

`hassRenderInputsChanged` watches the new formatter's identity too: a plan built entirely out of attribute readings never calls the state formatter, so its identity isn't a signal that *this* plan's wording changed.

## Tests

- A card-level browser test mounting a cover with a position label. Verified failing without the fix: `expected 'Blind · 50' to contain '50%'` — the exact reported symptom.
- Two node tests: the formatter survives the `RenderHass` build, and rebuilding it triggers a re-render.

## Not in scope

The *badge* value path (`badgeReading`) reads attributes straight off the state object and appends a unit only from its own `DOMAIN_BADGE_READING` table, which has no `cover` entry. That path behaves identically in the editor and on the card, so it isn't this bug — but a cover position shown as a **badge** still has no `%`. Happy to add `cover: { attribute: "current_position", unit: "%" }` there as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)