### PR TITLE
Areas: centre room names by floor area instead of vertex count

### DIFF
--- a/src/card-area-label.browser.test.ts
+++ b/src/card-area-label.browser.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, expect, it } from "vitest";
+import "./floorplan-card";
+import type { FloorplanCard } from "./floorplan-card";
+import type { FloorplanCardConfig } from "./types";
+
+afterEach(() => { document.body.innerHTML = ""; });
+it.each([0, 90, 180, 270] as const)("renders the area-weighted label anchor at rotation %s", async (rotation) => {
+  const card = document.createElement("easy-floorplan-card") as FloorplanCard;
+  // A rectangle with an extra vertex on its top edge: its floor centre remains (50, 30).
+  card.setConfig({
+    type: "custom:easy-floorplan-card", width: 200, height: 100, rotation,
+    floors: [{ id: "ground", name: "Ground", walls: [], openings: [], items: [], texts: [], furniture: [], trackers: [],
+      areas: [{ id: "room", name: "Room", points: [
+        { x: 0, y: 0 }, { x: 20, y: 0 }, { x: 100, y: 0 }, { x: 100, y: 60 }, { x: 0, y: 60 },
+      ] }],
+    }],
+  } as FloorplanCardConfig);
+  card.hass = { states: {}, entities: {} } as FloorplanCard["hass"];
+  document.body.append(card);
+  await card.updateComplete;
+  const label = card.shadowRoot!.querySelector(".area-label") as HTMLElement;
+  const expected = { 0: [25, 30], 90: [70, 25], 180: [75, 70], 270: [30, 75] }[rotation]!;
+  expect(parseFloat(label.style.left)).toBeCloseTo(expected[0]!, 2);
+  expect(parseFloat(label.style.top)).toBeCloseTo(expected[1]!, 2);
+});

--- a/src/floorplan-card.ts
+++ b/src/floorplan-card.ts
@@ -83,7 +83,7 @@ import {
   wallsLightPassesThrough,
   openingClearFraction,
   glowClearSpan,
-  polygonCentroid,
+  areaLabelPoint,
   trackerSensorReading,
   entityIsActive,
   itemBadgeLabel,
@@ -874,7 +874,7 @@ export class FloorplanCard extends LitElement {
     scale: OverlayScale
   ): TemplateResult | typeof nothing {
     if (!a.name || (a.showName ?? true) === false) return nothing;
-    const centroid = polygonCentroid(a.points);
+    const centroid = areaLabelPoint(a.points);
     const p = rotatePlanPoint(centroid.x, centroid.y, c.width, c.height, rot);
     const d = rotatedCanvasSize(c.width, c.height, rot);
     // Empty unless the size has something to say the stylesheet doesn't — see

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -129,6 +129,7 @@ import {
   rotatePlanPoint,
   planRotationTransform,
   polygonCentroid,
+  areaLabelPoint,
   areaZoomTransform,
   resolveAreaZoom,
   zoomedOverlayScale,
@@ -3982,6 +3983,53 @@ describe("overlay size while zoomed (issue #222)", () => {
     expect(zoomedOverlayScale(4, 0)).toBeCloseTo(0.25);
     expect(zoomedOverlayScale(4, -2)).toBeCloseTo(0.25);
     expect(zoomedOverlayScale(NaN, 2)).toBe(1);
+  });
+});
+
+describe("areaLabelPoint", () => {
+  it("does not move a room name when an extra vertex splits a straight wall", () => {
+    const rect = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 20 }, { x: 0, y: 20 }];
+    const subdivided = [rect[0]!, { x: 3, y: 0 }, ...rect.slice(1)];
+    expect(areaLabelPoint(subdivided)).toEqual(areaLabelPoint(rect));
+    expect(polygonCentroid(subdivided)).not.toEqual(polygonCentroid(rect));
+  });
+
+  it("agrees with the vertex mean on a rectangle", () => {
+    const rect = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 20 }, { x: 0, y: 20 }];
+    expect(areaLabelPoint(rect)).toEqual({ x: 5, y: 10 });
+  });
+
+  it("centres on the floor of an L-shaped room, not on its corners", () => {
+    // The kitchen that surfaced this: four of six vertices sit on the right,
+    // so the vertex mean lands at x=300 — outside the room's visual middle.
+    const kitchen = [
+      { x: 80, y: 120 }, { x: 460, y: 120 }, { x: 460, y: 260 },
+      { x: 360, y: 260 }, { x: 360, y: 420 }, { x: 80, y: 420 },
+    ];
+    const p = areaLabelPoint(kitchen);
+    expect(p.x).toBeCloseTo(247.1, 1);
+    expect(p.y).toBeCloseTo(258.6, 1);
+    expect(polygonCentroid(kitchen).x).toBe(300);
+  });
+
+  it("does not care which way the polygon winds", () => {
+    const cw = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 20 }, { x: 0, y: 20 }];
+    expect(areaLabelPoint([...cw].reverse())).toEqual(areaLabelPoint(cw));
+  });
+
+  it("falls back to the vertex mean when the centroid escapes a U-shaped room", () => {
+    // Centre of mass sits in the notch between the arms, outside the polygon.
+    const u = [
+      { x: 0, y: 0 }, { x: 30, y: 0 }, { x: 30, y: 30 }, { x: 20, y: 30 },
+      { x: 20, y: 10 }, { x: 10, y: 10 }, { x: 10, y: 30 }, { x: 0, y: 30 },
+    ];
+    expect(areaLabelPoint(u)).toEqual(polygonCentroid(u));
+  });
+
+  it("falls back for a polygon with no area", () => {
+    const line = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }];
+    expect(areaLabelPoint(line)).toEqual({ x: 10, y: 0 });
+    expect(areaLabelPoint([])).toEqual({ x: 0, y: 0 });
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -4676,13 +4676,51 @@ export function renderWallMask(
 /**
  * Arithmetic-mean centroid of a polygon's vertices. Not an exact
  * center-of-mass for a non-convex shape, but that precision isn't needed
- * here — it's only used for name-label placement and marquee/click
+ * here — it's only used for approximate editor positions and marquee/click
  * hit-testing (see `elementsInRect` in editor-geometry.ts).
  */
 export function polygonCentroid(points: readonly AreaPoint[]): { x: number; y: number } {
   if (!points.length) return { x: 0, y: 0 };
   const sum = points.reduce((s, p) => ({ x: s.x + p.x, y: s.y + p.y }), { x: 0, y: 0 });
   return { x: sum.x / points.length, y: sum.y / points.length };
+}
+
+/**
+ * Area-weighted centroid — the polygon's centre of *mass* by the shoelace
+ * formula — or undefined when the polygon encloses no area (fewer than three
+ * points, or all of them collinear), where the quantity is not defined.
+ *
+ * Winding does not matter: signed area appears in both the numerator and the
+ * denominator, so a clockwise polygon and its counter-clockwise twin return
+ * the same point.
+ */
+function polygonAreaCentroid(points: readonly AreaPoint[]): { x: number; y: number } | undefined {
+  if (points.length < 3) return undefined;
+  let twiceArea = 0;
+  let x = 0;
+  let y = 0;
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const pi = points[i]!;
+    const pj = points[j]!;
+    const cross = pj.x * pi.y - pi.x * pj.y;
+    twiceArea += cross;
+    x += (pj.x + pi.x) * cross;
+    y += (pj.y + pi.y) * cross;
+  }
+  if (twiceArea === 0) return undefined;
+  return { x: x / (3 * twiceArea), y: y / (3 * twiceArea) };
+}
+
+/**
+ * Centre room labels by floor area, rather than the number of vertices on each
+ * side. Keep the previous placement when the area centroid is outside a concave
+ * room or the polygon has no area. This fallback does not guarantee an interior
+ * label for every concave polygon.
+ */
+export function areaLabelPoint(points: readonly AreaPoint[]): { x: number; y: number } {
+  const centroid = polygonAreaCentroid(points);
+  if (centroid && pointInPolygon(points, centroid.x, centroid.y)) return centroid;
+  return polygonCentroid(points);
 }
 
 /** Neutral (unzoomed) result of {@link areaZoomTransform} — identity view. */


### PR DESCRIPTION
Room names currently use the arithmetic mean of a room's vertices. Extra vertices on one wall pull the name toward that wall even when the room's shape has not changed; an L-shaped room can also look visibly off-centre.

This positions the live card's room name at the polygon's area-weighted centroid when that point lies inside the room. The example kitchen moves from x=300 to approximately x=247.14, and the rectangular study centres at (725, 270) despite extra vertices along its top wall. Display rotation still applies to the resulting anchor. Editor hit-testing keeps its existing approximate centroid.

For degenerate polygons or a concave room whose area centroid lies outside, the previous vertex-mean position is retained. This deliberately preserves the fallback behavior: it does **not** guarantee an interior label for every U-shaped room.

### Before / after in the development Home Assistant container

Home Assistant **2026.9.2**, Chromium 151, identical dashboard/configuration and **1000 × 760 CSS-pixel viewport**. Before uses upstream `3f89501`; after uses this branch. The study is rectangular, with extra collinear vertices on its top wall.

| Before | After |
| --- | --- |
| ![Before: room names are pulled toward extra vertices](https://raw.githubusercontent.com/superflyer11/easy-floorplan/c90b7b1294a5802f45e8513b4be7d3d1296fc0e8/assets/pr-review-2026-09-12/labels-before.png) | ![After: room names follow floor area](https://raw.githubusercontent.com/superflyer11/easy-floorplan/c90b7b1294a5802f45e8513b4be7d3d1296fc0e8/assets/pr-review-2026-09-12/labels-after.png) |

[Reproduction configuration and measured positions](https://github.com/superflyer11/easy-floorplan/tree/c90b7b1294a5802f45e8513b4be7d3d1296fc0e8/assets/pr-review-2026-09-12). These are real Lovelace screenshots captured in the repository's development container.

### Validation

- `npm run typecheck` — passed.
- `npm test` — **1,524 passed**.
- `npm run test:browser` — **59 passed**.
- `npm run build` — passed.
- Unit cases cover rectangles, L-shaped rooms, extra collinear vertices, winding direction, U-shaped fallback and zero-area input.
- Four browser cases verify the actual label anchor at 0°, 90°, 180° and 270°. All four fail against unchanged upstream and pass here.
- No browser page errors during the Home Assistant captures.

This PR is independent of the optional minimum overlay-size setting.
